### PR TITLE
Phase 1d: real-database integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Single-admin session-cookie authentication (`APP_ADMIN_USER` / `APP_ADMIN_PASSWORD`), with `APP_AUTH_DISABLED=true` reverse-proxy mode. New endpoints: `POST /api/v1/auth/login`, `POST /api/v1/auth/logout`, `GET /api/v1/auth/me`.
 - `/health/ready` readiness endpoint (503 until the database answers).
 - Login page, automatic redirect to it on API 401 responses, and a logout button in the sidebar (hidden when auth is disabled).
+- Real-TimescaleDB integration test suite (`pytest -m integration`): startup migrations, end-to-end ingestion (rows/rotation/poison-recovery), repository CAGG-routing.
 
 ### Changed
 
@@ -38,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Vite `@` alias resolved to the filesystem root instead of `resources/`.
 - Stale geo-location cache entries after a rollback no longer poison subsequent inserts.
+- Location-cache entries that predate the current run (e.g. after a crashed commit) are evicted when a flush fails, so a poisoned id cannot wedge ingestion permanently.
 - Server modules no longer fail to import when the GeoIP database is missing.
 - CAGG summary returned no data for ranges with geo events but zero access logs.
 - `provice_summary_stats_repo` typo.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,30 @@ uv run litestar --app geometrikks.server.core:create_app run --debug
 ```
 See .env.example for configuration
 
+## Testing
+
+```bash
+uv run pytest                    # unit tests — no docker needed
+```
+
+Integration tests need the compose TimescaleDB and are marked `integration`.
+When the database is unreachable they are skipped automatically, so the plain
+run above always stays green.
+
+```bash
+docker compose up -d timescale_db
+uv run pytest -m integration     # the real-database suite
+```
+
+The integration suite creates a scratch database `geometrikks_it` on the
+compose server (migrated to alembic head + timescale objects), and drops it
+at session end — it never touches the `geometrikks` dev database. Connection
+overrides: `IT_DB_HOST`, `IT_DB_PORT`, `IT_DB_USER`, `IT_DB_PASSWORD`.
+
+> CI note (Phase 1.5): `ci.yml` should run the integration suite with a
+> `timescale/timescaledb-ha:pg18` service container — the `IT_DB_*` env vars
+> exist for exactly that.
+
 ## Authentication
 
 GeoMetrikks ships with single-admin session-cookie authentication. Set the

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -420,6 +420,12 @@ class LogIngestionService:
                     except Exception as rollback_err:
                         logger.error("Rollback failed: %s", rollback_err)
                     self._evict_uncommitted_locations()
+                    # The failing record may have hit a poisoned cache entry
+                    # (an id cached before this service run whose row does not
+                    # exist, e.g. after a crashed commit). Uncommitted-tracking
+                    # can't see those, so drop the record's own geohash too.
+                    if record.geo_data:
+                        self._location_cache.pop(record.geo_data.geohash, None)
 
             try:
                 await session.commit()
@@ -428,6 +434,12 @@ class LogIngestionService:
                 logger.error("Batch commit failed (rolling back): %s", e)
                 await session.rollback()
                 self._evict_uncommitted_locations()
+                # Same poisoned-entry hazard as above, but here we don't know
+                # which record broke the commit — evict every geohash the
+                # batch touched so the next flush re-resolves them from the DB.
+                for record in batch:
+                    if record.geo_data:
+                        self._location_cache.pop(record.geo_data.geohash, None)
 
         logger.debug(
             "Committed batch of %d records. (Geo: %d | Log: %d | Debug: %d)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dev = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+markers = [
+    "integration: needs a live TimescaleDB (docker compose up -d timescale_db); auto-skipped when unreachable",
+]
 filterwarnings = [
     # Reduce noise from third-party libs; keep real test warnings visible
     "ignore:There is no current event loop:DeprecationWarning",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,138 @@
+"""Fixtures for real-TimescaleDB integration tests.
+
+Creates a scratch database `geometrikks_it` on the compose `timescale_db`
+server, migrates it to alembic head, runs setup_timescaledb, and drops it
+at session end. All tests in this package are marked `integration` and are
+skipped automatically when the server is unreachable.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
+
+PG_HOST = os.getenv("IT_DB_HOST", "localhost")
+PG_PORT = int(os.getenv("IT_DB_PORT", "5432"))
+PG_USER = os.getenv("IT_DB_USER", "geouser")
+PG_PASSWORD = os.getenv("IT_DB_PASSWORD", "geopass")
+IT_DBNAME = "geometrikks_it"
+
+ADMIN_URL = f"postgresql+asyncpg://{PG_USER}:{PG_PASSWORD}@{PG_HOST}:{PG_PORT}/postgres"
+IT_URL = f"postgresql+asyncpg://{PG_USER}:{PG_PASSWORD}@{PG_HOST}:{PG_PORT}/{IT_DBNAME}"
+
+
+def _server_reachable() -> bool:
+    try:
+        with socket.create_connection((PG_HOST, PG_PORT), timeout=1):
+            return True
+    except OSError:
+        return False
+
+
+def pytest_collection_modifyitems(config, items):
+    """Mark everything in this package `integration`; skip if no server."""
+    integration_items = [
+        item
+        for item in items
+        if "tests/integration" in str(item.fspath).replace(os.sep, "/")
+    ]
+    if not integration_items:
+        return
+    reachable = _server_reachable()
+    skip = pytest.mark.skip(reason="TimescaleDB not reachable (docker compose up -d timescale_db)")
+    for item in integration_items:
+        item.add_marker(pytest.mark.integration)
+        if not reachable:
+            item.add_marker(skip)
+
+
+@pytest.fixture(scope="session")
+def it_database_url() -> str:
+    """Create the scratch DB (dropping any stale one), yield its URL, drop it."""
+
+    async def _admin_exec(sql: str) -> None:
+        engine = create_async_engine(ADMIN_URL, isolation_level="AUTOCOMMIT")
+        try:
+            async with engine.connect() as conn:
+                await conn.execute(text(sql))
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_admin_exec(f"DROP DATABASE IF EXISTS {IT_DBNAME} WITH (FORCE)"))
+    asyncio.run(_admin_exec(f"CREATE DATABASE {IT_DBNAME}"))
+    yield IT_URL
+    asyncio.run(_admin_exec(f"DROP DATABASE IF EXISTS {IT_DBNAME} WITH (FORCE)"))
+
+
+@pytest.fixture(scope="session")
+def monkeypatch_session():
+    """Session-scoped monkeypatch (pytest's default fixture is function-scoped)."""
+    from _pytest.monkeypatch import MonkeyPatch
+
+    mp = MonkeyPatch()
+    yield mp
+    mp.undo()
+
+
+@pytest.fixture(scope="session")
+def migrated_database_url(it_database_url: str, monkeypatch_session) -> str:
+    """Scratch DB migrated to head with timescale objects set up."""
+    from geometrikks.config.settings import get_settings
+    from geometrikks.server.migrations import upgrade_to_head
+    from geometrikks.server.timescale import setup_timescaledb
+
+    # Point settings at the scratch DB for the duration of the session.
+    # NOTE: the DatabaseSettings field is `database` (env prefix DB_), so the
+    # env var is DB_DATABASE — DB_NAME would silently leave settings on the
+    # dev `geometrikks` database and alembic would migrate THAT instead.
+    monkeypatch_session.setenv("DB_HOST", PG_HOST)
+    monkeypatch_session.setenv("DB_PORT", str(PG_PORT))
+    monkeypatch_session.setenv("DB_USER", PG_USER)
+    monkeypatch_session.setenv("DB_PASSWORD", PG_PASSWORD)
+    monkeypatch_session.setenv("DB_DATABASE", IT_DBNAME)
+    get_settings.cache_clear()
+    assert get_settings().database.database == IT_DBNAME
+
+    upgrade_to_head()  # sync; runs alembic upgrade head against DB_* env
+
+    async def _setup() -> None:
+        engine = create_async_engine(it_database_url)
+        try:
+            await setup_timescaledb(engine, get_settings().analytics)
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_setup())
+    yield it_database_url
+    get_settings.cache_clear()
+
+
+@pytest.fixture()
+async def pg_engine(migrated_database_url: str) -> AsyncEngine:
+    engine = create_async_engine(migrated_database_url)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture()
+def pg_session_maker(pg_engine: AsyncEngine):
+    return async_sessionmaker(pg_engine, expire_on_commit=False)
+
+
+@pytest.fixture()
+async def clean_tables(pg_engine: AsyncEngine):
+    """Truncate data tables before each test that requests this fixture.
+
+    NOTE: TRUNCATE on a hypertable does not clear CAGG materialized data, and
+    the scratch DB has live refresh policies. Tests that assert on CAGG
+    contents must refresh their full seed window explicitly (see Task 4 tests).
+    """
+    async with pg_engine.begin() as conn:
+        await conn.execute(
+            text("TRUNCATE geo_events, access_logs, access_log_debug, geo_locations RESTART IDENTITY CASCADE")
+        )
+    yield

--- a/tests/integration/test_ingestion_pg.py
+++ b/tests/integration/test_ingestion_pg.py
@@ -1,0 +1,178 @@
+"""End-to-end ingestion against real TimescaleDB.
+
+Covers the three design-mandated scenarios:
+1. write lines -> rows land in geo_events/access_logs/geo_locations
+2. simulate rotation -> tailing continues on the new file
+3. poison the location cache -> flush fails, cache is evicted, next flush recovers
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from sqlalchemy import text
+
+from geometrikks.services.ingestion.service import LogIngestionService
+from geometrikks.services.logparser.logparser import LogParser
+
+GEOIP_DB_PATH = "tests/GeoLite2-City-Test.mmdb"
+TEST_IP = "2.125.160.216"   # resolves in the MaxMind test DB
+TEST_IP_2 = "81.2.69.142"   # second location in the test DB
+
+
+def make_log_line(ip: str) -> str:
+    """A line in the project's custom nginx log format (mirrors tests/valid_ipv4_log.txt).
+
+    Unlike the unit-test helper this stamps the current time: the scratch DB
+    has live retention policies (raw data > 180 days is droppable), so a fixed
+    2024 date could vanish if a background job fires mid-session.
+    """
+    ts = datetime.now(timezone.utc).strftime("%d/%b/%Y:%H:%M:%S +0000")
+    return (
+        f'{ip} - - [{ts}]"GET /index.php HTTP/2.0" 200 1024"-" '
+        f'example.com "-""0.002" "0.001""City" "CC"'
+    )
+
+
+def make_service(log_path: Path, session_maker, **kwargs) -> LogIngestionService:
+    parser = LogParser(log_path=log_path, send_logs=True, poll_interval=0.05)
+    return LogIngestionService(
+        parsers=[parser],
+        session_maker=session_maker,
+        geoip_path=GEOIP_DB_PATH,
+        locales=["en"],
+        batch_size=kwargs.pop("batch_size", 5),
+        commit_interval=kwargs.pop("commit_interval", 0.2),
+        **kwargs,
+    )
+
+
+async def count(session_maker, table: str) -> int:
+    async with session_maker() as session:
+        result = await session.execute(text(f"SELECT COUNT(*) FROM {table}"))
+        return result.scalar_one()
+
+
+async def wait_for(predicate, timeout: float = 10.0, interval: float = 0.1):
+    """Poll an async predicate until truthy or timeout."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if await predicate():
+            return
+        await asyncio.sleep(interval)
+    raise AssertionError("condition not met within timeout")
+
+
+async def _rows_landed(session_maker, n: int) -> bool:
+    return await count(session_maker, "access_logs") >= n
+
+
+async def start_tailing(service: LogIngestionService) -> None:
+    """Start the service and yield until the tail task has opened the file.
+
+    start() only schedules the tail tasks; the tailer stats the file and seeks
+    to its end when it first runs. Lines written before that seek are skipped,
+    so tests must not write until the tailer is actually streaming.
+    """
+    await service.start(skip_validation=True)
+    await asyncio.sleep(0.25)
+
+
+async def test_lines_become_rows(tmp_path: Path, pg_session_maker, clean_tables):
+    log_file = tmp_path / "access.log"
+    log_file.write_text("")  # file must exist before tailing starts
+
+    service = make_service(log_file, pg_session_maker)
+    await start_tailing(service)
+    try:
+        with log_file.open("a") as f:
+            for _ in range(10):
+                f.write(make_log_line(TEST_IP) + "\n")
+
+        await wait_for(lambda: _rows_landed(pg_session_maker, 10))
+    finally:
+        await service.stop(timeout=5.0)
+
+    assert await count(pg_session_maker, "access_logs") == 10
+    assert await count(pg_session_maker, "geo_events") == 10
+    assert await count(pg_session_maker, "geo_locations") == 1  # same IP -> one location
+
+
+async def test_rotation_is_survived(tmp_path: Path, pg_session_maker, clean_tables):
+    log_file = tmp_path / "access.log"
+    log_file.write_text("")
+
+    service = make_service(log_file, pg_session_maker)
+    await start_tailing(service)
+    try:
+        with log_file.open("a") as f:
+            for _ in range(5):
+                f.write(make_log_line(TEST_IP) + "\n")
+        await wait_for(lambda: _rows_landed(pg_session_maker, 5))
+
+        # Rotate: move the old file away, create a fresh one (new inode).
+        os.rename(log_file, tmp_path / "access.log.1")
+        log_file.write_text("")
+        # Give the poll loop a moment to detect the inode change.
+        await asyncio.sleep(0.5)
+
+        with log_file.open("a") as f:
+            for _ in range(5):
+                f.write(make_log_line(TEST_IP_2) + "\n")
+        await wait_for(lambda: _rows_landed(pg_session_maker, 10))
+    finally:
+        await service.stop(timeout=5.0)
+
+    assert await count(pg_session_maker, "access_logs") == 10
+    assert await count(pg_session_maker, "geo_locations") == 2
+
+
+def _cache_evicted(service: LogIngestionService, geohash: str):
+    async def check() -> bool:
+        return service._location_cache.get(geohash) != 999999
+    return check
+
+
+async def test_poisoned_location_cache_recovers(tmp_path: Path, pg_session_maker, clean_tables):
+    """A stale cached location id (FK violation) must not poison ingestion forever.
+
+    This is the Phase-1a bug class: cache held an id whose row never
+    committed. We simulate it by planting a bogus id for the geohash the
+    test IP resolves to, then asserting the service recovers on its own.
+    """
+    log_file = tmp_path / "access.log"
+    log_file.write_text("")
+
+    service = make_service(log_file, pg_session_maker, batch_size=1, commit_interval=0.1)
+
+    # Resolve the geohash the same way the parser will.
+    import geohash2
+    from geoip2.database import Reader
+
+    with Reader(GEOIP_DB_PATH) as reader:
+        city = reader.city(TEST_IP)
+        geohash = geohash2.encode(city.location.latitude, city.location.longitude)
+
+    # Plant the poison: id 999999 does not exist in geo_locations.
+    service._location_cache[geohash] = 999999
+
+    await start_tailing(service)
+    try:
+        with log_file.open("a") as f:
+            f.write(make_log_line(TEST_IP) + "\n")
+
+        # First flush fails on FK; the rollback path must evict the geohash.
+        await wait_for(_cache_evicted(service, geohash), timeout=5.0)
+
+        # Feed another line: with the cache clean, this one must land.
+        with log_file.open("a") as f:
+            f.write(make_log_line(TEST_IP) + "\n")
+        await wait_for(lambda: _rows_landed(pg_session_maker, 1))
+    finally:
+        await service.stop(timeout=5.0)
+
+    assert await count(pg_session_maker, "geo_events") >= 1
+    assert service._location_cache.get(geohash) != 999999

--- a/tests/integration/test_repositories_pg.py
+++ b/tests/integration/test_repositories_pg.py
@@ -14,7 +14,12 @@ from geometrikks.domain.geo.repositories import GeoLocationRepository
 from geometrikks.server.timescale import refresh_caggs_range
 from tests.seed.factories import AccessLogFactory, GeoLocationFactory, seed_factories
 
-NOW = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+# Derived from the wall clock, not hard-coded: the scratch DB has live
+# retention policies (raw data > 180 days is droppable), so a fixed date
+# would eventually age out of the window and let a policy job drop seeded
+# rows mid-session. Hour-aligned so seeds land deterministically in hourly
+# CAGG buckets.
+NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
 
 LOCATION_COLUMNS = (
     "geohash", "latitude", "longitude", "country_code", "country_name",

--- a/tests/integration/test_repositories_pg.py
+++ b/tests/integration/test_repositories_pg.py
@@ -1,0 +1,140 @@
+"""Repository + CAGG-routing tests on real TimescaleDB, seeded via polyfactory."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import text
+
+from geometrikks.domain.analytics.repositories import (
+    StatsGranularity,
+    SummaryStatsRepository,
+    get_stats_granularity,
+)
+from geometrikks.domain.geo.repositories import GeoLocationRepository
+from geometrikks.server.timescale import refresh_caggs_range
+from tests.seed.factories import AccessLogFactory, GeoLocationFactory, seed_factories
+
+NOW = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+
+LOCATION_COLUMNS = (
+    "geohash", "latitude", "longitude", "country_code", "country_name",
+    "state", "state_code", "city", "postal_code", "timezone",
+)
+
+
+async def seed(session_maker, *, days_back: int, per_day: int) -> None:
+    """Insert locations + paired access logs/geo events spread over days_back days.
+
+    Plain SQL INSERTs with factory-generated values rather than ORM add():
+    keeps the fixture independent of the ingestion code under test. geo_events
+    and access_logs are id-only bases (no created_at/updated_at columns);
+    geo_locations is an audit base and has both.
+    """
+    seed_factories(42)
+    async with session_maker() as session:
+        location_ids: list[int] = []
+        for loc in GeoLocationFactory.batch_dicts(3):
+            result = await session.execute(
+                text(
+                    "INSERT INTO geo_locations "
+                    "(geohash, latitude, longitude, geographic_point, country_code, "
+                    " country_name, state, state_code, city, postal_code, timezone, "
+                    " last_hit, created_at, updated_at) "
+                    "VALUES (:geohash, :latitude, :longitude, "
+                    " ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography, "
+                    " :country_code, :country_name, :state, :state_code, :city, "
+                    " :postal_code, :timezone, now(), now(), now()) "
+                    "RETURNING id"
+                ),
+                {k: loc[k] for k in LOCATION_COLUMNS},
+            )
+            location_ids.append(result.scalar_one())
+
+        for day in range(days_back):
+            ts = NOW - timedelta(days=day, hours=1)
+            for i in range(per_day):
+                log = AccessLogFactory.build_dict(timestamp=ts, ip_address=f"10.0.{day}.{i}")
+                await session.execute(
+                    text(
+                        "INSERT INTO access_logs (timestamp, ip_address, method, url, "
+                        " status_code, bytes_sent, request_time) "
+                        "VALUES (:timestamp, :ip_address, 'GET', '/x', :status_code, "
+                        " :bytes_sent, :request_time)"
+                    ),
+                    {
+                        "timestamp": ts,
+                        "ip_address": log["ip_address"],
+                        "status_code": 200,
+                        "bytes_sent": 1000,
+                        "request_time": 0.01,
+                    },
+                )
+                await session.execute(
+                    text(
+                        "INSERT INTO geo_events (timestamp, ip_address, hostname, location_id) "
+                        "VALUES (:timestamp, :ip_address, 'it-test', :location_id)"
+                    ),
+                    {
+                        "timestamp": ts,
+                        "ip_address": log["ip_address"],
+                        "location_id": location_ids[i % len(location_ids)],
+                    },
+                )
+        await session.commit()
+
+
+class TestGranularityRouting:
+    """Pure routing thresholds (no DB) — belongs here for spec locality."""
+
+    def test_raw_up_to_24h(self):
+        assert get_stats_granularity(NOW - timedelta(hours=24), NOW) is StatsGranularity.RAW
+
+    def test_hourly_between_24h_and_30d(self):
+        assert get_stats_granularity(NOW - timedelta(days=2), NOW) is StatsGranularity.HOURLY
+        assert get_stats_granularity(NOW - timedelta(days=30), NOW) is StatsGranularity.HOURLY
+
+    def test_daily_beyond_30d(self):
+        assert get_stats_granularity(NOW - timedelta(days=31), NOW) is StatsGranularity.DAILY
+
+
+async def test_raw_summary_counts_are_exact(pg_session_maker, clean_tables):
+    await seed(pg_session_maker, days_back=1, per_day=10)
+    async with pg_session_maker() as session:
+        repo = SummaryStatsRepository(session=session)
+        stats = await repo.get_summary(NOW - timedelta(hours=23), NOW)
+    assert stats is not None
+    assert stats.total_log_records == 10
+    assert stats.total_geo_records == 10
+
+
+async def test_cagg_summary_after_refresh(pg_engine, pg_session_maker, clean_tables):
+    """>24h range routes to hourly CAGGs; after an explicit range refresh the
+    counts must match what was seeded.
+
+    The refresh window deliberately covers every timestamp this module seeds
+    (all tests share NOW): TRUNCATE does not clear CAGG materialized data, so
+    the refresh is also what wipes any stale buckets from earlier tests.
+    """
+    await seed(pg_session_maker, days_back=3, per_day=10)
+
+    await refresh_caggs_range(
+        pg_engine,
+        start=NOW - timedelta(days=4),
+        end=NOW + timedelta(hours=1),
+    )
+
+    async with pg_session_maker() as session:
+        repo = SummaryStatsRepository(session=session)
+        stats = await repo.get_summary(NOW - timedelta(days=3, hours=2), NOW)
+    assert stats is not None
+    assert stats.total_log_records == 30
+    assert stats.total_geo_records == 30
+
+
+async def test_geojson_event_counts_route_raw(pg_session_maker, clean_tables):
+    await seed(pg_session_maker, days_back=1, per_day=9)  # 3 locations x 3 events
+    async with pg_session_maker() as session:
+        repo = GeoLocationRepository(session=session)
+        rows = await repo.get_all_with_event_counts(NOW - timedelta(hours=23), NOW)
+    assert len(rows) == 3
+    assert sum(r.event_count for r in rows) == 9

--- a/tests/integration/test_startup_pg.py
+++ b/tests/integration/test_startup_pg.py
@@ -1,0 +1,60 @@
+"""Startup schema path against real TimescaleDB: alembic head + timescale objects."""
+from __future__ import annotations
+
+from sqlalchemy import text
+
+EXPECTED_TABLES = {"geo_locations", "geo_events", "access_logs", "access_log_debug"}
+EXPECTED_HYPERTABLES = {"geo_events", "access_logs", "access_log_debug"}
+EXPECTED_CAGGS = {
+    "summary_hourly_stats", "summary_daily_stats",
+    "geo_summary_hourly_stats", "geo_summary_daily_stats",
+    "location_hourly_stats", "location_daily_stats",
+    "ip_location_daily_stats",
+}
+
+
+async def test_alembic_head_created_all_tables(pg_engine):
+    async with pg_engine.connect() as conn:
+        rows = await conn.execute(text(
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+        ))
+        tables = {r.tablename for r in rows}
+    assert EXPECTED_TABLES <= tables
+    assert "alembic_versions" in tables, "version table must be stamped"
+
+
+async def test_alembic_version_matches_script_head(pg_engine):
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    cfg = Config("alembic.ini")
+    cfg.set_main_option("script_location", "migrations")
+    head = ScriptDirectory.from_config(cfg).get_current_head()
+
+    async with pg_engine.connect() as conn:
+        row = await conn.execute(text("SELECT version_num FROM alembic_versions"))
+        assert row.scalar() == head
+
+
+async def test_hypertables_created(pg_engine):
+    async with pg_engine.connect() as conn:
+        rows = await conn.execute(text(
+            "SELECT hypertable_name FROM timescaledb_information.hypertables"
+        ))
+        assert EXPECTED_HYPERTABLES <= {r.hypertable_name for r in rows}
+
+
+async def test_caggs_created(pg_engine):
+    async with pg_engine.connect() as conn:
+        rows = await conn.execute(text(
+            "SELECT view_name FROM timescaledb_information.continuous_aggregates"
+        ))
+        assert EXPECTED_CAGGS <= {r.view_name for r in rows}
+
+
+async def test_setup_timescaledb_is_idempotent(pg_engine):
+    """Second run on an initialized DB must not raise (startup re-runs it)."""
+    from geometrikks.config.settings import get_settings
+    from geometrikks.server.timescale import setup_timescaledb
+
+    await setup_timescaledb(pg_engine, get_settings().analytics)

--- a/tests/seed/factories.py
+++ b/tests/seed/factories.py
@@ -113,11 +113,12 @@ class GeoLocationFactory(BaseFactory[GeoLocation]):
     __model__ = GeoLocation
     __set_relationships__ = False
 
-    # Ignore auto-generated fields and relationships
+    # Ignore auto-generated fields (relationships are excluded via
+    # __set_relationships__ = False; declaring them here trips polyfactory's
+    # declared-fields-must-exist check)
     id = Ignore()
     created_at = Ignore()
     updated_at = Ignore()
-    geo_events = Ignore()
 
     @classmethod
     def build(cls, **kwargs: Any) -> GeoLocation:
@@ -189,9 +190,8 @@ class GeoEventFactory(BaseFactory[GeoEvent]):
     __model__ = GeoEvent
     __set_relationships__ = False
 
-    # Ignore auto-generated fields and relationships
+    # Ignore auto-generated fields (relationships excluded via __set_relationships__)
     id = Ignore()
-    location = Ignore()
 
     # Custom field providers
     timestamp = Use(lambda: datetime.now(timezone.utc))

--- a/tests/test_auth_endpoints.py
+++ b/tests/test_auth_endpoints.py
@@ -73,7 +73,9 @@ def test_login_logout_flow():
 
 def test_create_app_requires_password_when_auth_enabled(monkeypatch):
     monkeypatch.setenv("APP_AUTH_DISABLED", "false")
-    monkeypatch.delenv("APP_ADMIN_PASSWORD", raising=False)
+    # Empty string (falsy) rather than delenv: real env vars beat .env, so this
+    # holds even when a local .env sets APP_ADMIN_PASSWORD for dev.
+    monkeypatch.setenv("APP_ADMIN_PASSWORD", "")
     from geometrikks.server.core import create_app
     with pytest.raises(RuntimeError, match="APP_ADMIN_PASSWORD"):
         create_app()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -157,7 +157,9 @@ class TestAuthSettings:
     """APP_ADMIN_USER / APP_ADMIN_PASSWORD / APP_AUTH_DISABLED."""
 
     def test_auth_defaults(self):
-        settings = Settings()
+        # _env_file=None: a local .env (e.g. APP_ADMIN_PASSWORD for dev) must
+        # not leak into the defaults under test.
+        settings = Settings(_env_file=None)
         assert settings.auth_disabled is False
         assert settings.admin_user == "admin"
         assert settings.admin_password is None


### PR DESCRIPTION
## Summary

The real-database test suite the v0.1 design owes (spec section "1d. Tests for the new core", plus the startup-path tests owed from Phase 1b).

- **Scaffolding** (`tests/integration/`): each session creates a scratch database `geometrikks_it` on the compose `timescale_db` server, migrates it to alembic head, runs `setup_timescaledb`, and drops it afterwards — dev data is never touched. All tests in the package are auto-marked `integration` and skip cleanly when the server is unreachable, so `uv run pytest` without docker stays green.
- **Startup path** (`test_startup_pg.py`): alembic head creates all tables + stamps `alembic_versions` to the script head; hypertables and all 7 CAGGs exist; `setup_timescaledb` is idempotent.
- **End-to-end ingestion** (`test_ingestion_pg.py`): real `LogParser` tailing real temp files through the real service into TimescaleDB — lines become rows, log rotation is survived, and a poisoned location cache recovers.
- **Repositories/CAGG routing** (`test_repositories_pg.py`): granularity thresholds, exact raw counts, hourly-CAGG counts after an explicit `refresh_caggs_range`, and GeoJSON event counts — seeded via the `tests/seed` polyfactory factories.

## Bugs found and fixed along the way

- **`fix: evict failing batch geohashes from location cache on rollback`** — the poison-recovery test exposed a real gap: `_evict_uncommitted_locations` only clears geohashes cached *during* the current run, so a poisoned id that predates the run (e.g. after a crashed commit) was never evicted and wedged ingestion permanently. Both flush failure paths now also evict the geohashes referenced by the failing batch.
- **`fix: drop relationship Ignore() declarations rejected by polyfactory`** — `tests/seed/factories.py` failed to import under current polyfactory (declared fields must exist on the model; relationships are already excluded via `__set_relationships__ = False`).
- **`test: isolate auth default tests from local .env`** — two tests asserted default settings and broke when a local `.env` sets `APP_ADMIN_PASSWORD` for dev.

## Test plan

- [x] `docker compose stop timescale_db && uv run pytest` → 86 passed, 14 skipped
- [x] `docker compose up -d timescale_db && uv run pytest` → 100 passed
- [x] `uv run pytest -m integration` → 14 passed