### PR TITLE
Phase 2b: analytics page, percentile-correct CAGGs, map filters (+2c fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -380,3 +380,6 @@ pdm-pythn
 
 # openapi-ts failure logs
 openapi-ts-error-*.log
+
+# TanStack Router generator cache
+.tanstack/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   duplicate protection skips a file already imported (`--force` to
   re-import), and a post-import refresh of the continuous aggregates covers
   the imported time range.
+- `/analytics` page with per-bucket charts (requests, status classes,
+  bandwidth, latency avg/p50/p95/p99) and top-URLs / top-user-agents tables.
+- New analytics endpoints: `GET /api/v1/analytics/time-series`,
+  `/analytics/geo-time-series`, `/analytics/top-urls`,
+  `/analytics/top-user-agents`.
+- Country/city filters on the map: repeatable `country_code` / `city` query
+  params on `GET /api/v1/geo-locations/geojson` plus multi-select comboboxes
+  in the map controls.
+- The generated `@hey-api/openapi-ts` client is now the typed transport for
+  the new frontend fetchers; the drifted hand-written GeoJSON/time-series
+  interfaces were removed in favor of generated types.
+
+### Fixed
+
+- Summary CAGG percentiles are now mathematically correct: buckets store a
+  mergeable `percentile_agg` (uddsketch) and queries read
+  `approx_percentile(...)` rollups, instead of averaging per-bucket
+  percentiles (an AVG of p50s/p95s/p99s is not a percentile).
+- `get_time_series` / `get_geo_time_series` raised for ranges ≤ 24 h (they
+  built a nonexistent `summary_raw_stats` table name); sub-24h ranges now
+  clamp to the hourly CAGGs, which real-time aggregation keeps current.
+- The map no longer remounts its GeoJSON source (and every layer) on each
+  data refresh, and fit-to-bounds no longer risks a stack overflow on large
+  feature sets (spread-based `Math.min/max` replaced with a single pass).
+- Chart palette (`--chart-1..5`) replaced with CVD-validated sets for both
+  themes; the previous light palette's 4xx/5xx hues were indistinguishable
+  under deuteranopia.
+
+### Changed
+
+- **Summary CAGG schema changed and is auto-upgraded on startup**: old-shape
+  `summary_hourly_stats` / `summary_daily_stats` views are dropped and
+  recreated, and their materialized data is rebuilt from raw access logs.
+  Raw logs only survive `raw_retention_days` (default 180 d), so summary
+  history older than that cannot be rebuilt and **is permanently lost** by
+  the upgrade (the daily CAGGs were its only permanent store).
+- `/analytics/summary` percentile values change where the old averaging math
+  was wrong (intended).
 
 ## [0.1.0-alpha.1] - 2026-07-10
 

--- a/geometrikks/api/v1/analytics_controller.py
+++ b/geometrikks/api/v1/analytics_controller.py
@@ -21,6 +21,10 @@ from geometrikks.domain.analytics.dtos import (
     PercentChange,
     CumulativeDataPoint,
     CumulativeTimeSeriesResponse,
+    TopUrlDTO,
+    TopUrlsResponse,
+    TopUserAgentDTO,
+    TopUserAgentsResponse,
 )
 from geometrikks.domain.analytics.repositories import get_stats_granularity
 
@@ -370,5 +374,67 @@ class AnalyticsController(Controller):
             start_date=start_date.isoformat(),
             end_date=end_date.isoformat(),
             data=data_points,
+        )
+
+    @get("/top-urls", description="Top URLs by hits from raw access logs (time-bounded).")
+    async def get_top_urls(
+        self,
+        live_stats_repo: NamedDependency[LiveStatsRepository],
+        start_date: Annotated[
+            datetime,
+            Parameter(
+                description="Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                examples=[Example(value="2024-01-01T00:00:00Z")],
+            ),
+        ],
+        end_date: Annotated[
+            datetime,
+            Parameter(
+                description="End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                examples=[Example(value="2024-12-31T23:59:59Z")],
+            ),
+        ],
+        limit: Annotated[
+            int,
+            Parameter(description="Maximum number of URLs to return", ge=1, le=100),
+        ] = 25,
+    ) -> TopUrlsResponse:
+        """Get the top URLs by hit count for a date range."""
+        rows = await live_stats_repo.get_top_urls(start_date, end_date, limit=limit)
+        return TopUrlsResponse(
+            start_date=start_date.isoformat(),
+            end_date=end_date.isoformat(),
+            items=[TopUrlDTO(**vars(r)) for r in rows],
+        )
+
+    @get("/top-user-agents", description="Top user agents by hits from raw access logs.")
+    async def get_top_user_agents(
+        self,
+        live_stats_repo: NamedDependency[LiveStatsRepository],
+        start_date: Annotated[
+            datetime,
+            Parameter(
+                description="Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                examples=[Example(value="2024-01-01T00:00:00Z")],
+            ),
+        ],
+        end_date: Annotated[
+            datetime,
+            Parameter(
+                description="End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                examples=[Example(value="2024-12-31T23:59:59Z")],
+            ),
+        ],
+        limit: Annotated[
+            int,
+            Parameter(description="Maximum number of user agents to return", ge=1, le=100),
+        ] = 25,
+    ) -> TopUserAgentsResponse:
+        """Get the top user agents by hit count for a date range."""
+        rows = await live_stats_repo.get_top_user_agents(start_date, end_date, limit=limit)
+        return TopUserAgentsResponse(
+            start_date=start_date.isoformat(),
+            end_date=end_date.isoformat(),
+            items=[TopUserAgentDTO(**vars(r)) for r in rows],
         )
 

--- a/geometrikks/api/v1/analytics_controller.py
+++ b/geometrikks/api/v1/analytics_controller.py
@@ -21,12 +21,16 @@ from geometrikks.domain.analytics.dtos import (
     PercentChange,
     CumulativeDataPoint,
     CumulativeTimeSeriesResponse,
+    GeoEventsDataPoint,
+    GeoEventsTimeSeriesResponse,
+    TimeSeriesDataPoint,
+    TimeSeriesResponse,
     TopUrlDTO,
     TopUrlsResponse,
     TopUserAgentDTO,
     TopUserAgentsResponse,
 )
-from geometrikks.domain.analytics.repositories import get_stats_granularity
+from geometrikks.domain.analytics.repositories import StatsGranularity, get_stats_granularity
 
 from geometrikks.api.dependencies import (
     provide_live_stats_repo,
@@ -374,6 +378,94 @@ class AnalyticsController(Controller):
             start_date=start_date.isoformat(),
             end_date=end_date.isoformat(),
             data=data_points,
+        )
+
+    @get("/time-series", description="Per-bucket access-log metrics for charts.")
+    async def get_time_series(
+        self,
+        summary_stats_repo: NamedDependency[SummaryStatsRepository],
+        start_date: Annotated[
+            datetime,
+            Parameter(
+                description="Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                examples=[Example(value="2024-01-01T00:00:00Z")],
+            ),
+        ],
+        end_date: Annotated[
+            datetime,
+            Parameter(
+                description="End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                examples=[Example(value="2024-12-31T23:59:59Z")],
+            ),
+        ],
+    ) -> TimeSeriesResponse:
+        """Get per-bucket access-log metrics (requests, status, bytes, latency)."""
+        rows = await summary_stats_repo.get_time_series(start_date, end_date)
+        granularity = get_stats_granularity(start_date, end_date)
+        if granularity == StatsGranularity.RAW:
+            granularity = StatsGranularity.HOURLY  # matches the repo's clamp
+        return TimeSeriesResponse(
+            granularity=granularity.value,
+            start_date=start_date.isoformat(),
+            end_date=end_date.isoformat(),
+            data=[
+                TimeSeriesDataPoint(
+                    timestamp=row.bucket.isoformat(),
+                    total_requests=row.total_requests,
+                    total_geo_events=0,  # geo series is its own endpoint
+                    total_bytes_sent=row.total_bytes,
+                    status_2xx=row.status_2xx,
+                    status_3xx=row.status_3xx,
+                    status_4xx=row.status_4xx,
+                    status_5xx=row.status_5xx,
+                    error_rate=(row.status_4xx + row.status_5xx) / row.total_requests if row.total_requests else 0.0,
+                    avg_request_time=row.avg_request_time,
+                    p50_request_time=row.p50_request_time,
+                    p95_request_time=row.p95_request_time,
+                    p99_request_time=row.p99_request_time,
+                )
+                for row in rows
+            ],
+        )
+
+    @get("/geo-time-series", description="Per-bucket geo-event metrics for charts.")
+    async def get_geo_time_series(
+        self,
+        summary_stats_repo: NamedDependency[SummaryStatsRepository],
+        start_date: Annotated[
+            datetime,
+            Parameter(
+                description="Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                examples=[Example(value="2024-01-01T00:00:00Z")],
+            ),
+        ],
+        end_date: Annotated[
+            datetime,
+            Parameter(
+                description="End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                examples=[Example(value="2024-12-31T23:59:59Z")],
+            ),
+        ],
+    ) -> GeoEventsTimeSeriesResponse:
+        """Get per-bucket geo-event metrics (events, unique IPs/countries/cities)."""
+        rows = await summary_stats_repo.get_geo_time_series(start_date, end_date)
+        granularity = get_stats_granularity(start_date, end_date)
+        if granularity == StatsGranularity.RAW:
+            granularity = StatsGranularity.HOURLY  # matches the repo's clamp
+        return GeoEventsTimeSeriesResponse(
+            granularity=granularity.value,
+            start_date=start_date.isoformat(),
+            end_date=end_date.isoformat(),
+            data=[
+                GeoEventsDataPoint(
+                    timestamp=row["bucket"].isoformat(),
+                    total_geo_events=row["total_events"],
+                    unique_ips=row["unique_ips"],
+                    unique_countries=row["unique_countries"],
+                    unique_cities=row["unique_cities"],
+                )
+                for row in rows
+            ],
         )
 
     @get("/top-urls", description="Top URLs by hits from raw access logs (time-bounded).")

--- a/geometrikks/api/v1/geo_locations_controller.py
+++ b/geometrikks/api/v1/geo_locations_controller.py
@@ -76,6 +76,14 @@ class GeoLocationController(Controller):
                 examples=[Example(value="2024-12-31T23:59:59Z")],
             ),
         ],
+        country_code: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these ISO country codes (repeatable)", required=False),
+        ] = None,
+        city: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these city names (repeatable)", required=False),
+        ] = None,
     ) -> GeoJSONFeatureCollection:
         """Get all locations with event counts as GeoJSON FeatureCollection.
 
@@ -94,7 +102,7 @@ class GeoLocationController(Controller):
             to_timestamp = to_timestamp.replace(tzinfo=timezone.utc)
 
         locations_with_counts = await geo_location_repo.get_all_with_event_counts(
-            from_timestamp, to_timestamp
+            from_timestamp, to_timestamp, country_codes=country_code, cities=city
         )
         
         events: int = sum(loc.event_count for loc in locations_with_counts)

--- a/geometrikks/domain/analytics/dtos.py
+++ b/geometrikks/domain/analytics/dtos.py
@@ -21,6 +21,10 @@ class TimeSeriesDataPoint:
     status_4xx: int
     status_5xx: int
     error_rate: float
+    avg_request_time: float
+    p50_request_time: float
+    p95_request_time: float
+    p99_request_time: float
 
 
 @dataclass
@@ -52,6 +56,7 @@ class GeoEventsDataPoint:
     total_geo_events: int
     unique_ips: int
     unique_countries: int
+    unique_cities: int
 
 
 @dataclass

--- a/geometrikks/domain/analytics/dtos.py
+++ b/geometrikks/domain/analytics/dtos.py
@@ -184,3 +184,40 @@ class CumulativeTimeSeriesResponse:
     start_date: str
     end_date: str
     data: list[CumulativeDataPoint] = field(default_factory=list)
+
+
+@dataclass
+class TopUrlDTO:
+    """A single URL with its aggregate hit metrics."""
+
+    url: str
+    hits: int
+    error_hits: int
+    total_bytes: int
+    avg_request_time: float
+
+
+@dataclass
+class TopUrlsResponse:
+    """Response containing top URLs by hit count."""
+
+    start_date: str
+    end_date: str
+    items: list[TopUrlDTO] = field(default_factory=list)
+
+
+@dataclass
+class TopUserAgentDTO:
+    """A single user agent with its hit count."""
+
+    user_agent: str
+    hits: int
+
+
+@dataclass
+class TopUserAgentsResponse:
+    """Response containing top user agents by hit count."""
+
+    start_date: str
+    end_date: str
+    items: list[TopUserAgentDTO] = field(default_factory=list)

--- a/geometrikks/domain/analytics/dtos.py
+++ b/geometrikks/domain/analytics/dtos.py
@@ -61,12 +61,16 @@ class GeoEventsDataPoint:
 
 @dataclass
 class TimeSeriesResponse:
-    """Response containing time-series data for charts."""
+    """Response containing time-series data for charts.
+
+    ``data`` is deliberately default-less so it is required in OpenAPI and
+    non-optional in the generated TS client.
+    """
 
     granularity: str  # "hourly" or "daily"
     start_date: str
     end_date: str
-    data: list[TimeSeriesDataPoint] = field(default_factory=list)
+    data: list[TimeSeriesDataPoint]
 
 
 @dataclass
@@ -91,12 +95,15 @@ class BandwidthTimeSeriesResponse:
 
 @dataclass
 class GeoEventsTimeSeriesResponse:
-    """Response containing geo events time-series data."""
+    """Response containing geo events time-series data.
+
+    ``data`` is deliberately default-less (see TimeSeriesResponse).
+    """
 
     granularity: str
     start_date: str
     end_date: str
-    data: list[GeoEventsDataPoint] = field(default_factory=list)
+    data: list[GeoEventsDataPoint]
 
 
 @dataclass
@@ -204,11 +211,15 @@ class TopUrlDTO:
 
 @dataclass
 class TopUrlsResponse:
-    """Response containing top URLs by hit count."""
+    """Response containing top URLs by hit count.
+
+    ``items`` is deliberately default-less: a dataclass default makes it
+    non-required in OpenAPI and therefore optional in the generated TS client.
+    """
 
     start_date: str
     end_date: str
-    items: list[TopUrlDTO] = field(default_factory=list)
+    items: list[TopUrlDTO]
 
 
 @dataclass
@@ -221,8 +232,11 @@ class TopUserAgentDTO:
 
 @dataclass
 class TopUserAgentsResponse:
-    """Response containing top user agents by hit count."""
+    """Response containing top user agents by hit count.
+
+    ``items`` is deliberately default-less (see TopUrlsResponse).
+    """
 
     start_date: str
     end_date: str
-    items: list[TopUserAgentDTO] = field(default_factory=list)
+    items: list[TopUserAgentDTO]

--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -314,9 +314,9 @@ class SummaryStatsRepository:
                     COALESCE(SUM(status_5xx), 0) AS status_5xx,
                     COALESCE(AVG(avg_request_time), 0) AS avg_request_time,
                     COALESCE(MAX(max_request_time), 0) AS max_request_time,
-                    COALESCE(AVG(p50_request_time), 0) AS p50_request_time,
-                    COALESCE(AVG(p95_request_time), 0) AS p95_request_time,
-                    COALESCE(AVG(p99_request_time), 0) AS p99_request_time
+                    COALESCE(approx_percentile(0.50, rollup(pct_agg)), 0) AS p50_request_time,
+                    COALESCE(approx_percentile(0.95, rollup(pct_agg)), 0) AS p95_request_time,
+                    COALESCE(approx_percentile(0.99, rollup(pct_agg)), 0) AS p99_request_time
                 FROM {summary_table}
                 WHERE bucket >= time_bucket('{bucket_interval}', CAST(:start AS timestamptz))
                 AND bucket < :end
@@ -399,9 +399,9 @@ class SummaryStatsRepository:
                 status_5xx,
                 avg_request_time,
                 max_request_time,
-                p50_request_time,
-                p95_request_time,
-                p99_request_time
+                approx_percentile(0.50, pct_agg) AS p50_request_time,
+                approx_percentile(0.95, pct_agg) AS p95_request_time,
+                approx_percentile(0.99, pct_agg) AS p99_request_time
             FROM {table}
             WHERE bucket >= time_bucket('{bucket_interval}', CAST(:start AS timestamptz))
               AND bucket < :end

--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -385,6 +385,8 @@ class SummaryStatsRepository:
             List of SummaryStatsRow ordered by bucket ascending.
         """
         granularity = get_stats_granularity(start, end)
+        if granularity == StatsGranularity.RAW:
+            granularity = StatsGranularity.HOURLY  # no raw CAGG; hourly + real-time agg covers ≤24h
         table = f"summary_{granularity.value}_stats"
         bucket_interval = "1 hour" if granularity == StatsGranularity.HOURLY else "1 day"
 
@@ -446,6 +448,8 @@ class SummaryStatsRepository:
             List of dicts with bucket, total_events, unique_ips, unique_countries, unique_cities.
         """
         granularity = get_stats_granularity(start, end)
+        if granularity == StatsGranularity.RAW:
+            granularity = StatsGranularity.HOURLY  # no raw CAGG; hourly + real-time agg covers ≤24h
         table = f"geo_summary_{granularity.value}_stats"
         bucket_interval = "1 hour" if granularity == StatsGranularity.HOURLY else "1 day"
 

--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -579,6 +579,25 @@ class SummaryStatsRepository:
         return [dict(row._mapping) for row in result.fetchall()]
 
 
+@dataclass
+class TopUrlRow:
+    """A top-URL aggregate row from raw access_logs."""
+
+    url: str
+    hits: int
+    error_hits: int
+    total_bytes: int
+    avg_request_time: float
+
+
+@dataclass
+class TopUserAgentRow:
+    """A top-user-agent aggregate row from raw access_logs."""
+
+    user_agent: str
+    hits: int
+
+
 class LiveStatsRepository:
     """Repository for querying live statistics directly from raw hypertables.
 
@@ -690,3 +709,51 @@ class LiveStatsRepository:
             unique_cities=geo_row.unique_cities if geo_row else 0,
             malformed_requests=malformed_row.malformed_requests if malformed_row else 0,
         )
+
+    async def get_top_urls(
+        self, start: datetime, end: datetime, limit: int = 25
+    ) -> list[TopUrlRow]:
+        """Top URLs by hit count from raw access_logs (time-bounded).
+
+        Raw-table scan by design: no CAGG exists for URL cardinality yet
+        (future optimization; fine at homelab volume with chunk exclusion).
+        """
+        stmt = text("""
+            SELECT
+                url,
+                CAST(COUNT(*) AS BIGINT) AS hits,
+                CAST(COUNT(*) FILTER (WHERE status_code >= 400) AS BIGINT) AS error_hits,
+                CAST(COALESCE(SUM(bytes_sent), 0) AS BIGINT) AS total_bytes,
+                COALESCE(AVG(request_time), 0) AS avg_request_time
+            FROM access_logs
+            WHERE timestamp >= :start AND timestamp < :end AND url IS NOT NULL
+            GROUP BY url
+            ORDER BY hits DESC
+            LIMIT :limit
+        """)
+        result = await self.session.execute(stmt, {"start": start, "end": end, "limit": limit})
+        return [
+            TopUrlRow(
+                url=row.url,
+                hits=row.hits,
+                error_hits=row.error_hits,
+                total_bytes=row.total_bytes,
+                avg_request_time=float(row.avg_request_time),
+            )
+            for row in result.fetchall()
+        ]
+
+    async def get_top_user_agents(
+        self, start: datetime, end: datetime, limit: int = 25
+    ) -> list[TopUserAgentRow]:
+        """Top user agents by hit count from raw access_logs (time-bounded)."""
+        stmt = text("""
+            SELECT user_agent, CAST(COUNT(*) AS BIGINT) AS hits
+            FROM access_logs
+            WHERE timestamp >= :start AND timestamp < :end AND user_agent IS NOT NULL
+            GROUP BY user_agent
+            ORDER BY hits DESC
+            LIMIT :limit
+        """)
+        result = await self.session.execute(stmt, {"start": start, "end": end, "limit": limit})
+        return [TopUserAgentRow(user_agent=row.user_agent, hits=row.hits) for row in result.fetchall()]

--- a/geometrikks/domain/geo/dtos.py
+++ b/geometrikks/domain/geo/dtos.py
@@ -46,10 +46,15 @@ class TopIPDTO:
 
 @dataclass
 class GeoJSONPointGeometry:
-    """GeoJSON Point geometry."""
+    """GeoJSON Point geometry.
 
-    type: str = "Point"
-    coordinates: tuple[float, float] = field(default_factory=lambda: (0.0, 0.0))
+    Fields are deliberately default-less: dataclass defaults make them
+    non-required in OpenAPI, which turns into optional fields in the
+    generated TS client. The controller always constructs them explicitly.
+    """
+
+    type: str
+    coordinates: tuple[float, float]
 
 
 @dataclass
@@ -74,26 +79,26 @@ class GeoJSONFeatureProperties:
 class GeoJSONFeature:
     """GeoJSON Feature representing a location."""
 
-    type: str = "Feature"
-    geometry: GeoJSONPointGeometry = field(default_factory=GeoJSONPointGeometry)
-    properties: GeoJSONFeatureProperties | None = None
+    type: str
+    geometry: GeoJSONPointGeometry
+    properties: GeoJSONFeatureProperties
 
 @dataclass
 class GeoJSONFeatureStats:
     """Statistics for GeoJSONFeatureCollection."""
 
-    events: int = 0
-    countries: int = 0
-    cities: int = 0
-    locations: int = 0
+    events: int
+    countries: int
+    cities: int
+    locations: int
 
 @dataclass
 class GeoJSONFeatureCollection:
     """GeoJSON FeatureCollection for locations with event counts."""
 
-    type: str = "FeatureCollection"
-    features: list[GeoJSONFeature] = field(default_factory=list)
-    stats: GeoJSONFeatureStats = field(default_factory=GeoJSONFeatureStats)
+    type: str
+    features: list[GeoJSONFeature]
+    stats: GeoJSONFeatureStats
 
 
 @dataclass

--- a/geometrikks/domain/geo/repositories.py
+++ b/geometrikks/domain/geo/repositories.py
@@ -106,7 +106,11 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
         return await self.list(country_code=country_code)
 
     async def get_all_with_event_counts(
-        self, from_timestamp: datetime, to_timestamp: datetime
+        self,
+        from_timestamp: datetime,
+        to_timestamp: datetime,
+        country_codes: list[str] | None = None,
+        cities: list[str] | None = None,
     ) -> list[LocationWithEventCount]:
         """Retrieve all GeoLocations with their associated event counts.
 
@@ -118,6 +122,8 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
         Args:
             from_timestamp: Start datetime for filtering events.
             to_timestamp: End datetime for filtering events.
+            country_codes: Optional ISO country codes to filter to.
+            cities: Optional city names to filter to.
 
         Returns:
             list[LocationWithEventCount]: List containing location and event count.
@@ -139,15 +145,24 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
             to_timestamp,
         )
 
+        filters_sql = ""
+        params: dict[str, object] = {"from_ts": from_timestamp, "to_ts": to_timestamp}
+        if country_codes:
+            filters_sql += " AND gl.country_code = ANY(:country_codes)"
+            params["country_codes"] = [c.upper() for c in country_codes]
+        if cities:
+            filters_sql += " AND gl.city = ANY(:cities)"
+            params["cities"] = cities
+
         if granularity == StatsGranularity.RAW:
             # Query raw geo_events table for exact time range granularity
-            stmt = text("""
+            stmt = text(f"""
                 SELECT
                     gl.*,
                     CAST(COUNT(ge.id) AS INTEGER) AS event_count
                 FROM geo_locations gl
                 JOIN geo_events ge ON ge.location_id = gl.id
-                WHERE ge.timestamp >= :from_ts AND ge.timestamp < :to_ts
+                WHERE ge.timestamp >= :from_ts AND ge.timestamp < :to_ts{filters_sql}
                 GROUP BY gl.id
                 ORDER BY event_count DESC
             """)
@@ -165,14 +180,12 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
                 FROM geo_locations gl
                 JOIN {table} ls ON ls.location_id = gl.id
                 WHERE ls.bucket >= time_bucket('{bucket_interval}', CAST(:from_ts AS timestamptz))
-                  AND ls.bucket < :to_ts
+                  AND ls.bucket < :to_ts{filters_sql}
                 GROUP BY gl.id
                 ORDER BY event_count DESC
             """)
 
-        result = await self.session.execute(
-            stmt, {"from_ts": from_timestamp, "to_ts": to_timestamp}
-        )
+        result = await self.session.execute(stmt, params)
         rows = result.fetchall()
 
         if not rows:

--- a/geometrikks/server/timescale.py
+++ b/geometrikks/server/timescale.py
@@ -16,13 +16,12 @@ CAGG Structure:
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 from sqlalchemy import text
 
 if TYPE_CHECKING:
-    from datetime import datetime
-
     from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
 
     from geometrikks.config.settings import AnalyticsSettings
@@ -111,9 +110,7 @@ async def _create_summary_caggs(conn: "AsyncConnection") -> None:
             COUNT(*) FILTER (WHERE status_code >= 500 AND status_code < 600) AS status_5xx,
             AVG(request_time) AS avg_request_time,
             MAX(request_time) AS max_request_time,
-            PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY request_time) AS p50_request_time,
-            PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY request_time) AS p95_request_time,
-            PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY request_time) AS p99_request_time
+            percentile_agg(request_time) AS pct_agg
         FROM access_logs
         GROUP BY bucket
         WITH NO DATA
@@ -133,9 +130,7 @@ async def _create_summary_caggs(conn: "AsyncConnection") -> None:
             COUNT(*) FILTER (WHERE status_code >= 500 AND status_code < 600) AS status_5xx,
             AVG(request_time) AS avg_request_time,
             MAX(request_time) AS max_request_time,
-            PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY request_time) AS p50_request_time,
-            PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY request_time) AS p95_request_time,
-            PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY request_time) AS p99_request_time
+            percentile_agg(request_time) AS pct_agg
         FROM access_logs
         GROUP BY bucket
         WITH NO DATA
@@ -471,6 +466,41 @@ async def teardown_timescaledb(conn: "AsyncConnection") -> None:
     logger.info("TimescaleDB teardown complete")
 
 
+SUMMARY_CAGGS = ["summary_hourly_stats", "summary_daily_stats"]
+
+
+async def _summary_caggs_need_upgrade(conn: "AsyncConnection") -> bool:
+    """True when a summary CAGG exists in the pre-percentile_agg shape.
+
+    CAGGs are plain views over the internal materialized hypertable, so
+    information_schema.columns lists their columns directly — one probe is
+    enough.
+    """
+    result = await conn.execute(text("""
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = ANY(:views) AND column_name = 'p50_request_time'
+        LIMIT 1
+    """), {"views": SUMMARY_CAGGS})
+    return bool(result.scalar())
+
+
+async def _upgrade_summary_caggs(conn: "AsyncConnection") -> None:
+    """Drop old-shape summary CAGGs so setup recreates them with pct_agg.
+
+    Materialized data is lost and rebuilt from raw access_logs: refresh
+    policies backfill their windows and the caller schedules a full refresh.
+    CAVEAT: raw data only survives raw_retention_days (default 180d), so
+    daily-summary history OLDER than that cannot be rebuilt and is
+    permanently discarded by this upgrade.
+    """
+    for cagg in SUMMARY_CAGGS:
+        await conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {cagg} CASCADE"))
+        logger.warning(
+            "Recreating %s with percentile_agg (old percentile columns were mathematically wrong)",
+            cagg,
+        )
+
+
 async def setup_timescaledb(
     engine: "AsyncEngine",
     analytics: "AnalyticsSettings",
@@ -490,6 +520,11 @@ async def setup_timescaledb(
         # Create hypertables
         await _create_hypertables(conn)
 
+        # Upgrade pre-percentile_agg summary CAGGs (drop; recreated below)
+        upgraded = await _summary_caggs_need_upgrade(conn)
+        if upgraded:
+            await _upgrade_summary_caggs(conn)
+
         # Create continuous aggregates
         await _create_summary_caggs(conn)
         await _create_geo_summary_caggs(conn)
@@ -508,6 +543,17 @@ async def setup_timescaledb(
             analytics.hourly_retention_days,
         )
         await _add_compression_policies(conn, analytics.compression_after_days)
+
+    if upgraded:
+        # Rebuild the recreated summary CAGGs from raw logs. Bounded by the
+        # raw retention window: older raw rows are already dropped, so
+        # refreshing further back is pure waste.
+        await refresh_caggs_range(
+            engine,
+            start=datetime.now(timezone.utc) - timedelta(days=analytics.raw_retention_days),
+            end=datetime.now(timezone.utc),
+            caggs=SUMMARY_CAGGS,
+        )
 
     logger.info("TimescaleDB setup complete")
 

--- a/geometrikks/services/logparser/constants.py
+++ b/geometrikks/services/logparser/constants.py
@@ -17,7 +17,7 @@ class Rgx:
     HTTP_VERSION_PATTERN = r'(HTTP\/[1-3]\.[0-9])'
     STATUS_CODE_PATTERN = r'(\d{3})'
     BYTES_SENT_PATTERN = r'(\d{1,99})'
-    URL_PATTERN = r'(?:\-|.+)'
+    URL_PATTERN = r'(?:\-|[^"]+)'
     HOST_PATTERN = r'(.+?)'
     USER_AGENT_PATTERN = r'(.+?)'
     REQUEST_TIME_PATTERN = r'(.+?)'
@@ -57,7 +57,7 @@ def create_log_pattern(ip_pattern: str) -> re.Pattern[str]:
     \s?"
     (?P<url>{Rgx.URL_PATTERN})"
     (?P<host>{Rgx.HOST_PATTERN})"
-    (?P<user_agent>{Rgx.USER_AGENT_PATTERN})
+    (?P<user_agent>{Rgx.USER_AGENT_PATTERN})"
     (?:
         \s?"
         (?P<request_time>{Rgx.REQUEST_TIME_PATTERN})"

--- a/resources/components/analytics/bytes-chart.tsx
+++ b/resources/components/analytics/bytes-chart.tsx
@@ -1,0 +1,66 @@
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart"
+import { Skeleton } from "@/components/ui/skeleton"
+import { formatBytes } from "@/lib/api"
+import { useTimeSeries } from "@/lib/queries"
+import { formatBucketTick } from "./chart-utils"
+
+const chartConfig = {
+  total_bytes_sent: { label: "Bytes sent", color: "var(--chart-2)" },
+} satisfies ChartConfig
+
+export function BytesChart() {
+  const { data, isLoading } = useTimeSeries()
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Bandwidth</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading || !data ? (
+          <Skeleton className="h-[240px] w-full" />
+        ) : (
+          <ChartContainer config={chartConfig} className="h-[240px] w-full">
+            <AreaChart data={data.data}>
+              <CartesianGrid vertical={false} />
+              <XAxis
+                dataKey="timestamp"
+                tickLine={false}
+                axisLine={false}
+                tickFormatter={formatBucketTick(data.granularity)}
+              />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                width={64}
+                tickFormatter={(v: number) => formatBytes(v)}
+              />
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    formatter={(value) => formatBytes(Number(value))}
+                  />
+                }
+              />
+              <Area
+                dataKey="total_bytes_sent"
+                type="monotone"
+                fill="var(--color-total_bytes_sent)"
+                fillOpacity={0.2}
+                stroke="var(--color-total_bytes_sent)"
+                strokeWidth={2}
+              />
+            </AreaChart>
+          </ChartContainer>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/resources/components/analytics/chart-utils.ts
+++ b/resources/components/analytics/chart-utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared axis/tick helpers for the analytics charts.
+ */
+
+/** Format a bucket timestamp for the X axis: day+hour for hourly, day for daily. */
+export function formatBucketTick(granularity: string) {
+  return (value: string) =>
+    new Date(value).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      ...(granularity === "hourly" && { hour: "2-digit" }),
+    })
+}

--- a/resources/components/analytics/latency-chart.tsx
+++ b/resources/components/analytics/latency-chart.tsx
@@ -1,0 +1,86 @@
+import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart"
+import { Skeleton } from "@/components/ui/skeleton"
+import { formatDuration } from "@/lib/api"
+import { useTimeSeries } from "@/lib/queries"
+import { formatBucketTick } from "./chart-utils"
+
+const chartConfig = {
+  avg_request_time: { label: "avg", color: "var(--chart-1)" },
+  p50_request_time: { label: "p50", color: "var(--chart-2)" },
+  p95_request_time: { label: "p95", color: "var(--chart-3)" },
+  p99_request_time: { label: "p99", color: "var(--chart-4)" },
+} satisfies ChartConfig
+
+const SERIES = Object.keys(chartConfig) as (keyof typeof chartConfig)[]
+
+export function LatencyChart() {
+  const { data, isLoading } = useTimeSeries()
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Latency (avg / p50 / p95 / p99)</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading || !data ? (
+          <Skeleton className="h-[240px] w-full" />
+        ) : (
+          <ChartContainer config={chartConfig} className="h-[240px] w-full">
+            <LineChart data={data.data}>
+              <CartesianGrid vertical={false} />
+              <XAxis
+                dataKey="timestamp"
+                tickLine={false}
+                axisLine={false}
+                tickFormatter={formatBucketTick(data.granularity)}
+              />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                width={56}
+                // request_time is seconds; formatDuration takes ms
+                tickFormatter={(v: number) => formatDuration(v * 1000)}
+              />
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    formatter={(value, name) => (
+                      <span className="flex w-full justify-between gap-2">
+                        <span className="text-muted-foreground">
+                          {chartConfig[name as keyof typeof chartConfig]?.label ?? name}
+                        </span>
+                        <span className="font-mono tabular-nums">
+                          {formatDuration(Number(value) * 1000)}
+                        </span>
+                      </span>
+                    )}
+                  />
+                }
+              />
+              <ChartLegend content={<ChartLegendContent />} />
+              {SERIES.map((key) => (
+                <Line
+                  key={key}
+                  dataKey={key}
+                  type="monotone"
+                  stroke={`var(--color-${key})`}
+                  strokeWidth={2}
+                  dot={false}
+                />
+              ))}
+            </LineChart>
+          </ChartContainer>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/resources/components/analytics/requests-chart.tsx
+++ b/resources/components/analytics/requests-chart.tsx
@@ -1,0 +1,60 @@
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart"
+import { Skeleton } from "@/components/ui/skeleton"
+import { formatNumber } from "@/lib/api"
+import { useTimeSeries } from "@/lib/queries"
+import { formatBucketTick } from "./chart-utils"
+
+const chartConfig = {
+  total_requests: { label: "Requests", color: "var(--chart-1)" },
+} satisfies ChartConfig
+
+export function RequestsChart() {
+  const { data, isLoading } = useTimeSeries()
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Requests</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading || !data ? (
+          <Skeleton className="h-[240px] w-full" />
+        ) : (
+          <ChartContainer config={chartConfig} className="h-[240px] w-full">
+            <AreaChart data={data.data}>
+              <CartesianGrid vertical={false} />
+              <XAxis
+                dataKey="timestamp"
+                tickLine={false}
+                axisLine={false}
+                tickFormatter={formatBucketTick(data.granularity)}
+              />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                width={48}
+                tickFormatter={(v: number) => formatNumber(v)}
+              />
+              <ChartTooltip content={<ChartTooltipContent />} />
+              <Area
+                dataKey="total_requests"
+                type="monotone"
+                fill="var(--color-total_requests)"
+                fillOpacity={0.2}
+                stroke="var(--color-total_requests)"
+                strokeWidth={2}
+              />
+            </AreaChart>
+          </ChartContainer>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/resources/components/analytics/status-chart.tsx
+++ b/resources/components/analytics/status-chart.tsx
@@ -1,0 +1,65 @@
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart"
+import { Skeleton } from "@/components/ui/skeleton"
+import { formatNumber } from "@/lib/api"
+import { useTimeSeries } from "@/lib/queries"
+import { formatBucketTick } from "./chart-utils"
+
+// Slot order matches the stack order: adjacent-pair CVD separation of the
+// palette is only guaranteed for slots used in sequence.
+const chartConfig = {
+  status_2xx: { label: "2xx", color: "var(--chart-1)" },
+  status_3xx: { label: "3xx", color: "var(--chart-2)" },
+  status_4xx: { label: "4xx", color: "var(--chart-3)" },
+  status_5xx: { label: "5xx", color: "var(--chart-4)" },
+} satisfies ChartConfig
+
+export function StatusChart() {
+  const { data, isLoading } = useTimeSeries()
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Status classes</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading || !data ? (
+          <Skeleton className="h-[240px] w-full" />
+        ) : (
+          <ChartContainer config={chartConfig} className="h-[240px] w-full">
+            <BarChart data={data.data}>
+              <CartesianGrid vertical={false} />
+              <XAxis
+                dataKey="timestamp"
+                tickLine={false}
+                axisLine={false}
+                tickFormatter={formatBucketTick(data.granularity)}
+              />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                width={48}
+                tickFormatter={(v: number) => formatNumber(v)}
+              />
+              <ChartTooltip content={<ChartTooltipContent />} />
+              <ChartLegend content={<ChartLegendContent />} />
+              {/* stroke = card surface: the 2px spacer between stacked segments */}
+              <Bar dataKey="status_2xx" stackId="s" fill="var(--color-status_2xx)" stroke="var(--card)" strokeWidth={1} />
+              <Bar dataKey="status_3xx" stackId="s" fill="var(--color-status_3xx)" stroke="var(--card)" strokeWidth={1} />
+              <Bar dataKey="status_4xx" stackId="s" fill="var(--color-status_4xx)" stroke="var(--card)" strokeWidth={1} />
+              <Bar dataKey="status_5xx" stackId="s" fill="var(--color-status_5xx)" stroke="var(--card)" strokeWidth={1} radius={[2, 2, 0, 0]} />
+            </BarChart>
+          </ChartContainer>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/resources/components/analytics/top-urls-table.tsx
+++ b/resources/components/analytics/top-urls-table.tsx
@@ -1,0 +1,52 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Skeleton } from "@/components/ui/skeleton"
+import { formatBytes, formatDuration, formatNumber } from "@/lib/api"
+import { useTopUrls } from "@/lib/queries"
+
+export function TopUrlsTable() {
+  const { data, isLoading } = useTopUrls({ limit: 25 })
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Top URLs</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading || !data ? (
+          <Skeleton className="h-48 w-full" />
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>URL</TableHead>
+                <TableHead className="text-right">Hits</TableHead>
+                <TableHead className="text-right">Errors</TableHead>
+                <TableHead className="text-right">Bytes</TableHead>
+                <TableHead className="text-right">Avg time</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.items.map((row) => (
+                <TableRow key={row.url}>
+                  <TableCell className="font-mono text-xs max-w-[420px] truncate">{row.url}</TableCell>
+                  <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
+                  <TableCell className="text-right tabular-nums">{formatNumber(row.error_hits)}</TableCell>
+                  <TableCell className="text-right tabular-nums">{formatBytes(row.total_bytes)}</TableCell>
+                  <TableCell className="text-right tabular-nums">{formatDuration(row.avg_request_time * 1000)}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/resources/components/analytics/top-user-agents-table.tsx
+++ b/resources/components/analytics/top-user-agents-table.tsx
@@ -1,0 +1,46 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Skeleton } from "@/components/ui/skeleton"
+import { formatNumber } from "@/lib/api"
+import { useTopUserAgents } from "@/lib/queries"
+
+export function TopUserAgentsTable() {
+  const { data, isLoading } = useTopUserAgents({ limit: 25 })
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Top user agents</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading || !data ? (
+          <Skeleton className="h-48 w-full" />
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>User agent</TableHead>
+                <TableHead className="text-right">Hits</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.items.map((row) => (
+                <TableRow key={row.user_agent}>
+                  <TableCell className="font-mono text-xs max-w-[640px] truncate">{row.user_agent}</TableCell>
+                  <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/resources/components/map/GeoMap.tsx
+++ b/resources/components/map/GeoMap.tsx
@@ -389,7 +389,7 @@ export default function GeoMap() {
             key={`geo-data-${geojson.stats.events}-${geojson.features.length}`}
             id="geo-data"
             type="geojson"
-            data={geojson}
+            data={geojson as unknown as GeoJSON.FeatureCollection}
             cluster={activeLayer === "markers"}
             clusterMaxZoom={14}
             clusterRadius={50}

--- a/resources/components/map/GeoMap.tsx
+++ b/resources/components/map/GeoMap.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useState, useCallback, useRef } from "react"
+import { useMemo } from "react"
 import Map, {
   Source,
   Layer,
@@ -247,7 +248,12 @@ const unclusteredPointLabelLayer: LayerSpecification = {
 export default function GeoMap() {
   const mapRef = useRef<MapRef>(null)
   const { mapStyle } = useMapStyle()
-  const { data: geojson, isLoading: isLoadingGeoJSON, isError, error } = useGeoJSON()
+  const [selectedCountries, setSelectedCountries] = useState<string[]>([])
+  const [selectedCities, setSelectedCities] = useState<string[]>([])
+  const { data: geojson, isLoading: isLoadingGeoJSON, isError, error } = useGeoJSON({
+    countryCodes: selectedCountries,
+    cities: selectedCities,
+  })
   const { data: globalTopIPs, isLoading: isLoadingTopIPs } = useGlobalTopIPs()
 
   const isLoading = isLoadingGeoJSON || isLoadingTopIPs
@@ -255,6 +261,29 @@ export default function GeoMap() {
   const [viewState, setViewState] = useState(INITIAL_VIEW_STATE)
   const [activeLayer, setActiveLayer] = useState<LayerType>("markers")
   const [popup, setPopup] = useState<PopupInfo | null>(null)
+
+  // Filter options come from the last UNFILTERED result (a second query just
+  // for options would be wasteful), held in a ref so the option lists don't
+  // shrink to the filtered subset while a filter is active.
+  const optionsRef = useRef<{ countries: string[]; cities: string[] }>({
+    countries: [],
+    cities: [],
+  })
+  const filterOptions = useMemo(() => {
+    if (geojson && selectedCountries.length === 0 && selectedCities.length === 0) {
+      const countries = new Set<string>()
+      const cities = new Set<string>()
+      for (const f of geojson.features) {
+        if (f.properties.country_code) countries.add(f.properties.country_code)
+        if (f.properties.city) cities.add(f.properties.city)
+      }
+      optionsRef.current = {
+        countries: [...countries].sort(),
+        cities: [...cities].sort(),
+      }
+    }
+    return optionsRef.current
+  }, [geojson, selectedCountries, selectedCities])
 
   // Handle view state changes
   const onMove = useCallback((evt: ViewStateChangeEvent) => {
@@ -265,19 +294,20 @@ export default function GeoMap() {
   const fitToBounds = useCallback(() => {
     if (!geojson?.features.length || !mapRef.current) return
 
-    const coordinates = geojson.features.map(
-      (f) => f.geometry.coordinates as [number, number]
-    )
-
-    if (coordinates.length === 0) return
-
-    // Calculate bounding box
-    const lngs = coordinates.map((c) => c[0])
-    const lats = coordinates.map((c) => c[1])
+    // Single pass: spreading thousands of coordinates into Math.min/max
+    // can blow the call stack.
+    let minLng = Infinity, minLat = Infinity, maxLng = -Infinity, maxLat = -Infinity
+    for (const f of geojson.features) {
+      const [lng, lat] = f.geometry.coordinates as [number, number]
+      if (lng < minLng) minLng = lng
+      if (lng > maxLng) maxLng = lng
+      if (lat < minLat) minLat = lat
+      if (lat > maxLat) maxLat = lat
+    }
 
     const bounds: [[number, number], [number, number]] = [
-      [Math.min(...lngs), Math.min(...lats)],
-      [Math.max(...lngs), Math.max(...lats)],
+      [minLng, minLat],
+      [maxLng, maxLat],
     ]
 
     mapRef.current.fitBounds(bounds, {
@@ -384,9 +414,11 @@ export default function GeoMap() {
         <NavigationControl position="bottom-right" showCompass={true} />
 
         {/* GeoJSON data source */}
+        {/* No key prop: react-map-gl diffs `data` and calls setData on the
+            underlying source, so data updates must not remount the Source
+            (a remount tears down and re-adds every layer). */}
         {geojson && (
           <Source
-            key={`geo-data-${geojson.stats.events}-${geojson.features.length}`}
             id="geo-data"
             type="geojson"
             data={geojson as unknown as GeoJSON.FeatureCollection}
@@ -433,6 +465,12 @@ export default function GeoMap() {
         featureStats={geojson?.stats ?? { events: 0, countries: 0, cities: 0, locations: 0 }}
         topIPs={globalTopIPs?.top_ips ?? []}
         onFlyToLocation={flyToLocation}
+        countryOptions={filterOptions.countries}
+        cityOptions={filterOptions.cities}
+        selectedCountries={selectedCountries}
+        selectedCities={selectedCities}
+        onCountriesChange={setSelectedCountries}
+        onCitiesChange={setSelectedCities}
       />
 
       {/* Legend - show for both modes */}

--- a/resources/components/map/MapControls.tsx
+++ b/resources/components/map/MapControls.tsx
@@ -11,7 +11,7 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { Flame, MapPin, Maximize2, Loader2, SlidersHorizontal, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import type { LayerType } from "./GeoMap"
-import { GEOJSONFeatureStats, TopIPDTO, formatNumber } from "@/lib/api"
+import { GeoJSONFeatureStats, TopIPDTO, formatNumber } from "@/lib/api"
 
 
 interface MapControlsProps {
@@ -19,7 +19,7 @@ interface MapControlsProps {
   onLayerChange: (layer: LayerType) => void
   onFitBounds: () => void
   isLoading?: boolean
-  featureStats: GEOJSONFeatureStats
+  featureStats: GeoJSONFeatureStats
   topIPs: TopIPDTO[]
   onFlyToLocation?: (lat: number, lng: number) => void
 }

--- a/resources/components/map/MapControls.tsx
+++ b/resources/components/map/MapControls.tsx
@@ -7,6 +7,18 @@ import { useState, useEffect } from "react"
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxValue,
+  useComboboxAnchor,
+} from "@/components/ui/combobox"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { Flame, MapPin, Maximize2, Loader2, SlidersHorizontal, X } from "lucide-react"
 import { cn } from "@/lib/utils"
@@ -22,6 +34,62 @@ interface MapControlsProps {
   featureStats: GeoJSONFeatureStats
   topIPs: TopIPDTO[]
   onFlyToLocation?: (lat: number, lng: number) => void
+  countryOptions: string[]
+  cityOptions: string[]
+  selectedCountries: string[]
+  selectedCities: string[]
+  onCountriesChange: (values: string[]) => void
+  onCitiesChange: (values: string[]) => void
+}
+
+function FilterCombobox({
+  options,
+  selected,
+  onChange,
+  placeholder,
+}: {
+  options: string[]
+  selected: string[]
+  onChange: (values: string[]) => void
+  placeholder: string
+}) {
+  const anchor = useComboboxAnchor()
+  return (
+    <Combobox
+      multiple
+      items={options}
+      value={selected}
+      onValueChange={(value) => onChange(value as string[])}
+    >
+      <ComboboxChips ref={anchor} className="min-h-8 px-1.5 py-1 text-xs">
+        <ComboboxValue>
+          {(value: string[]) => (
+            <>
+              {value.map((v) => (
+                <ComboboxChip key={v} className="text-[10px]">
+                  {v}
+                </ComboboxChip>
+              ))}
+              <ComboboxChipsInput
+                placeholder={value.length === 0 ? placeholder : ""}
+                className="text-xs"
+              />
+            </>
+          )}
+        </ComboboxValue>
+      </ComboboxChips>
+      <ComboboxContent anchor={anchor}>
+        <ComboboxEmpty>No matches</ComboboxEmpty>
+        <ComboboxList>
+          {(item: string) => (
+            <ComboboxItem key={item} value={item} className="text-xs">
+              {item}
+            </ComboboxItem>
+          )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  )
 }
 
 export function MapControls({
@@ -31,7 +99,13 @@ export function MapControls({
   isLoading = false,
   featureStats,
   topIPs,
-  onFlyToLocation
+  onFlyToLocation,
+  countryOptions,
+  cityOptions,
+  selectedCountries,
+  selectedCities,
+  onCountriesChange,
+  onCitiesChange,
 }: MapControlsProps) {
   const { events, countries, cities, locations } = featureStats
   const [isExpanded, setIsExpanded] = useState(true)
@@ -104,6 +178,23 @@ export function MapControls({
             <span className="text-sm font-medium">Markers</span>
           </ToggleGroupItem>
         </ToggleGroup>
+      </Card>
+
+      {/* Country / city filters */}
+      <Card className="p-2 gap-1.5 shrink-0">
+        <div className="text-xs font-medium text-muted-foreground">Filters</div>
+        <FilterCombobox
+          options={countryOptions}
+          selected={selectedCountries}
+          onChange={onCountriesChange}
+          placeholder="Country"
+        />
+        <FilterCombobox
+          options={cityOptions}
+          selected={selectedCities}
+          onChange={onCitiesChange}
+          placeholder="City"
+        />
       </Card>
 
       {/* Fit Bounds Button */}

--- a/resources/generated/api/schemas.gen.ts
+++ b/resources/generated/api/schemas.gen.ts
@@ -167,7 +167,7 @@ export const GeoEventsTimeSeriesResponseSchema = {
       type: "string",
     },
   },
-  required: ["end_date", "granularity", "start_date"],
+  required: ["data", "end_date", "granularity", "start_date"],
   title: "GeoEventsTimeSeriesResponse",
   type: "object",
 } as const;
@@ -1124,7 +1124,7 @@ export const TimeSeriesResponseSchema = {
       type: "string",
     },
   },
-  required: ["end_date", "granularity", "start_date"],
+  required: ["data", "end_date", "granularity", "start_date"],
   title: "TimeSeriesResponse",
   type: "object",
 } as const;
@@ -1229,7 +1229,7 @@ export const TopUrlsResponseSchema = {
       type: "string",
     },
   },
-  required: ["end_date", "start_date"],
+  required: ["end_date", "items", "start_date"],
   title: "TopUrlsResponse",
   type: "object",
 } as const;
@@ -1263,7 +1263,7 @@ export const TopUserAgentsResponseSchema = {
       type: "string",
     },
   },
-  required: ["end_date", "start_date"],
+  required: ["end_date", "items", "start_date"],
   title: "TopUserAgentsResponse",
   type: "object",
 } as const;

--- a/resources/generated/api/schemas.gen.ts
+++ b/resources/generated/api/schemas.gen.ts
@@ -120,27 +120,71 @@ export const EmbeddedLocationDTOSchema = {
   type: "object",
 } as const;
 
+export const GeoEventsDataPointSchema = {
+  properties: {
+    timestamp: {
+      type: "string",
+    },
+    total_geo_events: {
+      type: "integer",
+    },
+    unique_cities: {
+      type: "integer",
+    },
+    unique_countries: {
+      type: "integer",
+    },
+    unique_ips: {
+      type: "integer",
+    },
+  },
+  required: [
+    "timestamp",
+    "total_geo_events",
+    "unique_cities",
+    "unique_countries",
+    "unique_ips",
+  ],
+  title: "GeoEventsDataPoint",
+  type: "object",
+} as const;
+
+export const GeoEventsTimeSeriesResponseSchema = {
+  properties: {
+    data: {
+      items: {
+        $ref: "#/components/schemas/GeoEventsDataPoint",
+      },
+      type: "array",
+    },
+    end_date: {
+      type: "string",
+    },
+    granularity: {
+      type: "string",
+    },
+    start_date: {
+      type: "string",
+    },
+  },
+  required: ["end_date", "granularity", "start_date"],
+  title: "GeoEventsTimeSeriesResponse",
+  type: "object",
+} as const;
+
 export const GeoJSONFeatureSchema = {
   properties: {
     geometry: {
       $ref: "#/components/schemas/GeoJSONPointGeometry",
     },
     properties: {
-      oneOf: [
-        {
-          $ref: "#/components/schemas/GeoJSONFeatureProperties",
-        },
-        {
-          type: "null",
-        },
-      ],
+      $ref: "#/components/schemas/GeoJSONFeatureProperties",
     },
     type: {
-      default: "Feature",
       type: "string",
     },
   },
-  required: [],
+  required: ["geometry", "properties", "type"],
   title: "GeoJSONFeature",
   type: "object",
 } as const;
@@ -157,11 +201,10 @@ export const GeoJSONFeatureCollectionSchema = {
       $ref: "#/components/schemas/GeoJSONFeatureStats",
     },
     type: {
-      default: "FeatureCollection",
       type: "string",
     },
   },
-  required: [],
+  required: ["features", "stats", "type"],
   title: "GeoJSONFeatureCollection",
   type: "object",
 } as const;
@@ -271,23 +314,19 @@ export const GeoJSONFeaturePropertiesSchema = {
 export const GeoJSONFeatureStatsSchema = {
   properties: {
     cities: {
-      default: 0,
       type: "integer",
     },
     countries: {
-      default: 0,
       type: "integer",
     },
     events: {
-      default: 0,
       type: "integer",
     },
     locations: {
-      default: 0,
       type: "integer",
     },
   },
-  required: [],
+  required: ["cities", "countries", "events", "locations"],
   title: "GeoJSONFeatureStats",
   type: "object",
 } as const;
@@ -306,11 +345,10 @@ export const GeoJSONPointGeometrySchema = {
       type: "array",
     },
     type: {
-      default: "Point",
       type: "string",
     },
   },
-  required: [],
+  required: ["coordinates", "type"],
   title: "GeoJSONPointGeometry",
   type: "object",
 } as const;
@@ -1007,6 +1045,90 @@ export const SummaryResponseSchema = {
   type: "object",
 } as const;
 
+export const TimeSeriesDataPointSchema = {
+  properties: {
+    avg_request_time: {
+      type: "number",
+    },
+    error_rate: {
+      type: "number",
+    },
+    p50_request_time: {
+      type: "number",
+    },
+    p95_request_time: {
+      type: "number",
+    },
+    p99_request_time: {
+      type: "number",
+    },
+    status_2xx: {
+      type: "integer",
+    },
+    status_3xx: {
+      type: "integer",
+    },
+    status_4xx: {
+      type: "integer",
+    },
+    status_5xx: {
+      type: "integer",
+    },
+    timestamp: {
+      type: "string",
+    },
+    total_bytes_sent: {
+      type: "integer",
+    },
+    total_geo_events: {
+      type: "integer",
+    },
+    total_requests: {
+      type: "integer",
+    },
+  },
+  required: [
+    "avg_request_time",
+    "error_rate",
+    "p50_request_time",
+    "p95_request_time",
+    "p99_request_time",
+    "status_2xx",
+    "status_3xx",
+    "status_4xx",
+    "status_5xx",
+    "timestamp",
+    "total_bytes_sent",
+    "total_geo_events",
+    "total_requests",
+  ],
+  title: "TimeSeriesDataPoint",
+  type: "object",
+} as const;
+
+export const TimeSeriesResponseSchema = {
+  properties: {
+    data: {
+      items: {
+        $ref: "#/components/schemas/TimeSeriesDataPoint",
+      },
+      type: "array",
+    },
+    end_date: {
+      type: "string",
+    },
+    granularity: {
+      type: "string",
+    },
+    start_date: {
+      type: "string",
+    },
+  },
+  required: ["end_date", "granularity", "start_date"],
+  title: "TimeSeriesResponse",
+  type: "object",
+} as const;
+
 export const TopCountriesResponseSchema = {
   properties: {
     top_countries: {
@@ -1066,5 +1188,82 @@ export const TopIPDTOSchema = {
   },
   required: ["event_count", "ip_address"],
   title: "TopIPDTO",
+  type: "object",
+} as const;
+
+export const TopUrlDTOSchema = {
+  properties: {
+    avg_request_time: {
+      type: "number",
+    },
+    error_hits: {
+      type: "integer",
+    },
+    hits: {
+      type: "integer",
+    },
+    total_bytes: {
+      type: "integer",
+    },
+    url: {
+      type: "string",
+    },
+  },
+  required: ["avg_request_time", "error_hits", "hits", "total_bytes", "url"],
+  title: "TopUrlDTO",
+  type: "object",
+} as const;
+
+export const TopUrlsResponseSchema = {
+  properties: {
+    end_date: {
+      type: "string",
+    },
+    items: {
+      items: {
+        $ref: "#/components/schemas/TopUrlDTO",
+      },
+      type: "array",
+    },
+    start_date: {
+      type: "string",
+    },
+  },
+  required: ["end_date", "start_date"],
+  title: "TopUrlsResponse",
+  type: "object",
+} as const;
+
+export const TopUserAgentDTOSchema = {
+  properties: {
+    hits: {
+      type: "integer",
+    },
+    user_agent: {
+      type: "string",
+    },
+  },
+  required: ["hits", "user_agent"],
+  title: "TopUserAgentDTO",
+  type: "object",
+} as const;
+
+export const TopUserAgentsResponseSchema = {
+  properties: {
+    end_date: {
+      type: "string",
+    },
+    items: {
+      items: {
+        $ref: "#/components/schemas/TopUserAgentDTO",
+      },
+      type: "array",
+    },
+    start_date: {
+      type: "string",
+    },
+  },
+  required: ["end_date", "start_date"],
+  title: "TopUserAgentsResponse",
   type: "object",
 } as const;

--- a/resources/generated/api/sdk.gen.ts
+++ b/resources/generated/api/sdk.gen.ts
@@ -9,6 +9,9 @@ import type {
   ApiV1AccessLogsListAccessLogsData,
   ApiV1AccessLogsListAccessLogsErrors,
   ApiV1AccessLogsListAccessLogsResponses,
+  ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesData,
+  ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesErrors,
+  ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesResponses,
   ApiV1AnalyticsLiveSummaryGetLiveSummaryData,
   ApiV1AnalyticsLiveSummaryGetLiveSummaryErrors,
   ApiV1AnalyticsLiveSummaryGetLiveSummaryResponses,
@@ -18,6 +21,15 @@ import type {
   ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesData,
   ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesErrors,
   ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses,
+  ApiV1AnalyticsTimeSeriesGetTimeSeriesData,
+  ApiV1AnalyticsTimeSeriesGetTimeSeriesErrors,
+  ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses,
+  ApiV1AnalyticsTopUrlsGetTopUrlsData,
+  ApiV1AnalyticsTopUrlsGetTopUrlsErrors,
+  ApiV1AnalyticsTopUrlsGetTopUrlsResponses,
+  ApiV1AnalyticsTopUserAgentsGetTopUserAgentsData,
+  ApiV1AnalyticsTopUserAgentsGetTopUserAgentsErrors,
+  ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponses,
   ApiV1AuthLoginLoginData,
   ApiV1AuthLoginLoginErrors,
   ApiV1AuthLoginLoginResponses,
@@ -119,6 +131,35 @@ export const apiV1AccessLogsListAccessLogs = <
   });
 
 /**
+ * GetGeoTimeSeries
+ *
+ * Per-bucket geo-event metrics for charts.
+ */
+export const apiV1AnalyticsGeoTimeSeriesGetGeoTimeSeries = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesData,
+    ThrowOnError
+  >,
+) =>
+  (options.client ?? client).get<
+    ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesResponses,
+    ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/analytics/geo-time-series",
+    ...options,
+  });
+
+/**
  * GetLiveSummary
  *
  * Get live summary statistics by querying raw data tables.
@@ -171,6 +212,32 @@ export const apiV1AnalyticsSummaryGetSummary = <
   });
 
 /**
+ * GetTimeSeries
+ *
+ * Per-bucket access-log metrics for charts.
+ */
+export const apiV1AnalyticsTimeSeriesGetTimeSeries = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<ApiV1AnalyticsTimeSeriesGetTimeSeriesData, ThrowOnError>,
+) =>
+  (options.client ?? client).get<
+    ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses,
+    ApiV1AnalyticsTimeSeriesGetTimeSeriesErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/analytics/time-series",
+    ...options,
+  });
+
+/**
  * GetCumulativeTimeSeries
  *
  * Get cumulative time series data for area charts.
@@ -196,6 +263,61 @@ export const apiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeries = <
       },
     ],
     url: "/api/v1/analytics/time-series/cumulative",
+    ...options,
+  });
+
+/**
+ * GetTopUrls
+ *
+ * Top URLs by hits from raw access logs (time-bounded).
+ */
+export const apiV1AnalyticsTopUrlsGetTopUrls = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<ApiV1AnalyticsTopUrlsGetTopUrlsData, ThrowOnError>,
+) =>
+  (options.client ?? client).get<
+    ApiV1AnalyticsTopUrlsGetTopUrlsResponses,
+    ApiV1AnalyticsTopUrlsGetTopUrlsErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/analytics/top-urls",
+    ...options,
+  });
+
+/**
+ * GetTopUserAgents
+ *
+ * Top user agents by hits from raw access logs.
+ */
+export const apiV1AnalyticsTopUserAgentsGetTopUserAgents = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    ApiV1AnalyticsTopUserAgentsGetTopUserAgentsData,
+    ThrowOnError
+  >,
+) =>
+  (options.client ?? client).get<
+    ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponses,
+    ApiV1AnalyticsTopUserAgentsGetTopUserAgentsErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/analytics/top-user-agents",
     ...options,
   });
 

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -47,21 +47,42 @@ export type EmbeddedLocationDto = {
 };
 
 /**
+ * GeoEventsDataPoint
+ */
+export type GeoEventsDataPoint = {
+  timestamp: string;
+  total_geo_events: number;
+  unique_cities: number;
+  unique_countries: number;
+  unique_ips: number;
+};
+
+/**
+ * GeoEventsTimeSeriesResponse
+ */
+export type GeoEventsTimeSeriesResponse = {
+  data?: Array<GeoEventsDataPoint>;
+  end_date: string;
+  granularity: string;
+  start_date: string;
+};
+
+/**
  * GeoJSONFeature
  */
 export type GeoJsonFeature = {
-  geometry?: GeoJsonPointGeometry;
-  properties?: GeoJsonFeatureProperties | null;
-  type?: string;
+  geometry: GeoJsonPointGeometry;
+  properties: GeoJsonFeatureProperties;
+  type: string;
 };
 
 /**
  * GeoJSONFeatureCollection
  */
 export type GeoJsonFeatureCollection = {
-  features?: Array<GeoJsonFeature>;
-  stats?: GeoJsonFeatureStats;
-  type?: string;
+  features: Array<GeoJsonFeature>;
+  stats: GeoJsonFeatureStats;
+  type: string;
 };
 
 /**
@@ -86,18 +107,18 @@ export type GeoJsonFeatureProperties = {
  * GeoJSONFeatureStats
  */
 export type GeoJsonFeatureStats = {
-  cities?: number;
-  countries?: number;
-  events?: number;
-  locations?: number;
+  cities: number;
+  countries: number;
+  events: number;
+  locations: number;
 };
 
 /**
  * GeoJSONPointGeometry
  */
 export type GeoJsonPointGeometry = {
-  coordinates?: [number, number];
-  type?: string;
+  coordinates: [number, number];
+  type: string;
 };
 
 /**
@@ -284,6 +305,35 @@ export type SummaryResponse = {
 };
 
 /**
+ * TimeSeriesDataPoint
+ */
+export type TimeSeriesDataPoint = {
+  avg_request_time: number;
+  error_rate: number;
+  p50_request_time: number;
+  p95_request_time: number;
+  p99_request_time: number;
+  status_2xx: number;
+  status_3xx: number;
+  status_4xx: number;
+  status_5xx: number;
+  timestamp: string;
+  total_bytes_sent: number;
+  total_geo_events: number;
+  total_requests: number;
+};
+
+/**
+ * TimeSeriesResponse
+ */
+export type TimeSeriesResponse = {
+  data?: Array<TimeSeriesDataPoint>;
+  end_date: string;
+  granularity: string;
+  start_date: string;
+};
+
+/**
  * TopCountriesResponse
  */
 export type TopCountriesResponse = {
@@ -306,6 +356,43 @@ export type TopIpdto = {
   event_count: number;
   ip_address: string;
   location?: EmbeddedLocationDto | null;
+};
+
+/**
+ * TopUrlDTO
+ */
+export type TopUrlDto = {
+  avg_request_time: number;
+  error_hits: number;
+  hits: number;
+  total_bytes: number;
+  url: string;
+};
+
+/**
+ * TopUrlsResponse
+ */
+export type TopUrlsResponse = {
+  end_date: string;
+  items?: Array<TopUrlDto>;
+  start_date: string;
+};
+
+/**
+ * TopUserAgentDTO
+ */
+export type TopUserAgentDto = {
+  hits: number;
+  user_agent: string;
+};
+
+/**
+ * TopUserAgentsResponse
+ */
+export type TopUserAgentsResponse = {
+  end_date: string;
+  items?: Array<TopUserAgentDto>;
+  start_date: string;
 };
 
 export type ApiV1AccessLogDebugListAccessLogDebugsData = {
@@ -414,6 +501,51 @@ export type ApiV1AccessLogsListAccessLogsResponses = {
 export type ApiV1AccessLogsListAccessLogsResponse =
   ApiV1AccessLogsListAccessLogsResponses[keyof ApiV1AccessLogsListAccessLogsResponses];
 
+export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
+     */
+    start_date: string;
+    /**
+     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
+     */
+    end_date: string;
+  };
+  url: "/api/v1/analytics/geo-time-series";
+};
+
+export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+    status_code: number;
+  };
+};
+
+export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesError =
+  ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesErrors[keyof ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesErrors];
+
+export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: GeoEventsTimeSeriesResponse;
+};
+
+export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesResponse =
+  ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesResponses[keyof ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesResponses];
+
 export type ApiV1AnalyticsLiveSummaryGetLiveSummaryData = {
   body?: never;
   path?: never;
@@ -512,6 +644,51 @@ export type ApiV1AnalyticsSummaryGetSummaryResponses = {
 export type ApiV1AnalyticsSummaryGetSummaryResponse =
   ApiV1AnalyticsSummaryGetSummaryResponses[keyof ApiV1AnalyticsSummaryGetSummaryResponses];
 
+export type ApiV1AnalyticsTimeSeriesGetTimeSeriesData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
+     */
+    start_date: string;
+    /**
+     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
+     */
+    end_date: string;
+  };
+  url: "/api/v1/analytics/time-series";
+};
+
+export type ApiV1AnalyticsTimeSeriesGetTimeSeriesErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+    status_code: number;
+  };
+};
+
+export type ApiV1AnalyticsTimeSeriesGetTimeSeriesError =
+  ApiV1AnalyticsTimeSeriesGetTimeSeriesErrors[keyof ApiV1AnalyticsTimeSeriesGetTimeSeriesErrors];
+
+export type ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: TimeSeriesResponse;
+};
+
+export type ApiV1AnalyticsTimeSeriesGetTimeSeriesResponse =
+  ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses[keyof ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses];
+
 export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesData = {
   body?: never;
   path?: never;
@@ -557,6 +734,104 @@ export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses =
 
 export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponse =
   ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses[keyof ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses];
+
+export type ApiV1AnalyticsTopUrlsGetTopUrlsData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
+     */
+    start_date: string;
+    /**
+     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
+     */
+    end_date: string;
+    /**
+     * Maximum number of URLs to return
+     */
+    limit?: number;
+  };
+  url: "/api/v1/analytics/top-urls";
+};
+
+export type ApiV1AnalyticsTopUrlsGetTopUrlsErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+    status_code: number;
+  };
+};
+
+export type ApiV1AnalyticsTopUrlsGetTopUrlsError =
+  ApiV1AnalyticsTopUrlsGetTopUrlsErrors[keyof ApiV1AnalyticsTopUrlsGetTopUrlsErrors];
+
+export type ApiV1AnalyticsTopUrlsGetTopUrlsResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: TopUrlsResponse;
+};
+
+export type ApiV1AnalyticsTopUrlsGetTopUrlsResponse =
+  ApiV1AnalyticsTopUrlsGetTopUrlsResponses[keyof ApiV1AnalyticsTopUrlsGetTopUrlsResponses];
+
+export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
+     */
+    start_date: string;
+    /**
+     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
+     */
+    end_date: string;
+    /**
+     * Maximum number of user agents to return
+     */
+    limit?: number;
+  };
+  url: "/api/v1/analytics/top-user-agents";
+};
+
+export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+    status_code: number;
+  };
+};
+
+export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsError =
+  ApiV1AnalyticsTopUserAgentsGetTopUserAgentsErrors[keyof ApiV1AnalyticsTopUserAgentsGetTopUserAgentsErrors];
+
+export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: TopUserAgentsResponse;
+};
+
+export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponse =
+  ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponses[keyof ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponses];
 
 export type ApiV1AuthLoginLoginData = {
   body: LoginPayload;
@@ -746,6 +1021,14 @@ export type ApiV1GeoLocationsGeojsonGetGeojsonData = {
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
     to_timestamp: string;
+    /**
+     * Filter to these ISO country codes (repeatable)
+     */
+    country_code?: Array<string> | null;
+    /**
+     * Filter to these city names (repeatable)
+     */
+    city?: Array<string> | null;
   };
   url: "/api/v1/geo-locations/geojson";
 };

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -61,7 +61,7 @@ export type GeoEventsDataPoint = {
  * GeoEventsTimeSeriesResponse
  */
 export type GeoEventsTimeSeriesResponse = {
-  data?: Array<GeoEventsDataPoint>;
+  data: Array<GeoEventsDataPoint>;
   end_date: string;
   granularity: string;
   start_date: string;
@@ -327,7 +327,7 @@ export type TimeSeriesDataPoint = {
  * TimeSeriesResponse
  */
 export type TimeSeriesResponse = {
-  data?: Array<TimeSeriesDataPoint>;
+  data: Array<TimeSeriesDataPoint>;
   end_date: string;
   granularity: string;
   start_date: string;
@@ -374,7 +374,7 @@ export type TopUrlDto = {
  */
 export type TopUrlsResponse = {
   end_date: string;
-  items?: Array<TopUrlDto>;
+  items: Array<TopUrlDto>;
   start_date: string;
 };
 
@@ -391,7 +391,7 @@ export type TopUserAgentDto = {
  */
 export type TopUserAgentsResponse = {
   end_date: string;
-  items?: Array<TopUserAgentDto>;
+  items: Array<TopUserAgentDto>;
   start_date: string;
 };
 

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -125,27 +125,77 @@
         "title": "EmbeddedLocationDTO",
         "type": "object"
       },
+      "GeoEventsDataPoint": {
+        "properties": {
+          "timestamp": {
+            "type": "string"
+          },
+          "total_geo_events": {
+            "type": "integer"
+          },
+          "unique_cities": {
+            "type": "integer"
+          },
+          "unique_countries": {
+            "type": "integer"
+          },
+          "unique_ips": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "timestamp",
+          "total_geo_events",
+          "unique_cities",
+          "unique_countries",
+          "unique_ips"
+        ],
+        "title": "GeoEventsDataPoint",
+        "type": "object"
+      },
+      "GeoEventsTimeSeriesResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/GeoEventsDataPoint"
+            },
+            "type": "array"
+          },
+          "end_date": {
+            "type": "string"
+          },
+          "granularity": {
+            "type": "string"
+          },
+          "start_date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "end_date",
+          "granularity",
+          "start_date"
+        ],
+        "title": "GeoEventsTimeSeriesResponse",
+        "type": "object"
+      },
       "GeoJSONFeature": {
         "properties": {
           "geometry": {
             "$ref": "#/components/schemas/GeoJSONPointGeometry"
           },
           "properties": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/GeoJSONFeatureProperties"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "$ref": "#/components/schemas/GeoJSONFeatureProperties"
           },
           "type": {
-            "default": "Feature",
             "type": "string"
           }
         },
-        "required": [],
+        "required": [
+          "geometry",
+          "properties",
+          "type"
+        ],
         "title": "GeoJSONFeature",
         "type": "object"
       },
@@ -161,11 +211,14 @@
             "$ref": "#/components/schemas/GeoJSONFeatureStats"
           },
           "type": {
-            "default": "FeatureCollection",
             "type": "string"
           }
         },
-        "required": [],
+        "required": [
+          "features",
+          "stats",
+          "type"
+        ],
         "title": "GeoJSONFeatureCollection",
         "type": "object"
       },
@@ -273,23 +326,24 @@
       "GeoJSONFeatureStats": {
         "properties": {
           "cities": {
-            "default": 0,
             "type": "integer"
           },
           "countries": {
-            "default": 0,
             "type": "integer"
           },
           "events": {
-            "default": 0,
             "type": "integer"
           },
           "locations": {
-            "default": 0,
             "type": "integer"
           }
         },
-        "required": [],
+        "required": [
+          "cities",
+          "countries",
+          "events",
+          "locations"
+        ],
         "title": "GeoJSONFeatureStats",
         "type": "object"
       },
@@ -307,11 +361,13 @@
             "type": "array"
           },
           "type": {
-            "default": "Point",
             "type": "string"
           }
         },
-        "required": [],
+        "required": [
+          "coordinates",
+          "type"
+        ],
         "title": "GeoJSONPointGeometry",
         "type": "object"
       },
@@ -1028,6 +1084,92 @@
         "title": "SummaryResponse",
         "type": "object"
       },
+      "TimeSeriesDataPoint": {
+        "properties": {
+          "avg_request_time": {
+            "type": "number"
+          },
+          "error_rate": {
+            "type": "number"
+          },
+          "p50_request_time": {
+            "type": "number"
+          },
+          "p95_request_time": {
+            "type": "number"
+          },
+          "p99_request_time": {
+            "type": "number"
+          },
+          "status_2xx": {
+            "type": "integer"
+          },
+          "status_3xx": {
+            "type": "integer"
+          },
+          "status_4xx": {
+            "type": "integer"
+          },
+          "status_5xx": {
+            "type": "integer"
+          },
+          "timestamp": {
+            "type": "string"
+          },
+          "total_bytes_sent": {
+            "type": "integer"
+          },
+          "total_geo_events": {
+            "type": "integer"
+          },
+          "total_requests": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "avg_request_time",
+          "error_rate",
+          "p50_request_time",
+          "p95_request_time",
+          "p99_request_time",
+          "status_2xx",
+          "status_3xx",
+          "status_4xx",
+          "status_5xx",
+          "timestamp",
+          "total_bytes_sent",
+          "total_geo_events",
+          "total_requests"
+        ],
+        "title": "TimeSeriesDataPoint",
+        "type": "object"
+      },
+      "TimeSeriesResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/TimeSeriesDataPoint"
+            },
+            "type": "array"
+          },
+          "end_date": {
+            "type": "string"
+          },
+          "granularity": {
+            "type": "string"
+          },
+          "start_date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "end_date",
+          "granularity",
+          "start_date"
+        ],
+        "title": "TimeSeriesResponse",
+        "type": "object"
+      },
       "TopCountriesResponse": {
         "properties": {
           "top_countries": {
@@ -1092,6 +1234,94 @@
           "ip_address"
         ],
         "title": "TopIPDTO",
+        "type": "object"
+      },
+      "TopUrlDTO": {
+        "properties": {
+          "avg_request_time": {
+            "type": "number"
+          },
+          "error_hits": {
+            "type": "integer"
+          },
+          "hits": {
+            "type": "integer"
+          },
+          "total_bytes": {
+            "type": "integer"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "avg_request_time",
+          "error_hits",
+          "hits",
+          "total_bytes",
+          "url"
+        ],
+        "title": "TopUrlDTO",
+        "type": "object"
+      },
+      "TopUrlsResponse": {
+        "properties": {
+          "end_date": {
+            "type": "string"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TopUrlDTO"
+            },
+            "type": "array"
+          },
+          "start_date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "end_date",
+          "start_date"
+        ],
+        "title": "TopUrlsResponse",
+        "type": "object"
+      },
+      "TopUserAgentDTO": {
+        "properties": {
+          "hits": {
+            "type": "integer"
+          },
+          "user_agent": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "hits",
+          "user_agent"
+        ],
+        "title": "TopUserAgentDTO",
+        "type": "object"
+      },
+      "TopUserAgentsResponse": {
+        "properties": {
+          "end_date": {
+            "type": "string"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TopUserAgentDTO"
+            },
+            "type": "array"
+          },
+          "start_date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "end_date",
+          "start_date"
+        ],
+        "title": "TopUserAgentsResponse",
         "type": "object"
       }
     },
@@ -1326,6 +1556,114 @@
         "summary": "ListAccessLogs",
         "tags": [
           "Access Logs"
+        ]
+      }
+    },
+    "/api/v1/analytics/geo-time-series": {
+      "get": {
+        "deprecated": false,
+        "description": "Per-bucket geo-event metrics for charts.",
+        "operationId": "ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeries",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+            "examples": {
+              "start_date-example-1": {
+                "value": "2024-01-01T00:00:00Z"
+              }
+            },
+            "in": "query",
+            "name": "start_date",
+            "required": true,
+            "schema": {
+              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+              "examples": [
+                "2024-01-01T00:00:00Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+            "examples": {
+              "end_date-example-1": {
+                "value": "2024-12-31T23:59:59Z"
+              }
+            },
+            "in": "query",
+            "name": "end_date",
+            "required": true,
+            "schema": {
+              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+              "examples": [
+                "2024-12-31T23:59:59Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeoEventsTimeSeriesResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetGeoTimeSeries",
+        "tags": [
+          "Analytics"
         ]
       }
     },
@@ -1573,6 +1911,114 @@
         ]
       }
     },
+    "/api/v1/analytics/time-series": {
+      "get": {
+        "deprecated": false,
+        "description": "Per-bucket access-log metrics for charts.",
+        "operationId": "ApiV1AnalyticsTimeSeriesGetTimeSeries",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+            "examples": {
+              "start_date-example-1": {
+                "value": "2024-01-01T00:00:00Z"
+              }
+            },
+            "in": "query",
+            "name": "start_date",
+            "required": true,
+            "schema": {
+              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+              "examples": [
+                "2024-01-01T00:00:00Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+            "examples": {
+              "end_date-example-1": {
+                "value": "2024-12-31T23:59:59Z"
+              }
+            },
+            "in": "query",
+            "name": "end_date",
+            "required": true,
+            "schema": {
+              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+              "examples": [
+                "2024-12-31T23:59:59Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimeSeriesResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetTimeSeries",
+        "tags": [
+          "Analytics"
+        ]
+      }
+    },
     "/api/v1/analytics/time-series/cumulative": {
       "get": {
         "deprecated": false,
@@ -1676,6 +2122,254 @@
           }
         },
         "summary": "GetCumulativeTimeSeries",
+        "tags": [
+          "Analytics"
+        ]
+      }
+    },
+    "/api/v1/analytics/top-urls": {
+      "get": {
+        "deprecated": false,
+        "description": "Top URLs by hits from raw access logs (time-bounded).",
+        "operationId": "ApiV1AnalyticsTopUrlsGetTopUrls",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+            "examples": {
+              "start_date-example-1": {
+                "value": "2024-01-01T00:00:00Z"
+              }
+            },
+            "in": "query",
+            "name": "start_date",
+            "required": true,
+            "schema": {
+              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+              "examples": [
+                "2024-01-01T00:00:00Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+            "examples": {
+              "end_date-example-1": {
+                "value": "2024-12-31T23:59:59Z"
+              }
+            },
+            "in": "query",
+            "name": "end_date",
+            "required": true,
+            "schema": {
+              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+              "examples": [
+                "2024-12-31T23:59:59Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Maximum number of URLs to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "description": "Maximum number of URLs to return",
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopUrlsResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetTopUrls",
+        "tags": [
+          "Analytics"
+        ]
+      }
+    },
+    "/api/v1/analytics/top-user-agents": {
+      "get": {
+        "deprecated": false,
+        "description": "Top user agents by hits from raw access logs.",
+        "operationId": "ApiV1AnalyticsTopUserAgentsGetTopUserAgents",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+            "examples": {
+              "start_date-example-1": {
+                "value": "2024-01-01T00:00:00Z"
+              }
+            },
+            "in": "query",
+            "name": "start_date",
+            "required": true,
+            "schema": {
+              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+              "examples": [
+                "2024-01-01T00:00:00Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+            "examples": {
+              "end_date-example-1": {
+                "value": "2024-12-31T23:59:59Z"
+              }
+            },
+            "in": "query",
+            "name": "end_date",
+            "required": true,
+            "schema": {
+              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+              "examples": [
+                "2024-12-31T23:59:59Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Maximum number of user agents to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "description": "Maximum number of user agents to return",
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopUserAgentsResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetTopUserAgents",
         "tags": [
           "Analytics"
         ]
@@ -2057,6 +2751,52 @@
               ],
               "format": "date-time",
               "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these ISO country codes (repeatable)",
+            "in": "query",
+            "name": "country_code",
+            "required": false,
+            "schema": {
+              "description": "Filter to these ISO country codes (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these city names (repeatable)",
+            "in": "query",
+            "name": "city",
+            "required": false,
+            "schema": {
+              "description": "Filter to these city names (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           }
         ],

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -172,6 +172,7 @@
           }
         },
         "required": [
+          "data",
           "end_date",
           "granularity",
           "start_date"
@@ -1163,6 +1164,7 @@
           }
         },
         "required": [
+          "data",
           "end_date",
           "granularity",
           "start_date"
@@ -1281,6 +1283,7 @@
         },
         "required": [
           "end_date",
+          "items",
           "start_date"
         ],
         "title": "TopUrlsResponse",
@@ -1319,6 +1322,7 @@
         },
         "required": [
           "end_date",
+          "items",
           "start_date"
         ],
         "title": "TopUserAgentsResponse",

--- a/resources/generated/routes.json
+++ b/resources/generated/routes.json
@@ -1,6 +1,13 @@
 {
   "litestar_version": "Version(major=2, minor=24, patch=0, release_level='final', serial=0)",
   "routes": {
+    "disabled_vite_hmr_http": {
+      "method": "get",
+      "methods": [
+        "GET"
+      ],
+      "uri": "/static/vite-hmr"
+    },
     "get_cumulative_time_series": {
       "method": "get",
       "methods": [
@@ -12,12 +19,25 @@
       },
       "uri": "/api/v1/analytics/time-series/cumulative"
     },
+    "get_geo_time_series": {
+      "method": "get",
+      "methods": [
+        "GET"
+      ],
+      "queryParameters": {
+        "end_date": "DateTime",
+        "start_date": "DateTime"
+      },
+      "uri": "/api/v1/analytics/geo-time-series"
+    },
     "get_geojson": {
       "method": "get",
       "methods": [
         "GET"
       ],
       "queryParameters": {
+        "city": "string[] | undefined",
+        "country_code": "string[] | undefined",
         "from_timestamp": "DateTime",
         "to_timestamp": "DateTime"
       },
@@ -77,6 +97,17 @@
       },
       "uri": "/api/v1/analytics/summary"
     },
+    "get_time_series": {
+      "method": "get",
+      "methods": [
+        "GET"
+      ],
+      "queryParameters": {
+        "end_date": "DateTime",
+        "start_date": "DateTime"
+      },
+      "uri": "/api/v1/analytics/time-series"
+    },
     "get_top_countries": {
       "method": "get",
       "methods": [
@@ -88,6 +119,30 @@
         "to_timestamp": "DateTime"
       },
       "uri": "/api/v1/geo-locations/top-countries"
+    },
+    "get_top_urls": {
+      "method": "get",
+      "methods": [
+        "GET"
+      ],
+      "queryParameters": {
+        "end_date": "DateTime",
+        "limit": "number | undefined",
+        "start_date": "DateTime"
+      },
+      "uri": "/api/v1/analytics/top-urls"
+    },
+    "get_top_user_agents": {
+      "method": "get",
+      "methods": [
+        "GET"
+      ],
+      "queryParameters": {
+        "end_date": "DateTime",
+        "limit": "number | undefined",
+        "start_date": "DateTime"
+      },
+      "uri": "/api/v1/analytics/top-user-agents"
     },
     "health": {
       "method": "get",

--- a/resources/generated/routes.ts
+++ b/resources/generated/routes.ts
@@ -15,13 +15,18 @@ export type URI = string;
 
 /** All available route names */
 export type RouteName =
+  | 'disabled_vite_hmr_http'
   | 'get_cumulative_time_series'
+  | 'get_geo_time_series'
   | 'get_geojson'
   | 'get_global_top_ips'
   | 'get_live_summary'
   | 'get_location_top_ips'
   | 'get_summary'
+  | 'get_time_series'
   | 'get_top_countries'
+  | 'get_top_urls'
+  | 'get_top_user_agents'
   | 'health'
   | 'health_ready'
   | 'list_access_log_debugs'
@@ -41,7 +46,9 @@ export type RouteName =
 
 /** Path parameter definitions per route */
 export interface RoutePathParams {
+  'disabled_vite_hmr_http': Record<string, never>;
   'get_cumulative_time_series': Record<string, never>;
+  'get_geo_time_series': Record<string, never>;
   'get_geojson': Record<string, never>;
   'get_global_top_ips': Record<string, never>;
   'get_live_summary': Record<string, never>;
@@ -49,7 +56,10 @@ export interface RoutePathParams {
     location_id: number;
   };
   'get_summary': Record<string, never>;
+  'get_time_series': Record<string, never>;
   'get_top_countries': Record<string, never>;
+  'get_top_urls': Record<string, never>;
+  'get_top_user_agents': Record<string, never>;
   'health': Record<string, never>;
   'health_ready': Record<string, never>;
   'list_access_log_debugs': Record<string, never>;
@@ -74,11 +84,18 @@ export interface RoutePathParams {
 
 /** Query parameter definitions per route */
 export interface RouteQueryParams {
+  'disabled_vite_hmr_http': Record<string, never>;
   'get_cumulative_time_series': {
     end_date: DateTime;
     start_date: DateTime;
   };
+  'get_geo_time_series': {
+    end_date: DateTime;
+    start_date: DateTime;
+  };
   'get_geojson': {
+    city?: string[];
+    country_code?: string[];
     from_timestamp: DateTime;
     to_timestamp: DateTime;
   };
@@ -102,10 +119,24 @@ export interface RouteQueryParams {
     end_date: DateTime;
     start_date: DateTime;
   };
+  'get_time_series': {
+    end_date: DateTime;
+    start_date: DateTime;
+  };
   'get_top_countries': {
     from_timestamp: DateTime;
     limit?: number;
     to_timestamp: DateTime;
+  };
+  'get_top_urls': {
+    end_date: DateTime;
+    limit?: number;
+    start_date: DateTime;
+  };
+  'get_top_user_agents': {
+    end_date: DateTime;
+    limit?: number;
+    start_date: DateTime;
   };
   'health': Record<string, never>;
   'health_ready': Record<string, never>;
@@ -146,8 +177,22 @@ export type RouteParams<T extends RouteName> = MergeParams<RoutePathParams[T], R
 
 /** Route metadata */
 export const routeDefinitions = {
+  'disabled_vite_hmr_http': {
+    path: '/static/vite-hmr',
+    methods: ['GET'] as const,
+    method: 'get',
+    pathParams: [] as const,
+    queryParams: [] as const,
+  },
   'get_cumulative_time_series': {
     path: '/api/v1/analytics/time-series/cumulative',
+    methods: ['GET'] as const,
+    method: 'get',
+    pathParams: [] as const,
+    queryParams: ['end_date', 'start_date'] as const,
+  },
+  'get_geo_time_series': {
+    path: '/api/v1/analytics/geo-time-series',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
@@ -158,7 +203,7 @@ export const routeDefinitions = {
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['from_timestamp', 'to_timestamp'] as const,
+    queryParams: ['city', 'country_code', 'from_timestamp', 'to_timestamp'] as const,
   },
   'get_global_top_ips': {
     path: '/api/v1/geo-locations/top-ips',
@@ -188,12 +233,33 @@ export const routeDefinitions = {
     pathParams: [] as const,
     queryParams: ['compare_previous', 'end_date', 'start_date'] as const,
   },
+  'get_time_series': {
+    path: '/api/v1/analytics/time-series',
+    methods: ['GET'] as const,
+    method: 'get',
+    pathParams: [] as const,
+    queryParams: ['end_date', 'start_date'] as const,
+  },
   'get_top_countries': {
     path: '/api/v1/geo-locations/top-countries',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
     queryParams: ['from_timestamp', 'limit', 'to_timestamp'] as const,
+  },
+  'get_top_urls': {
+    path: '/api/v1/analytics/top-urls',
+    methods: ['GET'] as const,
+    method: 'get',
+    pathParams: [] as const,
+    queryParams: ['end_date', 'limit', 'start_date'] as const,
+  },
+  'get_top_user_agents': {
+    path: '/api/v1/analytics/top-user-agents',
+    methods: ['GET'] as const,
+    method: 'get',
+    pathParams: [] as const,
+    queryParams: ['end_date', 'limit', 'start_date'] as const,
   },
   'health': {
     path: '/health',

--- a/resources/lib/api.ts
+++ b/resources/lib/api.ts
@@ -203,6 +203,8 @@ export interface TimeSeriesParams {
 export interface GeoJSONParams {
   fromTimestamp: string // Full ISO timestamp
   toTimestamp: string
+  countryCodes?: string[]
+  cities?: string[]
 }
 
 export async function fetchGeoJSON(params: GeoJSONParams): Promise<GeoJSONFeatureCollection> {
@@ -210,7 +212,12 @@ export async function fetchGeoJSON(params: GeoJSONParams): Promise<GeoJSONFeatur
     params: {
       from_timestamp: params.fromTimestamp,
       to_timestamp: params.toTimestamp,
+      country_code: params.countryCodes?.length ? params.countryCodes : undefined,
+      city: params.cities?.length ? params.cities : undefined,
     },
+    // Litestar expects repeated keys (?country_code=NO&country_code=SE),
+    // not axios' default bracket form (country_code[]=NO).
+    paramsSerializer: { indexes: null },
   })
   return data
 }

--- a/resources/lib/api.ts
+++ b/resources/lib/api.ts
@@ -3,6 +3,13 @@
  */
 
 import axios from "axios"
+import {
+  apiV1AnalyticsGeoTimeSeriesGetGeoTimeSeries,
+  apiV1AnalyticsTimeSeriesGetTimeSeries,
+  apiV1AnalyticsTopUrlsGetTopUrls,
+  apiV1AnalyticsTopUserAgentsGetTopUserAgents,
+} from "@/generated/api/sdk.gen"
+import type { GeoJsonFeatureCollection as GeoJSONFeatureCollection } from "@/generated/api/types.gen"
 
 // Create axios instance with base configuration
 export const api = axios.create({
@@ -107,51 +114,14 @@ export interface SummaryResponse {
   percent_changes: PercentChange | null
 }
 
-export interface TimeSeriesDataPoint {
-  timestamp: string
-  total_requests: number
-  total_geo_events: number
-  total_bytes_sent: number
-  status_2xx: number
-  status_3xx: number
-  status_4xx: number
-  status_5xx: number
-  error_rate: number
-}
-
-export interface TimeSeriesResponse {
-  granularity: "hourly" | "daily"
-  start_date: string
-  end_date: string
-  data: TimeSeriesDataPoint[]
-}
-
-export interface PerformanceDataPoint {
-  timestamp: string
-  avg_request_time: number
-  max_request_time: number
-}
-
-export interface PerformanceTimeSeriesResponse {
-  granularity: "hourly" | "daily"
-  start_date: string
-  end_date: string
-  data: PerformanceDataPoint[]
-}
-
-export interface GeoEventsDataPoint {
-  timestamp: string
-  total_geo_events: number
-  unique_ips: number
-  unique_countries: number
-}
-
-export interface GeoEventsTimeSeriesResponse {
-  granularity: "hourly" | "daily"
-  start_date: string
-  end_date: string
-  data: GeoEventsDataPoint[]
-}
+// Time-series shapes come from the generated client (the old manual
+// interfaces drifted: they lacked the percentile and unique_cities fields).
+export type {
+  TimeSeriesDataPoint,
+  TimeSeriesResponse,
+  GeoEventsDataPoint,
+  GeoEventsTimeSeriesResponse,
+} from "@/generated/api/types.gen"
 
 // ============================================================================
 // Types - GeoJSON API
@@ -172,43 +142,15 @@ export interface TopIPDTO {
   location: EmbeddedLocationDTO | null
 }
 
-export interface GeoJSONFeatureProperties {
-  id: number
-  geohash: string
-  country_code: string | null
-  country_name: string | null
-  state: string | null
-  state_code: string | null
-  city: string | null
-  postal_code: string | null
-  timezone: string | null
-  event_count: number
-  last_hit: string | null
-}
-
-export interface GeoJSONPointGeometry {
-  type: "Point"
-  coordinates: [number, number] // [longitude, latitude]
-}
-
-export interface GeoJSONFeature {
-  type: "Feature"
-  geometry: GeoJSONPointGeometry
-  properties: GeoJSONFeatureProperties
-}
-
-export interface GEOJSONFeatureStats {
-  events: number
-  countries: number
-  cities: number
-  locations: number
-}
-
-export interface GeoJSONFeatureCollection {
-  type: "FeatureCollection"
-  features: GeoJSONFeature[]
-  stats: GEOJSONFeatureStats
-}
+// GeoJSON shapes come from the generated client; the aliases keep the
+// codebase's GeoJSON* casing.
+export type {
+  GeoJsonFeatureCollection as GeoJSONFeatureCollection,
+  GeoJsonFeature as GeoJSONFeature,
+  GeoJsonFeatureProperties as GeoJSONFeatureProperties,
+  GeoJsonFeatureStats as GeoJSONFeatureStats,
+  GeoJsonPointGeometry as GeoJSONPointGeometry,
+} from "@/generated/api/types.gen"
 
 // ============================================================================
 // API Functions
@@ -369,6 +311,42 @@ export async function fetchTopCountries(params: TopIPsParams): Promise<TopCountr
       to_timestamp: params.toTimestamp,
       limit: params.limit ?? 10,
     },
+  })
+  return data
+}
+
+// ============================================================================
+// Analytics fetchers on the generated SDK (types flow from the OpenAPI schema)
+// ============================================================================
+
+export async function fetchTimeSeries(params: TimeSeriesParams) {
+  const { data } = await apiV1AnalyticsTimeSeriesGetTimeSeries({
+    query: { start_date: params.startDate, end_date: params.endDate },
+    throwOnError: true,
+  })
+  return data
+}
+
+export async function fetchGeoTimeSeries(params: TimeSeriesParams) {
+  const { data } = await apiV1AnalyticsGeoTimeSeriesGetGeoTimeSeries({
+    query: { start_date: params.startDate, end_date: params.endDate },
+    throwOnError: true,
+  })
+  return data
+}
+
+export async function fetchTopUrls(params: TimeSeriesParams & { limit?: number }) {
+  const { data } = await apiV1AnalyticsTopUrlsGetTopUrls({
+    query: { start_date: params.startDate, end_date: params.endDate, limit: params.limit ?? 25 },
+    throwOnError: true,
+  })
+  return data
+}
+
+export async function fetchTopUserAgents(params: TimeSeriesParams & { limit?: number }) {
+  const { data } = await apiV1AnalyticsTopUserAgentsGetTopUserAgents({
+    query: { start_date: params.startDate, end_date: params.endDate, limit: params.limit ?? 25 },
+    throwOnError: true,
   })
   return data
 }

--- a/resources/lib/client.ts
+++ b/resources/lib/client.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared configuration for the generated @hey-api fetch client.
+ * Mirrors the axios instance's 401 handling in lib/api.ts.
+ */
+import { client } from "@/generated/api/client.gen"
+
+client.setConfig({ baseUrl: "" }) // same-origin; session cookie rides along
+
+client.interceptors.response.use((response) => {
+  if (
+    response.status === 401 &&
+    window.location.pathname !== "/login" &&
+    !response.url.includes("/auth/login")
+  ) {
+    window.location.href = "/login"
+  }
+  return response
+})

--- a/resources/lib/queries.ts
+++ b/resources/lib/queries.ts
@@ -133,6 +133,10 @@ export interface UseTimeSeriesOptions {
 export interface UseGeoJSONOptions {
   /** Enable/disable the query */
   enabled?: boolean
+  /** Filter to these ISO country codes */
+  countryCodes?: string[]
+  /** Filter to these city names */
+  cities?: string[]
 }
 
 /**
@@ -140,18 +144,20 @@ export interface UseGeoJSONOptions {
  * Uses TimeRangeContext for time filtering.
  */
 export function useGeoJSON(options: UseGeoJSONOptions = {}) {
-  const { enabled = true } = options
+  const { enabled = true, countryCodes, cities } = options
   const { range, pollInterval, lastRefresh } = useTimeRange()
 
   return useQuery({
     // Query key uses lastRefresh for cache invalidation on manual refresh
-    queryKey: queryKeys.geo.geojson({ range }, lastRefresh),
+    queryKey: queryKeys.geo.geojson({ range, countryCodes, cities }, lastRefresh),
     // Compute date range at fetch time so polls get fresh data
     queryFn: () => {
       const { startDate, endDate } = parseTimeRange(range, Date.now())
       return fetchGeoJSON({
         fromTimestamp: startDate,
         toTimestamp: endDate,
+        countryCodes,
+        cities,
       })
     },
     enabled,

--- a/resources/lib/queries.ts
+++ b/resources/lib/queries.ts
@@ -7,9 +7,13 @@ import {
   fetchSummary,
   fetchLiveSummary,
   fetchGeoJSON,
+  fetchGeoTimeSeries,
   fetchGlobalTopIPs,
   fetchLocationTopIPs,
+  fetchTimeSeries,
   fetchTopCountries,
+  fetchTopUrls,
+  fetchTopUserAgents,
   fetchCumulativeTimeSeries,
   parseTimeRange,
   type SummaryParams,
@@ -33,6 +37,14 @@ export const queryKeys = {
       [...queryKeys.analytics.all, "live-summary", params, refreshKey] as const,
     cumulativeTimeSeries: (params: Record<string, unknown>, refreshKey?: number) =>
       [...queryKeys.analytics.all, "cumulative-time-series", params, refreshKey] as const,
+    timeSeries: (params: Record<string, unknown>, refreshKey?: number) =>
+      [...queryKeys.analytics.all, "time-series", params, refreshKey] as const,
+    geoTimeSeries: (params: Record<string, unknown>, refreshKey?: number) =>
+      [...queryKeys.analytics.all, "geo-time-series", params, refreshKey] as const,
+    topUrls: (params: Record<string, unknown>, refreshKey?: number) =>
+      [...queryKeys.analytics.all, "top-urls", params, refreshKey] as const,
+    topUserAgents: (params: Record<string, unknown>, refreshKey?: number) =>
+      [...queryKeys.analytics.all, "top-user-agents", params, refreshKey] as const,
   },
   geo: {
     all: ["geo"] as const,
@@ -266,6 +278,101 @@ export function useCumulativeTimeSeries(options: UseCumulativeTimeSeriesOptions 
         startDate,
         endDate,
       })
+    },
+    enabled,
+    staleTime: 60 * 1000,
+    refetchInterval: pollInterval || false,
+  })
+}
+
+// ============================================================================
+// Analytics page hooks (generated-SDK fetchers; types infer from the fetcher
+// so the generated shapes — percentiles, unique_cities — flow to the charts)
+// ============================================================================
+
+export interface UseAnalyticsQueryOptions {
+  /** Enable/disable the query */
+  enabled?: boolean
+}
+
+export interface UseTopListOptions extends UseAnalyticsQueryOptions {
+  /** Maximum number of rows to return */
+  limit?: number
+}
+
+/**
+ * Fetch per-bucket access-log metrics (requests, status, bytes, latency).
+ * Uses TimeRangeContext for time filtering.
+ */
+export function useTimeSeries(options: UseAnalyticsQueryOptions = {}) {
+  const { enabled = true } = options
+  const { range, pollInterval, lastRefresh } = useTimeRange()
+
+  return useQuery({
+    queryKey: queryKeys.analytics.timeSeries({ range }, lastRefresh),
+    queryFn: () => {
+      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      return fetchTimeSeries({ startDate, endDate })
+    },
+    enabled,
+    staleTime: 60 * 1000,
+    refetchInterval: pollInterval || false,
+  })
+}
+
+/**
+ * Fetch per-bucket geo-event metrics (events, unique IPs/countries/cities).
+ * Uses TimeRangeContext for time filtering.
+ */
+export function useGeoTimeSeries(options: UseAnalyticsQueryOptions = {}) {
+  const { enabled = true } = options
+  const { range, pollInterval, lastRefresh } = useTimeRange()
+
+  return useQuery({
+    queryKey: queryKeys.analytics.geoTimeSeries({ range }, lastRefresh),
+    queryFn: () => {
+      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      return fetchGeoTimeSeries({ startDate, endDate })
+    },
+    enabled,
+    staleTime: 60 * 1000,
+    refetchInterval: pollInterval || false,
+  })
+}
+
+/**
+ * Fetch the top URLs by hit count.
+ * Uses TimeRangeContext for time filtering.
+ */
+export function useTopUrls(options: UseTopListOptions = {}) {
+  const { enabled = true, limit = 25 } = options
+  const { range, pollInterval, lastRefresh } = useTimeRange()
+
+  return useQuery({
+    queryKey: queryKeys.analytics.topUrls({ range, limit }, lastRefresh),
+    queryFn: () => {
+      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      return fetchTopUrls({ startDate, endDate, limit })
+    },
+    enabled,
+    staleTime: 60 * 1000,
+    refetchInterval: pollInterval || false,
+  })
+}
+
+/**
+ * Fetch the top user agents by hit count.
+ * Uses TimeRangeContext for time filtering.
+ */
+export function useTopUserAgents(options: UseTopListOptions = {}) {
+  const { enabled = true, limit = 25 } = options
+  const { range, pollInterval, lastRefresh } = useTimeRange()
+
+  return useQuery({
+    queryKey: queryKeys.analytics.topUserAgents({ range, limit }, lastRefresh),
+    queryFn: () => {
+      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      return fetchTopUserAgents({ startDate, endDate, limit })
     },
     enabled,
     staleTime: 60 * 1000,

--- a/resources/main.css
+++ b/resources/main.css
@@ -95,11 +95,14 @@
   --border: oklch(0.928 0.006 264.531);
   --input: oklch(0.928 0.006 264.531);
   --ring: oklch(0.707 0.022 261.325);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
+  /* CVD-validated categorical slots (fixed order — assign series 1..5, never
+     cycle). Adjacent-pair deltas checked on white; aqua/yellow are sub-3:1 on
+     the surface, so multi-series charts must keep a legend or table view. */
+  --chart-1: #2a78d6;
+  --chart-2: #1baf7a;
+  --chart-3: #eda100;
+  --chart-4: #008300;
+  --chart-5: #4a3aa7;
   --sidebar: oklch(0.985 0.002 247.839);
   --sidebar-foreground: oklch(0.13 0.028 261.692);
   --sidebar-primary: oklch(0.21 0.034 264.665);
@@ -145,11 +148,13 @@
   --border: oklch(1 0 0 / 8%);
   --input: oklch(1 0 0 / 12%);
   --ring: oklch(0.72 0.15 192);
-  --chart-1: oklch(0.72 0.15 192);
-  --chart-2: oklch(0.65 0.18 160);
-  --chart-3: oklch(0.75 0.16 85);
-  --chart-4: oklch(0.65 0.22 300);
-  --chart-5: oklch(0.70 0.20 30);
+  /* Same brand hues re-stepped into the dark lightness band and validated
+     as a set against the card surface (all >= 3:1, worst adjacent CVD 30). */
+  --chart-1: #00a9a6;
+  --chart-2: #00a764;
+  --chart-3: #b58800;
+  --chart-4: #9e64ee;
+  --chart-5: #e9523f;
   --sidebar: oklch(0.14 0.022 250);
   --sidebar-foreground: oklch(0.92 0.01 220);
   --sidebar-primary: oklch(0.72 0.15 192);

--- a/resources/main.tsx
+++ b/resources/main.tsx
@@ -4,6 +4,7 @@ import { RouterProvider, createRouter } from "@tanstack/react-router"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import { routeTree } from "./routeTree.gen"
+import "@/lib/client"
 import "@/main.css"
 
 // Create a query client

--- a/resources/routeTree.gen.ts
+++ b/resources/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as MapRouteImport } from './routes/map'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as AnalyticsRouteImport } from './routes/analytics'
 import { Route as IndexRouteImport } from './routes/index'
 
 const MapRoute = MapRouteImport.update({
@@ -23,6 +24,11 @@ const LoginRoute = LoginRouteImport.update({
   path: '/login',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AnalyticsRoute = AnalyticsRouteImport.update({
+  id: '/analytics',
+  path: '/analytics',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -31,30 +37,34 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/analytics': typeof AnalyticsRoute
   '/login': typeof LoginRoute
   '/map': typeof MapRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/analytics': typeof AnalyticsRoute
   '/login': typeof LoginRoute
   '/map': typeof MapRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/analytics': typeof AnalyticsRoute
   '/login': typeof LoginRoute
   '/map': typeof MapRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/login' | '/map'
+  fullPaths: '/' | '/analytics' | '/login' | '/map'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/map'
-  id: '__root__' | '/' | '/login' | '/map'
+  to: '/' | '/analytics' | '/login' | '/map'
+  id: '__root__' | '/' | '/analytics' | '/login' | '/map'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AnalyticsRoute: typeof AnalyticsRoute
   LoginRoute: typeof LoginRoute
   MapRoute: typeof MapRoute
 }
@@ -75,6 +85,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LoginRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/analytics': {
+      id: '/analytics'
+      path: '/analytics'
+      fullPath: '/analytics'
+      preLoaderRoute: typeof AnalyticsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -87,6 +104,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AnalyticsRoute: AnalyticsRoute,
   LoginRoute: LoginRoute,
   MapRoute: MapRoute,
 }

--- a/resources/routes/analytics.tsx
+++ b/resources/routes/analytics.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { RequestsChart } from "@/components/analytics/requests-chart"
+import { StatusChart } from "@/components/analytics/status-chart"
+import { BytesChart } from "@/components/analytics/bytes-chart"
+import { LatencyChart } from "@/components/analytics/latency-chart"
+import { TopUrlsTable } from "@/components/analytics/top-urls-table"
+import { TopUserAgentsTable } from "@/components/analytics/top-user-agents-table"
+
+export const Route = createFileRoute("/analytics")({
+  component: AnalyticsPage,
+})
+
+function AnalyticsPage() {
+  return (
+    <div className="p-4 space-y-4">
+      <div className="grid gap-4 md:grid-cols-2">
+        <RequestsChart />
+        <StatusChart />
+        <BytesChart />
+        <LatencyChart />
+      </div>
+      <TopUrlsTable />
+      <TopUserAgentsTable />
+    </div>
+  )
+}

--- a/tests/integration/test_analytics_endpoints.py
+++ b/tests/integration/test_analytics_endpoints.py
@@ -1,0 +1,82 @@
+"""Repo-level tests for the analytics top-lists (and later time-series) endpoints.
+
+Tests go through the repositories rather than HTTP so they stay independent
+of auth wiring.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import text
+
+from geometrikks.domain.analytics.repositories import LiveStatsRepository
+
+# Wall-clock derived, hour-aligned (see test_repositories_pg.py for why).
+NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+
+
+async def _insert_log(session, *, ts, url, user_agent, status=200, bytes_sent=100, rt=0.01):
+    # access_logs is an id-only base: no created_at/updated_at columns.
+    await session.execute(text(
+        "INSERT INTO access_logs (timestamp, ip_address, method, url, "
+        "status_code, bytes_sent, request_time, user_agent) "
+        "VALUES (:ts, '10.0.0.1', 'GET', :url, :status, :bytes, :rt, :ua)"
+    ), {"ts": ts, "url": url, "status": status, "bytes": bytes_sent, "rt": rt, "ua": user_agent})
+
+
+async def test_top_urls_ordering_and_math(pg_session_maker, clean_tables):
+    ts = NOW - timedelta(hours=1)
+    async with pg_session_maker() as session:
+        for _ in range(5):
+            await _insert_log(session, ts=ts, url="/busy", user_agent="bot/1.0", bytes_sent=200)
+        await _insert_log(session, ts=ts, url="/busy", user_agent="bot/1.0", status=500, bytes_sent=200)
+        for _ in range(2):
+            await _insert_log(session, ts=ts, url="/quiet", user_agent="curl/8.0")
+        await session.commit()
+
+    async with pg_session_maker() as session:
+        rows = await LiveStatsRepository(session=session).get_top_urls(
+            NOW - timedelta(hours=2), NOW, limit=10
+        )
+
+    assert [r.url for r in rows] == ["/busy", "/quiet"]
+    busy = rows[0]
+    assert busy.hits == 6
+    assert busy.error_hits == 1
+    assert busy.total_bytes == 6 * 200
+    assert 0.005 < busy.avg_request_time < 0.02
+
+
+async def test_top_user_agents_ordering(pg_session_maker, clean_tables):
+    ts = NOW - timedelta(hours=1)
+    async with pg_session_maker() as session:
+        for _ in range(3):
+            await _insert_log(session, ts=ts, url="/a", user_agent="bot/1.0")
+        await _insert_log(session, ts=ts, url="/a", user_agent="curl/8.0")
+        await session.commit()
+
+    async with pg_session_maker() as session:
+        rows = await LiveStatsRepository(session=session).get_top_user_agents(
+            NOW - timedelta(hours=2), NOW, limit=10
+        )
+
+    assert [(r.user_agent, r.hits) for r in rows] == [("bot/1.0", 3), ("curl/8.0", 1)]
+
+
+async def test_top_lists_respect_limit_and_window(pg_session_maker, clean_tables):
+    inside = NOW - timedelta(hours=1)
+    outside = NOW - timedelta(hours=30)
+    async with pg_session_maker() as session:
+        for i in range(3):
+            await _insert_log(session, ts=inside, url=f"/u{i}", user_agent=f"ua{i}")
+        await _insert_log(session, ts=outside, url="/old", user_agent="old-ua")
+        await session.commit()
+
+    async with pg_session_maker() as session:
+        repo = LiveStatsRepository(session=session)
+        urls = await repo.get_top_urls(NOW - timedelta(hours=2), NOW, limit=2)
+        agents = await repo.get_top_user_agents(NOW - timedelta(hours=2), NOW, limit=10)
+
+    assert len(urls) == 2
+    assert all(r.url != "/old" for r in urls)
+    assert all(r.user_agent != "old-ua" for r in agents)

--- a/tests/integration/test_analytics_endpoints.py
+++ b/tests/integration/test_analytics_endpoints.py
@@ -80,3 +80,17 @@ async def test_top_lists_respect_limit_and_window(pg_session_maker, clean_tables
     assert len(urls) == 2
     assert all(r.url != "/old" for r in urls)
     assert all(r.user_agent != "old-ua" for r in agents)
+
+
+async def test_time_series_methods_survive_sub_24h_ranges(pg_session_maker, clean_tables):
+    """Regression: RAW granularity used to build nonexistent summary_raw_stats /
+    geo_summary_raw_stats table names. Sub-24h ranges must clamp to hourly."""
+    from geometrikks.domain.analytics.repositories import SummaryStatsRepository
+
+    async with pg_session_maker() as session:
+        repo = SummaryStatsRepository(session=session)
+        series = await repo.get_time_series(NOW - timedelta(hours=2), NOW)
+        geo_series = await repo.get_geo_time_series(NOW - timedelta(hours=2), NOW)
+
+    assert isinstance(series, list)
+    assert isinstance(geo_series, list)

--- a/tests/integration/test_percentile_caggs.py
+++ b/tests/integration/test_percentile_caggs.py
@@ -1,0 +1,119 @@
+"""Summary CAGGs must expose pct_agg and correct percentiles after upgrade."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import text
+
+from geometrikks.server.timescale import refresh_caggs_range
+
+# Derived from the wall clock, not hard-coded: the scratch DB has live
+# retention/refresh policies, so a fixed date would age out of their windows
+# (see test_repositories_pg.py). Hour-aligned for deterministic bucketing.
+NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+
+
+async def _seed_latency_data(session_maker) -> None:
+    """100 requests over 3 days: 99 at 10ms, one 10s outlier in the newest day."""
+    async with session_maker() as session:
+        for day in range(3):
+            ts = NOW - timedelta(days=day, hours=2)
+            for i in range(33):
+                # access_logs is an id-only base: no created_at/updated_at.
+                await session.execute(text(
+                    "INSERT INTO access_logs (timestamp, ip_address, method, url, "
+                    "status_code, bytes_sent, request_time) "
+                    "VALUES (:ts, '10.0.0.1', 'GET', '/x', 200, 100, :rt)"
+                ), {"ts": ts, "rt": 10.0 if (day == 0 and i == 0) else 0.01})
+        await session.commit()
+
+
+async def test_summary_caggs_have_pct_agg_column(pg_engine):
+    async with pg_engine.connect() as conn:
+        rows = await conn.execute(text("""
+            SELECT table_name, column_name FROM information_schema.columns
+            WHERE table_name IN ('summary_hourly_stats', 'summary_daily_stats')
+        """))
+        cols = {(r.table_name, r.column_name) for r in rows}
+    for view in ("summary_hourly_stats", "summary_daily_stats"):
+        assert (view, "pct_agg") in cols
+        assert (view, "p50_request_time") not in cols
+
+
+async def test_rolled_up_percentile_is_sane(pg_engine, pg_session_maker, clean_tables):
+    """The rolled-up p50 over all buckets must be ~10ms despite the 10s
+    outlier, and p99 must reflect the outlier's tail — and crucially
+    approx_percentile(rollup(pct_agg)) must execute at all."""
+    await _seed_latency_data(pg_session_maker)
+
+    await refresh_caggs_range(
+        pg_engine, start=NOW - timedelta(days=5), end=NOW + timedelta(hours=1),
+        caggs=["summary_hourly_stats"],
+    )
+
+    async with pg_engine.connect() as conn:
+        row = (await conn.execute(text("""
+            SELECT
+                approx_percentile(0.50, rollup(pct_agg)) AS p50,
+                approx_percentile(0.99, rollup(pct_agg)) AS p99
+            FROM summary_hourly_stats
+            WHERE bucket >= :start AND bucket < :end
+        """), {"start": NOW - timedelta(days=5), "end": NOW})).one()
+
+    assert 0.005 < row.p50 < 0.02, f"p50 {row.p50} should be ~0.01"
+    assert row.p99 > 0.01, "p99 must reflect the outlier's tail"
+
+
+async def test_repo_summary_and_time_series_percentiles(pg_engine, pg_session_maker, clean_tables):
+    """Repo reads percentiles via approx_percentile rollups on the CAGG path."""
+    from geometrikks.domain.analytics.repositories import SummaryStatsRepository
+
+    await _seed_latency_data(pg_session_maker)
+    await refresh_caggs_range(
+        pg_engine, start=NOW - timedelta(days=5), end=NOW + timedelta(hours=1),
+    )
+
+    async with pg_session_maker() as session:
+        repo = SummaryStatsRepository(session=session)
+        stats = await repo.get_summary(NOW - timedelta(days=3, hours=3), NOW)  # >24h -> CAGG path
+        series = await repo.get_time_series(NOW - timedelta(days=3, hours=3), NOW)
+
+    assert stats is not None and 0.005 < stats.p50_request_time < 0.02
+    assert len(series) >= 3
+    assert all(p.p50_request_time >= 0 for p in series)
+
+
+async def test_old_shape_summary_caggs_are_upgraded(pg_engine):
+    """setup_timescaledb must drop pre-percentile_agg summary CAGGs and
+    recreate them with pct_agg (the alpha-install upgrade path)."""
+    from geometrikks.config.settings import get_settings
+    from geometrikks.server.timescale import SUMMARY_CAGGS, setup_timescaledb
+
+    old_shape = """
+        CREATE MATERIALIZED VIEW {name}
+        WITH (timescaledb.continuous) AS
+        SELECT
+            time_bucket('{bucket}', timestamp) AS bucket,
+            COUNT(*) AS total_requests,
+            PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY request_time) AS p50_request_time
+        FROM access_logs
+        GROUP BY 1
+        WITH NO DATA
+    """
+    async with pg_engine.begin() as conn:
+        for cagg in SUMMARY_CAGGS:
+            await conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {cagg} CASCADE"))
+        await conn.execute(text(old_shape.format(name="summary_hourly_stats", bucket="1 hour")))
+        await conn.execute(text(old_shape.format(name="summary_daily_stats", bucket="1 day")))
+
+    await setup_timescaledb(pg_engine, get_settings().analytics)
+
+    async with pg_engine.connect() as conn:
+        rows = await conn.execute(text("""
+            SELECT table_name, column_name FROM information_schema.columns
+            WHERE table_name = ANY(:views)
+        """), {"views": SUMMARY_CAGGS})
+        cols = {(r.table_name, r.column_name) for r in rows}
+    for view in SUMMARY_CAGGS:
+        assert (view, "pct_agg") in cols
+        assert (view, "p50_request_time") not in cols

--- a/tests/integration/test_repositories_pg.py
+++ b/tests/integration/test_repositories_pg.py
@@ -143,3 +143,37 @@ async def test_geojson_event_counts_route_raw(pg_session_maker, clean_tables):
         rows = await repo.get_all_with_event_counts(NOW - timedelta(hours=23), NOW)
     assert len(rows) == 3
     assert sum(r.event_count for r in rows) == 9
+
+
+async def test_geojson_country_filter(pg_session_maker, clean_tables):
+    await seed(pg_session_maker, days_back=1, per_day=9)
+    async with pg_session_maker() as session:
+        repo = GeoLocationRepository(session=session)
+        all_rows = await repo.get_all_with_event_counts(NOW - timedelta(hours=23), NOW)
+        one_code = all_rows[0].location.country_code
+        one_city = all_rows[0].location.city
+        filtered = await repo.get_all_with_event_counts(
+            NOW - timedelta(hours=23), NOW, country_codes=[one_code]
+        )
+        city_filtered = await repo.get_all_with_event_counts(
+            NOW - timedelta(hours=23), NOW, cities=[one_city]
+        )
+    assert filtered and all(r.location.country_code == one_code for r in filtered)
+    assert len(filtered) <= len(all_rows)
+    assert city_filtered and all(r.location.city == one_city for r in city_filtered)
+
+
+async def test_geojson_country_filter_cagg_path(pg_engine, pg_session_maker, clean_tables):
+    """>24h range routes to the location CAGG; filters must apply there too."""
+    await seed(pg_session_maker, days_back=3, per_day=9)
+    await refresh_caggs_range(
+        pg_engine, start=NOW - timedelta(days=4), end=NOW + timedelta(hours=1),
+    )
+    async with pg_session_maker() as session:
+        repo = GeoLocationRepository(session=session)
+        all_rows = await repo.get_all_with_event_counts(NOW - timedelta(days=3, hours=2), NOW)
+        one_code = all_rows[0].location.country_code
+        filtered = await repo.get_all_with_event_counts(
+            NOW - timedelta(days=3, hours=2), NOW, country_codes=[one_code]
+        )
+    assert filtered and all(r.location.country_code == one_code for r in filtered)

--- a/tests/test_logparser.py
+++ b/tests/test_logparser.py
@@ -95,6 +95,52 @@ def test_regex_tester_invalid(load_unparseable_logs: list[str], ipv4_log_pattern
         assert bool(ipv4_log_pattern.match(line)) is False
         assert bool(ipv6_log_pattern.match(line)) is False
 
+def test_user_agent_fully_captured(ipv4_log_pattern: re.Pattern[str]) -> None:
+    """Regression: the user_agent group must capture the whole UA string.
+
+    The non-greedy ``(.+?)`` had no required trailing token (request_time and
+    upstream groups are optional, no ``$`` anchor), so it matched a single
+    character -- e.g. "Mozilla/5.0 ..." collapsed to "M". Anchoring the group
+    with the closing quote forces it to consume the full UA.
+    """
+    combined = (
+        '4.255.101.233 - - [28/Jul/2024:02:00:50 +0200] '
+        '"GET /manager/html HTTP/1.1" 301 162 "-" "Mozilla/5.0 zgrab/0.x"'
+    )
+    m = ipv4_log_pattern.match(combined)
+    assert m is not None
+    assert m.group("user_agent") == "Mozilla/5.0 zgrab/0.x"
+
+    # Project's custom format: anchoring also lets request_time parse cleanly.
+    custom = (
+        '1.2.3.4 - - [03/Aug/2024:13:14:17 +0200]"GET /i HTTP/2.0" 200 1024"-" '
+        'example.com "Mozilla/5.0 (X11)""0.002" "0.001""City" "CC"'
+    )
+    m2 = ipv4_log_pattern.match(custom)
+    assert m2 is not None
+    assert m2.group("user_agent") == "Mozilla/5.0 (X11)"
+    assert m2.group("request_time") == "0.002"
+
+
+def test_non_dash_referrer_does_not_swallow_following_fields(ipv4_log_pattern: re.Pattern[str]) -> None:
+    """Regression: the referrer/url field must not cross quotes.
+
+    ``URL_PATTERN`` used a greedy ``.+`` anchored only by a later ``"``. When the
+    quoted field held a real value (not ``-``), it swallowed host, user_agent and
+    the trailing fields, so user_agent ended up as the country code. Fixtures all
+    use ``"-"`` there, which matched the ``\\-`` alternative and hid the bug.
+    """
+    line = (
+        '1.2.3.4 - - [03/Aug/2024:13:14:17 +0200]"GET /p?a=1 HTTP/2.0" 200 1024'
+        '"http://ref.example/x" host.tld "curl/8.0""0.002" "0.001""City" "CC"'
+    )
+    m = ipv4_log_pattern.match(line)
+    assert m is not None
+    assert m.group("url") == "http://ref.example/x"
+    assert m.group("user_agent") == "curl/8.0"
+    assert m.group("request_time") == "0.002"
+    assert m.group("upstream_response_time") == "0.001"
+
 def test_get_ip_type(log_parser: LogParser) -> None:
     """Test the module-level get_ip_type function."""
     assert get_ip_type("10.10.10.1") == "PRIVATE"


### PR DESCRIPTION
## Summary

- **Percentile-correct summary CAGGs**: `summary_hourly_stats` / `summary_daily_stats` now store a mergeable `percentile_agg` (uddsketch) per bucket; repos read `approx_percentile(p, rollup(pct_agg))`. The old columns averaged per-bucket percentiles, which is not a percentile. Old-shape views are detected and auto-upgraded on startup (drop + recreate + bounded backfill over the raw retention window).
- **New analytics endpoints**: `GET /api/v1/analytics/time-series`, `/geo-time-series`, `/top-urls`, `/top-user-agents`. The time-series repo methods also got a RAW→HOURLY clamp — they previously built a nonexistent `summary_raw_stats` table name for ≤24h ranges.
- **Map filters**: repeatable `country_code` / `city` params on the geojson endpoint (`= ANY(:codes)` on both the RAW and CAGG branches) + multi-select chip comboboxes in the map controls.
- **Generated API client adopted**: new fetchers go through `@hey-api/openapi-ts` SDK; drifted manual GeoJSON/time-series interfaces deleted and re-exported from generated types; geojson + new-response DTO fields made required in the OpenAPI schema so the generated types are non-optional.
- **`/analytics` page**: requests / status-classes / bandwidth / latency (avg, p50, p95, p99) charts + top-URLs and top-user-agents tables. Chart palette (`--chart-1..5`) replaced with CVD-validated sets for both themes (the old light palette's 4xx/5xx hues were ΔE 7.3 apart under deuteranopia).
- **2c GeoMap fixes**: no more `<Source key=...>` remount on data refresh; fit-to-bounds uses a single pass instead of spreading thousands of coords into `Math.min/max`.

## Breaking / data note

The CAGG upgrade rebuilds summary data from raw logs. Raw retention defaults to 180 days, so **summary history older than `raw_retention_days` is permanently lost** on first startup after this change (see CHANGELOG).

## Verification

- [x] `uv run pytest` — 137 passed (incl. new integration tests: pct_agg shape, rolled-up percentile sanity, old-shape upgrade path, repo percentiles, RAW-clamp regression, top-lists math, geojson filters on both RAW and CAGG paths)
- [x] `bun run build` green (vite + strict tsc)
- [ ] Manual verify gate with a real multi-month dataset: analytics totals vs `zcat | wc -l`, CAGG percentiles vs a raw-range percentile query over the same window, map filter narrows features + stats, live map updates without Source remount