### PR TITLE
Phase 3: real-time live feed (WS pub/sub, map pulses, historical + live-tail access logs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The generated `@hey-api/openapi-ts` client is now the typed transport for
   the new frontend fetchers; the drifted hand-written GeoJSON/time-series
   interfaces were removed in favor of generated types.
+- Authenticated `/ws/live` WebSocket streaming committed ingestion events
+  (geo-events + access-logs) to the browser as batched, coalesced JSON
+  frames (~6.7 frames/s, per-frame event cap, and a `dropped` counter on
+  burst overflow). The handshake is authenticated by the same session
+  cookie as the REST API, and stays open when `APP_AUTH_DISABLED=true`.
+- Live geo-event pulses on the map, behind a "Live" toggle in the map
+  controls.
+- Historical + live-tail access-log views at `/access-logs`: a time-scoped,
+  newest-first, paginated table (History mode) and a virtualized live-tail
+  (Live mode, prepend + pause-on-hover), switched by a History/Live toggle.
+- Live-feed connection status indicator in the sidebar, with auto-reconnect
+  and exponential backoff.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Data is visualized with GeoJSON on a world map and on a summary dashbord.
 - Basic auth
 - Analytics page with different charts / stats etc
 - More map filtering options (Country,City etc)
-- Real time log feeds (Geolocation / Access Logs)
 - Batch import of access log files
 - Caching
 
@@ -117,6 +116,23 @@ APP_AUTH_DISABLED=true  # only safe behind an authenticating proxy
 
 In this mode the `/api/v1/auth/*` endpoints are not registered (404) and the
 sidebar hides the logout button.
+
+## Live feed
+
+GeoMetrikks streams committed ingestion events to the browser over a
+session-authenticated `/ws/live` WebSocket, batching and coalescing them into
+a few frames per second so the UI stays responsive under bursty log traffic.
+Two views consume it: the map's "Live" toggle, which pulses incoming
+geo-events on top of the base layers, and the Live mode on the
+`/access-logs` page, which prepends new rows to a virtualized table (pause
+on hover). A connection status indicator in the sidebar shows live-feed
+health and reconnects automatically with exponential backoff if the
+connection drops.
+
+The WebSocket handshake is authenticated by the same session cookie as the
+REST API, so it's guarded identically — anonymous connections are rejected
+unless auth is disabled. With `APP_AUTH_DISABLED=true` the WebSocket is left
+open, just like the API, for reverse-proxy deployments.
 
 ## Sending Nginx log metrics with request and upstream response times
 

--- a/geometrikks/api/v1/access_log_controller.py
+++ b/geometrikks/api/v1/access_log_controller.py
@@ -1,9 +1,13 @@
 """AccessLog API endpoints."""
 from __future__ import annotations
 
+from datetime import datetime
+from typing import Annotated
+
 from litestar import Controller, get
 from litestar.di import NamedDependency, Provide
 from litestar.pagination import OffsetPagination
+from litestar.params import QueryParameter
 from litestar.status_codes import HTTP_201_CREATED, HTTP_204_NO_CONTENT
 from advanced_alchemy.extensions.litestar import filters
 
@@ -12,6 +16,26 @@ from geometrikks.domain.logs.repositories import AccessLogRepository
 from geometrikks.domain.logs.dtos import AccessLogDTO
 
 from geometrikks.api.dependencies import provide_access_log_repo
+
+
+def build_list_filters(
+    from_timestamp: datetime | None,
+    to_timestamp: datetime | None,
+) -> list[filters.FilterTypes]:
+    """Newest-first ordering plus an optional inclusive [from, to] window on timestamp."""
+    result: list[filters.FilterTypes] = [
+        filters.OrderBy(field_name="timestamp", sort_order="desc"),
+    ]
+    if from_timestamp is not None or to_timestamp is not None:
+        result.append(
+            filters.OnBeforeAfter(
+                field_name="timestamp",
+                on_or_after=from_timestamp,
+                on_or_before=to_timestamp,
+            )
+        )
+    return result
+
 
 class AccessLogController(Controller):
     """Access log endpoints
@@ -31,9 +55,12 @@ class AccessLogController(Controller):
         self,
         access_log_repo: NamedDependency[AccessLogRepository],
         limit_offset: NamedDependency[filters.LimitOffset],
+        from_timestamp: Annotated[datetime | None, QueryParameter(required=False)] = None,
+        to_timestamp: Annotated[datetime | None, QueryParameter(required=False)] = None,
     ) -> OffsetPagination[AccessLog]:
-        """List all access logs with pagination."""
-        results, total = await access_log_repo.list_and_count(limit_offset)
+        """List access logs newest-first, optionally within a time window."""
+        list_filters = build_list_filters(from_timestamp, to_timestamp)
+        results, total = await access_log_repo.get_many_and_count(*list_filters, limit_offset)
         return OffsetPagination[AccessLog](
             items=results,
             total=total,

--- a/geometrikks/api/v1/access_log_controller.py
+++ b/geometrikks/api/v1/access_log_controller.py
@@ -8,7 +8,6 @@ from litestar import Controller, get
 from litestar.di import NamedDependency, Provide
 from litestar.pagination import OffsetPagination
 from litestar.params import QueryParameter
-from litestar.status_codes import HTTP_201_CREATED, HTTP_204_NO_CONTENT
 from advanced_alchemy.extensions.litestar import filters
 
 from geometrikks.domain.logs.models import AccessLog

--- a/geometrikks/api/v1/live_controller.py
+++ b/geometrikks/api/v1/live_controller.py
@@ -1,0 +1,117 @@
+"""Live event feed over WebSocket.
+
+Protocol: one JSON frame per message —
+  {"type": "batch", "events": [...], "dropped": n}
+Events are converted from post-commit ParsedLogRecords; frames flush every
+FLUSH_INTERVAL seconds with at most MAX_EVENTS_PER_FRAME events (overflow is
+counted in `dropped` — the browser gets a rate signal instead of melting).
+
+Auth: /ws/ paths are NOT excluded in AUTH_EXCLUDE_PATTERNS, so the session
+middleware authenticates the handshake exactly like an API request.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import Any
+
+from litestar import WebSocket, websocket
+from litestar.exceptions import WebSocketDisconnect
+
+from geometrikks.services.logparser.schemas import ParsedLogRecord
+
+logger = logging.getLogger(__name__)
+
+FLUSH_INTERVAL = 0.15          # seconds -> ~6.7 frames/s, under the ~10/s cap
+MAX_EVENTS_PER_FRAME = 100
+
+
+def record_to_events(record: ParsedLogRecord) -> list[dict[str, Any]]:
+    """Convert one committed record to wire events (0, 1, or 2)."""
+    events: list[dict[str, Any]] = []
+    if record.geo_data and record.ip_address:
+        g = record.geo_data
+        events.append({
+            "type": "geo_event",
+            "data": {
+                "timestamp": g.timestamp.isoformat(),
+                "ip_address": record.ip_address,
+                "latitude": g.latitude,
+                "longitude": g.longitude,
+                "city": g.city,
+                "country_code": g.country_code,
+            },
+        })
+    if record.access_log:
+        a = record.access_log
+        events.append({
+            "type": "access_log",
+            "data": {
+                "timestamp": a.timestamp.isoformat(),
+                "ip_address": a.ip_address,
+                "method": a.method,
+                "url": a.url,
+                "status_code": a.status_code,
+                "bytes_sent": a.bytes_sent,
+                "request_time": a.request_time,
+                "host": a.host,
+            },
+        })
+    return events
+
+
+async def _watch_disconnect(socket: WebSocket) -> None:
+    """Consume incoming messages so a client disconnect is noticed.
+
+    The handler is send-only; without a reader, a client that disconnects
+    while no events are flowing is never observed and its queue stays
+    subscribed forever (dead connections accumulate on quiet log files).
+    litestar raises WebSocketDisconnect from receive on close.
+    """
+    while True:
+        await socket.receive_data(mode="text")
+
+
+@websocket("/ws/live")
+async def live_feed(socket: WebSocket) -> None:
+    """Stream committed ingestion events, batched and coalesced."""
+    ingestion = getattr(socket.app.state, "ingestion_service", None)
+    await socket.accept()
+    if ingestion is None:
+        await socket.close(code=1013, reason="ingestion not running")  # 1013 = try again later
+        return
+
+    queue = ingestion.subscribe()
+    watcher = asyncio.create_task(_watch_disconnect(socket))
+    try:
+        pending: list[dict[str, Any]] = []
+        dropped = 0
+        while not watcher.done():
+            # Drain until the flush deadline.
+            deadline = asyncio.get_running_loop().time() + FLUSH_INTERVAL
+            while True:
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    break
+                try:
+                    record = await asyncio.wait_for(queue.get(), timeout=remaining)
+                except asyncio.TimeoutError:
+                    break
+                for event in record_to_events(record):
+                    if len(pending) >= MAX_EVENTS_PER_FRAME:
+                        dropped += 1
+                    else:
+                        pending.append(event)
+
+            if (pending or dropped) and not watcher.done():
+                await socket.send_json({"type": "batch", "events": pending, "dropped": dropped})
+                pending, dropped = [], 0
+    except WebSocketDisconnect:
+        pass  # client went away between the watcher check and the send
+    finally:
+        watcher.cancel()
+        with contextlib.suppress(asyncio.CancelledError, WebSocketDisconnect):
+            await watcher  # retrieve its exception so no "never retrieved" warning
+        ingestion.unsubscribe(queue)

--- a/geometrikks/server/auth.py
+++ b/geometrikks/server/auth.py
@@ -23,13 +23,15 @@ if TYPE_CHECKING:
     from geometrikks.config.settings import Settings
 
 # Paths that never require a session:
-# - "^/(?!api/|ws/)" — everything that is not under /api/ or /ws/ (the SPA
-#   shell, its assets, /health, /schema, /favicon...). The SPA must load
-#   unauthenticated so it can render the login page; /ws/ is *excluded from the
-#   exclusion* so the live-feed handshake is authenticated like an API request.
+# - "^/(?!api(/|$)|ws(/|$))" — everything that is not /api, /ws, or under them
+#   (the SPA shell, its assets, /health, /schema, /favicon...). The SPA must
+#   load unauthenticated so it can render the login page; /ws is *excluded from
+#   the exclusion* so the live-feed handshake is authenticated like an API
+#   request. The (/|$) boundary keeps bare "/ws" and "/api" authenticated too,
+#   not just their slash-suffixed children.
 # - the login endpoint itself.
 AUTH_EXCLUDE_PATTERNS: list[str] = [
-    "^/(?!api/|ws/)",
+    "^/(?!api(/|$)|ws(/|$))",
     "^/api/v1/auth/login$",
 ]
 

--- a/geometrikks/server/auth.py
+++ b/geometrikks/server/auth.py
@@ -23,12 +23,13 @@ if TYPE_CHECKING:
     from geometrikks.config.settings import Settings
 
 # Paths that never require a session:
-# - "^/(?!api/)" — everything that is not under /api/ (the SPA shell, its
-#   assets, /health, /schema, /favicon...). The SPA must load unauthenticated
-#   so it can render the login page.
+# - "^/(?!api/|ws/)" — everything that is not under /api/ or /ws/ (the SPA
+#   shell, its assets, /health, /schema, /favicon...). The SPA must load
+#   unauthenticated so it can render the login page; /ws/ is *excluded from the
+#   exclusion* so the live-feed handshake is authenticated like an API request.
 # - the login endpoint itself.
 AUTH_EXCLUDE_PATTERNS: list[str] = [
-    "^/(?!api/)",
+    "^/(?!api/|ws/)",
     "^/api/v1/auth/login$",
 ]
 

--- a/geometrikks/server/routes.py
+++ b/geometrikks/server/routes.py
@@ -7,6 +7,7 @@ from geometrikks.api.v1.access_log_controller import AccessLogController
 from geometrikks.api.v1.access_log_debug_controller import AccessLogDebugController
 from geometrikks.api.v1.analytics_controller import AnalyticsController
 from geometrikks.api.v1.auth_controller import AuthController
+from geometrikks.api.v1.live_controller import live_feed
 from geometrikks.api.v1.settings import read_settings
 from geometrikks.api.v1.stats import stats
 from geometrikks.api.health import health, health_ready
@@ -26,6 +27,7 @@ def get_route_handlers(*, include_auth: bool = True) -> list[ControllerRouterHan
         AccessLogController,
         AccessLogDebugController,
         AnalyticsController,
+        live_feed,
         read_settings,
         stats,
         health,

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -124,6 +124,9 @@ class LogIngestionService:
         self.store_debug_lines: bool = store_debug_lines
         self._queue_maxsize: int = queue_maxsize
 
+        # Live-feed fan-out: bounded queues, publish post-commit only.
+        self._subscribers: set[asyncio.Queue[ParsedLogRecord]] = set()
+
         # In-memory cache: geohash -> committed (or pending-commit) GeoLocation id.
         # Ids cached since the last successful commit are tracked so a rollback
         # can evict them (their rows never landed -> FK poison otherwise).
@@ -413,18 +416,24 @@ class LogIngestionService:
             return
         batch, self._batch = self._batch, []
         flushed = {"geo": 0, "log": 0, "debug": 0}
+        # Records that processed without raising; only these are published
+        # post-commit. A per-record failure rolls back earlier records of this
+        # batch (matching existing semantics), so reset the list on failure too.
+        committed_candidates: list[ParsedLogRecord] = []
 
         async with self._session_maker() as session:
             repos = self._repos_factory(session)
             for record in batch:
                 try:
                     await self._process_record(record, repos, flushed)
+                    committed_candidates.append(record)
                 except Exception as e:
                     logger.error(
                         "Failed to process record (rolling back batch): %s - raw_line preview: %.100s",
                         e,
                         record.raw_line[:100] if record.raw_line else "N/A",
                     )
+                    committed_candidates = []
                     try:
                         await session.rollback()
                     except Exception as rollback_err:
@@ -440,6 +449,7 @@ class LogIngestionService:
             try:
                 await session.commit()
                 self._uncommitted_geohashes.clear()
+                self._publish(committed_candidates)
             except Exception as e:
                 logger.error("Batch commit failed (rolling back): %s", e)
                 await session.rollback()
@@ -467,6 +477,32 @@ class LogIngestionService:
         """
         self._batch.extend(records)
         await self._flush_batch()
+
+    def subscribe(self, maxsize: int = 1000) -> asyncio.Queue[ParsedLogRecord]:
+        """Register a live-feed subscriber. Caller must unsubscribe()."""
+        queue: asyncio.Queue[ParsedLogRecord] = asyncio.Queue(maxsize=maxsize)
+        self._subscribers.add(queue)
+        return queue
+
+    def unsubscribe(self, queue: asyncio.Queue[ParsedLogRecord]) -> None:
+        self._subscribers.discard(queue)
+
+    def _publish(self, records: list[ParsedLogRecord]) -> None:
+        """Fan committed records out to subscribers; drop oldest when full.
+
+        Never blocks and never raises: a slow browser must not backpressure
+        ingestion.
+        """
+        for queue in self._subscribers:
+            for record in records:
+                try:
+                    queue.put_nowait(record)
+                except asyncio.QueueFull:
+                    try:
+                        queue.get_nowait()
+                        queue.put_nowait(record)
+                    except (asyncio.QueueEmpty, asyncio.QueueFull):
+                        pass
 
     def _to_access_log_model(self, parsed: ParsedAccessLog) -> AccessLog:
         """Convert ParsedAccessLog schema to ORM model."""

--- a/resources/components/access-logs/access-logs-table.tsx
+++ b/resources/components/access-logs/access-logs-table.tsx
@@ -1,0 +1,135 @@
+/**
+ * Historical access-logs table: server-paginated, newest-first, scoped to the
+ * global time range. Pairs with GET /api/v1/access-logs/.
+ */
+import { useState } from "react"
+import { ChevronLeft, ChevronRight } from "lucide-react"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useAccessLogs } from "@/lib/queries"
+import { formatBytes, formatDuration } from "@/lib/api"
+
+const PAGE_SIZE = 50
+
+function statusVariant(code: number): "destructive" | "outline" | "secondary" {
+  if (code >= 500) return "destructive"
+  if (code >= 400) return "outline"
+  return "secondary"
+}
+
+export function AccessLogsTable() {
+  const [page, setPage] = useState(1)
+  const { data, isLoading, isError, isPlaceholderData } = useAccessLogs({
+    currentPage: page,
+    pageSize: PAGE_SIZE,
+  })
+
+  const rows = data?.items ?? []
+  const total = data?.total ?? 0
+  const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE))
+
+  if (isError) {
+    return (
+      <div className="rounded-md border p-6 text-sm text-destructive">
+        Failed to load access logs.
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-md border">
+      <div className="overflow-x-auto">
+        <Table className="text-xs">
+          <TableHeader>
+            <TableRow>
+              <TableHead>Time</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Method</TableHead>
+              <TableHead>URL</TableHead>
+              <TableHead>IP</TableHead>
+              <TableHead className="text-right">Bytes</TableHead>
+              <TableHead className="text-right">Req time</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading
+              ? Array.from({ length: 10 }).map((_, i) => (
+                  <TableRow key={i}>
+                    {Array.from({ length: 7 }).map((__, j) => (
+                      <TableCell key={j}>
+                        <Skeleton className="h-4 w-full" />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              : rows.map((row) => (
+                  <TableRow key={row.id}>
+                    <TableCell className="whitespace-nowrap text-muted-foreground">
+                      {new Date(row.timestamp).toLocaleString()}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={statusVariant(row.statusCode)} className="tabular-nums">
+                        {row.statusCode}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="font-mono">{row.method ?? "-"}</TableCell>
+                    <TableCell
+                      className="max-w-[320px] truncate font-mono"
+                      title={row.url ?? undefined}
+                    >
+                      {row.url ?? "-"}
+                    </TableCell>
+                    <TableCell className="font-mono">{row.ipAddress}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatBytes(row.bytesSent)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatDuration(row.requestTime * 1000)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+            {!isLoading && rows.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={7} className="h-24 text-center text-muted-foreground">
+                  No access logs in this time range.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-between border-t px-3 py-2 text-xs text-muted-foreground">
+        <span>
+          {total.toLocaleString()} rows — page {page} of {pageCount}
+        </span>
+        <div className="flex gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page <= 1 || isPlaceholderData}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+          >
+            <ChevronLeft className="h-4 w-4" /> Prev
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= pageCount || isPlaceholderData}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Next <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/resources/components/access-logs/live-tail.tsx
+++ b/resources/components/access-logs/live-tail.tsx
@@ -1,0 +1,78 @@
+/**
+ * Live-tail view: prepends incoming access_log events, keeps at most
+ * MAX_ROWS, auto-scrolls to top unless the pointer is over the list.
+ */
+import { useRef, useState } from "react"
+import { useVirtualizer } from "@tanstack/react-virtual"
+import { Badge } from "@/components/ui/badge"
+import { useLiveEvents } from "@/lib/live-feed-context"
+import type { LiveEvent } from "@/lib/websocket"
+
+const MAX_ROWS = 500
+
+type AccessLogEvent = Extract<LiveEvent, { type: "access_log" }>["data"]
+
+export function LiveTail({ enabled }: { enabled: boolean }) {
+  const [rows, setRows] = useState<AccessLogEvent[]>([])
+  const [dropped, setDropped] = useState(0)
+  const [paused, setPaused] = useState(false)
+  const parentRef = useRef<HTMLDivElement>(null)
+
+  useLiveEvents((events, droppedCount) => {
+    if (paused) return
+    const logs = events
+      .filter((e): e is Extract<LiveEvent, { type: "access_log" }> => e.type === "access_log")
+      .map((e) => e.data)
+    if (logs.length === 0 && droppedCount === 0) return
+    setRows((prev) => [...logs.reverse(), ...prev].slice(0, MAX_ROWS))
+    if (droppedCount) setDropped((d) => d + droppedCount)
+    parentRef.current?.scrollTo({ top: 0 })
+  }, enabled)
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 32,
+    overscan: 20,
+  })
+
+  return (
+    <div className="rounded-md border">
+      <div className="flex items-center justify-between px-3 py-1.5 text-xs text-muted-foreground border-b">
+        <span>{paused ? "Paused (pointer over list)" : "Streaming"} — {rows.length} rows{dropped > 0 && `, ${dropped} dropped`}</span>
+      </div>
+      <div
+        ref={parentRef}
+        className="h-[600px] overflow-auto font-mono text-xs"
+        onMouseEnter={() => setPaused(true)}
+        onMouseLeave={() => setPaused(false)}
+      >
+        <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+          {virtualizer.getVirtualItems().map((item) => {
+            const row = rows[item.index]
+            return (
+              <div
+                key={item.key}
+                className="absolute left-0 w-full flex items-center gap-2 px-3 border-b border-border/40"
+                style={{ top: 0, height: item.size, transform: `translateY(${item.start}px)` }}
+              >
+                <span className="text-muted-foreground shrink-0">
+                  {new Date(row.timestamp).toLocaleTimeString()}
+                </span>
+                <Badge
+                  variant={row.status_code >= 500 ? "destructive" : row.status_code >= 400 ? "outline" : "secondary"}
+                  className="tabular-nums shrink-0"
+                >
+                  {row.status_code}
+                </Badge>
+                <span className="shrink-0 w-12">{row.method ?? "-"}</span>
+                <span className="truncate flex-1">{row.url ?? "-"}</span>
+                <span className="text-muted-foreground shrink-0">{row.ip_address}</span>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/resources/components/app-sidebar.tsx
+++ b/resources/components/app-sidebar.tsx
@@ -34,6 +34,7 @@ import {
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { fetchHealth, fetchMe, logout } from "@/lib/api"
+import { useLiveFeedStatus } from "@/lib/live-feed-context"
 
 const navigationItems = [
   {
@@ -260,6 +261,49 @@ function LiveIndicator({ collapsed }: { collapsed: boolean }) {
   )
 }
 
+function LiveFeedIndicator({ collapsed }: { collapsed: boolean }) {
+  // WebSocket live-feed status — distinct from the ingestion-health dot above.
+  // Lazy-connect: reads "Live feed off" until a consumer (map pulses or the
+  // access-logs live tail) subscribes to the shared connection.
+  const status = useLiveFeedStatus()
+  const color =
+    status === "connected"
+      ? "bg-emerald-400"
+      : status === "connecting"
+        ? "bg-amber-400 animate-pulse"
+        : "bg-sidebar-foreground/30"
+  const label =
+    status === "connected" ? "Live feed" : status === "connecting" ? "Connecting" : "Live feed off"
+  const tooltip =
+    status === "connected"
+      ? "Live event feed connected"
+      : status === "connecting"
+        ? "Connecting to live event feed"
+        : "Live feed idle (no active subscribers)"
+
+  if (collapsed) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="flex items-center justify-center py-1 mx-2">
+            <span className={cn("inline-flex w-2 h-2 rounded-full", color)} />
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="right">
+          <span>{tooltip}</span>
+        </TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-1 mx-2 text-xs text-sidebar-foreground/60">
+      <span className={cn("inline-flex w-2 h-2 rounded-full", color)} />
+      <span className="font-medium">{label}</span>
+    </div>
+  )
+}
+
 function LogoutButton() {
   const { state, isMobile } = useSidebar()
   const collapsed = isMobile ? false : state === "collapsed"
@@ -375,8 +419,9 @@ export function AppSidebar() {
       <SidebarSeparator className="opacity-50" />
 
       <SidebarContent>
-        {/* Live status indicator */}
+        {/* Live status indicators: ingestion health + websocket live feed */}
         <LiveIndicator collapsed={collapsed} />
+        <LiveFeedIndicator collapsed={collapsed} />
 
         <SidebarGroup className="mt-2">
           <SidebarGroupLabel

--- a/resources/components/map/GeoMap.tsx
+++ b/resources/components/map/GeoMap.tsx
@@ -17,6 +17,7 @@ import "maplibre-gl/dist/maplibre-gl.css"
 import { useGeoJSON, useGlobalTopIPs } from "@/lib/queries"
 import { useMapStyle } from "./hooks/useMapStyle"
 import { MapControls } from "./MapControls"
+import { LivePulses } from "./LivePulses"
 import { MapLegend } from "./MapLegend"
 import { MapPopup, type PopupInfo } from "./MapPopup"
 import { Card, CardContent } from "@/components/ui/card"
@@ -260,6 +261,7 @@ export default function GeoMap() {
 
   const [viewState, setViewState] = useState(INITIAL_VIEW_STATE)
   const [activeLayer, setActiveLayer] = useState<LayerType>("markers")
+  const [liveMode, setLiveMode] = useState(false)
   const [popup, setPopup] = useState<PopupInfo | null>(null)
 
   // Filter options come from the last UNFILTERED result (a second query just
@@ -445,6 +447,9 @@ export default function GeoMap() {
           </Source>
         )}
 
+        {/* Live geo-event pulses */}
+        <LivePulses enabled={liveMode} />
+
         {/* Popup */}
         {popup && activeLayer === "markers" && (
           <MapPopup
@@ -460,6 +465,8 @@ export default function GeoMap() {
       <MapControls
         activeLayer={activeLayer}
         onLayerChange={setActiveLayer}
+        liveMode={liveMode}
+        onLiveModeChange={setLiveMode}
         onFitBounds={fitToBounds}
         isLoading={isLoading}
         featureStats={geojson?.stats ?? { events: 0, countries: 0, cities: 0, locations: 0 }}

--- a/resources/components/map/LivePulses.tsx
+++ b/resources/components/map/LivePulses.tsx
@@ -1,0 +1,76 @@
+/**
+ * Transient pulse animation at live geo-event coordinates.
+ * One GeoJSON source ("live-pulses") + one circle layer; a rAF loop fades
+ * each pulse over PULSE_MS and prunes it. Concurrent pulses capped.
+ */
+import { useEffect, useRef } from "react"
+import { Layer, Source, useMap } from "react-map-gl/maplibre"
+import type { GeoJSONSource } from "maplibre-gl"
+import { useLiveEvents } from "@/lib/live-feed-context"
+
+const PULSE_MS = 1500
+const MAX_PULSES = 50
+
+interface Pulse {
+  lng: number
+  lat: number
+  born: number
+}
+
+export function LivePulses({ enabled }: { enabled: boolean }) {
+  const { current: map } = useMap()
+  const pulses = useRef<Pulse[]>([])
+  const raf = useRef<number>(0)
+
+  useLiveEvents((events) => {
+    const now = performance.now()
+    for (const e of events) {
+      if (e.type !== "geo_event") continue
+      pulses.current.push({ lng: e.data.longitude, lat: e.data.latitude, born: now })
+    }
+    if (pulses.current.length > MAX_PULSES) {
+      pulses.current = pulses.current.slice(-MAX_PULSES)
+    }
+  }, enabled)
+
+  useEffect(() => {
+    if (!enabled) {
+      pulses.current = []
+      return
+    }
+    const tick = () => {
+      const now = performance.now()
+      pulses.current = pulses.current.filter((p) => now - p.born < PULSE_MS)
+      const source = map?.getSource("live-pulses") as GeoJSONSource | undefined
+      source?.setData({
+        type: "FeatureCollection",
+        features: pulses.current.map((p) => ({
+          type: "Feature" as const,
+          geometry: { type: "Point" as const, coordinates: [p.lng, p.lat] },
+          properties: { age: (now - p.born) / PULSE_MS }, // 0 -> 1
+        })),
+      })
+      raf.current = requestAnimationFrame(tick)
+    }
+    raf.current = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf.current)
+  }, [enabled, map])
+
+  if (!enabled) return null
+  return (
+    <Source id="live-pulses" type="geojson" data={{ type: "FeatureCollection", features: [] }}>
+      <Layer
+        id="live-pulse-circles"
+        type="circle"
+        paint={{
+          "circle-radius": ["interpolate", ["linear"], ["get", "age"], 0, 4, 1, 22],
+          "circle-color": "rgba(34, 211, 238, 1)", // geo-cyan, matches the UI accent
+          "circle-opacity": ["interpolate", ["linear"], ["get", "age"], 0, 0.8, 1, 0],
+          "circle-stroke-width": 1.5,
+          "circle-stroke-color": "rgba(34, 211, 238, 0.9)",
+          "circle-stroke-opacity": ["interpolate", ["linear"], ["get", "age"], 0, 0.9, 1, 0],
+        }}
+      />
+    </Source>
+  )
+}

--- a/resources/components/map/MapControls.tsx
+++ b/resources/components/map/MapControls.tsx
@@ -20,7 +20,7 @@ import {
   useComboboxAnchor,
 } from "@/components/ui/combobox"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
-import { Flame, MapPin, Maximize2, Loader2, SlidersHorizontal, X } from "lucide-react"
+import { Flame, MapPin, Maximize2, Loader2, SlidersHorizontal, X, Radio } from "lucide-react"
 import { cn } from "@/lib/utils"
 import type { LayerType } from "./GeoMap"
 import { GeoJSONFeatureStats, TopIPDTO, formatNumber } from "@/lib/api"
@@ -29,6 +29,8 @@ import { GeoJSONFeatureStats, TopIPDTO, formatNumber } from "@/lib/api"
 interface MapControlsProps {
   activeLayer: LayerType
   onLayerChange: (layer: LayerType) => void
+  liveMode: boolean
+  onLiveModeChange: (enabled: boolean) => void
   onFitBounds: () => void
   isLoading?: boolean
   featureStats: GeoJSONFeatureStats
@@ -95,6 +97,8 @@ function FilterCombobox({
 export function MapControls({
   activeLayer,
   onLayerChange,
+  liveMode,
+  onLiveModeChange,
   onFitBounds,
   isLoading = false,
   featureStats,
@@ -178,6 +182,19 @@ export function MapControls({
             <span className="text-sm font-medium">Markers</span>
           </ToggleGroupItem>
         </ToggleGroup>
+        {/* Live geo-event pulses toggle (independent of the layer choice) */}
+        <Button
+          variant="outline"
+          onClick={() => onLiveModeChange(!liveMode)}
+          aria-pressed={liveMode}
+          className={cn(
+            "mt-1 cursor-pointer w-full justify-start gap-2 px-3",
+            liveMode && "bg-geo-cyan/15 text-geo-cyan border-geo-cyan/30"
+          )}
+        >
+          <Radio className={cn("h-4 w-4", liveMode && "animate-pulse")} />
+          <span className="text-sm font-medium">Live</span>
+        </Button>
       </Card>
 
       {/* Country / city filters */}

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -454,6 +454,8 @@ export type ApiV1AccessLogsListAccessLogsData = {
   query?: {
     currentPage?: number;
     pageSize?: number;
+    from_timestamp?: string | null;
+    to_timestamp?: string | null;
   };
   url: "/api/v1/access-logs";
 };

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -1484,6 +1484,44 @@
               "minimum": 1.0,
               "type": "integer"
             }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "from_timestamp",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "to_timestamp",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
           }
         ],
         "responses": {

--- a/resources/generated/routes.json
+++ b/resources/generated/routes.json
@@ -1,13 +1,6 @@
 {
   "litestar_version": "Version(major=2, minor=24, patch=0, release_level='final', serial=0)",
   "routes": {
-    "disabled_vite_hmr_http": {
-      "method": "get",
-      "methods": [
-        "GET"
-      ],
-      "uri": "/static/vite-hmr"
-    },
     "get_cumulative_time_series": {
       "method": "get",
       "methods": [
@@ -176,7 +169,9 @@
       ],
       "queryParameters": {
         "currentPage": "number | undefined",
-        "pageSize": "number | undefined"
+        "from_timestamp": "DateTime | undefined",
+        "pageSize": "number | undefined",
+        "to_timestamp": "DateTime | undefined"
       },
       "uri": "/api/v1/access-logs"
     },

--- a/resources/generated/routes.ts
+++ b/resources/generated/routes.ts
@@ -15,7 +15,6 @@ export type URI = string;
 
 /** All available route names */
 export type RouteName =
-  | 'disabled_vite_hmr_http'
   | 'get_cumulative_time_series'
   | 'get_geo_time_series'
   | 'get_geojson'
@@ -46,7 +45,6 @@ export type RouteName =
 
 /** Path parameter definitions per route */
 export interface RoutePathParams {
-  'disabled_vite_hmr_http': Record<string, never>;
   'get_cumulative_time_series': Record<string, never>;
   'get_geo_time_series': Record<string, never>;
   'get_geojson': Record<string, never>;
@@ -84,7 +82,6 @@ export interface RoutePathParams {
 
 /** Query parameter definitions per route */
 export interface RouteQueryParams {
-  'disabled_vite_hmr_http': Record<string, never>;
   'get_cumulative_time_series': {
     end_date: DateTime;
     start_date: DateTime;
@@ -146,7 +143,9 @@ export interface RouteQueryParams {
   };
   'list_access_logs': {
     currentPage?: number;
+    from_timestamp?: DateTime;
     pageSize?: number;
+    to_timestamp?: DateTime;
   };
   'list_geo_events': {
     currentPage?: number;
@@ -177,13 +176,6 @@ export type RouteParams<T extends RouteName> = MergeParams<RoutePathParams[T], R
 
 /** Route metadata */
 export const routeDefinitions = {
-  'disabled_vite_hmr_http': {
-    path: '/static/vite-hmr',
-    methods: ['GET'] as const,
-    method: 'get',
-    pathParams: [] as const,
-    queryParams: [] as const,
-  },
   'get_cumulative_time_series': {
     path: '/api/v1/analytics/time-series/cumulative',
     methods: ['GET'] as const,
@@ -287,7 +279,7 @@ export const routeDefinitions = {
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['currentPage', 'pageSize'] as const,
+    queryParams: ['currentPage', 'from_timestamp', 'pageSize', 'to_timestamp'] as const,
   },
   'list_geo_events': {
     path: '/api/v1/geo-events',

--- a/resources/lib/api.ts
+++ b/resources/lib/api.ts
@@ -372,6 +372,56 @@ export async function fetchCumulativeTimeSeries(params: TimeSeriesParams): Promi
 }
 
 // ============================================================================
+// Types & Functions - Access Logs API
+// ============================================================================
+
+export interface AccessLog {
+  id: number
+  timestamp: string
+  ipAddress: string
+  remoteUser: string | null
+  method: string | null
+  url: string | null
+  httpVersion: string | null
+  statusCode: number
+  bytesSent: number
+  referrer: string | null
+  userAgent: string | null
+  requestTime: number
+  upstreamResponseTime: number | null
+  host: string | null
+  countryCode: string | null
+  countryName: string | null
+  city: string | null
+}
+
+export interface AccessLogsPage {
+  items: AccessLog[]
+  total: number
+  limit: number
+  offset: number
+}
+
+export interface AccessLogsParams {
+  fromTimestamp: string
+  toTimestamp: string
+  currentPage?: number
+  pageSize?: number
+}
+
+export async function fetchAccessLogs(params: AccessLogsParams): Promise<AccessLogsPage> {
+  const { data } = await api.get<AccessLogsPage>("/access-logs/", {
+    params: {
+      from_timestamp: params.fromTimestamp,
+      to_timestamp: params.toTimestamp,
+      currentPage: params.currentPage ?? 1,
+      pageSize: params.pageSize ?? 50,
+    },
+  })
+  return data
+}
+
+// ============================================================================
 // Utility Functions
 // ============================================================================
 

--- a/resources/lib/live-feed-context.tsx
+++ b/resources/lib/live-feed-context.tsx
@@ -1,0 +1,27 @@
+import { createContext, useContext, useEffect, useRef, useState } from "react"
+import { liveFeed, type LiveEvent, type LiveFeedStatus } from "./websocket"
+
+const StatusContext = createContext<LiveFeedStatus>("disconnected")
+
+export function LiveFeedProvider({ children }: { children: React.ReactNode }) {
+  const [status, setStatus] = useState<LiveFeedStatus>("disconnected")
+  useEffect(() => liveFeed.onStatus(setStatus), [])
+  return <StatusContext.Provider value={status}>{children}</StatusContext.Provider>
+}
+
+export function useLiveFeedStatus(): LiveFeedStatus {
+  return useContext(StatusContext)
+}
+
+/** Subscribe to live events while enabled; cb identity may change freely. */
+export function useLiveEvents(
+  cb: (events: LiveEvent[], dropped: number) => void,
+  enabled: boolean,
+): void {
+  const cbRef = useRef(cb)
+  cbRef.current = cb
+  useEffect(() => {
+    if (!enabled) return
+    return liveFeed.onEvents((events, dropped) => cbRef.current(events, dropped))
+  }, [enabled])
+}

--- a/resources/lib/queries.ts
+++ b/resources/lib/queries.ts
@@ -15,12 +15,14 @@ import {
   fetchTopUrls,
   fetchTopUserAgents,
   fetchCumulativeTimeSeries,
+  fetchAccessLogs,
   parseTimeRange,
   type SummaryParams,
   type GlobalTopIPsResponse,
   type LocationTopIPsResponse,
   type TopCountriesResponse,
   type CumulativeTimeSeriesResponse,
+  type AccessLogsPage,
 } from "./api"
 import { useTimeRange } from "./time-range-context"
 
@@ -56,6 +58,11 @@ export const queryKeys = {
       [...queryKeys.geo.all, "location-top-ips", locationId, params, refreshKey] as const,
     topCountries: (params: Record<string, unknown>, refreshKey?: number) =>
       [...queryKeys.geo.all, "top-countries", params, refreshKey] as const,
+  },
+  accessLogs: {
+    all: ["access-logs"] as const,
+    list: (params: Record<string, unknown>, refreshKey?: number) =>
+      [...queryKeys.accessLogs.all, "list", params, refreshKey] as const,
   },
 }
 
@@ -382,6 +389,42 @@ export function useTopUserAgents(options: UseTopListOptions = {}) {
     },
     enabled,
     staleTime: 60 * 1000,
+    refetchInterval: pollInterval || false,
+  })
+}
+
+// ============================================================================
+// Access logs
+// ============================================================================
+
+export interface UseAccessLogsOptions {
+  currentPage?: number
+  pageSize?: number
+  enabled?: boolean
+}
+
+/**
+ * Fetch a page of historical access logs within the global time range.
+ * Server-side pagination; keeps the previous page visible while the next loads.
+ */
+export function useAccessLogs(options: UseAccessLogsOptions = {}) {
+  const { currentPage = 1, pageSize = 50, enabled = true } = options
+  const { range, pollInterval, lastRefresh } = useTimeRange()
+
+  return useQuery<AccessLogsPage>({
+    queryKey: queryKeys.accessLogs.list({ range, currentPage, pageSize }, lastRefresh),
+    queryFn: () => {
+      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      return fetchAccessLogs({
+        fromTimestamp: startDate,
+        toTimestamp: endDate,
+        currentPage,
+        pageSize,
+      })
+    },
+    enabled,
+    placeholderData: (prev) => prev, // v5 keepPreviousData: no blank flash while paging
+    staleTime: 15 * 1000,
     refetchInterval: pollInterval || false,
   })
 }

--- a/resources/lib/websocket.ts
+++ b/resources/lib/websocket.ts
@@ -1,0 +1,94 @@
+/**
+ * Reconnecting WebSocket client for /ws/live.
+ * Exponential backoff (1s -> 30s cap, reset on successful open).
+ * The connection is lazy: first onEvents subscriber connects, last one disconnects.
+ */
+
+export type LiveEvent =
+  | { type: "geo_event"; data: { timestamp: string; ip_address: string; latitude: number; longitude: number; city: string | null; country_code: string | null } }
+  | { type: "access_log"; data: { timestamp: string; ip_address: string; method: string | null; url: string | null; status_code: number; bytes_sent: number; request_time: number; host: string | null } }
+
+interface BatchFrame {
+  type: "batch"
+  events: LiveEvent[]
+  dropped: number
+}
+
+export type LiveFeedStatus = "connecting" | "connected" | "disconnected"
+
+type EventsListener = (events: LiveEvent[], dropped: number) => void
+type StatusListener = (status: LiveFeedStatus) => void
+
+export class LiveFeedClient {
+  private ws: WebSocket | null = null
+  private eventsListeners = new Set<EventsListener>()
+  private statusListeners = new Set<StatusListener>()
+  private status: LiveFeedStatus = "disconnected"
+  private backoffMs = 1000
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private shouldRun = false
+
+  private url(): string {
+    const proto = window.location.protocol === "https:" ? "wss:" : "ws:"
+    return `${proto}//${window.location.host}/ws/live`
+  }
+
+  onEvents(cb: EventsListener): () => void {
+    this.eventsListeners.add(cb)
+    if (this.eventsListeners.size === 1) this.connect()
+    return () => {
+      this.eventsListeners.delete(cb)
+      if (this.eventsListeners.size === 0) this.disconnect()
+    }
+  }
+
+  onStatus(cb: StatusListener): () => void {
+    this.statusListeners.add(cb)
+    cb(this.status)
+    return () => this.statusListeners.delete(cb)
+  }
+
+  connect(): void {
+    if (this.shouldRun) return
+    this.shouldRun = true
+    this.open()
+  }
+
+  disconnect(): void {
+    this.shouldRun = false
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer)
+    this.ws?.close()
+    this.ws = null
+    this.setStatus("disconnected")
+  }
+
+  private open(): void {
+    this.setStatus("connecting")
+    this.ws = new WebSocket(this.url())
+    this.ws.onopen = () => {
+      this.backoffMs = 1000
+      this.setStatus("connected")
+    }
+    this.ws.onmessage = (msg) => {
+      const frame = JSON.parse(msg.data) as BatchFrame
+      if (frame.type === "batch") {
+        this.eventsListeners.forEach((cb) => cb(frame.events, frame.dropped))
+      }
+    }
+    this.ws.onclose = () => {
+      this.setStatus("disconnected")
+      if (this.shouldRun) {
+        this.reconnectTimer = setTimeout(() => this.open(), this.backoffMs)
+        this.backoffMs = Math.min(this.backoffMs * 2, 30000)
+      }
+    }
+    this.ws.onerror = () => this.ws?.close()
+  }
+
+  private setStatus(status: LiveFeedStatus): void {
+    this.status = status
+    this.statusListeners.forEach((cb) => cb(status))
+  }
+}
+
+export const liveFeed = new LiveFeedClient()

--- a/resources/lib/websocket.ts
+++ b/resources/lib/websocket.ts
@@ -70,7 +70,16 @@ export class LiveFeedClient {
       this.setStatus("connected")
     }
     this.ws.onmessage = (msg) => {
-      const frame = JSON.parse(msg.data) as BatchFrame
+      // The server only ever sends JSON text frames; ignore anything else
+      // (a Blob/ArrayBuffer or malformed payload) rather than throwing and
+      // tearing down live updates.
+      if (typeof msg.data !== "string") return
+      let frame: BatchFrame
+      try {
+        frame = JSON.parse(msg.data) as BatchFrame
+      } catch {
+        return
+      }
       if (frame.type === "batch") {
         this.eventsListeners.forEach((cb) => cb(frame.events, frame.dropped))
       }

--- a/resources/routeTree.gen.ts
+++ b/resources/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as MapRouteImport } from './routes/map'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as AnalyticsRouteImport } from './routes/analytics'
+import { Route as AccessLogsRouteImport } from './routes/access-logs'
 import { Route as IndexRouteImport } from './routes/index'
 
 const MapRoute = MapRouteImport.update({
@@ -29,6 +30,11 @@ const AnalyticsRoute = AnalyticsRouteImport.update({
   path: '/analytics',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AccessLogsRoute = AccessLogsRouteImport.update({
+  id: '/access-logs',
+  path: '/access-logs',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -37,12 +43,14 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/access-logs': typeof AccessLogsRoute
   '/analytics': typeof AnalyticsRoute
   '/login': typeof LoginRoute
   '/map': typeof MapRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/access-logs': typeof AccessLogsRoute
   '/analytics': typeof AnalyticsRoute
   '/login': typeof LoginRoute
   '/map': typeof MapRoute
@@ -50,20 +58,22 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/access-logs': typeof AccessLogsRoute
   '/analytics': typeof AnalyticsRoute
   '/login': typeof LoginRoute
   '/map': typeof MapRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/analytics' | '/login' | '/map'
+  fullPaths: '/' | '/access-logs' | '/analytics' | '/login' | '/map'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/analytics' | '/login' | '/map'
-  id: '__root__' | '/' | '/analytics' | '/login' | '/map'
+  to: '/' | '/access-logs' | '/analytics' | '/login' | '/map'
+  id: '__root__' | '/' | '/access-logs' | '/analytics' | '/login' | '/map'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AccessLogsRoute: typeof AccessLogsRoute
   AnalyticsRoute: typeof AnalyticsRoute
   LoginRoute: typeof LoginRoute
   MapRoute: typeof MapRoute
@@ -92,6 +102,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AnalyticsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/access-logs': {
+      id: '/access-logs'
+      path: '/access-logs'
+      fullPath: '/access-logs'
+      preLoaderRoute: typeof AccessLogsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -104,6 +121,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AccessLogsRoute: AccessLogsRoute,
   AnalyticsRoute: AnalyticsRoute,
   LoginRoute: LoginRoute,
   MapRoute: MapRoute,

--- a/resources/routes/__root.tsx
+++ b/resources/routes/__root.tsx
@@ -20,6 +20,7 @@ import { Separator } from "@/components/ui/separator"
 import { AppSidebar } from "@/components/app-sidebar"
 import { ModeToggle } from "@/components/mode-toggle"
 import { TimeRangeProvider } from "@/lib/time-range-context"
+import { LiveFeedProvider } from "@/lib/live-feed-context"
 import { TimeRangeToolbar } from "@/components/time-range-toolbar"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -91,6 +92,7 @@ function RootLayout() {
     <ThemeProvider defaultTheme="dark" storageKey="geometrikks-theme">
       <TooltipProvider delayDuration={0}>
         <TimeRangeProvider>
+          <LiveFeedProvider>
           <SidebarProvider defaultOpen={true}>
             <AppSidebar />
             <SidebarInset className="bg-background">
@@ -114,6 +116,7 @@ function RootLayout() {
               </main>
             </SidebarInset>
           </SidebarProvider>
+          </LiveFeedProvider>
         </TimeRangeProvider>
       </TooltipProvider>
     </ThemeProvider>

--- a/resources/routes/access-logs.tsx
+++ b/resources/routes/access-logs.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { AccessLogsTable } from "@/components/access-logs/access-logs-table"
+
+export const Route = createFileRoute("/access-logs")({
+  component: AccessLogsPage,
+})
+
+function AccessLogsPage() {
+  return (
+    <div className="p-4">
+      <AccessLogsTable />
+    </div>
+  )
+}

--- a/resources/routes/access-logs.tsx
+++ b/resources/routes/access-logs.tsx
@@ -1,14 +1,37 @@
+import { useState } from "react"
 import { createFileRoute } from "@tanstack/react-router"
+import { History, Radio } from "lucide-react"
+import { Button } from "@/components/ui/button"
 import { AccessLogsTable } from "@/components/access-logs/access-logs-table"
+import { LiveTail } from "@/components/access-logs/live-tail"
 
 export const Route = createFileRoute("/access-logs")({
   component: AccessLogsPage,
 })
 
+type Mode = "history" | "live"
+
 function AccessLogsPage() {
+  const [mode, setMode] = useState<Mode>("history")
   return (
-    <div className="p-4">
-      <AccessLogsTable />
+    <div className="p-4 space-y-4">
+      <div className="flex justify-end gap-1">
+        <Button
+          variant={mode === "history" ? "default" : "outline"}
+          size="sm"
+          onClick={() => setMode("history")}
+        >
+          <History className="h-4 w-4 mr-2" /> History
+        </Button>
+        <Button
+          variant={mode === "live" ? "default" : "outline"}
+          size="sm"
+          onClick={() => setMode("live")}
+        >
+          <Radio className="h-4 w-4 mr-2" /> Live tail
+        </Button>
+      </div>
+      {mode === "history" ? <AccessLogsTable /> : <LiveTail enabled={mode === "live"} />}
     </div>
   )
 }

--- a/tests/integration/test_access_logs_list_pg.py
+++ b/tests/integration/test_access_logs_list_pg.py
@@ -1,0 +1,50 @@
+"""Ordering + time-window filtering for the access-logs list, on real TimescaleDB."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from advanced_alchemy.extensions.litestar import filters
+from sqlalchemy import text
+
+from geometrikks.api.v1.access_log_controller import build_list_filters
+from geometrikks.domain.logs.repositories import AccessLogRepository
+
+# Wall-clock-relative so seeds stay inside the raw-retention window (see conftest).
+NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+
+
+async def _insert(session_maker, ts: datetime, ip: str) -> None:
+    async with session_maker() as session:
+        await session.execute(
+            text(
+                "INSERT INTO access_logs (timestamp, ip_address, method, url, "
+                " status_code, bytes_sent, request_time) "
+                "VALUES (:ts, :ip, 'GET', '/x', 200, 100, 0.01)"
+            ),
+            {"ts": ts, "ip": ip},
+        )
+        await session.commit()
+
+
+async def test_list_orders_newest_first(pg_session_maker, clean_tables) -> None:
+    await _insert(pg_session_maker, NOW - timedelta(hours=2), "10.0.0.1")
+    await _insert(pg_session_maker, NOW - timedelta(hours=1), "10.0.0.2")
+    async with pg_session_maker() as session:
+        repo = AccessLogRepository(session=session)
+        results, total = await repo.get_many_and_count(
+            *build_list_filters(None, None), filters.LimitOffset(50, 0)
+        )
+    assert total == 2
+    assert [str(r.ip_address) for r in results] == ["10.0.0.2", "10.0.0.1"]
+
+
+async def test_list_window_excludes_rows_outside_range(pg_session_maker, clean_tables) -> None:
+    await _insert(pg_session_maker, NOW - timedelta(days=2), "10.0.0.9")
+    await _insert(pg_session_maker, NOW - timedelta(hours=1), "10.0.0.2")
+    async with pg_session_maker() as session:
+        repo = AccessLogRepository(session=session)
+        results, total = await repo.get_many_and_count(
+            *build_list_filters(NOW - timedelta(hours=3), NOW), filters.LimitOffset(50, 0)
+        )
+    assert total == 1
+    assert str(results[0].ip_address) == "10.0.0.2"

--- a/tests/test_access_log_controller.py
+++ b/tests/test_access_log_controller.py
@@ -1,0 +1,29 @@
+"""Filter construction for the historical access-logs list endpoint."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from advanced_alchemy.extensions.litestar import filters
+
+from geometrikks.api.v1.access_log_controller import build_list_filters
+
+
+def test_orders_newest_first_by_default() -> None:
+    result = build_list_filters(None, None)
+    order = next(f for f in result if isinstance(f, filters.OrderBy))
+    assert order.field_name == "timestamp"
+    assert order.sort_order == "desc"
+
+
+def test_no_window_when_both_bounds_none() -> None:
+    result = build_list_filters(None, None)
+    assert not any(isinstance(f, filters.OnBeforeAfter) for f in result)
+
+
+def test_adds_window_when_bounds_present() -> None:
+    start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    end = datetime(2026, 7, 2, tzinfo=timezone.utc)
+    window = next(f for f in build_list_filters(start, end) if isinstance(f, filters.OnBeforeAfter))
+    assert window.field_name == "timestamp"
+    assert window.on_or_after == start
+    assert window.on_or_before == end

--- a/tests/test_auth_endpoints.py
+++ b/tests/test_auth_endpoints.py
@@ -9,7 +9,10 @@ from litestar.testing import TestClient
 
 from geometrikks.config.settings import Settings
 from geometrikks.api.v1.auth_controller import AuthController
+from geometrikks.api.v1.live_controller import live_feed
 from geometrikks.server.auth import build_auth_state, create_session_auth
+
+from tests.test_live_ws import FakeIngestion
 
 
 @get("/api/v1/protected")
@@ -26,10 +29,13 @@ def make_app(**settings_kwargs) -> Litestar:
     settings = Settings(admin_user="admin", admin_password="bestpasswordintheworldnojoke", **settings_kwargs)
     session_auth = create_session_auth(settings)
     app = Litestar(
-        route_handlers=[AuthController, protected, fake_health],
+        route_handlers=[AuthController, protected, fake_health, live_feed],
         on_app_init=[session_auth.on_app_init],
     )
     app.state.auth_state = build_auth_state(settings)
+    # A working ingestion service so the authenticated branch streams rather
+    # than taking the 1013-close (no-service) path.
+    app.state.ingestion_service = FakeIngestion()
     return app
 
 
@@ -69,6 +75,39 @@ def test_login_logout_flow():
 
         assert client.post("/api/v1/auth/logout").status_code == 204
         assert client.get("/api/v1/protected").status_code == 401
+
+
+def test_ws_live_rejected_without_session():
+    from litestar.exceptions import WebSocketDisconnect
+
+    with TestClient(app=make_app()) as client:
+        # The middleware's NotAuthorizedException closes the handshake
+        # (4000 + 401 = 4401), surfaced by the test client as a disconnect.
+        with pytest.raises(WebSocketDisconnect):
+            with client.websocket_connect("/ws/live") as ws:
+                ws.receive_json(timeout=2)
+
+
+def test_ws_live_streams_after_login():
+    with TestClient(app=make_app()) as client:
+        res = client.post(
+            "/api/v1/auth/login",
+            json={"username": "admin", "password": "bestpasswordintheworldnojoke"},
+        )
+        assert res.status_code == 200
+        # Same client -> the session cookie persists onto the WS handshake.
+        ingestion = client.app.state.ingestion_service
+        with client.websocket_connect("/ws/live") as ws:
+            ingestion.queue.put_nowait(_ws_record())
+            frame = ws.receive_json(timeout=5)
+        assert frame["type"] == "batch"
+        assert [e["type"] for e in frame["events"]] == ["geo_event", "access_log"]
+
+
+def _ws_record():
+    from tests.test_live_ws import make_record
+
+    return make_record()
 
 
 def test_create_app_requires_password_when_auth_enabled(monkeypatch):

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 
 import asyncio
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+from geohash2 import encode
 from geoip2.database import Reader
 
 from geometrikks.domain.geo.models import GeoEvent, GeoLocation
@@ -429,9 +431,6 @@ async def test_committed_locations_survive_in_cache_as_ids(tmp_path: Path) -> No
 @pytest.mark.asyncio
 async def test_flush_records_writes_through_batch_machinery() -> None:
     """flush_records must reuse _flush_batch (cache + rollback semantics)."""
-    from datetime import datetime, timezone
-    from geohash2 import encode
-
     service, _repos, sessions = make_service([])
 
     # Build ParsedLogRecord objects for TEST_DB_IPS
@@ -517,3 +516,61 @@ async def test_flush_records_writes_through_batch_machinery() -> None:
     assert service.pending_records == 0
     assert len(sessions) == 1 and sessions[0].commits == 1
     assert service.total_processed == len(records)
+
+
+def make_parsed_record(ip: str) -> ParsedLogRecord:
+    """Minimal geo+log record (same field shape as the flush_records test data)."""
+    ts = datetime.now(timezone.utc)
+    return ParsedLogRecord(
+        ip_address=ip,
+        geo_data=ParsedGeoData(
+            latitude=51.5142, longitude=-0.0931, geohash=encode(51.5142, -0.0931),
+            country_code="GB", country_name="United Kingdom", city="London",
+            timestamp=ts,
+        ),
+        access_log=ParsedAccessLog(
+            timestamp=ts, ip_address=ip, remote_user=None, method="GET",
+            url="/", http_version="HTTP/1.1", status_code=200, bytes_sent=1024,
+            referrer=None, user_agent="test-agent", request_time=0.002,
+            upstream_response_time=None, host="example.com",
+            country_code="GB", country_name="United Kingdom", city="London",
+        ),
+        raw_line=make_log_line(ip),
+    )
+
+
+async def test_pubsub_subscribers_receive_committed_records() -> None:
+    service, _repos, _sessions = make_service([])
+    q = service.subscribe()
+    records = [make_parsed_record(ip) for ip in TEST_DB_IPS]
+
+    await service.flush_records(records)
+
+    got = [q.get_nowait() for _ in range(len(records))]
+    assert [r.ip_address for r in got] == [r.ip_address for r in records]
+
+
+async def test_pubsub_unsubscribed_queue_gets_nothing() -> None:
+    service, _repos, _sessions = make_service([])
+    q = service.subscribe()
+    service.unsubscribe(q)
+    await service.flush_records([make_parsed_record(TEST_DB_IPS[0])])
+    assert q.empty()
+
+
+async def test_pubsub_failed_commit_publishes_nothing() -> None:
+    service, repos, _sessions = make_service([])
+    repos.fail_next_commits = 1
+    q = service.subscribe()
+    await service.flush_records([make_parsed_record(TEST_DB_IPS[0])])
+    assert q.empty(), "post-commit publish only — rolled-back records must not stream"
+
+
+async def test_pubsub_full_subscriber_drops_oldest_not_ingestion() -> None:
+    service, _repos, _sessions = make_service([])
+    q = service.subscribe(maxsize=1)
+    r1, r2 = (make_parsed_record(ip) for ip in TEST_DB_IPS)
+    await service.flush_records([r1])
+    await service.flush_records([r2])   # must not block or raise
+    assert q.qsize() == 1
+    assert q.get_nowait().ip_address == r2.ip_address

--- a/tests/test_live_ws.py
+++ b/tests/test_live_ws.py
@@ -1,0 +1,93 @@
+"""Wire-format conversion + WS streaming behavior."""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+from litestar import Litestar
+from litestar.testing import TestClient
+
+from geometrikks.services.logparser.schemas import ParsedAccessLog, ParsedGeoData, ParsedLogRecord
+
+TS = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+
+
+def make_record(with_geo: bool = True, with_log: bool = True) -> ParsedLogRecord:
+    geo = ParsedGeoData(
+        latitude=51.5, longitude=-0.09, geohash="gcpvj", country_code="GB",
+        country_name="UK", timestamp=TS, city="London",
+    ) if with_geo else None
+    log = ParsedAccessLog(
+        timestamp=TS, ip_address="81.2.69.142", remote_user=None, method="GET",
+        url="/x", http_version="1.1", status_code=200, bytes_sent=123,
+        referrer=None, user_agent="curl", request_time=0.01,
+        upstream_response_time=None, host="example.com", country_code="GB",
+        country_name="UK", city="London",
+    ) if with_log else None
+    return ParsedLogRecord(
+        ip_address="81.2.69.142", geo_data=geo, access_log=log, raw_line="x",
+    )
+
+
+class TestRecordToEvents:
+    def test_full_record_yields_both_events(self):
+        from geometrikks.api.v1.live_controller import record_to_events
+        events = record_to_events(make_record())
+        types = [e["type"] for e in events]
+        assert types == ["geo_event", "access_log"]
+        geo = events[0]["data"]
+        assert geo["latitude"] == 51.5 and geo["country_code"] == "GB"
+        log = events[1]["data"]
+        assert log["status_code"] == 200 and log["url"] == "/x"
+
+    def test_geo_only_record(self):
+        from geometrikks.api.v1.live_controller import record_to_events
+        events = record_to_events(make_record(with_log=False))
+        assert [e["type"] for e in events] == ["geo_event"]
+
+    def test_malformed_record_yields_nothing(self):
+        from geometrikks.api.v1.live_controller import record_to_events
+        assert record_to_events(make_record(with_geo=False, with_log=False)) == []
+
+
+class FakeIngestion:
+    """subscribe/unsubscribe stub the handler can drive."""
+
+    def __init__(self) -> None:
+        self.queue: asyncio.Queue = asyncio.Queue()
+        self.unsubscribed = False
+
+    def subscribe(self, maxsize: int = 1000):
+        return self.queue
+
+    def unsubscribe(self, queue) -> None:
+        self.unsubscribed = True
+
+
+def make_app(ingestion) -> Litestar:
+    from geometrikks.api.v1.live_controller import live_feed
+    app = Litestar(route_handlers=[live_feed])
+    app.state.ingestion_service = ingestion
+    return app
+
+
+def test_ws_streams_batch_frames():
+    ingestion = FakeIngestion()
+    with TestClient(app=make_app(ingestion)) as client:
+        with client.websocket_connect("/ws/live") as ws:
+            ingestion.queue.put_nowait(make_record())
+            frame = ws.receive_json(timeout=5)
+    assert frame["type"] == "batch"
+    assert frame["dropped"] == 0
+    assert [e["type"] for e in frame["events"]] == ["geo_event", "access_log"]
+    assert ingestion.unsubscribed is True
+
+
+def test_ws_closes_when_no_ingestion_service():
+    import pytest
+    from litestar.exceptions import WebSocketDisconnect  # NOT starlette — litestar has no starlette dependency
+
+    with TestClient(app=make_app(None)) as client:
+        with pytest.raises(WebSocketDisconnect):
+            with client.websocket_connect("/ws/live") as ws:
+                ws.receive_json(timeout=2)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,11 @@ export default defineConfig({
         target: "http://localhost:8000",
         changeOrigin: true,
       },
+      "/ws": {
+        target: "http://localhost:8000",
+        ws: true,
+        changeOrigin: true,
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
## Phase 3 — Real-Time Live Feed

Live events now stream from ingestion to the browser end-to-end.

### What's included
- **`/ws/live` WebSocket** — session-authenticated, fed by an in-process post-commit pub/sub in the ingestion service. Events are published **only after a successful commit** (rolled-back rows never stream), batched every 150 ms and coalesced into one frame `{type:"batch", events:[...], dropped:n}`, ~6.7 frames/s with a 100-events/frame cap. Slow subscribers lose oldest messages (bounded queues, drop-oldest) — a slow browser can **never** backpressure ingestion.
- **Live map pulses** — transient geo-event pulses behind a "Live" toggle in the map controls (GeoJSON source + rAF fade, concurrent-pulse cap).
- **`/access-logs` page** — historical, time-scoped, newest-first paginated table (History mode) plus a virtualized **live-tail** (Live mode, prepend + pause-on-hover), switched by a History/Live toggle. Backend `GET /api/v1/access-logs/` gained newest-first ordering + an optional `[from_timestamp, to_timestamp]` window.
- **Sidebar connection status** — live-feed health dot with auto-reconnect (exponential backoff, 1s → 30s).

### Auth
The WebSocket handshake is guarded by the same session cookie as the REST API (the `AUTH_EXCLUDE_PATTERNS` regex was narrowed so `/ws/*` is authenticated). With `APP_AUTH_DISABLED=true` the WebSocket is open, just like the API — reverse-proxy mode.

### Verification
- **Backend suite:** `uv run pytest` → **155 passed, 0 warnings**.
- **Integration:** access-logs ordering/time-window tests ran against a live TimescaleDB (`tests/integration/test_access_logs_list_pg.py`) → passed.
- **Frontend:** `bun run build` green (tsc type-check + bundle).
- **Manual live-feed check:** verified working — pulses on the map + rows streaming into the Live-tail view; kill server → sidebar goes disconnected → restart → auto-reconnects and streaming resumes.

### Accepted v0.1 notes
- Queue-level drop-oldest is not reflected in the frame `dropped` counter (that counter only reflects per-frame overflow). Documented, fine for v0.1.
- `_watch_disconnect` reads text-only; no browser client sends WS data, so binary frames are treated as a disconnect (theoretical edge).
