### PR TITLE
Analytics page (issue #14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed stacking of the moving point pulse.
 - Live map packets now complete their route before coalesced follow-up traffic
   from the same visual corridor begins.
+  - Analytics page: Bandwidth card fix - Decimal-as-JSON-string was capping the Y-axis; now coerced to int.
 
 ### Added 
 
 - Add search and filter options to access logs.
 - Add more columns on the live tail access log view.
+- Analytics page: Selectable chart granularity - Auto / Hourly / Daily selector; never RAW above 24h, falls back to get_stats_granularity, avoids hourly buckets on ranges above 7d.
+- Analytics page: Added Top IPs and Top Countries / Cities cards (new API endpoints + tables).
+- Added custom absolute date-range picker (mobile-friendly)
+- Analytics page: Country / City / IP filters (multi-select + manual IP entry) wired to all charts and top-lists.
+- Added CAGG gap backfill - recovers history that predates refresh coverage so charts and top-lists agree.
 
 
 ## [0.2.1] - 2026-07-13

--- a/geometrikks/api/v1/analytics_controller.py
+++ b/geometrikks/api/v1/analytics_controller.py
@@ -29,6 +29,12 @@ from geometrikks.domain.analytics.dtos import (
     TopUrlsResponse,
     TopUserAgentDTO,
     TopUserAgentsResponse,
+    TopIpDTO,
+    TopIpsResponse,
+    TopCountryStatsDTO,
+    TopCountriesStatsResponse,
+    TopCityStatsDTO,
+    TopCitiesResponse,
 )
 from geometrikks.domain.analytics.repositories import StatsGranularity, get_stats_granularity
 
@@ -557,5 +563,80 @@ class AnalyticsController(Controller):
             start_date=start_date.isoformat(),
             end_date=end_date.isoformat(),
             items=[TopUserAgentDTO(**vars(r)) for r in rows],
+        )
+
+    @get("/top-ips", description="Top client IPs by hits from raw access logs (time-bounded).")
+    async def get_top_ips(
+        self,
+        live_stats_repo: NamedDependency[LiveStatsRepository],
+        start_date: Annotated[
+            datetime,
+            Parameter(description="Start date (ISO 8601)"),
+        ],
+        end_date: Annotated[
+            datetime,
+            Parameter(description="End date (ISO 8601)"),
+        ],
+        limit: Annotated[
+            int,
+            Parameter(description="Maximum number of IPs", ge=1, le=100),
+        ] = 25,
+    ) -> TopIpsResponse:
+        """Get the top client IPs by hit count for a date range."""
+        rows = await live_stats_repo.get_top_ips(start_date, end_date, limit=limit)
+        return TopIpsResponse(
+            start_date=start_date.isoformat(),
+            end_date=end_date.isoformat(),
+            items=[TopIpDTO(**vars(r)) for r in rows],
+        )
+
+    @get("/top-countries", description="Top countries by hits from raw access logs (time-bounded).")
+    async def get_top_countries(
+        self,
+        live_stats_repo: NamedDependency[LiveStatsRepository],
+        start_date: Annotated[
+            datetime,
+            Parameter(description="Start date (ISO 8601)"),
+        ],
+        end_date: Annotated[
+            datetime,
+            Parameter(description="End date (ISO 8601)"),
+        ],
+        limit: Annotated[
+            int,
+            Parameter(description="Maximum number of countries", ge=1, le=100),
+        ] = 25,
+    ) -> TopCountriesStatsResponse:
+        """Get the top countries by hit count for a date range."""
+        rows = await live_stats_repo.get_top_countries(start_date, end_date, limit=limit)
+        return TopCountriesStatsResponse(
+            start_date=start_date.isoformat(),
+            end_date=end_date.isoformat(),
+            items=[TopCountryStatsDTO(**vars(r)) for r in rows],
+        )
+
+    @get("/top-cities", description="Top cities by hits from raw access logs (time-bounded).")
+    async def get_top_cities(
+        self,
+        live_stats_repo: NamedDependency[LiveStatsRepository],
+        start_date: Annotated[
+            datetime,
+            Parameter(description="Start date (ISO 8601)"),
+        ],
+        end_date: Annotated[
+            datetime,
+            Parameter(description="End date (ISO 8601)"),
+        ],
+        limit: Annotated[
+            int,
+            Parameter(description="Maximum number of cities", ge=1, le=100),
+        ] = 25,
+    ) -> TopCitiesResponse:
+        """Get the top cities by hit count for a date range."""
+        rows = await live_stats_repo.get_top_cities(start_date, end_date, limit=limit)
+        return TopCitiesResponse(
+            start_date=start_date.isoformat(),
+            end_date=end_date.isoformat(),
+            items=[TopCityStatsDTO(**vars(r)) for r in rows],
         )
 

--- a/geometrikks/api/v1/analytics_controller.py
+++ b/geometrikks/api/v1/analytics_controller.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Annotated
+from typing import Annotated, Literal
 
 from litestar import Controller, get
 from litestar.di import NamedDependency, Provide
@@ -43,6 +43,23 @@ def _calculate_percent_change(current: float, previous: float) -> float | None:
     if previous == 0:
         return None
     return ((current - previous) / previous) * 100
+
+
+def _resolve_chart_granularity(
+    start: datetime, end: datetime, override: str | None
+) -> StatsGranularity:
+    """Chart bucket granularity: explicit override wins, else auto-route.
+
+    Only "hourly"/"daily" are accepted from the API, so RAW can never be
+    requested; the auto fallback clamps RAW to HOURLY (no raw CAGG exists,
+    hourly + real-time aggregation covers <= 24h ranges).
+    """
+    if override is not None:
+        return StatsGranularity(override)
+    granularity = get_stats_granularity(start, end)
+    if granularity == StatsGranularity.RAW:
+        granularity = StatsGranularity.HOURLY
+    return granularity
 
 
 class AnalyticsController(Controller):
@@ -398,14 +415,20 @@ class AnalyticsController(Controller):
                 examples=[Example(value="2024-12-31T23:59:59Z")],
             ),
         ],
+        granularity: Annotated[
+            Literal["hourly", "daily"] | None,
+            Parameter(
+                description="Bucket size override. Omit to auto-select "
+                "(hourly <= 30 days, daily above). RAW is never available.",
+                required=False,
+            ),
+        ] = None,
     ) -> TimeSeriesResponse:
         """Get per-bucket access-log metrics (requests, status, bytes, latency)."""
-        rows = await summary_stats_repo.get_time_series(start_date, end_date)
-        granularity = get_stats_granularity(start_date, end_date)
-        if granularity == StatsGranularity.RAW:
-            granularity = StatsGranularity.HOURLY  # matches the repo's clamp
+        resolved = _resolve_chart_granularity(start_date, end_date, granularity)
+        rows = await summary_stats_repo.get_time_series(start_date, end_date, granularity=resolved)
         return TimeSeriesResponse(
-            granularity=granularity.value,
+            granularity=resolved.value,
             start_date=start_date.isoformat(),
             end_date=end_date.isoformat(),
             data=[
@@ -446,14 +469,20 @@ class AnalyticsController(Controller):
                 examples=[Example(value="2024-12-31T23:59:59Z")],
             ),
         ],
+        granularity: Annotated[
+            Literal["hourly", "daily"] | None,
+            Parameter(
+                description="Bucket size override. Omit to auto-select "
+                "(hourly <= 30 days, daily above). RAW is never available.",
+                required=False,
+            ),
+        ] = None,
     ) -> GeoEventsTimeSeriesResponse:
         """Get per-bucket geo-event metrics (events, unique IPs/countries/cities)."""
-        rows = await summary_stats_repo.get_geo_time_series(start_date, end_date)
-        granularity = get_stats_granularity(start_date, end_date)
-        if granularity == StatsGranularity.RAW:
-            granularity = StatsGranularity.HOURLY  # matches the repo's clamp
+        resolved = _resolve_chart_granularity(start_date, end_date, granularity)
+        rows = await summary_stats_repo.get_geo_time_series(start_date, end_date, granularity=resolved)
         return GeoEventsTimeSeriesResponse(
-            granularity=granularity.value,
+            granularity=resolved.value,
             start_date=start_date.isoformat(),
             end_date=end_date.isoformat(),
             data=[

--- a/geometrikks/api/v1/analytics_controller.py
+++ b/geometrikks/api/v1/analytics_controller.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+import ipaddress
 from datetime import datetime, timedelta
 from typing import Annotated, Literal
 
 from litestar import Controller, get
 from litestar.di import NamedDependency, Provide
+from litestar.exceptions import ValidationException
 from litestar.params import Parameter
 from litestar.openapi.spec import Example
 
 from geometrikks.domain.analytics.repositories import (
+    AnalyticsFilters,
     LiveStatsRepository,
     SummaryStatsRepository,
     SummaryStats,
@@ -49,6 +52,24 @@ def _calculate_percent_change(current: float, previous: float) -> float | None:
     if previous == 0:
         return None
     return ((current - previous) / previous) * 100
+
+
+def _build_filters(
+    country_code: list[str] | None,
+    city: list[str] | None,
+    ip_address: list[str] | None,
+) -> AnalyticsFilters:
+    """Validate filter params; bad IPs become a 400 instead of a DB error."""
+    for ip in ip_address or []:
+        try:
+            ipaddress.ip_address(ip)
+        except ValueError as exc:
+            raise ValidationException(f"Invalid IP address: {ip!r}") from exc
+    return AnalyticsFilters(
+        country_codes=country_code or None,
+        cities=city or None,
+        ip_addresses=ip_address or None,
+    )
 
 
 def _resolve_chart_granularity(
@@ -407,6 +428,7 @@ class AnalyticsController(Controller):
     async def get_time_series(
         self,
         summary_stats_repo: NamedDependency[SummaryStatsRepository],
+        live_stats_repo: NamedDependency[LiveStatsRepository],
         start_date: Annotated[
             datetime,
             Parameter(
@@ -429,10 +451,39 @@ class AnalyticsController(Controller):
                 required=False,
             ),
         ] = None,
+        country_code: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these ISO country codes (repeatable)", required=False),
+        ] = None,
+        city: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these city names (repeatable)", required=False),
+        ] = None,
+        ip_address: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these client IPs (repeatable)", required=False),
+        ] = None,
     ) -> TimeSeriesResponse:
-        """Get per-bucket access-log metrics (requests, status, bytes, latency)."""
+        """Get per-bucket access-log metrics (requests, status, bytes, latency).
+
+        Perf note: when any of country_code/city/ip_address is set, this
+        scans raw access_logs instead of the CAGGs (which can't be sliced by
+        dimension). Filtered ranges are therefore bounded by
+        raw_retention_days (default 180d) and slower than the unfiltered,
+        CAGG-backed path - acceptable at homelab volume with chunk exclusion
+        (same trade-off as /top-urls).
+        """
+        filters = _build_filters(country_code, city, ip_address)
         resolved = _resolve_chart_granularity(start_date, end_date, granularity)
-        rows = await summary_stats_repo.get_time_series(start_date, end_date, granularity=resolved)
+        if filters.is_active():
+            interval = "1 hour" if resolved == StatsGranularity.HOURLY else "1 day"
+            rows = await live_stats_repo.get_time_series(
+                start_date, end_date, bucket_interval=interval, filters=filters
+            )
+        else:
+            rows = await summary_stats_repo.get_time_series(
+                start_date, end_date, granularity=resolved
+            )
         return TimeSeriesResponse(
             granularity=resolved.value,
             start_date=start_date.isoformat(),
@@ -525,9 +576,22 @@ class AnalyticsController(Controller):
             int,
             Parameter(description="Maximum number of URLs to return", ge=1, le=100),
         ] = 25,
+        country_code: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these ISO country codes (repeatable)", required=False),
+        ] = None,
+        city: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these city names (repeatable)", required=False),
+        ] = None,
+        ip_address: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these client IPs (repeatable)", required=False),
+        ] = None,
     ) -> TopUrlsResponse:
         """Get the top URLs by hit count for a date range."""
-        rows = await live_stats_repo.get_top_urls(start_date, end_date, limit=limit)
+        filters = _build_filters(country_code, city, ip_address)
+        rows = await live_stats_repo.get_top_urls(start_date, end_date, limit=limit, filters=filters)
         return TopUrlsResponse(
             start_date=start_date.isoformat(),
             end_date=end_date.isoformat(),
@@ -556,9 +620,22 @@ class AnalyticsController(Controller):
             int,
             Parameter(description="Maximum number of user agents to return", ge=1, le=100),
         ] = 25,
+        country_code: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these ISO country codes (repeatable)", required=False),
+        ] = None,
+        city: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these city names (repeatable)", required=False),
+        ] = None,
+        ip_address: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these client IPs (repeatable)", required=False),
+        ] = None,
     ) -> TopUserAgentsResponse:
         """Get the top user agents by hit count for a date range."""
-        rows = await live_stats_repo.get_top_user_agents(start_date, end_date, limit=limit)
+        filters = _build_filters(country_code, city, ip_address)
+        rows = await live_stats_repo.get_top_user_agents(start_date, end_date, limit=limit, filters=filters)
         return TopUserAgentsResponse(
             start_date=start_date.isoformat(),
             end_date=end_date.isoformat(),
@@ -581,9 +658,22 @@ class AnalyticsController(Controller):
             int,
             Parameter(description="Maximum number of IPs", ge=1, le=100),
         ] = 25,
+        country_code: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these ISO country codes (repeatable)", required=False),
+        ] = None,
+        city: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these city names (repeatable)", required=False),
+        ] = None,
+        ip_address: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these client IPs (repeatable)", required=False),
+        ] = None,
     ) -> TopIpsResponse:
         """Get the top client IPs by hit count for a date range."""
-        rows = await live_stats_repo.get_top_ips(start_date, end_date, limit=limit)
+        filters = _build_filters(country_code, city, ip_address)
+        rows = await live_stats_repo.get_top_ips(start_date, end_date, limit=limit, filters=filters)
         return TopIpsResponse(
             start_date=start_date.isoformat(),
             end_date=end_date.isoformat(),
@@ -606,9 +696,22 @@ class AnalyticsController(Controller):
             int,
             Parameter(description="Maximum number of countries", ge=1, le=100),
         ] = 25,
+        country_code: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these ISO country codes (repeatable)", required=False),
+        ] = None,
+        city: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these city names (repeatable)", required=False),
+        ] = None,
+        ip_address: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these client IPs (repeatable)", required=False),
+        ] = None,
     ) -> TopCountriesStatsResponse:
         """Get the top countries by hit count for a date range."""
-        rows = await live_stats_repo.get_top_countries(start_date, end_date, limit=limit)
+        filters = _build_filters(country_code, city, ip_address)
+        rows = await live_stats_repo.get_top_countries(start_date, end_date, limit=limit, filters=filters)
         return TopCountriesStatsResponse(
             start_date=start_date.isoformat(),
             end_date=end_date.isoformat(),
@@ -631,9 +734,22 @@ class AnalyticsController(Controller):
             int,
             Parameter(description="Maximum number of cities", ge=1, le=100),
         ] = 25,
+        country_code: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these ISO country codes (repeatable)", required=False),
+        ] = None,
+        city: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these city names (repeatable)", required=False),
+        ] = None,
+        ip_address: Annotated[
+            list[str] | None,
+            Parameter(description="Filter to these client IPs (repeatable)", required=False),
+        ] = None,
     ) -> TopCitiesResponse:
         """Get the top cities by hit count for a date range."""
-        rows = await live_stats_repo.get_top_cities(start_date, end_date, limit=limit)
+        filters = _build_filters(country_code, city, ip_address)
+        rows = await live_stats_repo.get_top_cities(start_date, end_date, limit=limit, filters=filters)
         return TopCitiesResponse(
             start_date=start_date.isoformat(),
             end_date=end_date.isoformat(),

--- a/geometrikks/domain/analytics/dtos.py
+++ b/geometrikks/domain/analytics/dtos.py
@@ -263,7 +263,7 @@ class TopIpsResponse:
 
     start_date: str
     end_date: str
-    items: list[TopIpDTO] = field(default_factory=list)
+    items: list[TopIpDTO]
 
 
 @dataclass
@@ -285,7 +285,7 @@ class TopCountriesStatsResponse:
 
     start_date: str
     end_date: str
-    items: list[TopCountryStatsDTO] = field(default_factory=list)
+    items: list[TopCountryStatsDTO]
 
 
 @dataclass
@@ -307,4 +307,4 @@ class TopCitiesResponse:
 
     start_date: str
     end_date: str
-    items: list[TopCityStatsDTO] = field(default_factory=list)
+    items: list[TopCityStatsDTO]

--- a/geometrikks/domain/analytics/dtos.py
+++ b/geometrikks/domain/analytics/dtos.py
@@ -240,3 +240,71 @@ class TopUserAgentsResponse:
     start_date: str
     end_date: str
     items: list[TopUserAgentDTO]
+
+
+@dataclass
+class TopIpDTO:
+    """A single IP address with its aggregate hit metrics."""
+
+    ip_address: str
+    hits: int
+    error_hits: int
+    total_bytes: int
+    country_code: str | None
+    city: str | None
+
+
+@dataclass
+class TopIpsResponse:
+    """Response containing top IPs by hit count.
+
+    ``items`` is deliberately default-less (see TopUrlsResponse).
+    """
+
+    start_date: str
+    end_date: str
+    items: list[TopIpDTO] = field(default_factory=list)
+
+
+@dataclass
+class TopCountryStatsDTO:
+    """A single country with its aggregate metrics."""
+
+    country_code: str
+    country_name: str | None
+    hits: int
+    unique_ips: int
+
+
+@dataclass
+class TopCountriesStatsResponse:
+    """Response containing top countries by hit count.
+
+    ``items`` is deliberately default-less (see TopUrlsResponse).
+    """
+
+    start_date: str
+    end_date: str
+    items: list[TopCountryStatsDTO] = field(default_factory=list)
+
+
+@dataclass
+class TopCityStatsDTO:
+    """A single city with its aggregate metrics."""
+
+    city: str
+    country_code: str | None
+    hits: int
+    unique_ips: int
+
+
+@dataclass
+class TopCitiesResponse:
+    """Response containing top cities by hit count.
+
+    ``items`` is deliberately default-less (see TopUrlsResponse).
+    """
+
+    start_date: str
+    end_date: str
+    items: list[TopCityStatsDTO] = field(default_factory=list)

--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -247,12 +247,12 @@ class SummaryStatsRepository:
 
         total_errors = ((access_row.status_4xx or 0) + (access_row.status_5xx or 0)) if access_row else 0
         error_rate = total_errors / total_log_records if total_log_records > 0 else 0.0
-        avg_bytes = (access_row.total_bytes if access_row else 0) / total_log_records if total_log_records > 0 else 0.0
+        avg_bytes = float(access_row.total_bytes if access_row else 0) / total_log_records if total_log_records > 0 else 0.0
 
         return SummaryStats(
             total_log_records=total_log_records,
-            total_bytes=access_row.total_bytes if access_row else 0,
-            avg_bytes_per_request=avg_bytes,
+            total_bytes=int(access_row.total_bytes) if access_row else 0,
+            avg_bytes_per_request=float(avg_bytes),
             status_2xx=access_row.status_2xx if access_row else 0,
             status_3xx=access_row.status_3xx if access_row else 0,
             status_4xx=access_row.status_4xx if access_row else 0,
@@ -347,11 +347,11 @@ class SummaryStatsRepository:
 
         total_errors = row.status_4xx + row.status_5xx
         error_rate = total_errors / row.total_log_records if row.total_log_records > 0 else 0.0
-        avg_bytes = row.total_bytes / row.total_log_records if row.total_log_records > 0 else 0.0
+        avg_bytes = float(row.total_bytes) / float(row.total_log_records) if row.total_log_records > 0 else 0.0
 
         return SummaryStats(
             total_log_records=row.total_log_records,
-            total_bytes=row.total_bytes,
+            total_bytes=int(row.total_bytes),
             avg_bytes_per_request=avg_bytes,
             status_2xx=row.status_2xx,
             status_3xx=row.status_3xx,
@@ -417,7 +417,7 @@ class SummaryStatsRepository:
             SummaryStatsRow(
                 bucket=row.bucket,
                 total_requests=row.total_requests or 0,
-                total_bytes=row.total_bytes or 0,
+                total_bytes=int(row.total_bytes or 0),
                 status_2xx=row.status_2xx or 0,
                 status_3xx=row.status_3xx or 0,
                 status_4xx=row.status_4xx or 0,
@@ -691,12 +691,12 @@ class LiveStatsRepository:
 
         total_errors = ((access_row.status_4xx or 0) + (access_row.status_5xx or 0)) if access_row else 0
         error_rate = total_errors / total_requests if total_requests > 0 else 0.0
-        avg_bytes = (access_row.total_bytes if access_row else 0) / total_requests if total_requests > 0 else 0.0
+        avg_bytes = float(access_row.total_bytes if access_row else 0) / float(total_requests) if total_requests > 0 else 0.0
 
         return SummaryStats(
             total_log_records=total_requests,
-            total_bytes=access_row.total_bytes if access_row else 0,
-            avg_bytes_per_request=avg_bytes,
+            total_bytes=int(access_row.total_bytes) if access_row else 0,
+            avg_bytes_per_request=float(avg_bytes),
             status_2xx=access_row.status_2xx if access_row else 0,
             status_3xx=access_row.status_3xx if access_row else 0,
             status_4xx=access_row.status_4xx if access_row else 0,

--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -610,6 +610,38 @@ class TopUserAgentRow:
     hits: int
 
 
+@dataclass
+class TopIpRow:
+    """A top-IP aggregate row from raw access_logs."""
+
+    ip_address: str
+    hits: int
+    error_hits: int
+    total_bytes: int
+    country_code: str | None
+    city: str | None
+
+
+@dataclass
+class TopCountryRow:
+    """A top-country aggregate row from raw access_logs."""
+
+    country_code: str
+    country_name: str | None
+    hits: int
+    unique_ips: int
+
+
+@dataclass
+class TopCityRow:
+    """A top-city aggregate row from raw access_logs."""
+
+    city: str
+    country_code: str | None
+    hits: int
+    unique_ips: int
+
+
 class LiveStatsRepository:
     """Repository for querying live statistics directly from raw hypertables.
 
@@ -769,3 +801,62 @@ class LiveStatsRepository:
         """)
         result = await self.session.execute(stmt, {"start": start, "end": end, "limit": limit})
         return [TopUserAgentRow(user_agent=row.user_agent, hits=row.hits) for row in result.fetchall()]
+
+    async def get_top_ips(
+        self, start: datetime, end: datetime, limit: int = 25
+    ) -> list[TopIpRow]:
+        """Top client IPs by hit count from raw access_logs (time-bounded)."""
+        stmt = text("""
+            SELECT
+                host(ip_address) AS ip_address,
+                CAST(COUNT(*) AS BIGINT) AS hits,
+                CAST(COUNT(*) FILTER (WHERE status_code >= 400) AS BIGINT) AS error_hits,
+                CAST(COALESCE(SUM(bytes_sent), 0) AS BIGINT) AS total_bytes,
+                MAX(country_code) AS country_code,
+                MAX(city) AS city
+            FROM access_logs
+            WHERE timestamp >= :start AND timestamp < :end
+            GROUP BY ip_address
+            ORDER BY hits DESC
+            LIMIT :limit
+        """)
+        result = await self.session.execute(stmt, {"start": start, "end": end, "limit": limit})
+        return [TopIpRow(**row._mapping) for row in result.fetchall()]
+
+    async def get_top_countries(
+        self, start: datetime, end: datetime, limit: int = 25
+    ) -> list[TopCountryRow]:
+        """Top countries by hit count from raw access_logs (time-bounded)."""
+        stmt = text("""
+            SELECT
+                country_code,
+                MAX(country_name) AS country_name,
+                CAST(COUNT(*) AS BIGINT) AS hits,
+                CAST(COUNT(DISTINCT ip_address) AS BIGINT) AS unique_ips
+            FROM access_logs
+            WHERE timestamp >= :start AND timestamp < :end AND country_code IS NOT NULL
+            GROUP BY country_code
+            ORDER BY hits DESC
+            LIMIT :limit
+        """)
+        result = await self.session.execute(stmt, {"start": start, "end": end, "limit": limit})
+        return [TopCountryRow(**row._mapping) for row in result.fetchall()]
+
+    async def get_top_cities(
+        self, start: datetime, end: datetime, limit: int = 25
+    ) -> list[TopCityRow]:
+        """Top cities by hit count from raw access_logs (time-bounded)."""
+        stmt = text("""
+            SELECT
+                city,
+                MAX(country_code) AS country_code,
+                CAST(COUNT(*) AS BIGINT) AS hits,
+                CAST(COUNT(DISTINCT ip_address) AS BIGINT) AS unique_ips
+            FROM access_logs
+            WHERE timestamp >= :start AND timestamp < :end AND city IS NOT NULL
+            GROUP BY city
+            ORDER BY hits DESC
+            LIMIT :limit
+        """)
+        result = await self.session.execute(stmt, {"start": start, "end": end, "limit": limit})
+        return [TopCityRow(**row._mapping) for row in result.fetchall()]

--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -642,6 +642,37 @@ class TopCityRow:
     unique_ips: int
 
 
+@dataclass
+class AnalyticsFilters:
+    """Optional dimension filters for analytics queries.
+
+    Filtered queries must hit raw access_logs: CAGGs aggregate globally and
+    cannot be sliced by country/city/IP.
+    """
+
+    country_codes: Sequence[str] | None = None
+    cities: Sequence[str] | None = None
+    ip_addresses: Sequence[str] | None = None
+
+    def is_active(self) -> bool:
+        return bool(self.country_codes or self.cities or self.ip_addresses)
+
+    def sql_conditions(self) -> tuple[str, dict]:
+        """WHERE-clause fragment (leading ``AND``) plus bound params."""
+        clauses: list[str] = []
+        params: dict = {}
+        if self.country_codes:
+            clauses.append("AND country_code = ANY(:filter_countries)")
+            params["filter_countries"] = list(self.country_codes)
+        if self.cities:
+            clauses.append("AND city = ANY(:filter_cities)")
+            params["filter_cities"] = list(self.cities)
+        if self.ip_addresses:
+            clauses.append("AND ip_address = ANY(CAST(:filter_ips AS inet[]))")
+            params["filter_ips"] = list(self.ip_addresses)
+        return " ".join(clauses), params
+
+
 class LiveStatsRepository:
     """Repository for querying live statistics directly from raw hypertables.
 
@@ -754,15 +785,73 @@ class LiveStatsRepository:
             malformed_requests=malformed_row.malformed_requests if malformed_row else 0,
         )
 
+    async def get_time_series(
+        self,
+        start: datetime,
+        end: datetime,
+        *,
+        bucket_interval: str,
+        filters: AnalyticsFilters | None = None,
+    ) -> Sequence[SummaryStatsRow]:
+        """Bucketed access-log metrics from the raw hypertable.
+
+        Used when dimension filters are active (CAGGs cannot filter).
+        bucket_interval is '1 hour' or '1 day' (validated by the caller).
+        """
+        if bucket_interval not in ("1 hour", "1 day"):
+            raise ValueError("bucket_interval must be '1 hour' or '1 day'")
+        filter_sql, filter_params = (filters or AnalyticsFilters()).sql_conditions()
+        stmt = text(f"""
+            SELECT
+                time_bucket('{bucket_interval}', timestamp) AS bucket,
+                CAST(COUNT(*) AS BIGINT) AS total_requests,
+                CAST(COALESCE(SUM(bytes_sent), 0) AS BIGINT) AS total_bytes,
+                COUNT(*) FILTER (WHERE status_code >= 200 AND status_code < 300) AS status_2xx,
+                COUNT(*) FILTER (WHERE status_code >= 300 AND status_code < 400) AS status_3xx,
+                COUNT(*) FILTER (WHERE status_code >= 400 AND status_code < 500) AS status_4xx,
+                COUNT(*) FILTER (WHERE status_code >= 500 AND status_code < 600) AS status_5xx,
+                COALESCE(AVG(request_time), 0) AS avg_request_time,
+                COALESCE(MAX(request_time), 0) AS max_request_time,
+                COALESCE(PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY request_time), 0) AS p50_request_time,
+                COALESCE(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY request_time), 0) AS p95_request_time,
+                COALESCE(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY request_time), 0) AS p99_request_time
+            FROM access_logs
+            WHERE timestamp >= :start AND timestamp < :end
+            {filter_sql}
+            GROUP BY bucket
+            ORDER BY bucket ASC
+        """)
+        result = await self.session.execute(
+            stmt, {"start": start, "end": end, **filter_params}
+        )
+        return [
+            SummaryStatsRow(
+                bucket=row.bucket,
+                total_requests=row.total_requests or 0,
+                total_bytes=int(row.total_bytes or 0),
+                status_2xx=row.status_2xx or 0,
+                status_3xx=row.status_3xx or 0,
+                status_4xx=row.status_4xx or 0,
+                status_5xx=row.status_5xx or 0,
+                avg_request_time=float(row.avg_request_time or 0.0),
+                max_request_time=float(row.max_request_time or 0.0),
+                p50_request_time=float(row.p50_request_time or 0.0),
+                p95_request_time=float(row.p95_request_time or 0.0),
+                p99_request_time=float(row.p99_request_time or 0.0),
+            )
+            for row in result.fetchall()
+        ]
+
     async def get_top_urls(
-        self, start: datetime, end: datetime, limit: int = 25
+        self, start: datetime, end: datetime, limit: int = 25, *, filters: AnalyticsFilters | None = None
     ) -> list[TopUrlRow]:
         """Top URLs by hit count from raw access_logs (time-bounded).
 
         Raw-table scan by design: no CAGG exists for URL cardinality yet
         (future optimization; fine at homelab volume with chunk exclusion).
         """
-        stmt = text("""
+        filter_sql, filter_params = (filters or AnalyticsFilters()).sql_conditions()
+        stmt = text(f"""
             SELECT
                 url,
                 CAST(COUNT(*) AS BIGINT) AS hits,
@@ -771,11 +860,14 @@ class LiveStatsRepository:
                 COALESCE(AVG(request_time), 0) AS avg_request_time
             FROM access_logs
             WHERE timestamp >= :start AND timestamp < :end AND url IS NOT NULL
+            {filter_sql}
             GROUP BY url
             ORDER BY hits DESC
             LIMIT :limit
         """)
-        result = await self.session.execute(stmt, {"start": start, "end": end, "limit": limit})
+        result = await self.session.execute(
+            stmt, {"start": start, "end": end, "limit": limit, **filter_params}
+        )
         return [
             TopUrlRow(
                 url=row.url,
@@ -788,25 +880,30 @@ class LiveStatsRepository:
         ]
 
     async def get_top_user_agents(
-        self, start: datetime, end: datetime, limit: int = 25
+        self, start: datetime, end: datetime, limit: int = 25, *, filters: AnalyticsFilters | None = None
     ) -> list[TopUserAgentRow]:
         """Top user agents by hit count from raw access_logs (time-bounded)."""
-        stmt = text("""
+        filter_sql, filter_params = (filters or AnalyticsFilters()).sql_conditions()
+        stmt = text(f"""
             SELECT user_agent, CAST(COUNT(*) AS BIGINT) AS hits
             FROM access_logs
             WHERE timestamp >= :start AND timestamp < :end AND user_agent IS NOT NULL
+            {filter_sql}
             GROUP BY user_agent
             ORDER BY hits DESC
             LIMIT :limit
         """)
-        result = await self.session.execute(stmt, {"start": start, "end": end, "limit": limit})
+        result = await self.session.execute(
+            stmt, {"start": start, "end": end, "limit": limit, **filter_params}
+        )
         return [TopUserAgentRow(user_agent=row.user_agent, hits=row.hits) for row in result.fetchall()]
 
     async def get_top_ips(
-        self, start: datetime, end: datetime, limit: int = 25
+        self, start: datetime, end: datetime, limit: int = 25, *, filters: AnalyticsFilters | None = None
     ) -> list[TopIpRow]:
         """Top client IPs by hit count from raw access_logs (time-bounded)."""
-        stmt = text("""
+        filter_sql, filter_params = (filters or AnalyticsFilters()).sql_conditions()
+        stmt = text(f"""
             SELECT
                 host(ip_address) AS ip_address,
                 CAST(COUNT(*) AS BIGINT) AS hits,
@@ -816,18 +913,22 @@ class LiveStatsRepository:
                 MAX(city) AS city
             FROM access_logs
             WHERE timestamp >= :start AND timestamp < :end
+            {filter_sql}
             GROUP BY ip_address
             ORDER BY hits DESC
             LIMIT :limit
         """)
-        result = await self.session.execute(stmt, {"start": start, "end": end, "limit": limit})
+        result = await self.session.execute(
+            stmt, {"start": start, "end": end, "limit": limit, **filter_params}
+        )
         return [TopIpRow(**row._mapping) for row in result.fetchall()]
 
     async def get_top_countries(
-        self, start: datetime, end: datetime, limit: int = 25
+        self, start: datetime, end: datetime, limit: int = 25, *, filters: AnalyticsFilters | None = None
     ) -> list[TopCountryRow]:
         """Top countries by hit count from raw access_logs (time-bounded)."""
-        stmt = text("""
+        filter_sql, filter_params = (filters or AnalyticsFilters()).sql_conditions()
+        stmt = text(f"""
             SELECT
                 country_code,
                 MAX(country_name) AS country_name,
@@ -835,18 +936,22 @@ class LiveStatsRepository:
                 CAST(COUNT(DISTINCT ip_address) AS BIGINT) AS unique_ips
             FROM access_logs
             WHERE timestamp >= :start AND timestamp < :end AND country_code IS NOT NULL
+            {filter_sql}
             GROUP BY country_code
             ORDER BY hits DESC
             LIMIT :limit
         """)
-        result = await self.session.execute(stmt, {"start": start, "end": end, "limit": limit})
+        result = await self.session.execute(
+            stmt, {"start": start, "end": end, "limit": limit, **filter_params}
+        )
         return [TopCountryRow(**row._mapping) for row in result.fetchall()]
 
     async def get_top_cities(
-        self, start: datetime, end: datetime, limit: int = 25
+        self, start: datetime, end: datetime, limit: int = 25, *, filters: AnalyticsFilters | None = None
     ) -> list[TopCityRow]:
         """Top cities by hit count from raw access_logs (time-bounded)."""
-        stmt = text("""
+        filter_sql, filter_params = (filters or AnalyticsFilters()).sql_conditions()
+        stmt = text(f"""
             SELECT
                 city,
                 MAX(country_code) AS country_code,
@@ -854,9 +959,12 @@ class LiveStatsRepository:
                 CAST(COUNT(DISTINCT ip_address) AS BIGINT) AS unique_ips
             FROM access_logs
             WHERE timestamp >= :start AND timestamp < :end AND city IS NOT NULL
+            {filter_sql}
             GROUP BY city
             ORDER BY hits DESC
             LIMIT :limit
         """)
-        result = await self.session.execute(stmt, {"start": start, "end": end, "limit": limit})
+        result = await self.session.execute(
+            stmt, {"start": start, "end": end, "limit": limit, **filter_params}
+        )
         return [TopCityRow(**row._mapping) for row in result.fetchall()]

--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -374,19 +374,23 @@ class SummaryStatsRepository:
         self,
         start: datetime,
         end: datetime,
+        granularity: StatsGranularity | None = None,
     ) -> Sequence[SummaryStatsRow]:
         """Get time series data for charts.
 
         Args:
             start: Start datetime.
             end: End datetime.
+            granularity: Explicit bucket granularity override. None auto-routes
+                via get_stats_granularity (RAW is clamped to HOURLY).
 
         Returns:
             List of SummaryStatsRow ordered by bucket ascending.
         """
-        granularity = get_stats_granularity(start, end)
+        if granularity is None:
+            granularity = get_stats_granularity(start, end)
         if granularity == StatsGranularity.RAW:
-            granularity = StatsGranularity.HOURLY  # no raw CAGG; hourly + real-time agg covers ≤24h
+            granularity = StatsGranularity.HOURLY  # no raw CAGG; hourly + real-time agg covers <=24h
         table = f"summary_{granularity.value}_stats"
         bucket_interval = "1 hour" if granularity == StatsGranularity.HOURLY else "1 day"
 
@@ -435,6 +439,7 @@ class SummaryStatsRepository:
         self,
         start: datetime,
         end: datetime,
+        granularity: StatsGranularity | None = None,
     ) -> Sequence[dict]:
         """Get geo event time series data for charts.
 
@@ -443,13 +448,16 @@ class SummaryStatsRepository:
         Args:
             start: Start datetime.
             end: End datetime.
+            granularity: Explicit bucket granularity override. None auto-routes
+                via get_stats_granularity (RAW is clamped to HOURLY).
 
         Returns:
             List of dicts with bucket, total_events, unique_ips, unique_countries, unique_cities.
         """
-        granularity = get_stats_granularity(start, end)
+        if granularity is None:
+            granularity = get_stats_granularity(start, end)
         if granularity == StatsGranularity.RAW:
-            granularity = StatsGranularity.HOURLY  # no raw CAGG; hourly + real-time agg covers ≤24h
+            granularity = StatsGranularity.HOURLY  # no raw CAGG; hourly + real-time agg covers <=24h
         table = f"geo_summary_{granularity.value}_stats"
         bucket_interval = "1 hour" if granularity == StatsGranularity.HOURLY else "1 day"
 

--- a/geometrikks/server/timescale.py
+++ b/geometrikks/server/timescale.py
@@ -555,6 +555,10 @@ async def setup_timescaledb(
             caggs=SUMMARY_CAGGS,
         )
 
+    # Repair deployments whose data predates CAGG refresh coverage
+    # (issue #14: long-range charts truncated while top lists are not).
+    await backfill_cagg_gaps(engine, raw_retention_days=analytics.raw_retention_days)
+
     logger.info("TimescaleDB setup complete")
 
 
@@ -600,4 +604,80 @@ async def refresh_caggs_range(
             logger.info("CAGG refreshed: %s (%s → %s)", cagg, start, end)
         except Exception as e:
             logger.warning("CAGG refresh failed: %s (%s → %s): %s", cagg, start, end, e)
+
+
+# CAGG -> raw source hypertable (all use a "timestamp" time column)
+CAGG_SOURCE_TABLES: dict[str, str] = {
+    "summary_hourly_stats": "access_logs",
+    "summary_daily_stats": "access_logs",
+    "geo_summary_hourly_stats": "geo_events",
+    "geo_summary_daily_stats": "geo_events",
+    "location_hourly_stats": "geo_events",
+    "location_daily_stats": "geo_events",
+    "ip_location_daily_stats": "geo_events",
+}
+
+
+async def backfill_cagg_gaps(engine: "AsyncEngine", *, raw_retention_days: int) -> None:
+    """Materialize CAGG history that predates refresh-policy coverage.
+
+    CAGGs are created WITH NO DATA and refresh policies only cover a
+    trailing window, so buckets older than the coverage are never
+    materialized. Once the watermark advances, the real-time union stops
+    reading those raw rows and the history disappears from CAGG queries
+    while raw-table queries still see it (issue #14 symptom). Detect the
+    gap (earliest raw row older than earliest materialized bucket) and
+    refresh the missing range. Idempotent and cheap when there is no gap.
+    """
+    horizon = datetime.now(timezone.utc) - timedelta(days=raw_retention_days)
+    to_backfill: list[tuple[str, datetime]] = []
+
+    for cagg, source in CAGG_SOURCE_TABLES.items():
+        # Isolate each CAGG on its own connection: a probe failure (e.g. a
+        # future CAGG whose time column is not "bucket") must not abort app
+        # startup, and a failed statement poisons its whole connection's
+        # transaction, so a shared connection would cascade the failure to
+        # every later CAGG. Matches refresh_caggs_range's per-item pattern.
+        try:
+            async with engine.connect() as conn:
+                raw_min = (await conn.execute(
+                    text(f"SELECT MIN(timestamp) FROM {source} WHERE timestamp >= :horizon"),  # noqa: S608 - allowlisted identifiers
+                    {"horizon": horizon},
+                )).scalar()
+                if raw_min is None:
+                    continue
+
+                mat_table = (await conn.execute(text("""
+                    SELECT format('%I.%I', materialization_hypertable_schema,
+                                  materialization_hypertable_name)
+                    FROM timescaledb_information.continuous_aggregates
+                    WHERE view_name = :cagg
+                """), {"cagg": cagg})).scalar()
+                if mat_table is None:
+                    continue
+
+                cagg_min = (await conn.execute(
+                    text(f"SELECT MIN(bucket) FROM {mat_table}")  # noqa: S608
+                )).scalar()
+        except Exception as e:
+            logger.warning("CAGG gap probe failed: %s: %s", cagg, e)
+            continue
+
+        bucket_width = timedelta(days=1) if "daily" in cagg else timedelta(hours=1)
+        if cagg_min is None or raw_min < cagg_min - bucket_width:
+            # refresh_continuous_aggregate silently skips the bucket
+            # containing an unaligned start (it does not floor it), so
+            # align start to the bucket boundary or the earliest row's
+            # bucket is dropped instead of backfilled.
+            if bucket_width == timedelta(days=1):
+                aligned_start = raw_min.replace(hour=0, minute=0, second=0, microsecond=0)
+            else:
+                aligned_start = raw_min.replace(minute=0, second=0, microsecond=0)
+            to_backfill.append((cagg, aligned_start))
+
+    for cagg, start in to_backfill:
+        logger.warning("CAGG %s is missing history since %s; backfilling", cagg, start)
+        await refresh_caggs_range(
+            engine, start=start, end=datetime.now(timezone.utc), caggs=[cagg]
+        )
 

--- a/resources/components/analytics/analytics-filter-bar.tsx
+++ b/resources/components/analytics/analytics-filter-bar.tsx
@@ -1,0 +1,153 @@
+/**
+ * Country / city / IP filter bar for the analytics page. Filters every chart
+ * and top-list on the page via AnalyticsFiltersContext (not geo-time-series,
+ * which stays unfiltered). Country/city options are lazy-loaded facets,
+ * matching the pattern in access-logs-table.tsx.
+ */
+import { useState } from "react"
+import { ChevronsUpDown, X } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { useAccessLogFacets } from "@/lib/queries"
+import { EMPTY_FILTERS, useAnalyticsFilters } from "@/lib/analytics-filters-context"
+
+/** Light shape check, not a full validator - the backend 400s on truly invalid IPs. */
+const IP_INPUT_RE = /^[0-9a-fA-F:.]+$/
+
+function toggleValue(values: string[], value: string): string[] {
+  return values.includes(value) ? values.filter((v) => v !== value) : [...values, value]
+}
+
+export function AnalyticsFilterBar() {
+  const { filters, setFilters } = useAnalyticsFilters()
+  const [ipInput, setIpInput] = useState("")
+  const [facetsEnabled, setFacetsEnabled] = useState(false)
+  const { data: facets } = useAccessLogFacets({ enabled: facetsEnabled })
+
+  const hasActiveFilters =
+    filters.countryCodes.length > 0 || filters.cities.length > 0 || filters.ips.length > 0
+
+  function toggleCountry(code: string) {
+    setFilters((prev) => ({ ...prev, countryCodes: toggleValue(prev.countryCodes, code) }))
+  }
+
+  function toggleCity(city: string) {
+    setFilters((prev) => ({ ...prev, cities: toggleValue(prev.cities, city) }))
+  }
+
+  function addIp() {
+    const value = ipInput.trim()
+    if (!value || !IP_INPUT_RE.test(value) || filters.ips.includes(value)) return
+    setFilters((prev) => ({ ...prev, ips: [...prev.ips, value] }))
+    setIpInput("")
+  }
+
+  function removeIp(ip: string) {
+    setFilters((prev) => ({ ...prev, ips: prev.ips.filter((v) => v !== ip) }))
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <DropdownMenu onOpenChange={(open) => open && setFacetsEnabled(true)}>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" className="h-8">
+            Country{filters.countryCodes.length > 0 && ` (${filters.countryCodes.length})`}
+            <ChevronsUpDown className="ml-1 h-3.5 w-3.5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="max-h-80 w-auto min-w-44 overflow-y-auto">
+          <DropdownMenuLabel>Country</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {!facets && (
+            <DropdownMenuLabel className="font-normal text-muted-foreground">Loading…</DropdownMenuLabel>
+          )}
+          {facets?.countries.map((c) => (
+            <DropdownMenuCheckboxItem
+              key={c.code}
+              checked={filters.countryCodes.includes(c.code)}
+              onCheckedChange={() => toggleCountry(c.code)}
+              onSelect={(e) => e.preventDefault()}
+            >
+              {c.name} ({c.code})
+            </DropdownMenuCheckboxItem>
+          ))}
+          {facets && facets.countries.length === 0 && (
+            <DropdownMenuLabel className="font-normal text-muted-foreground">No geo data</DropdownMenuLabel>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu onOpenChange={(open) => open && setFacetsEnabled(true)}>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" className="h-8">
+            City{filters.cities.length > 0 && ` (${filters.cities.length})`}
+            <ChevronsUpDown className="ml-1 h-3.5 w-3.5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="max-h-80 w-auto min-w-44 overflow-y-auto">
+          <DropdownMenuLabel>City</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {!facets && (
+            <DropdownMenuLabel className="font-normal text-muted-foreground">Loading…</DropdownMenuLabel>
+          )}
+          {facets?.cities.map((city) => (
+            <DropdownMenuCheckboxItem
+              key={city}
+              checked={filters.cities.includes(city)}
+              onCheckedChange={() => toggleCity(city)}
+              onSelect={(e) => e.preventDefault()}
+            >
+              {city}
+            </DropdownMenuCheckboxItem>
+          ))}
+          {facets && facets.cities.length === 0 && (
+            <DropdownMenuLabel className="font-normal text-muted-foreground">No geo data</DropdownMenuLabel>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Input
+        value={ipInput}
+        onChange={(e) => setIpInput(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault()
+            addIp()
+          }
+        }}
+        placeholder="Add IP + Enter"
+        aria-invalid={ipInput !== "" && !IP_INPUT_RE.test(ipInput)}
+        className="h-8 w-40 font-mono text-xs"
+      />
+
+      {filters.ips.map((ip) => (
+        <Badge key={ip} variant="secondary" className="font-mono">
+          {ip}
+          <button
+            type="button"
+            onClick={() => removeIp(ip)}
+            aria-label={`Remove ${ip}`}
+            className="ml-1 rounded-full hover:text-destructive"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </Badge>
+      ))}
+
+      {hasActiveFilters && (
+        <Button variant="ghost" size="sm" className="h-8" onClick={() => setFilters(EMPTY_FILTERS)}>
+          Clear filters
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/resources/components/analytics/table-pagination.tsx
+++ b/resources/components/analytics/table-pagination.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react"
+import { ChevronLeft, ChevronRight } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+
+export const TABLE_PAGE_SIZE = 10
+
+/** Client-side pagination over an already-fetched list. */
+export function usePagedRows<T>(items: T[] | undefined, pageSize = TABLE_PAGE_SIZE) {
+  const [page, setPage] = useState(1)
+  const total = items?.length ?? 0
+  const pageCount = Math.max(1, Math.ceil(total / pageSize))
+  const current = Math.min(page, pageCount) // clamp when the list shrinks (e.g. after a filter change)
+  const start = (current - 1) * pageSize
+  const pageItems = (items ?? []).slice(start, start + pageSize)
+  return { pageItems, page: current, pageCount, total, setPage, pageSize }
+}
+
+export function TablePaginationFooter({
+  page,
+  pageCount,
+  total,
+  pageSize,
+  onPageChange,
+}: {
+  page: number
+  pageCount: number
+  total: number
+  pageSize: number
+  onPageChange: (page: number) => void
+}) {
+  if (total <= pageSize) return null
+  return (
+    <div className="flex items-center justify-between pt-3 text-xs text-muted-foreground">
+      <span>
+        {total} rows - page {page} of {pageCount}
+      </span>
+      <div className="flex gap-1">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={page <= 1}
+          onClick={() => onPageChange(Math.max(1, page - 1))}
+        >
+          <ChevronLeft className="h-4 w-4" /> Prev
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={page >= pageCount}
+          onClick={() => onPageChange(page + 1)}
+        >
+          Next <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/resources/components/analytics/top-countries-cities.tsx
+++ b/resources/components/analytics/top-countries-cities.tsx
@@ -11,10 +11,13 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { formatNumber } from "@/lib/api"
 import { useTopCityStats, useTopCountryStats } from "@/lib/queries"
+import { TablePaginationFooter, usePagedRows } from "./table-pagination"
 
 export function TopCountriesCities() {
   const { data: countryData, isLoading: isCountryLoading } = useTopCountryStats({ limit: 25 })
   const { data: cityData, isLoading: isCityLoading } = useTopCityStats({ limit: 25 })
+  const { pageItems: countryItems, ...countryPagination } = usePagedRows(countryData?.items)
+  const { pageItems: cityItems, ...cityPagination } = usePagedRows(cityData?.items)
 
   return (
     <Card>
@@ -31,48 +34,54 @@ export function TopCountriesCities() {
             {isCountryLoading || !countryData ? (
               <Skeleton className="h-48 w-full" />
             ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Country</TableHead>
-                    <TableHead className="text-right">Hits</TableHead>
-                    <TableHead className="text-right">Unique IPs</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {countryData.items.map((row) => (
-                    <TableRow key={row.country_code}>
-                      <TableCell>{row.country_name ?? row.country_code}</TableCell>
-                      <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
-                      <TableCell className="text-right tabular-nums">{formatNumber(row.unique_ips)}</TableCell>
+              <>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Country</TableHead>
+                      <TableHead className="text-right">Hits</TableHead>
+                      <TableHead className="text-right">Unique IPs</TableHead>
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+                  </TableHeader>
+                  <TableBody>
+                    {countryItems.map((row) => (
+                      <TableRow key={row.country_code}>
+                        <TableCell>{row.country_name ?? row.country_code}</TableCell>
+                        <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
+                        <TableCell className="text-right tabular-nums">{formatNumber(row.unique_ips)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+                <TablePaginationFooter {...countryPagination} onPageChange={countryPagination.setPage} />
+              </>
             )}
           </TabsContent>
           <TabsContent value="cities">
             {isCityLoading || !cityData ? (
               <Skeleton className="h-48 w-full" />
             ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>City</TableHead>
-                    <TableHead className="text-right">Hits</TableHead>
-                    <TableHead className="text-right">Unique IPs</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {cityData.items.map((row, index) => (
-                    <TableRow key={`${row.city}-${row.country_code}-${index}`}>
-                      <TableCell>{row.city}</TableCell>
-                      <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
-                      <TableCell className="text-right tabular-nums">{formatNumber(row.unique_ips)}</TableCell>
+              <>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>City</TableHead>
+                      <TableHead className="text-right">Hits</TableHead>
+                      <TableHead className="text-right">Unique IPs</TableHead>
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+                  </TableHeader>
+                  <TableBody>
+                    {cityItems.map((row, index) => (
+                      <TableRow key={`${row.city}-${row.country_code}-${index}`}>
+                        <TableCell>{row.city}</TableCell>
+                        <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
+                        <TableCell className="text-right tabular-nums">{formatNumber(row.unique_ips)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+                <TablePaginationFooter {...cityPagination} onPageChange={cityPagination.setPage} />
+              </>
             )}
           </TabsContent>
         </Tabs>

--- a/resources/components/analytics/top-countries-cities.tsx
+++ b/resources/components/analytics/top-countries-cities.tsx
@@ -1,0 +1,82 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { formatNumber } from "@/lib/api"
+import { useTopCityStats, useTopCountryStats } from "@/lib/queries"
+
+export function TopCountriesCities() {
+  const { data: countryData, isLoading: isCountryLoading } = useTopCountryStats({ limit: 25 })
+  const { data: cityData, isLoading: isCityLoading } = useTopCityStats({ limit: 25 })
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Top Countries / Cities</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Tabs defaultValue="countries">
+          <TabsList>
+            <TabsTrigger value="countries">Countries</TabsTrigger>
+            <TabsTrigger value="cities">Cities</TabsTrigger>
+          </TabsList>
+          <TabsContent value="countries">
+            {isCountryLoading || !countryData ? (
+              <Skeleton className="h-48 w-full" />
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Country</TableHead>
+                    <TableHead className="text-right">Hits</TableHead>
+                    <TableHead className="text-right">Unique IPs</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {countryData.items.map((row) => (
+                    <TableRow key={row.country_code}>
+                      <TableCell>{row.country_name ?? row.country_code}</TableCell>
+                      <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
+                      <TableCell className="text-right tabular-nums">{formatNumber(row.unique_ips)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </TabsContent>
+          <TabsContent value="cities">
+            {isCityLoading || !cityData ? (
+              <Skeleton className="h-48 w-full" />
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>City</TableHead>
+                    <TableHead className="text-right">Hits</TableHead>
+                    <TableHead className="text-right">Unique IPs</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {cityData.items.map((row, index) => (
+                    <TableRow key={`${row.city}-${row.country_code}-${index}`}>
+                      <TableCell>{row.city}</TableCell>
+                      <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
+                      <TableCell className="text-right tabular-nums">{formatNumber(row.unique_ips)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+    </Card>
+  )
+}

--- a/resources/components/analytics/top-ips-table.tsx
+++ b/resources/components/analytics/top-ips-table.tsx
@@ -10,9 +10,11 @@ import {
 import { Skeleton } from "@/components/ui/skeleton"
 import { formatBytes, formatNumber } from "@/lib/api"
 import { useTopIpStats } from "@/lib/queries"
+import { TablePaginationFooter, usePagedRows } from "./table-pagination"
 
 export function TopIpsTable() {
   const { data, isLoading } = useTopIpStats({ limit: 25 })
+  const { pageItems, ...pagination } = usePagedRows(data?.items)
 
   return (
     <Card>
@@ -23,30 +25,33 @@ export function TopIpsTable() {
         {isLoading || !data ? (
           <Skeleton className="h-48 w-full" />
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>IP</TableHead>
-                <TableHead>Country</TableHead>
-                <TableHead>City</TableHead>
-                <TableHead className="text-right">Hits</TableHead>
-                <TableHead className="text-right">Errors</TableHead>
-                <TableHead className="text-right">Bytes</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {data.items.map((row) => (
-                <TableRow key={row.ip_address}>
-                  <TableCell className="font-mono text-xs">{row.ip_address}</TableCell>
-                  <TableCell>{row.country_code ?? "-"}</TableCell>
-                  <TableCell>{row.city ?? "-"}</TableCell>
-                  <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
-                  <TableCell className="text-right tabular-nums">{formatNumber(row.error_hits)}</TableCell>
-                  <TableCell className="text-right tabular-nums">{formatBytes(row.total_bytes)}</TableCell>
+          <>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>IP</TableHead>
+                  <TableHead>Country</TableHead>
+                  <TableHead>City</TableHead>
+                  <TableHead className="text-right">Hits</TableHead>
+                  <TableHead className="text-right">Errors</TableHead>
+                  <TableHead className="text-right">Bytes</TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {pageItems.map((row) => (
+                  <TableRow key={row.ip_address}>
+                    <TableCell className="font-mono text-xs">{row.ip_address}</TableCell>
+                    <TableCell>{row.country_code ?? "-"}</TableCell>
+                    <TableCell>{row.city ?? "-"}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatNumber(row.error_hits)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatBytes(row.total_bytes)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            <TablePaginationFooter {...pagination} onPageChange={pagination.setPage} />
+          </>
         )}
       </CardContent>
     </Card>

--- a/resources/components/analytics/top-ips-table.tsx
+++ b/resources/components/analytics/top-ips-table.tsx
@@ -1,0 +1,54 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Skeleton } from "@/components/ui/skeleton"
+import { formatBytes, formatNumber } from "@/lib/api"
+import { useTopIpStats } from "@/lib/queries"
+
+export function TopIpsTable() {
+  const { data, isLoading } = useTopIpStats({ limit: 25 })
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Top IPs</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading || !data ? (
+          <Skeleton className="h-48 w-full" />
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>IP</TableHead>
+                <TableHead>Country</TableHead>
+                <TableHead>City</TableHead>
+                <TableHead className="text-right">Hits</TableHead>
+                <TableHead className="text-right">Errors</TableHead>
+                <TableHead className="text-right">Bytes</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.items.map((row) => (
+                <TableRow key={row.ip_address}>
+                  <TableCell className="font-mono text-xs">{row.ip_address}</TableCell>
+                  <TableCell>{row.country_code ?? "-"}</TableCell>
+                  <TableCell>{row.city ?? "-"}</TableCell>
+                  <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
+                  <TableCell className="text-right tabular-nums">{formatNumber(row.error_hits)}</TableCell>
+                  <TableCell className="text-right tabular-nums">{formatBytes(row.total_bytes)}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/resources/components/analytics/top-urls-table.tsx
+++ b/resources/components/analytics/top-urls-table.tsx
@@ -10,9 +10,11 @@ import {
 import { Skeleton } from "@/components/ui/skeleton"
 import { formatBytes, formatDuration, formatNumber } from "@/lib/api"
 import { useTopUrls } from "@/lib/queries"
+import { TablePaginationFooter, usePagedRows } from "./table-pagination"
 
 export function TopUrlsTable() {
   const { data, isLoading } = useTopUrls({ limit: 25 })
+  const { pageItems, ...pagination } = usePagedRows(data?.items)
 
   return (
     <Card>
@@ -23,28 +25,31 @@ export function TopUrlsTable() {
         {isLoading || !data ? (
           <Skeleton className="h-48 w-full" />
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>URL</TableHead>
-                <TableHead className="text-right">Hits</TableHead>
-                <TableHead className="text-right">Errors</TableHead>
-                <TableHead className="text-right">Bytes</TableHead>
-                <TableHead className="text-right">Avg time</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {data.items.map((row) => (
-                <TableRow key={row.url}>
-                  <TableCell className="font-mono text-xs max-w-[420px] truncate">{row.url}</TableCell>
-                  <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
-                  <TableCell className="text-right tabular-nums">{formatNumber(row.error_hits)}</TableCell>
-                  <TableCell className="text-right tabular-nums">{formatBytes(row.total_bytes)}</TableCell>
-                  <TableCell className="text-right tabular-nums">{formatDuration(row.avg_request_time * 1000)}</TableCell>
+          <>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>URL</TableHead>
+                  <TableHead className="text-right">Hits</TableHead>
+                  <TableHead className="text-right">Errors</TableHead>
+                  <TableHead className="text-right">Bytes</TableHead>
+                  <TableHead className="text-right">Avg time</TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {pageItems.map((row) => (
+                  <TableRow key={row.url}>
+                    <TableCell className="font-mono text-xs max-w-[420px] truncate">{row.url}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatNumber(row.error_hits)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatBytes(row.total_bytes)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatDuration(row.avg_request_time * 1000)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            <TablePaginationFooter {...pagination} onPageChange={pagination.setPage} />
+          </>
         )}
       </CardContent>
     </Card>

--- a/resources/components/analytics/top-user-agents-table.tsx
+++ b/resources/components/analytics/top-user-agents-table.tsx
@@ -10,9 +10,11 @@ import {
 import { Skeleton } from "@/components/ui/skeleton"
 import { formatNumber } from "@/lib/api"
 import { useTopUserAgents } from "@/lib/queries"
+import { TablePaginationFooter, usePagedRows } from "./table-pagination"
 
 export function TopUserAgentsTable() {
   const { data, isLoading } = useTopUserAgents({ limit: 25 })
+  const { pageItems, ...pagination } = usePagedRows(data?.items)
 
   return (
     <Card>
@@ -23,22 +25,25 @@ export function TopUserAgentsTable() {
         {isLoading || !data ? (
           <Skeleton className="h-48 w-full" />
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>User agent</TableHead>
-                <TableHead className="text-right">Hits</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {data.items.map((row) => (
-                <TableRow key={row.user_agent}>
-                  <TableCell className="font-mono text-xs max-w-[640px] truncate">{row.user_agent}</TableCell>
-                  <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
+          <>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>User agent</TableHead>
+                  <TableHead className="text-right">Hits</TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {pageItems.map((row) => (
+                  <TableRow key={row.user_agent}>
+                    <TableCell className="font-mono text-xs max-w-[640px] truncate">{row.user_agent}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            <TablePaginationFooter {...pagination} onPageChange={pagination.setPage} />
+          </>
         )}
       </CardContent>
     </Card>

--- a/resources/components/time-range-toolbar.tsx
+++ b/resources/components/time-range-toolbar.tsx
@@ -40,7 +40,12 @@ const GRANULARITY_OPTIONS: { label: string; value: ChartGranularity }[] = [
 
 function CustomRangeFields({ onApply }: { onApply: (r: CustomTimeRange) => void }) {
   const { customRange } = useTimeRange()
-  const toLocal = (iso?: string) => (iso ? iso.slice(0, 16) : "") // datetime-local value
+  const toLocal = (iso?: string) => {
+    if (!iso) return ""
+    const d = new Date(iso)
+    const pad = (n: number) => String(n).padStart(2, "0")
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+  } // datetime-local value (local wall-clock, not UTC)
   const [from, setFrom] = useState(toLocal(customRange?.from))
   const [to, setTo] = useState(toLocal(customRange?.to))
   const valid = from && to && new Date(from) < new Date(to)

--- a/resources/components/time-range-toolbar.tsx
+++ b/resources/components/time-range-toolbar.tsx
@@ -1,4 +1,4 @@
-import { RotateCw, Filter, SlidersHorizontal } from "lucide-react"
+import { RotateCw, Filter, SlidersHorizontal, BarChart3 } from "lucide-react"
 
 import {
   DropdownMenu,
@@ -25,12 +25,18 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { useTimeRange } from "@/lib/time-range-context"
-import { TIME_RANGE_PRESETS, POLL_INTERVAL_OPTIONS } from "@/lib/api"
+import { TIME_RANGE_PRESETS, POLL_INTERVAL_OPTIONS, type ChartGranularity } from "@/lib/api"
 import { cn } from "@/lib/utils"
 import { useIsFetching } from "@tanstack/react-query"
 
+const GRANULARITY_OPTIONS: { label: string; value: ChartGranularity }[] = [
+  { label: "Auto", value: "auto" },
+  { label: "Hourly", value: "hourly" },
+  { label: "Daily", value: "daily" },
+]
+
 export function TimeRangeToolbar() {
-  const { range, pollInterval, setRange, setPollInterval, refresh } = useTimeRange()
+  const { range, pollInterval, granularity, setRange, setPollInterval, setGranularity, refresh } = useTimeRange()
   const isFetching = useIsFetching()
 
   return (
@@ -103,6 +109,23 @@ export function TimeRangeToolbar() {
             ))}
           </SelectContent>
         </Select>
+
+        {/* Chart Granularity Select */}
+        <Select
+          value={granularity}
+          onValueChange={(value) => setGranularity(value as ChartGranularity)}
+        >
+          <SelectTrigger size="sm" className="w-[90px] text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {GRANULARITY_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       {/* Mobile Layout - 3 icon buttons */}
@@ -166,6 +189,33 @@ export function TimeRangeToolbar() {
                 <DropdownMenuRadioItem
                   key={option.value}
                   value={String(option.value)}
+                  className="text-xs"
+                >
+                  {option.label}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* Chart Granularity Dropdown */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="icon-sm" className="shrink-0">
+              <BarChart3 className="h-4 w-4" />
+              <span className="sr-only">Chart Granularity</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuLabel>Chart Granularity</DropdownMenuLabel>
+            <DropdownMenuRadioGroup
+              value={granularity}
+              onValueChange={(value) => setGranularity(value as ChartGranularity)}
+            >
+              {GRANULARITY_OPTIONS.map((option) => (
+                <DropdownMenuRadioItem
+                  key={option.value}
+                  value={option.value}
                   className="text-xs"
                 >
                   {option.label}

--- a/resources/components/time-range-toolbar.tsx
+++ b/resources/components/time-range-toolbar.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { RotateCw, Filter, SlidersHorizontal, BarChart3 } from "lucide-react"
 
 import {
@@ -8,9 +9,11 @@ import {
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
+  DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu"
 
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import {
   Select,
   SelectContent,
@@ -25,7 +28,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { useTimeRange } from "@/lib/time-range-context"
-import { TIME_RANGE_PRESETS, POLL_INTERVAL_OPTIONS, type ChartGranularity } from "@/lib/api"
+import { TIME_RANGE_PRESETS, POLL_INTERVAL_OPTIONS, type ChartGranularity, type CustomTimeRange } from "@/lib/api"
 import { cn } from "@/lib/utils"
 import { useIsFetching } from "@tanstack/react-query"
 
@@ -35,9 +38,47 @@ const GRANULARITY_OPTIONS: { label: string; value: ChartGranularity }[] = [
   { label: "Daily", value: "daily" },
 ]
 
+function CustomRangeFields({ onApply }: { onApply: (r: CustomTimeRange) => void }) {
+  const { customRange } = useTimeRange()
+  const toLocal = (iso?: string) => (iso ? iso.slice(0, 16) : "") // datetime-local value
+  const [from, setFrom] = useState(toLocal(customRange?.from))
+  const [to, setTo] = useState(toLocal(customRange?.to))
+  const valid = from && to && new Date(from) < new Date(to)
+  return (
+    <div className="flex flex-col gap-2 p-2 w-64">
+      <label className="text-xs text-muted-foreground">From</label>
+      <Input type="datetime-local" value={from} onChange={(e) => setFrom(e.target.value)} />
+      <label className="text-xs text-muted-foreground">To</label>
+      <Input type="datetime-local" value={to} onChange={(e) => setTo(e.target.value)} />
+      <Button
+        size="sm"
+        disabled={!valid}
+        onClick={() => onApply({ from: new Date(from).toISOString(), to: new Date(to).toISOString() })}
+      >
+        Apply
+      </Button>
+    </div>
+  )
+}
+
 export function TimeRangeToolbar() {
-  const { range, pollInterval, granularity, setRange, setPollInterval, setGranularity, refresh } = useTimeRange()
+  const {
+    range,
+    customRange,
+    pollInterval,
+    granularity,
+    setRange,
+    setCustomRange,
+    setPollInterval,
+    setGranularity,
+    refresh,
+  } = useTimeRange()
   const isFetching = useIsFetching()
+
+  const rangeLabel =
+    range === "custom" && customRange
+      ? `${new Date(customRange.from).toLocaleDateString(undefined, { month: "short", day: "numeric" })} → ${new Date(customRange.to).toLocaleDateString(undefined, { month: "short", day: "numeric" })}`
+      : TIME_RANGE_PRESETS.find((p) => p.value === range)?.label || "Range"
 
   return (
     <>
@@ -48,9 +89,7 @@ export function TimeRangeToolbar() {
           <DropdownMenuTrigger asChild>
             <Button variant="outline" size="sm" className="flex items-center gap-2">
               <Filter className="w-4 h-4" />
-              <span className="text-xs">
-                {TIME_RANGE_PRESETS.find((p) => p.value === range)?.label || "Range"}
-              </span>
+              <span className="text-xs">{rangeLabel}</span>
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start">
@@ -66,6 +105,11 @@ export function TimeRangeToolbar() {
                 {preset.label}
               </DropdownMenuItem>
             ))}
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-xs">Custom range</DropdownMenuLabel>
+            <div onKeyDown={(e) => e.stopPropagation()}>
+              <CustomRangeFields onApply={setCustomRange} />
+            </div>
           </DropdownMenuContent>
         </DropdownMenu>
 
@@ -151,6 +195,11 @@ export function TimeRangeToolbar() {
                 </DropdownMenuRadioItem>
               ))}
             </DropdownMenuRadioGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-xs">Custom range</DropdownMenuLabel>
+            <div onKeyDown={(e) => e.stopPropagation()}>
+              <CustomRangeFields onApply={setCustomRange} />
+            </div>
           </DropdownMenuContent>
         </DropdownMenu>
 

--- a/resources/components/time-range-toolbar.tsx
+++ b/resources/components/time-range-toolbar.tsx
@@ -97,7 +97,7 @@ export function TimeRangeToolbar() {
               <span className="text-xs">{rangeLabel}</span>
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="start">
+          <DropdownMenuContent align="start" className="w-auto!">
             {TIME_RANGE_PRESETS.map((preset) => (
               <DropdownMenuItem
                 key={preset.value}
@@ -187,7 +187,7 @@ export function TimeRangeToolbar() {
               <span className="sr-only">Time Range</span>
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
+          <DropdownMenuContent align="end" className="w-auto!">
             <DropdownMenuLabel>Time Range</DropdownMenuLabel>
             <DropdownMenuRadioGroup value={range} onValueChange={(value) => setRange(value as typeof range)}>
               {TIME_RANGE_PRESETS.map((preset) => (

--- a/resources/generated/api/schemas.gen.ts
+++ b/resources/generated/api/schemas.gen.ts
@@ -2,27 +2,27 @@
 
 export const AccessLogFacetsSchema = {
   properties: {
-    cities: {
-      items: {
-        type: "string",
-      },
-      type: "array",
-    },
     countries: {
       items: {
         $ref: "#/components/schemas/CountryFacet",
       },
       type: "array",
     },
+    cities: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+    },
   },
+  type: "object",
   required: ["cities", "countries"],
   title: "AccessLogFacets",
-  type: "object",
 } as const;
 
 export const AnalyticsSettingsViewSchema = {
   properties: {
-    compression_after_days: {
+    raw_retention_days: {
       type: "integer",
     },
     debug_retention_days: {
@@ -31,10 +31,11 @@ export const AnalyticsSettingsViewSchema = {
     hourly_retention_days: {
       type: "integer",
     },
-    raw_retention_days: {
+    compression_after_days: {
       type: "integer",
     },
   },
+  type: "object",
   required: [
     "compression_after_days",
     "debug_retention_days",
@@ -42,7 +43,6 @@ export const AnalyticsSettingsViewSchema = {
     "raw_retention_days",
   ],
   title: "AnalyticsSettingsView",
-  type: "object",
 } as const;
 
 export const CountryFacetSchema = {
@@ -54,26 +54,27 @@ export const CountryFacetSchema = {
       type: "string",
     },
   },
+  type: "object",
   required: ["code", "name"],
   title: "CountryFacet",
-  type: "object",
 } as const;
 
 export const CumulativeDataPointSchema = {
   properties: {
+    timestamp: {
+      type: "string",
+    },
+    cumulative_geo_events: {
+      type: "integer",
+    },
     cumulative_access_logs: {
       type: "integer",
     },
     cumulative_bytes: {
       type: "integer",
     },
-    cumulative_geo_events: {
-      type: "integer",
-    },
-    timestamp: {
-      type: "string",
-    },
   },
+  type: "object",
   required: [
     "cumulative_access_logs",
     "cumulative_bytes",
@@ -81,34 +82,42 @@ export const CumulativeDataPointSchema = {
     "timestamp",
   ],
   title: "CumulativeDataPoint",
-  type: "object",
 } as const;
 
 export const CumulativeTimeSeriesResponseSchema = {
   properties: {
-    data: {
-      items: {
-        $ref: "#/components/schemas/CumulativeDataPoint",
-      },
-      type: "array",
-    },
-    end_date: {
-      type: "string",
-    },
     granularity: {
       type: "string",
     },
     start_date: {
       type: "string",
     },
+    end_date: {
+      type: "string",
+    },
+    data: {
+      items: {
+        $ref: "#/components/schemas/CumulativeDataPoint",
+      },
+      type: "array",
+    },
   },
+  type: "object",
   required: ["end_date", "granularity", "start_date"],
   title: "CumulativeTimeSeriesResponse",
-  type: "object",
 } as const;
 
 export const EmbeddedLocationDTOSchema = {
   properties: {
+    id: {
+      type: "integer",
+    },
+    latitude: {
+      type: "number",
+    },
+    longitude: {
+      type: "number",
+    },
     city: {
       oneOf: [
         {
@@ -139,19 +148,10 @@ export const EmbeddedLocationDTOSchema = {
         },
       ],
     },
-    id: {
-      type: "integer",
-    },
-    latitude: {
-      type: "number",
-    },
-    longitude: {
-      type: "number",
-    },
   },
+  type: "object",
   required: ["id", "latitude", "longitude"],
   title: "EmbeddedLocationDTO",
-  type: "object",
 } as const;
 
 export const GeoEventsDataPointSchema = {
@@ -162,16 +162,17 @@ export const GeoEventsDataPointSchema = {
     total_geo_events: {
       type: "integer",
     },
-    unique_cities: {
+    unique_ips: {
       type: "integer",
     },
     unique_countries: {
       type: "integer",
     },
-    unique_ips: {
+    unique_cities: {
       type: "integer",
     },
   },
+  type: "object",
   required: [
     "timestamp",
     "total_geo_events",
@@ -180,51 +181,53 @@ export const GeoEventsDataPointSchema = {
     "unique_ips",
   ],
   title: "GeoEventsDataPoint",
-  type: "object",
 } as const;
 
 export const GeoEventsTimeSeriesResponseSchema = {
   properties: {
-    data: {
-      items: {
-        $ref: "#/components/schemas/GeoEventsDataPoint",
-      },
-      type: "array",
-    },
-    end_date: {
-      type: "string",
-    },
     granularity: {
       type: "string",
     },
     start_date: {
       type: "string",
     },
+    end_date: {
+      type: "string",
+    },
+    data: {
+      items: {
+        $ref: "#/components/schemas/GeoEventsDataPoint",
+      },
+      type: "array",
+    },
   },
+  type: "object",
   required: ["data", "end_date", "granularity", "start_date"],
   title: "GeoEventsTimeSeriesResponse",
-  type: "object",
 } as const;
 
 export const GeoJSONFeatureSchema = {
   properties: {
+    type: {
+      type: "string",
+    },
     geometry: {
       $ref: "#/components/schemas/GeoJSONPointGeometry",
     },
     properties: {
       $ref: "#/components/schemas/GeoJSONFeatureProperties",
     },
-    type: {
-      type: "string",
-    },
   },
+  type: "object",
   required: ["geometry", "properties", "type"],
   title: "GeoJSONFeature",
-  type: "object",
 } as const;
 
 export const GeoJSONFeatureCollectionSchema = {
   properties: {
+    type: {
+      type: "string",
+    },
     features: {
       items: {
         $ref: "#/components/schemas/GeoJSONFeature",
@@ -234,26 +237,19 @@ export const GeoJSONFeatureCollectionSchema = {
     stats: {
       $ref: "#/components/schemas/GeoJSONFeatureStats",
     },
-    type: {
-      type: "string",
-    },
   },
+  type: "object",
   required: ["features", "stats", "type"],
   title: "GeoJSONFeatureCollection",
-  type: "object",
 } as const;
 
 export const GeoJSONFeaturePropertiesSchema = {
   properties: {
-    city: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
+    id: {
+      type: "integer",
+    },
+    geohash: {
+      type: "string",
     },
     country_code: {
       type: "string",
@@ -261,30 +257,11 @@ export const GeoJSONFeaturePropertiesSchema = {
     country_name: {
       type: "string",
     },
-    event_count: {
-      type: "integer",
-    },
-    geohash: {
-      type: "string",
-    },
-    id: {
-      type: "integer",
-    },
     last_hit: {
       oneOf: [
         {
+          type: "string",
           format: "date-time",
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    postal_code: {
-      oneOf: [
-        {
-          type: "string",
         },
         {
           type: "null",
@@ -311,6 +288,26 @@ export const GeoJSONFeaturePropertiesSchema = {
         },
       ],
     },
+    city: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    postal_code: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
     timezone: {
       oneOf: [
         {
@@ -321,6 +318,9 @@ export const GeoJSONFeaturePropertiesSchema = {
         },
       ],
     },
+    event_count: {
+      type: "integer",
+    },
     top_ips: {
       items: {
         $ref: "#/components/schemas/TopIPDTO",
@@ -328,6 +328,7 @@ export const GeoJSONFeaturePropertiesSchema = {
       type: "array",
     },
   },
+  type: "object",
   required: [
     "city",
     "country_code",
@@ -342,31 +343,33 @@ export const GeoJSONFeaturePropertiesSchema = {
     "timezone",
   ],
   title: "GeoJSONFeatureProperties",
-  type: "object",
 } as const;
 
 export const GeoJSONFeatureStatsSchema = {
   properties: {
-    cities: {
+    events: {
       type: "integer",
     },
     countries: {
       type: "integer",
     },
-    events: {
+    cities: {
       type: "integer",
     },
     locations: {
       type: "integer",
     },
   },
+  type: "object",
   required: ["cities", "countries", "events", "locations"],
   title: "GeoJSONFeatureStats",
-  type: "object",
 } as const;
 
 export const GeoJSONPointGeometrySchema = {
   properties: {
+    type: {
+      type: "string",
+    },
     coordinates: {
       prefixItems: [
         {
@@ -378,13 +381,10 @@ export const GeoJSONPointGeometrySchema = {
       ],
       type: "array",
     },
-    type: {
-      type: "string",
-    },
   },
+  type: "object",
   required: ["coordinates", "type"],
   title: "GeoJSONPointGeometry",
-  type: "object",
 } as const;
 
 export const GlobalTopIPsResponseSchema = {
@@ -396,9 +396,9 @@ export const GlobalTopIPsResponseSchema = {
       type: "array",
     },
   },
+  type: "object",
   required: [],
   title: "GlobalTopIPsResponse",
-  type: "object",
 } as const;
 
 export const ListAccessLogDebugsAccessLogDebugResponseBodySchema = {
@@ -414,15 +414,15 @@ export const ListAccessLogDebugsAccessLogDebugResponseBodySchema = {
       ],
     },
     createdAt: {
+      type: "string",
       format: "date-time",
+    },
+    rawLine: {
       type: "string",
     },
-    id: {
-      type: "integer",
-    },
     isMalformed: {
-      default: false,
       type: "boolean",
+      default: false,
     },
     parseError: {
       oneOf: [
@@ -434,22 +434,28 @@ export const ListAccessLogDebugsAccessLogDebugResponseBodySchema = {
         },
       ],
     },
-    rawLine: {
-      type: "string",
+    id: {
+      type: "integer",
     },
   },
+  type: "object",
   required: ["id", "rawLine"],
   title: "ListAccessLogDebugsAccessLogDebugResponseBody",
-  type: "object",
 } as const;
 
 export const ListAccessLogsAccessLogResponseBodySchema = {
   properties: {
-    bytesSent: {
-      default: 0,
-      type: "integer",
+    timestamp: {
+      type: "string",
+      format: "date-time",
     },
-    city: {
+    ipAddress: {
+      type: "string",
+    },
+    remoteUser: {
+      type: "string",
+    },
+    method: {
       oneOf: [
         {
           type: "string",
@@ -459,27 +465,7 @@ export const ListAccessLogsAccessLogResponseBodySchema = {
         },
       ],
     },
-    countryCode: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    countryName: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    host: {
+    url: {
       oneOf: [
         {
           type: "string",
@@ -499,57 +485,14 @@ export const ListAccessLogsAccessLogResponseBodySchema = {
         },
       ],
     },
-    id: {
-      type: "integer",
-    },
-    ipAddress: {
-      type: "string",
-    },
-    method: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    referrer: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    remoteUser: {
-      type: "string",
-    },
-    requestTime: {
-      default: 0,
-      type: "number",
-    },
     statusCode: {
       type: "integer",
     },
-    timestamp: {
-      format: "date-time",
-      type: "string",
+    bytesSent: {
+      type: "integer",
+      default: 0,
     },
-    upstreamResponseTime: {
-      oneOf: [
-        {
-          type: "number",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    url: {
+    referrer: {
       oneOf: [
         {
           type: "string",
@@ -569,15 +512,21 @@ export const ListAccessLogsAccessLogResponseBodySchema = {
         },
       ],
     },
-  },
-  required: ["id", "ipAddress", "statusCode", "timestamp"],
-  title: "ListAccessLogsAccessLogResponseBody",
-  type: "object",
-} as const;
-
-export const ListGeoEventsGeoEventGeoLocationResponseBodySchema = {
-  properties: {
-    city: {
+    requestTime: {
+      type: "number",
+      default: 0,
+    },
+    upstreamResponseTime: {
+      oneOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    host: {
       oneOf: [
         {
           type: "string",
@@ -588,28 +537,8 @@ export const ListGeoEventsGeoEventGeoLocationResponseBodySchema = {
       ],
     },
     countryCode: {
-      type: "string",
-    },
-    countryName: {
-      type: "string",
-    },
-    createdAt: {
-      format: "date-time",
-      type: "string",
-    },
-    geographicPoint: {
-      type: "string",
-    },
-    geohash: {
-      type: "string",
-    },
-    id: {
-      type: "integer",
-    },
-    lastHit: {
       oneOf: [
         {
-          format: "date-time",
           type: "string",
         },
         {
@@ -617,21 +546,54 @@ export const ListGeoEventsGeoEventGeoLocationResponseBodySchema = {
         },
       ],
     },
+    countryName: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    city: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    id: {
+      type: "integer",
+    },
+  },
+  type: "object",
+  required: ["id", "ipAddress", "statusCode", "timestamp"],
+  title: "ListAccessLogsAccessLogResponseBody",
+} as const;
+
+export const ListGeoEventsGeoEventGeoLocationResponseBodySchema = {
+  properties: {
     latitude: {
       type: "number",
     },
     longitude: {
       type: "number",
     },
-    postalCode: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
+    geohash: {
+      type: "string",
+    },
+    geographicPoint: {
+      type: "string",
+    },
+    countryCode: {
+      type: "string",
+    },
+    countryName: {
+      type: "string",
     },
     state: {
       oneOf: [
@@ -653,6 +615,26 @@ export const ListGeoEventsGeoEventGeoLocationResponseBodySchema = {
         },
       ],
     },
+    city: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    postalCode: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
     timezone: {
       oneOf: [
         {
@@ -663,11 +645,30 @@ export const ListGeoEventsGeoEventGeoLocationResponseBodySchema = {
         },
       ],
     },
-    updatedAt: {
-      format: "date-time",
+    lastHit: {
+      oneOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    createdAt: {
       type: "string",
+      format: "date-time",
+    },
+    updatedAt: {
+      type: "string",
+      format: "date-time",
+    },
+    id: {
+      type: "integer",
     },
   },
+  type: "object",
   required: [
     "countryCode",
     "countryName",
@@ -678,93 +679,54 @@ export const ListGeoEventsGeoEventGeoLocationResponseBodySchema = {
     "longitude",
   ],
   title: "ListGeoEventsGeoEventGeoLocationResponseBody",
-  type: "object",
 } as const;
 
 export const ListGeoEventsGeoEventResponseBodySchema = {
   properties: {
-    hostname: {
+    timestamp: {
       type: "string",
-    },
-    id: {
-      type: "integer",
+      format: "date-time",
     },
     ipAddress: {
       type: "string",
     },
-    location: {
-      $ref: "#/components/schemas/ListGeoEventsGeoEventGeoLocationResponseBody",
+    hostname: {
+      type: "string",
     },
     locationId: {
       type: "integer",
     },
-    timestamp: {
-      format: "date-time",
-      type: "string",
-    },
-  },
-  required: ["hostname", "id", "ipAddress", "location", "locationId"],
-  title: "ListGeoEventsGeoEventResponseBody",
-  type: "object",
-} as const;
-
-export const ListGeoLocationsGeoLocationResponseBodySchema = {
-  properties: {
-    city: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    countryCode: {
-      type: "string",
-    },
-    countryName: {
-      type: "string",
-    },
-    createdAt: {
-      format: "date-time",
-      type: "string",
-    },
-    geographicPoint: {
-      type: "string",
-    },
-    geohash: {
-      type: "string",
+    location: {
+      $ref: "#/components/schemas/ListGeoEventsGeoEventGeoLocationResponseBody",
     },
     id: {
       type: "integer",
     },
-    lastHit: {
-      oneOf: [
-        {
-          format: "date-time",
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
+  },
+  type: "object",
+  required: ["hostname", "id", "ipAddress", "location", "locationId"],
+  title: "ListGeoEventsGeoEventResponseBody",
+} as const;
+
+export const ListGeoLocationsGeoLocationResponseBodySchema = {
+  properties: {
     latitude: {
       type: "number",
     },
     longitude: {
       type: "number",
     },
-    postalCode: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
+    geohash: {
+      type: "string",
+    },
+    geographicPoint: {
+      type: "string",
+    },
+    countryCode: {
+      type: "string",
+    },
+    countryName: {
+      type: "string",
     },
     state: {
       oneOf: [
@@ -786,6 +748,26 @@ export const ListGeoLocationsGeoLocationResponseBodySchema = {
         },
       ],
     },
+    city: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    postalCode: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
     timezone: {
       oneOf: [
         {
@@ -796,11 +778,30 @@ export const ListGeoLocationsGeoLocationResponseBodySchema = {
         },
       ],
     },
-    updatedAt: {
-      format: "date-time",
+    lastHit: {
+      oneOf: [
+        {
+          type: "string",
+          format: "date-time",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    createdAt: {
       type: "string",
+      format: "date-time",
+    },
+    updatedAt: {
+      type: "string",
+      format: "date-time",
+    },
+    id: {
+      type: "integer",
     },
   },
+  type: "object",
   required: [
     "countryCode",
     "countryName",
@@ -811,7 +812,6 @@ export const ListGeoLocationsGeoLocationResponseBodySchema = {
     "longitude",
   ],
   title: "ListGeoLocationsGeoLocationResponseBody",
-  type: "object",
 } as const;
 
 export const LocationTopIPsResponseSchema = {
@@ -826,23 +826,23 @@ export const LocationTopIPsResponseSchema = {
       type: "array",
     },
   },
+  type: "object",
   required: ["location_id"],
   title: "LocationTopIPsResponse",
-  type: "object",
 } as const;
 
 export const LoginPayloadSchema = {
   properties: {
-    password: {
-      type: "string",
-    },
     username: {
       type: "string",
     },
+    password: {
+      type: "string",
+    },
   },
+  type: "object",
   required: ["password", "username"],
   title: "LoginPayload",
-  type: "object",
 } as const;
 
 export const LogparserSettingsViewSchema = {
@@ -860,9 +860,9 @@ export const LogparserSettingsViewSchema = {
       type: "boolean",
     },
   },
+  type: "object",
   required: ["log_paths", "send_logs", "store_debug_lines"],
   title: "LogparserSettingsView",
-  type: "object",
 } as const;
 
 export const MapSettingsViewSchema = {
@@ -888,13 +888,13 @@ export const MapSettingsViewSchema = {
       ],
     },
     home_source: {
-      enum: ["configured", "external_ip", null],
       type: ["null", "string"],
+      enum: ["configured", "external_ip", null],
     },
   },
+  type: "object",
   required: ["home_latitude", "home_longitude", "home_source"],
   title: "MapSettingsView",
-  type: "object",
 } as const;
 
 export const MeResponseSchema = {
@@ -903,34 +903,14 @@ export const MeResponseSchema = {
       type: "string",
     },
   },
+  type: "object",
   required: ["username"],
   title: "MeResponse",
-  type: "object",
 } as const;
 
 export const PercentChangeSchema = {
   properties: {
-    avg_request_time: {
-      oneOf: [
-        {
-          type: "number",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    bytes_sent: {
-      oneOf: [
-        {
-          type: "number",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    error_rate: {
+    log_records: {
       oneOf: [
         {
           type: "number",
@@ -950,7 +930,37 @@ export const PercentChangeSchema = {
         },
       ],
     },
-    log_records: {
+    unique_ips: {
+      oneOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    bytes_sent: {
+      oneOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    avg_request_time: {
+      oneOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    error_rate: {
       oneOf: [
         {
           type: "number",
@@ -970,37 +980,30 @@ export const PercentChangeSchema = {
         },
       ],
     },
-    unique_ips: {
-      oneOf: [
-        {
-          type: "number",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
   },
+  type: "object",
   required: [],
   title: "PercentChange",
-  type: "object",
 } as const;
 
 export const PeriodSummarySchema = {
   properties: {
-    avg_bytes_per_request: {
-      type: "number",
-    },
-    avg_request_time: {
-      type: "number",
-    },
-    error_rate: {
-      type: "number",
-    },
-    malformed_requests: {
+    total_requests: {
       type: "integer",
     },
-    max_request_time: {
+    total_geo_events: {
+      type: "integer",
+    },
+    unique_ips: {
+      type: "integer",
+    },
+    unique_countries: {
+      type: "integer",
+    },
+    total_bytes_sent: {
+      type: "integer",
+    },
+    avg_bytes_per_request: {
       type: "number",
     },
     status_2xx: {
@@ -1015,22 +1018,20 @@ export const PeriodSummarySchema = {
     status_5xx: {
       type: "integer",
     },
-    total_bytes_sent: {
+    avg_request_time: {
+      type: "number",
+    },
+    max_request_time: {
+      type: "number",
+    },
+    malformed_requests: {
       type: "integer",
     },
-    total_geo_events: {
-      type: "integer",
-    },
-    total_requests: {
-      type: "integer",
-    },
-    unique_countries: {
-      type: "integer",
-    },
-    unique_ips: {
-      type: "integer",
+    error_rate: {
+      type: "number",
     },
   },
+  type: "object",
   required: [
     "avg_bytes_per_request",
     "avg_request_time",
@@ -1048,13 +1049,15 @@ export const PeriodSummarySchema = {
     "unique_ips",
   ],
   title: "PeriodSummary",
-  type: "object",
 } as const;
 
 export const SafeSettingsResponseSchema = {
   properties: {
-    analytics: {
-      $ref: "#/components/schemas/AnalyticsSettingsView",
+    name: {
+      type: "string",
+    },
+    version: {
+      type: "string",
     },
     environment: {
       type: "string",
@@ -1062,38 +1065,28 @@ export const SafeSettingsResponseSchema = {
     logparser: {
       $ref: "#/components/schemas/LogparserSettingsView",
     },
+    analytics: {
+      $ref: "#/components/schemas/AnalyticsSettingsView",
+    },
     map: {
       $ref: "#/components/schemas/MapSettingsView",
     },
-    name: {
-      type: "string",
-    },
-    version: {
-      type: "string",
-    },
   },
+  type: "object",
   required: ["analytics", "environment", "logparser", "map", "name", "version"],
   title: "SafeSettingsResponse",
-  type: "object",
 } as const;
 
 export const SummaryResponseSchema = {
   properties: {
-    current_period: {
-      $ref: "#/components/schemas/PeriodSummary",
+    start_date: {
+      type: "string",
     },
     end_date: {
       type: "string",
     },
-    percent_changes: {
-      oneOf: [
-        {
-          $ref: "#/components/schemas/PercentChange",
-        },
-        {
-          type: "null",
-        },
-      ],
+    current_period: {
+      $ref: "#/components/schemas/PeriodSummary",
     },
     previous_period: {
       oneOf: [
@@ -1105,31 +1098,35 @@ export const SummaryResponseSchema = {
         },
       ],
     },
-    start_date: {
-      type: "string",
+    percent_changes: {
+      oneOf: [
+        {
+          $ref: "#/components/schemas/PercentChange",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
   },
+  type: "object",
   required: ["current_period", "end_date", "start_date"],
   title: "SummaryResponse",
-  type: "object",
 } as const;
 
 export const TimeSeriesDataPointSchema = {
   properties: {
-    avg_request_time: {
-      type: "number",
+    timestamp: {
+      type: "string",
     },
-    error_rate: {
-      type: "number",
+    total_requests: {
+      type: "integer",
     },
-    p50_request_time: {
-      type: "number",
+    total_geo_events: {
+      type: "integer",
     },
-    p95_request_time: {
-      type: "number",
-    },
-    p99_request_time: {
-      type: "number",
+    total_bytes_sent: {
+      type: "integer",
     },
     status_2xx: {
       type: "integer",
@@ -1143,19 +1140,23 @@ export const TimeSeriesDataPointSchema = {
     status_5xx: {
       type: "integer",
     },
-    timestamp: {
-      type: "string",
+    error_rate: {
+      type: "number",
     },
-    total_bytes_sent: {
-      type: "integer",
+    avg_request_time: {
+      type: "number",
     },
-    total_geo_events: {
-      type: "integer",
+    p50_request_time: {
+      type: "number",
     },
-    total_requests: {
-      type: "integer",
+    p95_request_time: {
+      type: "number",
+    },
+    p99_request_time: {
+      type: "number",
     },
   },
+  type: "object",
   required: [
     "avg_request_time",
     "error_rate",
@@ -1172,30 +1173,29 @@ export const TimeSeriesDataPointSchema = {
     "total_requests",
   ],
   title: "TimeSeriesDataPoint",
-  type: "object",
 } as const;
 
 export const TimeSeriesResponseSchema = {
   properties: {
-    data: {
-      items: {
-        $ref: "#/components/schemas/TimeSeriesDataPoint",
-      },
-      type: "array",
-    },
-    end_date: {
-      type: "string",
-    },
     granularity: {
       type: "string",
     },
     start_date: {
       type: "string",
     },
+    end_date: {
+      type: "string",
+    },
+    data: {
+      items: {
+        $ref: "#/components/schemas/TimeSeriesDataPoint",
+      },
+      type: "array",
+    },
   },
+  type: "object",
   required: ["data", "end_date", "granularity", "start_date"],
   title: "TimeSeriesResponse",
-  type: "object",
 } as const;
 
 export const TopCountriesResponseSchema = {
@@ -1207,9 +1207,9 @@ export const TopCountriesResponseSchema = {
       type: "array",
     },
   },
+  type: "object",
   required: [],
   title: "TopCountriesResponse",
-  type: "object",
 } as const;
 
 export const TopCountryDTOSchema = {
@@ -1231,18 +1231,18 @@ export const TopCountryDTOSchema = {
       type: "integer",
     },
   },
+  type: "object",
   required: ["country_code", "country_name", "event_count"],
   title: "TopCountryDTO",
-  type: "object",
 } as const;
 
 export const TopIPDTOSchema = {
   properties: {
-    event_count: {
-      type: "integer",
-    },
     ip_address: {
       type: "string",
+    },
+    event_count: {
+      type: "integer",
     },
     location: {
       oneOf: [
@@ -1255,36 +1255,39 @@ export const TopIPDTOSchema = {
       ],
     },
   },
+  type: "object",
   required: ["event_count", "ip_address"],
   title: "TopIPDTO",
-  type: "object",
 } as const;
 
 export const TopUrlDTOSchema = {
   properties: {
-    avg_request_time: {
-      type: "number",
-    },
-    error_hits: {
-      type: "integer",
+    url: {
+      type: "string",
     },
     hits: {
+      type: "integer",
+    },
+    error_hits: {
       type: "integer",
     },
     total_bytes: {
       type: "integer",
     },
-    url: {
-      type: "string",
+    avg_request_time: {
+      type: "number",
     },
   },
+  type: "object",
   required: ["avg_request_time", "error_hits", "hits", "total_bytes", "url"],
   title: "TopUrlDTO",
-  type: "object",
 } as const;
 
 export const TopUrlsResponseSchema = {
   properties: {
+    start_date: {
+      type: "string",
+    },
     end_date: {
       type: "string",
     },
@@ -1294,31 +1297,31 @@ export const TopUrlsResponseSchema = {
       },
       type: "array",
     },
-    start_date: {
-      type: "string",
-    },
   },
+  type: "object",
   required: ["end_date", "items", "start_date"],
   title: "TopUrlsResponse",
-  type: "object",
 } as const;
 
 export const TopUserAgentDTOSchema = {
   properties: {
-    hits: {
-      type: "integer",
-    },
     user_agent: {
       type: "string",
     },
+    hits: {
+      type: "integer",
+    },
   },
+  type: "object",
   required: ["hits", "user_agent"],
   title: "TopUserAgentDTO",
-  type: "object",
 } as const;
 
 export const TopUserAgentsResponseSchema = {
   properties: {
+    start_date: {
+      type: "string",
+    },
     end_date: {
       type: "string",
     },
@@ -1328,11 +1331,8 @@ export const TopUserAgentsResponseSchema = {
       },
       type: "array",
     },
-    start_date: {
-      type: "string",
-    },
   },
+  type: "object",
   required: ["end_date", "items", "start_date"],
   title: "TopUserAgentsResponse",
-  type: "object",
 } as const;

--- a/resources/generated/api/schemas.gen.ts
+++ b/resources/generated/api/schemas.gen.ts
@@ -2,27 +2,27 @@
 
 export const AccessLogFacetsSchema = {
   properties: {
-    countries: {
-      items: {
-        $ref: "#/components/schemas/CountryFacet",
-      },
-      type: "array",
-    },
     cities: {
       items: {
         type: "string",
       },
       type: "array",
     },
+    countries: {
+      items: {
+        $ref: "#/components/schemas/CountryFacet",
+      },
+      type: "array",
+    },
   },
-  type: "object",
   required: ["cities", "countries"],
   title: "AccessLogFacets",
+  type: "object",
 } as const;
 
 export const AnalyticsSettingsViewSchema = {
   properties: {
-    raw_retention_days: {
+    compression_after_days: {
       type: "integer",
     },
     debug_retention_days: {
@@ -31,11 +31,10 @@ export const AnalyticsSettingsViewSchema = {
     hourly_retention_days: {
       type: "integer",
     },
-    compression_after_days: {
+    raw_retention_days: {
       type: "integer",
     },
   },
-  type: "object",
   required: [
     "compression_after_days",
     "debug_retention_days",
@@ -43,6 +42,7 @@ export const AnalyticsSettingsViewSchema = {
     "raw_retention_days",
   ],
   title: "AnalyticsSettingsView",
+  type: "object",
 } as const;
 
 export const CountryFacetSchema = {
@@ -54,27 +54,26 @@ export const CountryFacetSchema = {
       type: "string",
     },
   },
-  type: "object",
   required: ["code", "name"],
   title: "CountryFacet",
+  type: "object",
 } as const;
 
 export const CumulativeDataPointSchema = {
   properties: {
-    timestamp: {
-      type: "string",
-    },
-    cumulative_geo_events: {
-      type: "integer",
-    },
     cumulative_access_logs: {
       type: "integer",
     },
     cumulative_bytes: {
       type: "integer",
     },
+    cumulative_geo_events: {
+      type: "integer",
+    },
+    timestamp: {
+      type: "string",
+    },
   },
-  type: "object",
   required: [
     "cumulative_access_logs",
     "cumulative_bytes",
@@ -82,42 +81,34 @@ export const CumulativeDataPointSchema = {
     "timestamp",
   ],
   title: "CumulativeDataPoint",
+  type: "object",
 } as const;
 
 export const CumulativeTimeSeriesResponseSchema = {
   properties: {
-    granularity: {
-      type: "string",
-    },
-    start_date: {
-      type: "string",
-    },
-    end_date: {
-      type: "string",
-    },
     data: {
       items: {
         $ref: "#/components/schemas/CumulativeDataPoint",
       },
       type: "array",
     },
+    end_date: {
+      type: "string",
+    },
+    granularity: {
+      type: "string",
+    },
+    start_date: {
+      type: "string",
+    },
   },
-  type: "object",
   required: ["end_date", "granularity", "start_date"],
   title: "CumulativeTimeSeriesResponse",
+  type: "object",
 } as const;
 
 export const EmbeddedLocationDTOSchema = {
   properties: {
-    id: {
-      type: "integer",
-    },
-    latitude: {
-      type: "number",
-    },
-    longitude: {
-      type: "number",
-    },
     city: {
       oneOf: [
         {
@@ -148,10 +139,19 @@ export const EmbeddedLocationDTOSchema = {
         },
       ],
     },
+    id: {
+      type: "integer",
+    },
+    latitude: {
+      type: "number",
+    },
+    longitude: {
+      type: "number",
+    },
   },
-  type: "object",
   required: ["id", "latitude", "longitude"],
   title: "EmbeddedLocationDTO",
+  type: "object",
 } as const;
 
 export const GeoEventsDataPointSchema = {
@@ -162,17 +162,16 @@ export const GeoEventsDataPointSchema = {
     total_geo_events: {
       type: "integer",
     },
-    unique_ips: {
+    unique_cities: {
       type: "integer",
     },
     unique_countries: {
       type: "integer",
     },
-    unique_cities: {
+    unique_ips: {
       type: "integer",
     },
   },
-  type: "object",
   required: [
     "timestamp",
     "total_geo_events",
@@ -181,53 +180,51 @@ export const GeoEventsDataPointSchema = {
     "unique_ips",
   ],
   title: "GeoEventsDataPoint",
+  type: "object",
 } as const;
 
 export const GeoEventsTimeSeriesResponseSchema = {
   properties: {
-    granularity: {
-      type: "string",
-    },
-    start_date: {
-      type: "string",
-    },
-    end_date: {
-      type: "string",
-    },
     data: {
       items: {
         $ref: "#/components/schemas/GeoEventsDataPoint",
       },
       type: "array",
     },
+    end_date: {
+      type: "string",
+    },
+    granularity: {
+      type: "string",
+    },
+    start_date: {
+      type: "string",
+    },
   },
-  type: "object",
   required: ["data", "end_date", "granularity", "start_date"],
   title: "GeoEventsTimeSeriesResponse",
+  type: "object",
 } as const;
 
 export const GeoJSONFeatureSchema = {
   properties: {
-    type: {
-      type: "string",
-    },
     geometry: {
       $ref: "#/components/schemas/GeoJSONPointGeometry",
     },
     properties: {
       $ref: "#/components/schemas/GeoJSONFeatureProperties",
     },
+    type: {
+      type: "string",
+    },
   },
-  type: "object",
   required: ["geometry", "properties", "type"],
   title: "GeoJSONFeature",
+  type: "object",
 } as const;
 
 export const GeoJSONFeatureCollectionSchema = {
   properties: {
-    type: {
-      type: "string",
-    },
     features: {
       items: {
         $ref: "#/components/schemas/GeoJSONFeature",
@@ -237,19 +234,26 @@ export const GeoJSONFeatureCollectionSchema = {
     stats: {
       $ref: "#/components/schemas/GeoJSONFeatureStats",
     },
+    type: {
+      type: "string",
+    },
   },
-  type: "object",
   required: ["features", "stats", "type"],
   title: "GeoJSONFeatureCollection",
+  type: "object",
 } as const;
 
 export const GeoJSONFeaturePropertiesSchema = {
   properties: {
-    id: {
-      type: "integer",
-    },
-    geohash: {
-      type: "string",
+    city: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     country_code: {
       type: "string",
@@ -257,11 +261,30 @@ export const GeoJSONFeaturePropertiesSchema = {
     country_name: {
       type: "string",
     },
+    event_count: {
+      type: "integer",
+    },
+    geohash: {
+      type: "string",
+    },
+    id: {
+      type: "integer",
+    },
     last_hit: {
       oneOf: [
         {
-          type: "string",
           format: "date-time",
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    postal_code: {
+      oneOf: [
+        {
+          type: "string",
         },
         {
           type: "null",
@@ -288,26 +311,6 @@ export const GeoJSONFeaturePropertiesSchema = {
         },
       ],
     },
-    city: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    postal_code: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
     timezone: {
       oneOf: [
         {
@@ -318,9 +321,6 @@ export const GeoJSONFeaturePropertiesSchema = {
         },
       ],
     },
-    event_count: {
-      type: "integer",
-    },
     top_ips: {
       items: {
         $ref: "#/components/schemas/TopIPDTO",
@@ -328,7 +328,6 @@ export const GeoJSONFeaturePropertiesSchema = {
       type: "array",
     },
   },
-  type: "object",
   required: [
     "city",
     "country_code",
@@ -343,33 +342,31 @@ export const GeoJSONFeaturePropertiesSchema = {
     "timezone",
   ],
   title: "GeoJSONFeatureProperties",
+  type: "object",
 } as const;
 
 export const GeoJSONFeatureStatsSchema = {
   properties: {
-    events: {
+    cities: {
       type: "integer",
     },
     countries: {
       type: "integer",
     },
-    cities: {
+    events: {
       type: "integer",
     },
     locations: {
       type: "integer",
     },
   },
-  type: "object",
   required: ["cities", "countries", "events", "locations"],
   title: "GeoJSONFeatureStats",
+  type: "object",
 } as const;
 
 export const GeoJSONPointGeometrySchema = {
   properties: {
-    type: {
-      type: "string",
-    },
     coordinates: {
       prefixItems: [
         {
@@ -381,10 +378,13 @@ export const GeoJSONPointGeometrySchema = {
       ],
       type: "array",
     },
+    type: {
+      type: "string",
+    },
   },
-  type: "object",
   required: ["coordinates", "type"],
   title: "GeoJSONPointGeometry",
+  type: "object",
 } as const;
 
 export const GlobalTopIPsResponseSchema = {
@@ -396,9 +396,9 @@ export const GlobalTopIPsResponseSchema = {
       type: "array",
     },
   },
-  type: "object",
   required: [],
   title: "GlobalTopIPsResponse",
+  type: "object",
 } as const;
 
 export const ListAccessLogDebugsAccessLogDebugResponseBodySchema = {
@@ -414,15 +414,15 @@ export const ListAccessLogDebugsAccessLogDebugResponseBodySchema = {
       ],
     },
     createdAt: {
-      type: "string",
       format: "date-time",
-    },
-    rawLine: {
       type: "string",
+    },
+    id: {
+      type: "integer",
     },
     isMalformed: {
-      type: "boolean",
       default: false,
+      type: "boolean",
     },
     parseError: {
       oneOf: [
@@ -434,28 +434,22 @@ export const ListAccessLogDebugsAccessLogDebugResponseBodySchema = {
         },
       ],
     },
-    id: {
-      type: "integer",
+    rawLine: {
+      type: "string",
     },
   },
-  type: "object",
   required: ["id", "rawLine"],
   title: "ListAccessLogDebugsAccessLogDebugResponseBody",
+  type: "object",
 } as const;
 
 export const ListAccessLogsAccessLogResponseBodySchema = {
   properties: {
-    timestamp: {
-      type: "string",
-      format: "date-time",
+    bytesSent: {
+      default: 0,
+      type: "integer",
     },
-    ipAddress: {
-      type: "string",
-    },
-    remoteUser: {
-      type: "string",
-    },
-    method: {
+    city: {
       oneOf: [
         {
           type: "string",
@@ -465,7 +459,27 @@ export const ListAccessLogsAccessLogResponseBodySchema = {
         },
       ],
     },
-    url: {
+    countryCode: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    countryName: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    host: {
       oneOf: [
         {
           type: "string",
@@ -485,14 +499,57 @@ export const ListAccessLogsAccessLogResponseBodySchema = {
         },
       ],
     },
+    id: {
+      type: "integer",
+    },
+    ipAddress: {
+      type: "string",
+    },
+    method: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    referrer: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    remoteUser: {
+      type: "string",
+    },
+    requestTime: {
+      default: 0,
+      type: "number",
+    },
     statusCode: {
       type: "integer",
     },
-    bytesSent: {
-      type: "integer",
-      default: 0,
+    timestamp: {
+      format: "date-time",
+      type: "string",
     },
-    referrer: {
+    upstreamResponseTime: {
+      oneOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    url: {
       oneOf: [
         {
           type: "string",
@@ -512,50 +569,14 @@ export const ListAccessLogsAccessLogResponseBodySchema = {
         },
       ],
     },
-    requestTime: {
-      type: "number",
-      default: 0,
-    },
-    upstreamResponseTime: {
-      oneOf: [
-        {
-          type: "number",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    host: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    countryCode: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    countryName: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
+  },
+  required: ["id", "ipAddress", "statusCode", "timestamp"],
+  title: "ListAccessLogsAccessLogResponseBody",
+  type: "object",
+} as const;
+
+export const ListGeoEventsGeoEventGeoLocationResponseBodySchema = {
+  properties: {
     city: {
       oneOf: [
         {
@@ -566,34 +587,51 @@ export const ListAccessLogsAccessLogResponseBodySchema = {
         },
       ],
     },
+    countryCode: {
+      type: "string",
+    },
+    countryName: {
+      type: "string",
+    },
+    createdAt: {
+      format: "date-time",
+      type: "string",
+    },
+    geographicPoint: {
+      type: "string",
+    },
+    geohash: {
+      type: "string",
+    },
     id: {
       type: "integer",
     },
-  },
-  type: "object",
-  required: ["id", "ipAddress", "statusCode", "timestamp"],
-  title: "ListAccessLogsAccessLogResponseBody",
-} as const;
-
-export const ListGeoEventsGeoEventGeoLocationResponseBodySchema = {
-  properties: {
+    lastHit: {
+      oneOf: [
+        {
+          format: "date-time",
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
     latitude: {
       type: "number",
     },
     longitude: {
       type: "number",
     },
-    geohash: {
-      type: "string",
-    },
-    geographicPoint: {
-      type: "string",
-    },
-    countryCode: {
-      type: "string",
-    },
-    countryName: {
-      type: "string",
+    postalCode: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     state: {
       oneOf: [
@@ -615,26 +653,6 @@ export const ListGeoEventsGeoEventGeoLocationResponseBodySchema = {
         },
       ],
     },
-    city: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    postalCode: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
     timezone: {
       oneOf: [
         {
@@ -645,30 +663,11 @@ export const ListGeoEventsGeoEventGeoLocationResponseBodySchema = {
         },
       ],
     },
-    lastHit: {
-      oneOf: [
-        {
-          type: "string",
-          format: "date-time",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    createdAt: {
-      type: "string",
-      format: "date-time",
-    },
     updatedAt: {
-      type: "string",
       format: "date-time",
-    },
-    id: {
-      type: "integer",
+      type: "string",
     },
   },
-  type: "object",
   required: [
     "countryCode",
     "countryName",
@@ -679,54 +678,93 @@ export const ListGeoEventsGeoEventGeoLocationResponseBodySchema = {
     "longitude",
   ],
   title: "ListGeoEventsGeoEventGeoLocationResponseBody",
+  type: "object",
 } as const;
 
 export const ListGeoEventsGeoEventResponseBodySchema = {
   properties: {
-    timestamp: {
-      type: "string",
-      format: "date-time",
-    },
-    ipAddress: {
-      type: "string",
-    },
     hostname: {
       type: "string",
-    },
-    locationId: {
-      type: "integer",
-    },
-    location: {
-      $ref: "#/components/schemas/ListGeoEventsGeoEventGeoLocationResponseBody",
     },
     id: {
       type: "integer",
     },
+    ipAddress: {
+      type: "string",
+    },
+    location: {
+      $ref: "#/components/schemas/ListGeoEventsGeoEventGeoLocationResponseBody",
+    },
+    locationId: {
+      type: "integer",
+    },
+    timestamp: {
+      format: "date-time",
+      type: "string",
+    },
   },
-  type: "object",
   required: ["hostname", "id", "ipAddress", "location", "locationId"],
   title: "ListGeoEventsGeoEventResponseBody",
+  type: "object",
 } as const;
 
 export const ListGeoLocationsGeoLocationResponseBodySchema = {
   properties: {
-    latitude: {
-      type: "number",
-    },
-    longitude: {
-      type: "number",
-    },
-    geohash: {
-      type: "string",
-    },
-    geographicPoint: {
-      type: "string",
+    city: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     countryCode: {
       type: "string",
     },
     countryName: {
       type: "string",
+    },
+    createdAt: {
+      format: "date-time",
+      type: "string",
+    },
+    geographicPoint: {
+      type: "string",
+    },
+    geohash: {
+      type: "string",
+    },
+    id: {
+      type: "integer",
+    },
+    lastHit: {
+      oneOf: [
+        {
+          format: "date-time",
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    latitude: {
+      type: "number",
+    },
+    longitude: {
+      type: "number",
+    },
+    postalCode: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     state: {
       oneOf: [
@@ -748,26 +786,6 @@ export const ListGeoLocationsGeoLocationResponseBodySchema = {
         },
       ],
     },
-    city: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    postalCode: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
     timezone: {
       oneOf: [
         {
@@ -778,30 +796,11 @@ export const ListGeoLocationsGeoLocationResponseBodySchema = {
         },
       ],
     },
-    lastHit: {
-      oneOf: [
-        {
-          type: "string",
-          format: "date-time",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    createdAt: {
-      type: "string",
-      format: "date-time",
-    },
     updatedAt: {
-      type: "string",
       format: "date-time",
-    },
-    id: {
-      type: "integer",
+      type: "string",
     },
   },
-  type: "object",
   required: [
     "countryCode",
     "countryName",
@@ -812,6 +811,7 @@ export const ListGeoLocationsGeoLocationResponseBodySchema = {
     "longitude",
   ],
   title: "ListGeoLocationsGeoLocationResponseBody",
+  type: "object",
 } as const;
 
 export const LocationTopIPsResponseSchema = {
@@ -826,23 +826,23 @@ export const LocationTopIPsResponseSchema = {
       type: "array",
     },
   },
-  type: "object",
   required: ["location_id"],
   title: "LocationTopIPsResponse",
+  type: "object",
 } as const;
 
 export const LoginPayloadSchema = {
   properties: {
-    username: {
-      type: "string",
-    },
     password: {
       type: "string",
     },
+    username: {
+      type: "string",
+    },
   },
-  type: "object",
   required: ["password", "username"],
   title: "LoginPayload",
+  type: "object",
 } as const;
 
 export const LogparserSettingsViewSchema = {
@@ -860,9 +860,9 @@ export const LogparserSettingsViewSchema = {
       type: "boolean",
     },
   },
-  type: "object",
   required: ["log_paths", "send_logs", "store_debug_lines"],
   title: "LogparserSettingsView",
+  type: "object",
 } as const;
 
 export const MapSettingsViewSchema = {
@@ -888,13 +888,13 @@ export const MapSettingsViewSchema = {
       ],
     },
     home_source: {
-      type: ["null", "string"],
       enum: ["configured", "external_ip", null],
+      type: ["null", "string"],
     },
   },
-  type: "object",
   required: ["home_latitude", "home_longitude", "home_source"],
   title: "MapSettingsView",
+  type: "object",
 } as const;
 
 export const MeResponseSchema = {
@@ -903,34 +903,14 @@ export const MeResponseSchema = {
       type: "string",
     },
   },
-  type: "object",
   required: ["username"],
   title: "MeResponse",
+  type: "object",
 } as const;
 
 export const PercentChangeSchema = {
   properties: {
-    log_records: {
-      oneOf: [
-        {
-          type: "number",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    geo_records: {
-      oneOf: [
-        {
-          type: "number",
-        },
-        {
-          type: "null",
-        },
-      ],
-    },
-    unique_ips: {
+    avg_request_time: {
       oneOf: [
         {
           type: "number",
@@ -950,7 +930,7 @@ export const PercentChangeSchema = {
         },
       ],
     },
-    avg_request_time: {
+    error_rate: {
       oneOf: [
         {
           type: "number",
@@ -960,7 +940,17 @@ export const PercentChangeSchema = {
         },
       ],
     },
-    error_rate: {
+    geo_records: {
+      oneOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    log_records: {
       oneOf: [
         {
           type: "number",
@@ -980,30 +970,37 @@ export const PercentChangeSchema = {
         },
       ],
     },
+    unique_ips: {
+      oneOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
   },
-  type: "object",
   required: [],
   title: "PercentChange",
+  type: "object",
 } as const;
 
 export const PeriodSummarySchema = {
   properties: {
-    total_requests: {
-      type: "integer",
-    },
-    total_geo_events: {
-      type: "integer",
-    },
-    unique_ips: {
-      type: "integer",
-    },
-    unique_countries: {
-      type: "integer",
-    },
-    total_bytes_sent: {
-      type: "integer",
-    },
     avg_bytes_per_request: {
+      type: "number",
+    },
+    avg_request_time: {
+      type: "number",
+    },
+    error_rate: {
+      type: "number",
+    },
+    malformed_requests: {
+      type: "integer",
+    },
+    max_request_time: {
       type: "number",
     },
     status_2xx: {
@@ -1018,20 +1015,22 @@ export const PeriodSummarySchema = {
     status_5xx: {
       type: "integer",
     },
-    avg_request_time: {
-      type: "number",
-    },
-    max_request_time: {
-      type: "number",
-    },
-    malformed_requests: {
+    total_bytes_sent: {
       type: "integer",
     },
-    error_rate: {
-      type: "number",
+    total_geo_events: {
+      type: "integer",
+    },
+    total_requests: {
+      type: "integer",
+    },
+    unique_countries: {
+      type: "integer",
+    },
+    unique_ips: {
+      type: "integer",
     },
   },
-  type: "object",
   required: [
     "avg_bytes_per_request",
     "avg_request_time",
@@ -1049,15 +1048,13 @@ export const PeriodSummarySchema = {
     "unique_ips",
   ],
   title: "PeriodSummary",
+  type: "object",
 } as const;
 
 export const SafeSettingsResponseSchema = {
   properties: {
-    name: {
-      type: "string",
-    },
-    version: {
-      type: "string",
+    analytics: {
+      $ref: "#/components/schemas/AnalyticsSettingsView",
     },
     environment: {
       type: "string",
@@ -1065,38 +1062,28 @@ export const SafeSettingsResponseSchema = {
     logparser: {
       $ref: "#/components/schemas/LogparserSettingsView",
     },
-    analytics: {
-      $ref: "#/components/schemas/AnalyticsSettingsView",
-    },
     map: {
       $ref: "#/components/schemas/MapSettingsView",
     },
+    name: {
+      type: "string",
+    },
+    version: {
+      type: "string",
+    },
   },
-  type: "object",
   required: ["analytics", "environment", "logparser", "map", "name", "version"],
   title: "SafeSettingsResponse",
+  type: "object",
 } as const;
 
 export const SummaryResponseSchema = {
   properties: {
-    start_date: {
-      type: "string",
-    },
-    end_date: {
-      type: "string",
-    },
     current_period: {
       $ref: "#/components/schemas/PeriodSummary",
     },
-    previous_period: {
-      oneOf: [
-        {
-          $ref: "#/components/schemas/PeriodSummary",
-        },
-        {
-          type: "null",
-        },
-      ],
+    end_date: {
+      type: "string",
     },
     percent_changes: {
       oneOf: [
@@ -1108,25 +1095,41 @@ export const SummaryResponseSchema = {
         },
       ],
     },
+    previous_period: {
+      oneOf: [
+        {
+          $ref: "#/components/schemas/PeriodSummary",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    start_date: {
+      type: "string",
+    },
   },
-  type: "object",
   required: ["current_period", "end_date", "start_date"],
   title: "SummaryResponse",
+  type: "object",
 } as const;
 
 export const TimeSeriesDataPointSchema = {
   properties: {
-    timestamp: {
-      type: "string",
+    avg_request_time: {
+      type: "number",
     },
-    total_requests: {
-      type: "integer",
+    error_rate: {
+      type: "number",
     },
-    total_geo_events: {
-      type: "integer",
+    p50_request_time: {
+      type: "number",
     },
-    total_bytes_sent: {
-      type: "integer",
+    p95_request_time: {
+      type: "number",
+    },
+    p99_request_time: {
+      type: "number",
     },
     status_2xx: {
       type: "integer",
@@ -1140,23 +1143,19 @@ export const TimeSeriesDataPointSchema = {
     status_5xx: {
       type: "integer",
     },
-    error_rate: {
-      type: "number",
+    timestamp: {
+      type: "string",
     },
-    avg_request_time: {
-      type: "number",
+    total_bytes_sent: {
+      type: "integer",
     },
-    p50_request_time: {
-      type: "number",
+    total_geo_events: {
+      type: "integer",
     },
-    p95_request_time: {
-      type: "number",
-    },
-    p99_request_time: {
-      type: "number",
+    total_requests: {
+      type: "integer",
     },
   },
-  type: "object",
   required: [
     "avg_request_time",
     "error_rate",
@@ -1173,36 +1172,34 @@ export const TimeSeriesDataPointSchema = {
     "total_requests",
   ],
   title: "TimeSeriesDataPoint",
+  type: "object",
 } as const;
 
 export const TimeSeriesResponseSchema = {
   properties: {
-    granularity: {
-      type: "string",
-    },
-    start_date: {
-      type: "string",
-    },
-    end_date: {
-      type: "string",
-    },
     data: {
       items: {
         $ref: "#/components/schemas/TimeSeriesDataPoint",
       },
       type: "array",
     },
+    end_date: {
+      type: "string",
+    },
+    granularity: {
+      type: "string",
+    },
+    start_date: {
+      type: "string",
+    },
   },
-  type: "object",
   required: ["data", "end_date", "granularity", "start_date"],
   title: "TimeSeriesResponse",
+  type: "object",
 } as const;
 
 export const TopCitiesResponseSchema = {
   properties: {
-    start_date: {
-      type: "string",
-    },
     end_date: {
       type: "string",
     },
@@ -1212,10 +1209,13 @@ export const TopCitiesResponseSchema = {
       },
       type: "array",
     },
+    start_date: {
+      type: "string",
+    },
   },
-  type: "object",
   required: ["end_date", "items", "start_date"],
   title: "TopCitiesResponse",
+  type: "object",
 } as const;
 
 export const TopCityStatsDTOSchema = {
@@ -1240,9 +1240,9 @@ export const TopCityStatsDTOSchema = {
       type: "integer",
     },
   },
-  type: "object",
   required: ["city", "country_code", "hits", "unique_ips"],
   title: "TopCityStatsDTO",
+  type: "object",
 } as const;
 
 export const TopCountriesResponseSchema = {
@@ -1254,16 +1254,13 @@ export const TopCountriesResponseSchema = {
       type: "array",
     },
   },
-  type: "object",
   required: [],
   title: "TopCountriesResponse",
+  type: "object",
 } as const;
 
 export const TopCountriesStatsResponseSchema = {
   properties: {
-    start_date: {
-      type: "string",
-    },
     end_date: {
       type: "string",
     },
@@ -1273,10 +1270,13 @@ export const TopCountriesStatsResponseSchema = {
       },
       type: "array",
     },
+    start_date: {
+      type: "string",
+    },
   },
-  type: "object",
   required: ["end_date", "items", "start_date"],
   title: "TopCountriesStatsResponse",
+  type: "object",
 } as const;
 
 export const TopCountryDTOSchema = {
@@ -1298,9 +1298,9 @@ export const TopCountryDTOSchema = {
       type: "integer",
     },
   },
-  type: "object",
   required: ["country_code", "country_name", "event_count"],
   title: "TopCountryDTO",
+  type: "object",
 } as const;
 
 export const TopCountryStatsDTOSchema = {
@@ -1325,18 +1325,18 @@ export const TopCountryStatsDTOSchema = {
       type: "integer",
     },
   },
-  type: "object",
   required: ["country_code", "country_name", "hits", "unique_ips"],
   title: "TopCountryStatsDTO",
+  type: "object",
 } as const;
 
 export const TopIPDTOSchema = {
   properties: {
-    ip_address: {
-      type: "string",
-    },
     event_count: {
       type: "integer",
+    },
+    ip_address: {
+      type: "string",
     },
     location: {
       oneOf: [
@@ -1349,24 +1349,22 @@ export const TopIPDTOSchema = {
       ],
     },
   },
-  type: "object",
   required: ["event_count", "ip_address"],
   title: "TopIPDTO",
+  type: "object",
 } as const;
 
 export const TopIpDTOSchema = {
   properties: {
-    ip_address: {
-      type: "string",
-    },
-    hits: {
-      type: "integer",
-    },
-    error_hits: {
-      type: "integer",
-    },
-    total_bytes: {
-      type: "integer",
+    city: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     country_code: {
       oneOf: [
@@ -1378,18 +1376,19 @@ export const TopIpDTOSchema = {
         },
       ],
     },
-    city: {
-      oneOf: [
-        {
-          type: "string",
-        },
-        {
-          type: "null",
-        },
-      ],
+    error_hits: {
+      type: "integer",
+    },
+    hits: {
+      type: "integer",
+    },
+    ip_address: {
+      type: "string",
+    },
+    total_bytes: {
+      type: "integer",
     },
   },
-  type: "object",
   required: [
     "city",
     "country_code",
@@ -1399,13 +1398,11 @@ export const TopIpDTOSchema = {
     "total_bytes",
   ],
   title: "TopIpDTO",
+  type: "object",
 } as const;
 
 export const TopIpsResponseSchema = {
   properties: {
-    start_date: {
-      type: "string",
-    },
     end_date: {
       type: "string",
     },
@@ -1415,40 +1412,40 @@ export const TopIpsResponseSchema = {
       },
       type: "array",
     },
+    start_date: {
+      type: "string",
+    },
   },
-  type: "object",
   required: ["end_date", "items", "start_date"],
   title: "TopIpsResponse",
+  type: "object",
 } as const;
 
 export const TopUrlDTOSchema = {
   properties: {
-    url: {
-      type: "string",
-    },
-    hits: {
-      type: "integer",
+    avg_request_time: {
+      type: "number",
     },
     error_hits: {
+      type: "integer",
+    },
+    hits: {
       type: "integer",
     },
     total_bytes: {
       type: "integer",
     },
-    avg_request_time: {
-      type: "number",
+    url: {
+      type: "string",
     },
   },
-  type: "object",
   required: ["avg_request_time", "error_hits", "hits", "total_bytes", "url"],
   title: "TopUrlDTO",
+  type: "object",
 } as const;
 
 export const TopUrlsResponseSchema = {
   properties: {
-    start_date: {
-      type: "string",
-    },
     end_date: {
       type: "string",
     },
@@ -1458,31 +1455,31 @@ export const TopUrlsResponseSchema = {
       },
       type: "array",
     },
+    start_date: {
+      type: "string",
+    },
   },
-  type: "object",
   required: ["end_date", "items", "start_date"],
   title: "TopUrlsResponse",
+  type: "object",
 } as const;
 
 export const TopUserAgentDTOSchema = {
   properties: {
-    user_agent: {
-      type: "string",
-    },
     hits: {
       type: "integer",
     },
+    user_agent: {
+      type: "string",
+    },
   },
-  type: "object",
   required: ["hits", "user_agent"],
   title: "TopUserAgentDTO",
+  type: "object",
 } as const;
 
 export const TopUserAgentsResponseSchema = {
   properties: {
-    start_date: {
-      type: "string",
-    },
     end_date: {
       type: "string",
     },
@@ -1492,8 +1489,11 @@ export const TopUserAgentsResponseSchema = {
       },
       type: "array",
     },
+    start_date: {
+      type: "string",
+    },
   },
-  type: "object",
   required: ["end_date", "items", "start_date"],
   title: "TopUserAgentsResponse",
+  type: "object",
 } as const;

--- a/resources/generated/api/schemas.gen.ts
+++ b/resources/generated/api/schemas.gen.ts
@@ -1198,6 +1198,53 @@ export const TimeSeriesResponseSchema = {
   title: "TimeSeriesResponse",
 } as const;
 
+export const TopCitiesResponseSchema = {
+  properties: {
+    start_date: {
+      type: "string",
+    },
+    end_date: {
+      type: "string",
+    },
+    items: {
+      items: {
+        $ref: "#/components/schemas/TopCityStatsDTO",
+      },
+      type: "array",
+    },
+  },
+  type: "object",
+  required: ["end_date", "items", "start_date"],
+  title: "TopCitiesResponse",
+} as const;
+
+export const TopCityStatsDTOSchema = {
+  properties: {
+    city: {
+      type: "string",
+    },
+    country_code: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    hits: {
+      type: "integer",
+    },
+    unique_ips: {
+      type: "integer",
+    },
+  },
+  type: "object",
+  required: ["city", "country_code", "hits", "unique_ips"],
+  title: "TopCityStatsDTO",
+} as const;
+
 export const TopCountriesResponseSchema = {
   properties: {
     top_countries: {
@@ -1210,6 +1257,26 @@ export const TopCountriesResponseSchema = {
   type: "object",
   required: [],
   title: "TopCountriesResponse",
+} as const;
+
+export const TopCountriesStatsResponseSchema = {
+  properties: {
+    start_date: {
+      type: "string",
+    },
+    end_date: {
+      type: "string",
+    },
+    items: {
+      items: {
+        $ref: "#/components/schemas/TopCountryStatsDTO",
+      },
+      type: "array",
+    },
+  },
+  type: "object",
+  required: ["end_date", "items", "start_date"],
+  title: "TopCountriesStatsResponse",
 } as const;
 
 export const TopCountryDTOSchema = {
@@ -1236,6 +1303,33 @@ export const TopCountryDTOSchema = {
   title: "TopCountryDTO",
 } as const;
 
+export const TopCountryStatsDTOSchema = {
+  properties: {
+    country_code: {
+      type: "string",
+    },
+    country_name: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    hits: {
+      type: "integer",
+    },
+    unique_ips: {
+      type: "integer",
+    },
+  },
+  type: "object",
+  required: ["country_code", "country_name", "hits", "unique_ips"],
+  title: "TopCountryStatsDTO",
+} as const;
+
 export const TopIPDTOSchema = {
   properties: {
     ip_address: {
@@ -1258,6 +1352,73 @@ export const TopIPDTOSchema = {
   type: "object",
   required: ["event_count", "ip_address"],
   title: "TopIPDTO",
+} as const;
+
+export const TopIpDTOSchema = {
+  properties: {
+    ip_address: {
+      type: "string",
+    },
+    hits: {
+      type: "integer",
+    },
+    error_hits: {
+      type: "integer",
+    },
+    total_bytes: {
+      type: "integer",
+    },
+    country_code: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    city: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+  },
+  type: "object",
+  required: [
+    "city",
+    "country_code",
+    "error_hits",
+    "hits",
+    "ip_address",
+    "total_bytes",
+  ],
+  title: "TopIpDTO",
+} as const;
+
+export const TopIpsResponseSchema = {
+  properties: {
+    start_date: {
+      type: "string",
+    },
+    end_date: {
+      type: "string",
+    },
+    items: {
+      items: {
+        $ref: "#/components/schemas/TopIpDTO",
+      },
+      type: "array",
+    },
+  },
+  type: "object",
+  required: ["end_date", "items", "start_date"],
+  title: "TopIpsResponse",
 } as const;
 
 export const TopUrlDTOSchema = {

--- a/resources/generated/api/sdk.gen.ts
+++ b/resources/generated/api/sdk.gen.ts
@@ -26,6 +26,15 @@ import type {
   ApiV1AnalyticsTimeSeriesGetTimeSeriesData,
   ApiV1AnalyticsTimeSeriesGetTimeSeriesErrors,
   ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses,
+  ApiV1AnalyticsTopCitiesGetTopCitiesData,
+  ApiV1AnalyticsTopCitiesGetTopCitiesErrors,
+  ApiV1AnalyticsTopCitiesGetTopCitiesResponses,
+  ApiV1AnalyticsTopCountriesGetTopCountriesData,
+  ApiV1AnalyticsTopCountriesGetTopCountriesErrors,
+  ApiV1AnalyticsTopCountriesGetTopCountriesResponses,
+  ApiV1AnalyticsTopIpsGetTopIpsData,
+  ApiV1AnalyticsTopIpsGetTopIpsErrors,
+  ApiV1AnalyticsTopIpsGetTopIpsResponses,
   ApiV1AnalyticsTopUrlsGetTopUrlsData,
   ApiV1AnalyticsTopUrlsGetTopUrlsErrors,
   ApiV1AnalyticsTopUrlsGetTopUrlsResponses,
@@ -447,6 +456,84 @@ export const apiV1AnalyticsTimeSeriesGetTimeSeries = <
       },
     ],
     url: "/api/v1/analytics/time-series",
+    ...options,
+  });
+
+/**
+ * GetTopCities
+ *
+ * Top cities by hits from raw access logs (time-bounded).
+ */
+export const apiV1AnalyticsTopCitiesGetTopCities = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<ApiV1AnalyticsTopCitiesGetTopCitiesData, ThrowOnError>,
+) =>
+  (options.client ?? client).get<
+    ApiV1AnalyticsTopCitiesGetTopCitiesResponses,
+    ApiV1AnalyticsTopCitiesGetTopCitiesErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/analytics/top-cities",
+    ...options,
+  });
+
+/**
+ * GetTopCountries
+ *
+ * Top countries by hits from raw access logs (time-bounded).
+ */
+export const apiV1AnalyticsTopCountriesGetTopCountries = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<ApiV1AnalyticsTopCountriesGetTopCountriesData, ThrowOnError>,
+) =>
+  (options.client ?? client).get<
+    ApiV1AnalyticsTopCountriesGetTopCountriesResponses,
+    ApiV1AnalyticsTopCountriesGetTopCountriesErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/analytics/top-countries",
+    ...options,
+  });
+
+/**
+ * GetTopIps
+ *
+ * Top client IPs by hits from raw access logs (time-bounded).
+ */
+export const apiV1AnalyticsTopIpsGetTopIps = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<ApiV1AnalyticsTopIpsGetTopIpsData, ThrowOnError>,
+) =>
+  (options.client ?? client).get<
+    ApiV1AnalyticsTopIpsGetTopIpsResponses,
+    ApiV1AnalyticsTopIpsGetTopIpsErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/analytics/top-ips",
     ...options,
   });
 

--- a/resources/generated/api/sdk.gen.ts
+++ b/resources/generated/api/sdk.gen.ts
@@ -94,16 +94,16 @@ export type Options<
 };
 
 /**
- * ListGeoEvents
+ * ListAccessLogDebugs
  */
-export const apiV1GeoEventsListGeoEvents = <
+export const apiV1AccessLogDebugListAccessLogDebugs = <
   ThrowOnError extends boolean = false,
 >(
-  options?: Options<ApiV1GeoEventsListGeoEventsData, ThrowOnError>,
+  options?: Options<ApiV1AccessLogDebugListAccessLogDebugsData, ThrowOnError>,
 ) =>
   (options?.client ?? client).get<
-    ApiV1GeoEventsListGeoEventsResponses,
-    ApiV1GeoEventsListGeoEventsErrors,
+    ApiV1AccessLogDebugListAccessLogDebugsResponses,
+    ApiV1AccessLogDebugListAccessLogDebugsErrors,
     ThrowOnError
   >({
     security: [
@@ -113,165 +113,7 @@ export const apiV1GeoEventsListGeoEvents = <
         type: "apiKey",
       },
     ],
-    url: "/api/v1/geo-events",
-    ...options,
-  });
-
-/**
- * GetGeojson
- *
- * Get all locations with event counts as GeoJSON FeatureCollection.
- */
-export const apiV1GeoLocationsGeojsonGetGeojson = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<ApiV1GeoLocationsGeojsonGetGeojsonData, ThrowOnError>,
-) =>
-  (options.client ?? client).get<
-    ApiV1GeoLocationsGeojsonGetGeojsonResponses,
-    ApiV1GeoLocationsGeojsonGetGeojsonErrors,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/geo-locations/geojson",
-    ...options,
-  });
-
-/**
- * GetGlobalTopIps
- *
- * Get global top IPs by event count with their primary locations.
- */
-export const apiV1GeoLocationsTopIpsGetGlobalTopIps = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<ApiV1GeoLocationsTopIpsGetGlobalTopIpsData, ThrowOnError>,
-) =>
-  (options.client ?? client).get<
-    ApiV1GeoLocationsTopIpsGetGlobalTopIpsResponses,
-    ApiV1GeoLocationsTopIpsGetGlobalTopIpsErrors,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/geo-locations/top-ips",
-    ...options,
-  });
-
-/**
- * GetLocationTopIps
- *
- * Get top IPs for a specific location.
- */
-export const apiV1GeoLocationsLocationIdTopIpsGetLocationTopIps = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<
-    ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsData,
-    ThrowOnError
-  >,
-) =>
-  (options.client ?? client).get<
-    ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponses,
-    ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsErrors,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/geo-locations/{location_id}/top-ips",
-    ...options,
-  });
-
-/**
- * GetTopCountries
- *
- * Get top countries by event count.
- */
-export const apiV1GeoLocationsTopCountriesGetTopCountries = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<
-    ApiV1GeoLocationsTopCountriesGetTopCountriesData,
-    ThrowOnError
-  >,
-) =>
-  (options.client ?? client).get<
-    ApiV1GeoLocationsTopCountriesGetTopCountriesResponses,
-    ApiV1GeoLocationsTopCountriesGetTopCountriesErrors,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/geo-locations/top-countries",
-    ...options,
-  });
-
-/**
- * ListGeoLocations
- */
-export const apiV1GeoLocationsListGeoLocations = <
-  ThrowOnError extends boolean = false,
->(
-  options?: Options<ApiV1GeoLocationsListGeoLocationsData, ThrowOnError>,
-) =>
-  (options?.client ?? client).get<
-    ApiV1GeoLocationsListGeoLocationsResponses,
-    ApiV1GeoLocationsListGeoLocationsErrors,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/geo-locations",
-    ...options,
-  });
-
-/**
- * GetAccessLogFacets
- */
-export const apiV1AccessLogsFacetsGetAccessLogFacets = <
-  ThrowOnError extends boolean = false,
->(
-  options?: Options<ApiV1AccessLogsFacetsGetAccessLogFacetsData, ThrowOnError>,
-) =>
-  (options?.client ?? client).get<
-    ApiV1AccessLogsFacetsGetAccessLogFacetsResponses,
-    unknown,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/access-logs/facets",
+    url: "/api/v1/access-log-debug",
     ...options,
   });
 
@@ -300,16 +142,16 @@ export const apiV1AccessLogsListAccessLogs = <
   });
 
 /**
- * ListAccessLogDebugs
+ * GetAccessLogFacets
  */
-export const apiV1AccessLogDebugListAccessLogDebugs = <
+export const apiV1AccessLogsFacetsGetAccessLogFacets = <
   ThrowOnError extends boolean = false,
 >(
-  options?: Options<ApiV1AccessLogDebugListAccessLogDebugsData, ThrowOnError>,
+  options?: Options<ApiV1AccessLogsFacetsGetAccessLogFacetsData, ThrowOnError>,
 ) =>
   (options?.client ?? client).get<
-    ApiV1AccessLogDebugListAccessLogDebugsResponses,
-    ApiV1AccessLogDebugListAccessLogDebugsErrors,
+    ApiV1AccessLogsFacetsGetAccessLogFacetsResponses,
+    unknown,
     ThrowOnError
   >({
     security: [
@@ -319,36 +161,7 @@ export const apiV1AccessLogDebugListAccessLogDebugs = <
         type: "apiKey",
       },
     ],
-    url: "/api/v1/access-log-debug",
-    ...options,
-  });
-
-/**
- * GetCumulativeTimeSeries
- *
- * Get cumulative time series data for area charts.
- */
-export const apiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeries = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<
-    ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesData,
-    ThrowOnError
-  >,
-) =>
-  (options.client ?? client).get<
-    ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses,
-    ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesErrors,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/analytics/time-series/cumulative",
+    url: "/api/v1/access-logs/facets",
     ...options,
   });
 
@@ -456,6 +269,35 @@ export const apiV1AnalyticsTimeSeriesGetTimeSeries = <
       },
     ],
     url: "/api/v1/analytics/time-series",
+    ...options,
+  });
+
+/**
+ * GetCumulativeTimeSeries
+ *
+ * Get cumulative time series data for area charts.
+ */
+export const apiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeries = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesData,
+    ThrowOnError
+  >,
+) =>
+  (options.client ?? client).get<
+    ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses,
+    ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/analytics/time-series/cumulative",
     ...options,
   });
 
@@ -593,6 +435,234 @@ export const apiV1AnalyticsTopUserAgentsGetTopUserAgents = <
   });
 
 /**
+ * Login
+ */
+export const apiV1AuthLoginLogin = <ThrowOnError extends boolean = false>(
+  options: Options<ApiV1AuthLoginLoginData, ThrowOnError>,
+) =>
+  (options.client ?? client).post<
+    ApiV1AuthLoginLoginResponses,
+    ApiV1AuthLoginLoginErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/auth/login",
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+  });
+
+/**
+ * Logout
+ */
+export const apiV1AuthLogoutLogout = <ThrowOnError extends boolean = false>(
+  options?: Options<ApiV1AuthLogoutLogoutData, ThrowOnError>,
+) =>
+  (options?.client ?? client).post<
+    ApiV1AuthLogoutLogoutResponses,
+    unknown,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/auth/logout",
+    ...options,
+  });
+
+/**
+ * Me
+ */
+export const apiV1AuthMeMe = <ThrowOnError extends boolean = false>(
+  options?: Options<ApiV1AuthMeMeData, ThrowOnError>,
+) =>
+  (options?.client ?? client).get<
+    ApiV1AuthMeMeResponses,
+    unknown,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/auth/me",
+    ...options,
+  });
+
+/**
+ * ListGeoEvents
+ */
+export const apiV1GeoEventsListGeoEvents = <
+  ThrowOnError extends boolean = false,
+>(
+  options?: Options<ApiV1GeoEventsListGeoEventsData, ThrowOnError>,
+) =>
+  (options?.client ?? client).get<
+    ApiV1GeoEventsListGeoEventsResponses,
+    ApiV1GeoEventsListGeoEventsErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/geo-events",
+    ...options,
+  });
+
+/**
+ * ListGeoLocations
+ */
+export const apiV1GeoLocationsListGeoLocations = <
+  ThrowOnError extends boolean = false,
+>(
+  options?: Options<ApiV1GeoLocationsListGeoLocationsData, ThrowOnError>,
+) =>
+  (options?.client ?? client).get<
+    ApiV1GeoLocationsListGeoLocationsResponses,
+    ApiV1GeoLocationsListGeoLocationsErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/geo-locations",
+    ...options,
+  });
+
+/**
+ * GetGeojson
+ *
+ * Get all locations with event counts as GeoJSON FeatureCollection.
+ */
+export const apiV1GeoLocationsGeojsonGetGeojson = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<ApiV1GeoLocationsGeojsonGetGeojsonData, ThrowOnError>,
+) =>
+  (options.client ?? client).get<
+    ApiV1GeoLocationsGeojsonGetGeojsonResponses,
+    ApiV1GeoLocationsGeojsonGetGeojsonErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/geo-locations/geojson",
+    ...options,
+  });
+
+/**
+ * GetTopCountries
+ *
+ * Get top countries by event count.
+ */
+export const apiV1GeoLocationsTopCountriesGetTopCountries = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    ApiV1GeoLocationsTopCountriesGetTopCountriesData,
+    ThrowOnError
+  >,
+) =>
+  (options.client ?? client).get<
+    ApiV1GeoLocationsTopCountriesGetTopCountriesResponses,
+    ApiV1GeoLocationsTopCountriesGetTopCountriesErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/geo-locations/top-countries",
+    ...options,
+  });
+
+/**
+ * GetGlobalTopIps
+ *
+ * Get global top IPs by event count with their primary locations.
+ */
+export const apiV1GeoLocationsTopIpsGetGlobalTopIps = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<ApiV1GeoLocationsTopIpsGetGlobalTopIpsData, ThrowOnError>,
+) =>
+  (options.client ?? client).get<
+    ApiV1GeoLocationsTopIpsGetGlobalTopIpsResponses,
+    ApiV1GeoLocationsTopIpsGetGlobalTopIpsErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/geo-locations/top-ips",
+    ...options,
+  });
+
+/**
+ * GetLocationTopIps
+ *
+ * Get top IPs for a specific location.
+ */
+export const apiV1GeoLocationsLocationIdTopIpsGetLocationTopIps = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsData,
+    ThrowOnError
+  >,
+) =>
+  (options.client ?? client).get<
+    ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponses,
+    ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/geo-locations/{location_id}/top-ips",
+    ...options,
+  });
+
+/**
  * ReadSettings
  */
 export const apiV1SettingsReadSettings = <ThrowOnError extends boolean = false>(
@@ -675,75 +745,5 @@ export const healthReadyHealthReady = <ThrowOnError extends boolean = false>(
       },
     ],
     url: "/health/ready",
-    ...options,
-  });
-
-/**
- * Login
- */
-export const apiV1AuthLoginLogin = <ThrowOnError extends boolean = false>(
-  options: Options<ApiV1AuthLoginLoginData, ThrowOnError>,
-) =>
-  (options.client ?? client).post<
-    ApiV1AuthLoginLoginResponses,
-    ApiV1AuthLoginLoginErrors,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/auth/login",
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...options.headers,
-    },
-  });
-
-/**
- * Logout
- */
-export const apiV1AuthLogoutLogout = <ThrowOnError extends boolean = false>(
-  options?: Options<ApiV1AuthLogoutLogoutData, ThrowOnError>,
-) =>
-  (options?.client ?? client).post<
-    ApiV1AuthLogoutLogoutResponses,
-    unknown,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/auth/logout",
-    ...options,
-  });
-
-/**
- * Me
- */
-export const apiV1AuthMeMe = <ThrowOnError extends boolean = false>(
-  options?: Options<ApiV1AuthMeMeData, ThrowOnError>,
-) =>
-  (options?.client ?? client).get<
-    ApiV1AuthMeMeResponses,
-    unknown,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/auth/me",
     ...options,
   });

--- a/resources/generated/api/sdk.gen.ts
+++ b/resources/generated/api/sdk.gen.ts
@@ -85,16 +85,16 @@ export type Options<
 };
 
 /**
- * ListAccessLogDebugs
+ * ListGeoEvents
  */
-export const apiV1AccessLogDebugListAccessLogDebugs = <
+export const apiV1GeoEventsListGeoEvents = <
   ThrowOnError extends boolean = false,
 >(
-  options?: Options<ApiV1AccessLogDebugListAccessLogDebugsData, ThrowOnError>,
+  options?: Options<ApiV1GeoEventsListGeoEventsData, ThrowOnError>,
 ) =>
   (options?.client ?? client).get<
-    ApiV1AccessLogDebugListAccessLogDebugsResponses,
-    ApiV1AccessLogDebugListAccessLogDebugsErrors,
+    ApiV1GeoEventsListGeoEventsResponses,
+    ApiV1GeoEventsListGeoEventsErrors,
     ThrowOnError
   >({
     security: [
@@ -104,7 +104,165 @@ export const apiV1AccessLogDebugListAccessLogDebugs = <
         type: "apiKey",
       },
     ],
-    url: "/api/v1/access-log-debug",
+    url: "/api/v1/geo-events",
+    ...options,
+  });
+
+/**
+ * GetGeojson
+ *
+ * Get all locations with event counts as GeoJSON FeatureCollection.
+ */
+export const apiV1GeoLocationsGeojsonGetGeojson = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<ApiV1GeoLocationsGeojsonGetGeojsonData, ThrowOnError>,
+) =>
+  (options.client ?? client).get<
+    ApiV1GeoLocationsGeojsonGetGeojsonResponses,
+    ApiV1GeoLocationsGeojsonGetGeojsonErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/geo-locations/geojson",
+    ...options,
+  });
+
+/**
+ * GetGlobalTopIps
+ *
+ * Get global top IPs by event count with their primary locations.
+ */
+export const apiV1GeoLocationsTopIpsGetGlobalTopIps = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<ApiV1GeoLocationsTopIpsGetGlobalTopIpsData, ThrowOnError>,
+) =>
+  (options.client ?? client).get<
+    ApiV1GeoLocationsTopIpsGetGlobalTopIpsResponses,
+    ApiV1GeoLocationsTopIpsGetGlobalTopIpsErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/geo-locations/top-ips",
+    ...options,
+  });
+
+/**
+ * GetLocationTopIps
+ *
+ * Get top IPs for a specific location.
+ */
+export const apiV1GeoLocationsLocationIdTopIpsGetLocationTopIps = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsData,
+    ThrowOnError
+  >,
+) =>
+  (options.client ?? client).get<
+    ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponses,
+    ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/geo-locations/{location_id}/top-ips",
+    ...options,
+  });
+
+/**
+ * GetTopCountries
+ *
+ * Get top countries by event count.
+ */
+export const apiV1GeoLocationsTopCountriesGetTopCountries = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    ApiV1GeoLocationsTopCountriesGetTopCountriesData,
+    ThrowOnError
+  >,
+) =>
+  (options.client ?? client).get<
+    ApiV1GeoLocationsTopCountriesGetTopCountriesResponses,
+    ApiV1GeoLocationsTopCountriesGetTopCountriesErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/geo-locations/top-countries",
+    ...options,
+  });
+
+/**
+ * ListGeoLocations
+ */
+export const apiV1GeoLocationsListGeoLocations = <
+  ThrowOnError extends boolean = false,
+>(
+  options?: Options<ApiV1GeoLocationsListGeoLocationsData, ThrowOnError>,
+) =>
+  (options?.client ?? client).get<
+    ApiV1GeoLocationsListGeoLocationsResponses,
+    ApiV1GeoLocationsListGeoLocationsErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/geo-locations",
+    ...options,
+  });
+
+/**
+ * GetAccessLogFacets
+ */
+export const apiV1AccessLogsFacetsGetAccessLogFacets = <
+  ThrowOnError extends boolean = false,
+>(
+  options?: Options<ApiV1AccessLogsFacetsGetAccessLogFacetsData, ThrowOnError>,
+) =>
+  (options?.client ?? client).get<
+    ApiV1AccessLogsFacetsGetAccessLogFacetsResponses,
+    unknown,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/access-logs/facets",
     ...options,
   });
 
@@ -133,16 +291,16 @@ export const apiV1AccessLogsListAccessLogs = <
   });
 
 /**
- * GetAccessLogFacets
+ * ListAccessLogDebugs
  */
-export const apiV1AccessLogsFacetsGetAccessLogFacets = <
+export const apiV1AccessLogDebugListAccessLogDebugs = <
   ThrowOnError extends boolean = false,
 >(
-  options?: Options<ApiV1AccessLogsFacetsGetAccessLogFacetsData, ThrowOnError>,
+  options?: Options<ApiV1AccessLogDebugListAccessLogDebugsData, ThrowOnError>,
 ) =>
   (options?.client ?? client).get<
-    ApiV1AccessLogsFacetsGetAccessLogFacetsResponses,
-    unknown,
+    ApiV1AccessLogDebugListAccessLogDebugsResponses,
+    ApiV1AccessLogDebugListAccessLogDebugsErrors,
     ThrowOnError
   >({
     security: [
@@ -152,7 +310,36 @@ export const apiV1AccessLogsFacetsGetAccessLogFacets = <
         type: "apiKey",
       },
     ],
-    url: "/api/v1/access-logs/facets",
+    url: "/api/v1/access-log-debug",
+    ...options,
+  });
+
+/**
+ * GetCumulativeTimeSeries
+ *
+ * Get cumulative time series data for area charts.
+ */
+export const apiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeries = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<
+    ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesData,
+    ThrowOnError
+  >,
+) =>
+  (options.client ?? client).get<
+    ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses,
+    ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/analytics/time-series/cumulative",
     ...options,
   });
 
@@ -264,35 +451,6 @@ export const apiV1AnalyticsTimeSeriesGetTimeSeries = <
   });
 
 /**
- * GetCumulativeTimeSeries
- *
- * Get cumulative time series data for area charts.
- */
-export const apiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeries = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<
-    ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesData,
-    ThrowOnError
-  >,
-) =>
-  (options.client ?? client).get<
-    ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses,
-    ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesErrors,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/analytics/time-series/cumulative",
-    ...options,
-  });
-
-/**
  * GetTopUrls
  *
  * Top URLs by hits from raw access logs (time-bounded).
@@ -344,234 +502,6 @@ export const apiV1AnalyticsTopUserAgentsGetTopUserAgents = <
       },
     ],
     url: "/api/v1/analytics/top-user-agents",
-    ...options,
-  });
-
-/**
- * Login
- */
-export const apiV1AuthLoginLogin = <ThrowOnError extends boolean = false>(
-  options: Options<ApiV1AuthLoginLoginData, ThrowOnError>,
-) =>
-  (options.client ?? client).post<
-    ApiV1AuthLoginLoginResponses,
-    ApiV1AuthLoginLoginErrors,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/auth/login",
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...options.headers,
-    },
-  });
-
-/**
- * Logout
- */
-export const apiV1AuthLogoutLogout = <ThrowOnError extends boolean = false>(
-  options?: Options<ApiV1AuthLogoutLogoutData, ThrowOnError>,
-) =>
-  (options?.client ?? client).post<
-    ApiV1AuthLogoutLogoutResponses,
-    unknown,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/auth/logout",
-    ...options,
-  });
-
-/**
- * Me
- */
-export const apiV1AuthMeMe = <ThrowOnError extends boolean = false>(
-  options?: Options<ApiV1AuthMeMeData, ThrowOnError>,
-) =>
-  (options?.client ?? client).get<
-    ApiV1AuthMeMeResponses,
-    unknown,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/auth/me",
-    ...options,
-  });
-
-/**
- * ListGeoEvents
- */
-export const apiV1GeoEventsListGeoEvents = <
-  ThrowOnError extends boolean = false,
->(
-  options?: Options<ApiV1GeoEventsListGeoEventsData, ThrowOnError>,
-) =>
-  (options?.client ?? client).get<
-    ApiV1GeoEventsListGeoEventsResponses,
-    ApiV1GeoEventsListGeoEventsErrors,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/geo-events",
-    ...options,
-  });
-
-/**
- * ListGeoLocations
- */
-export const apiV1GeoLocationsListGeoLocations = <
-  ThrowOnError extends boolean = false,
->(
-  options?: Options<ApiV1GeoLocationsListGeoLocationsData, ThrowOnError>,
-) =>
-  (options?.client ?? client).get<
-    ApiV1GeoLocationsListGeoLocationsResponses,
-    ApiV1GeoLocationsListGeoLocationsErrors,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/geo-locations",
-    ...options,
-  });
-
-/**
- * GetGeojson
- *
- * Get all locations with event counts as GeoJSON FeatureCollection.
- */
-export const apiV1GeoLocationsGeojsonGetGeojson = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<ApiV1GeoLocationsGeojsonGetGeojsonData, ThrowOnError>,
-) =>
-  (options.client ?? client).get<
-    ApiV1GeoLocationsGeojsonGetGeojsonResponses,
-    ApiV1GeoLocationsGeojsonGetGeojsonErrors,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/geo-locations/geojson",
-    ...options,
-  });
-
-/**
- * GetTopCountries
- *
- * Get top countries by event count.
- */
-export const apiV1GeoLocationsTopCountriesGetTopCountries = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<
-    ApiV1GeoLocationsTopCountriesGetTopCountriesData,
-    ThrowOnError
-  >,
-) =>
-  (options.client ?? client).get<
-    ApiV1GeoLocationsTopCountriesGetTopCountriesResponses,
-    ApiV1GeoLocationsTopCountriesGetTopCountriesErrors,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/geo-locations/top-countries",
-    ...options,
-  });
-
-/**
- * GetGlobalTopIps
- *
- * Get global top IPs by event count with their primary locations.
- */
-export const apiV1GeoLocationsTopIpsGetGlobalTopIps = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<ApiV1GeoLocationsTopIpsGetGlobalTopIpsData, ThrowOnError>,
-) =>
-  (options.client ?? client).get<
-    ApiV1GeoLocationsTopIpsGetGlobalTopIpsResponses,
-    ApiV1GeoLocationsTopIpsGetGlobalTopIpsErrors,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/geo-locations/top-ips",
-    ...options,
-  });
-
-/**
- * GetLocationTopIps
- *
- * Get top IPs for a specific location.
- */
-export const apiV1GeoLocationsLocationIdTopIpsGetLocationTopIps = <
-  ThrowOnError extends boolean = false,
->(
-  options: Options<
-    ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsData,
-    ThrowOnError
-  >,
-) =>
-  (options.client ?? client).get<
-    ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponses,
-    ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsErrors,
-    ThrowOnError
-  >({
-    security: [
-      {
-        in: "cookie",
-        name: "session",
-        type: "apiKey",
-      },
-    ],
-    url: "/api/v1/geo-locations/{location_id}/top-ips",
     ...options,
   });
 
@@ -658,5 +588,75 @@ export const healthReadyHealthReady = <ThrowOnError extends boolean = false>(
       },
     ],
     url: "/health/ready",
+    ...options,
+  });
+
+/**
+ * Login
+ */
+export const apiV1AuthLoginLogin = <ThrowOnError extends boolean = false>(
+  options: Options<ApiV1AuthLoginLoginData, ThrowOnError>,
+) =>
+  (options.client ?? client).post<
+    ApiV1AuthLoginLoginResponses,
+    ApiV1AuthLoginLoginErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/auth/login",
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+  });
+
+/**
+ * Logout
+ */
+export const apiV1AuthLogoutLogout = <ThrowOnError extends boolean = false>(
+  options?: Options<ApiV1AuthLogoutLogoutData, ThrowOnError>,
+) =>
+  (options?.client ?? client).post<
+    ApiV1AuthLogoutLogoutResponses,
+    unknown,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/auth/logout",
+    ...options,
+  });
+
+/**
+ * Me
+ */
+export const apiV1AuthMeMe = <ThrowOnError extends boolean = false>(
+  options?: Options<ApiV1AuthMeMeData, ThrowOnError>,
+) =>
+  (options?.client ?? client).get<
+    ApiV1AuthMeMeResponses,
+    unknown,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/auth/me",
     ...options,
   });

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -8,18 +8,18 @@ export type ClientOptions = {
  * AccessLogFacets
  */
 export type AccessLogFacets = {
-  countries: Array<CountryFacet>;
   cities: Array<string>;
+  countries: Array<CountryFacet>;
 };
 
 /**
  * AnalyticsSettingsView
  */
 export type AnalyticsSettingsView = {
-  raw_retention_days: number;
+  compression_after_days: number;
   debug_retention_days: number;
   hourly_retention_days: number;
-  compression_after_days: number;
+  raw_retention_days: number;
 };
 
 /**
@@ -34,32 +34,32 @@ export type CountryFacet = {
  * CumulativeDataPoint
  */
 export type CumulativeDataPoint = {
-  timestamp: string;
-  cumulative_geo_events: number;
   cumulative_access_logs: number;
   cumulative_bytes: number;
+  cumulative_geo_events: number;
+  timestamp: string;
 };
 
 /**
  * CumulativeTimeSeriesResponse
  */
 export type CumulativeTimeSeriesResponse = {
+  data?: Array<CumulativeDataPoint>;
+  end_date: string;
   granularity: string;
   start_date: string;
-  end_date: string;
-  data?: Array<CumulativeDataPoint>;
 };
 
 /**
  * EmbeddedLocationDTO
  */
 export type EmbeddedLocationDto = {
-  id: number;
-  latitude: number;
-  longitude: number;
   city?: string | null;
   country_code?: string | null;
   country_name?: string | null;
+  id: number;
+  latitude: number;
+  longitude: number;
 };
 
 /**
@@ -68,54 +68,54 @@ export type EmbeddedLocationDto = {
 export type GeoEventsDataPoint = {
   timestamp: string;
   total_geo_events: number;
-  unique_ips: number;
-  unique_countries: number;
   unique_cities: number;
+  unique_countries: number;
+  unique_ips: number;
 };
 
 /**
  * GeoEventsTimeSeriesResponse
  */
 export type GeoEventsTimeSeriesResponse = {
+  data: Array<GeoEventsDataPoint>;
+  end_date: string;
   granularity: string;
   start_date: string;
-  end_date: string;
-  data: Array<GeoEventsDataPoint>;
 };
 
 /**
  * GeoJSONFeature
  */
 export type GeoJsonFeature = {
-  type: string;
   geometry: GeoJsonPointGeometry;
   properties: GeoJsonFeatureProperties;
+  type: string;
 };
 
 /**
  * GeoJSONFeatureCollection
  */
 export type GeoJsonFeatureCollection = {
-  type: string;
   features: Array<GeoJsonFeature>;
   stats: GeoJsonFeatureStats;
+  type: string;
 };
 
 /**
  * GeoJSONFeatureProperties
  */
 export type GeoJsonFeatureProperties = {
-  id: number;
-  geohash: string;
+  city: string | null;
   country_code: string;
   country_name: string;
+  event_count: number;
+  geohash: string;
+  id: number;
   last_hit: string | null;
+  postal_code: string | null;
   state: string | null;
   state_code: string | null;
-  city: string | null;
-  postal_code: string | null;
   timezone: string | null;
-  event_count: number;
   top_ips?: Array<TopIpdto>;
 };
 
@@ -123,9 +123,9 @@ export type GeoJsonFeatureProperties = {
  * GeoJSONFeatureStats
  */
 export type GeoJsonFeatureStats = {
-  events: number;
-  countries: number;
   cities: number;
+  countries: number;
+  events: number;
   locations: number;
 };
 
@@ -133,8 +133,8 @@ export type GeoJsonFeatureStats = {
  * GeoJSONPointGeometry
  */
 export type GeoJsonPointGeometry = {
-  type: string;
   coordinates: [number, number];
+  type: string;
 };
 
 /**
@@ -150,87 +150,87 @@ export type GlobalTopIpsResponse = {
 export type ListAccessLogDebugsAccessLogDebugResponseBody = {
   accessLogId?: number | null;
   createdAt?: string;
-  rawLine: string;
+  id: number;
   isMalformed?: boolean;
   parseError?: string | null;
-  id: number;
+  rawLine: string;
 };
 
 /**
  * ListAccessLogsAccessLogResponseBody
  */
 export type ListAccessLogsAccessLogResponseBody = {
-  timestamp: string;
-  ipAddress: string;
-  remoteUser?: string;
-  method?: string | null;
-  url?: string | null;
-  httpVersion?: string | null;
-  statusCode: number;
   bytesSent?: number;
-  referrer?: string | null;
-  userAgent?: string | null;
-  requestTime?: number;
-  upstreamResponseTime?: number | null;
-  host?: string | null;
+  city?: string | null;
   countryCode?: string | null;
   countryName?: string | null;
-  city?: string | null;
+  host?: string | null;
+  httpVersion?: string | null;
   id: number;
+  ipAddress: string;
+  method?: string | null;
+  referrer?: string | null;
+  remoteUser?: string;
+  requestTime?: number;
+  statusCode: number;
+  timestamp: string;
+  upstreamResponseTime?: number | null;
+  url?: string | null;
+  userAgent?: string | null;
 };
 
 /**
  * ListGeoEventsGeoEventGeoLocationResponseBody
  */
 export type ListGeoEventsGeoEventGeoLocationResponseBody = {
-  latitude: number;
-  longitude: number;
-  geohash: string;
-  geographicPoint: string;
+  city?: string | null;
   countryCode: string;
   countryName: string;
+  createdAt?: string;
+  geographicPoint: string;
+  geohash: string;
+  id: number;
+  lastHit?: string | null;
+  latitude: number;
+  longitude: number;
+  postalCode?: string | null;
   state?: string | null;
   stateCode?: string | null;
-  city?: string | null;
-  postalCode?: string | null;
   timezone?: string | null;
-  lastHit?: string | null;
-  createdAt?: string;
   updatedAt?: string;
-  id: number;
 };
 
 /**
  * ListGeoEventsGeoEventResponseBody
  */
 export type ListGeoEventsGeoEventResponseBody = {
-  timestamp?: string;
-  ipAddress: string;
   hostname: string;
-  locationId: number;
-  location: ListGeoEventsGeoEventGeoLocationResponseBody;
   id: number;
+  ipAddress: string;
+  location: ListGeoEventsGeoEventGeoLocationResponseBody;
+  locationId: number;
+  timestamp?: string;
 };
 
 /**
  * ListGeoLocationsGeoLocationResponseBody
  */
 export type ListGeoLocationsGeoLocationResponseBody = {
-  latitude: number;
-  longitude: number;
-  geohash: string;
-  geographicPoint: string;
+  city?: string | null;
   countryCode: string;
   countryName: string;
+  createdAt?: string;
+  geographicPoint: string;
+  geohash: string;
+  id: number;
+  lastHit?: string | null;
+  latitude: number;
+  longitude: number;
+  postalCode?: string | null;
   state?: string | null;
   stateCode?: string | null;
-  city?: string | null;
-  postalCode?: string | null;
   timezone?: string | null;
-  lastHit?: string | null;
-  createdAt?: string;
   updatedAt?: string;
-  id: number;
 };
 
 /**
@@ -245,8 +245,8 @@ export type LocationTopIpsResponse = {
  * LoginPayload
  */
 export type LoginPayload = {
-  username: string;
   password: string;
+  username: string;
 };
 
 /**
@@ -278,94 +278,94 @@ export type MeResponse = {
  * PercentChange
  */
 export type PercentChange = {
-  log_records?: number | null;
-  geo_records?: number | null;
-  unique_ips?: number | null;
-  bytes_sent?: number | null;
   avg_request_time?: number | null;
+  bytes_sent?: number | null;
   error_rate?: number | null;
+  geo_records?: number | null;
+  log_records?: number | null;
   malformed_rate?: number | null;
+  unique_ips?: number | null;
 };
 
 /**
  * PeriodSummary
  */
 export type PeriodSummary = {
-  total_requests: number;
-  total_geo_events: number;
-  unique_ips: number;
-  unique_countries: number;
-  total_bytes_sent: number;
   avg_bytes_per_request: number;
+  avg_request_time: number;
+  error_rate: number;
+  malformed_requests: number;
+  max_request_time: number;
   status_2xx: number;
   status_3xx: number;
   status_4xx: number;
   status_5xx: number;
-  avg_request_time: number;
-  max_request_time: number;
-  malformed_requests: number;
-  error_rate: number;
+  total_bytes_sent: number;
+  total_geo_events: number;
+  total_requests: number;
+  unique_countries: number;
+  unique_ips: number;
 };
 
 /**
  * SafeSettingsResponse
  */
 export type SafeSettingsResponse = {
-  name: string;
-  version: string;
+  analytics: AnalyticsSettingsView;
   environment: string;
   logparser: LogparserSettingsView;
-  analytics: AnalyticsSettingsView;
   map: MapSettingsView;
+  name: string;
+  version: string;
 };
 
 /**
  * SummaryResponse
  */
 export type SummaryResponse = {
-  start_date: string;
-  end_date: string;
   current_period: PeriodSummary;
-  previous_period?: PeriodSummary | null;
+  end_date: string;
   percent_changes?: PercentChange | null;
+  previous_period?: PeriodSummary | null;
+  start_date: string;
 };
 
 /**
  * TimeSeriesDataPoint
  */
 export type TimeSeriesDataPoint = {
-  timestamp: string;
-  total_requests: number;
-  total_geo_events: number;
-  total_bytes_sent: number;
+  avg_request_time: number;
+  error_rate: number;
+  p50_request_time: number;
+  p95_request_time: number;
+  p99_request_time: number;
   status_2xx: number;
   status_3xx: number;
   status_4xx: number;
   status_5xx: number;
-  error_rate: number;
-  avg_request_time: number;
-  p50_request_time: number;
-  p95_request_time: number;
-  p99_request_time: number;
+  timestamp: string;
+  total_bytes_sent: number;
+  total_geo_events: number;
+  total_requests: number;
 };
 
 /**
  * TimeSeriesResponse
  */
 export type TimeSeriesResponse = {
+  data: Array<TimeSeriesDataPoint>;
+  end_date: string;
   granularity: string;
   start_date: string;
-  end_date: string;
-  data: Array<TimeSeriesDataPoint>;
 };
 
 /**
  * TopCitiesResponse
  */
 export type TopCitiesResponse = {
-  start_date: string;
   end_date: string;
   items: Array<TopCityStatsDto>;
+  start_date: string;
 };
 
 /**
@@ -389,9 +389,9 @@ export type TopCountriesResponse = {
  * TopCountriesStatsResponse
  */
 export type TopCountriesStatsResponse = {
-  start_date: string;
   end_date: string;
   items: Array<TopCountryStatsDto>;
+  start_date: string;
 };
 
 /**
@@ -417,8 +417,8 @@ export type TopCountryStatsDto = {
  * TopIPDTO
  */
 export type TopIpdto = {
-  ip_address: string;
   event_count: number;
+  ip_address: string;
   location?: EmbeddedLocationDto | null;
 };
 
@@ -426,76 +426,75 @@ export type TopIpdto = {
  * TopIpDTO
  */
 export type TopIpDto = {
-  ip_address: string;
-  hits: number;
-  error_hits: number;
-  total_bytes: number;
-  country_code: string | null;
   city: string | null;
+  country_code: string | null;
+  error_hits: number;
+  hits: number;
+  ip_address: string;
+  total_bytes: number;
 };
 
 /**
  * TopIpsResponse
  */
 export type TopIpsResponse = {
-  start_date: string;
   end_date: string;
   items: Array<TopIpDto>;
+  start_date: string;
 };
 
 /**
  * TopUrlDTO
  */
 export type TopUrlDto = {
-  url: string;
-  hits: number;
-  error_hits: number;
-  total_bytes: number;
   avg_request_time: number;
+  error_hits: number;
+  hits: number;
+  total_bytes: number;
+  url: string;
 };
 
 /**
  * TopUrlsResponse
  */
 export type TopUrlsResponse = {
-  start_date: string;
   end_date: string;
   items: Array<TopUrlDto>;
+  start_date: string;
 };
 
 /**
  * TopUserAgentDTO
  */
 export type TopUserAgentDto = {
-  user_agent: string;
   hits: number;
+  user_agent: string;
 };
 
 /**
  * TopUserAgentsResponse
  */
 export type TopUserAgentsResponse = {
-  start_date: string;
   end_date: string;
   items: Array<TopUserAgentDto>;
+  start_date: string;
 };
 
-export type ApiV1GeoEventsListGeoEventsData = {
+export type ApiV1AccessLogDebugListAccessLogDebugsData = {
   body?: never;
   path?: never;
   query?: {
     currentPage?: number;
     pageSize?: number;
   };
-  url: "/api/v1/geo-events";
+  url: "/api/v1/access-log-debug";
 };
 
-export type ApiV1GeoEventsListGeoEventsErrors = {
+export type ApiV1AccessLogDebugListAccessLogDebugsErrors = {
   /**
    * Validation Exception
    */
   400: {
-    status_code: number;
     detail: string;
     extra?:
       | null
@@ -503,18 +502,19 @@ export type ApiV1GeoEventsListGeoEventsErrors = {
           [key: string]: unknown;
         }
       | Array<unknown>;
+    status_code: number;
   };
 };
 
-export type ApiV1GeoEventsListGeoEventsError =
-  ApiV1GeoEventsListGeoEventsErrors[keyof ApiV1GeoEventsListGeoEventsErrors];
+export type ApiV1AccessLogDebugListAccessLogDebugsError =
+  ApiV1AccessLogDebugListAccessLogDebugsErrors[keyof ApiV1AccessLogDebugListAccessLogDebugsErrors];
 
-export type ApiV1GeoEventsListGeoEventsResponses = {
+export type ApiV1AccessLogDebugListAccessLogDebugsResponses = {
   /**
    * Request fulfilled, document follows
    */
   200: {
-    items?: Array<ListGeoEventsGeoEventResponseBody>;
+    items?: Array<ListAccessLogDebugsAccessLogDebugResponseBody>;
     /**
      * Maximal number of items to send.
      */
@@ -530,280 +530,8 @@ export type ApiV1GeoEventsListGeoEventsResponses = {
   };
 };
 
-export type ApiV1GeoEventsListGeoEventsResponse =
-  ApiV1GeoEventsListGeoEventsResponses[keyof ApiV1GeoEventsListGeoEventsResponses];
-
-export type ApiV1GeoLocationsGeojsonGetGeojsonData = {
-  body?: never;
-  path?: never;
-  query: {
-    /**
-     * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
-     */
-    from_timestamp: string;
-    /**
-     * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
-     */
-    to_timestamp: string;
-    /**
-     * Filter to these ISO country codes (repeatable)
-     */
-    country_code?: Array<string> | null;
-    /**
-     * Filter to these city names (repeatable)
-     */
-    city?: Array<string> | null;
-  };
-  url: "/api/v1/geo-locations/geojson";
-};
-
-export type ApiV1GeoLocationsGeojsonGetGeojsonErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    status_code: number;
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-  };
-};
-
-export type ApiV1GeoLocationsGeojsonGetGeojsonError =
-  ApiV1GeoLocationsGeojsonGetGeojsonErrors[keyof ApiV1GeoLocationsGeojsonGetGeojsonErrors];
-
-export type ApiV1GeoLocationsGeojsonGetGeojsonResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: GeoJsonFeatureCollection;
-};
-
-export type ApiV1GeoLocationsGeojsonGetGeojsonResponse =
-  ApiV1GeoLocationsGeojsonGetGeojsonResponses[keyof ApiV1GeoLocationsGeojsonGetGeojsonResponses];
-
-export type ApiV1GeoLocationsTopIpsGetGlobalTopIpsData = {
-  body?: never;
-  path?: never;
-  query: {
-    /**
-     * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
-     */
-    from_timestamp: string;
-    /**
-     * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
-     */
-    to_timestamp: string;
-    /**
-     * Maximum number of IPs to return
-     */
-    limit?: number;
-  };
-  url: "/api/v1/geo-locations/top-ips";
-};
-
-export type ApiV1GeoLocationsTopIpsGetGlobalTopIpsErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    status_code: number;
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-  };
-};
-
-export type ApiV1GeoLocationsTopIpsGetGlobalTopIpsError =
-  ApiV1GeoLocationsTopIpsGetGlobalTopIpsErrors[keyof ApiV1GeoLocationsTopIpsGetGlobalTopIpsErrors];
-
-export type ApiV1GeoLocationsTopIpsGetGlobalTopIpsResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: GlobalTopIpsResponse;
-};
-
-export type ApiV1GeoLocationsTopIpsGetGlobalTopIpsResponse =
-  ApiV1GeoLocationsTopIpsGetGlobalTopIpsResponses[keyof ApiV1GeoLocationsTopIpsGetGlobalTopIpsResponses];
-
-export type ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsData = {
-  body?: never;
-  path: {
-    location_id: number;
-  };
-  query: {
-    /**
-     * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
-     */
-    from_timestamp: string;
-    /**
-     * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
-     */
-    to_timestamp: string;
-    /**
-     * Maximum number of IPs to return
-     */
-    limit?: number;
-  };
-  url: "/api/v1/geo-locations/{location_id}/top-ips";
-};
-
-export type ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    status_code: number;
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-  };
-};
-
-export type ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsError =
-  ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsErrors[keyof ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsErrors];
-
-export type ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: LocationTopIpsResponse;
-};
-
-export type ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponse =
-  ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponses[keyof ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponses];
-
-export type ApiV1GeoLocationsTopCountriesGetTopCountriesData = {
-  body?: never;
-  path?: never;
-  query: {
-    /**
-     * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
-     */
-    from_timestamp: string;
-    /**
-     * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
-     */
-    to_timestamp: string;
-    /**
-     * Maximum number of countries to return
-     */
-    limit?: number;
-  };
-  url: "/api/v1/geo-locations/top-countries";
-};
-
-export type ApiV1GeoLocationsTopCountriesGetTopCountriesErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    status_code: number;
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-  };
-};
-
-export type ApiV1GeoLocationsTopCountriesGetTopCountriesError =
-  ApiV1GeoLocationsTopCountriesGetTopCountriesErrors[keyof ApiV1GeoLocationsTopCountriesGetTopCountriesErrors];
-
-export type ApiV1GeoLocationsTopCountriesGetTopCountriesResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: TopCountriesResponse;
-};
-
-export type ApiV1GeoLocationsTopCountriesGetTopCountriesResponse =
-  ApiV1GeoLocationsTopCountriesGetTopCountriesResponses[keyof ApiV1GeoLocationsTopCountriesGetTopCountriesResponses];
-
-export type ApiV1GeoLocationsListGeoLocationsData = {
-  body?: never;
-  path?: never;
-  query?: {
-    currentPage?: number;
-    pageSize?: number;
-  };
-  url: "/api/v1/geo-locations";
-};
-
-export type ApiV1GeoLocationsListGeoLocationsErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    status_code: number;
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-  };
-};
-
-export type ApiV1GeoLocationsListGeoLocationsError =
-  ApiV1GeoLocationsListGeoLocationsErrors[keyof ApiV1GeoLocationsListGeoLocationsErrors];
-
-export type ApiV1GeoLocationsListGeoLocationsResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: {
-    items?: Array<ListGeoLocationsGeoLocationResponseBody>;
-    /**
-     * Maximal number of items to send.
-     */
-    limit?: number;
-    /**
-     * Offset from the beginning of the query.
-     */
-    offset?: number;
-    /**
-     * Total number of items.
-     */
-    total?: number;
-  };
-};
-
-export type ApiV1GeoLocationsListGeoLocationsResponse =
-  ApiV1GeoLocationsListGeoLocationsResponses[keyof ApiV1GeoLocationsListGeoLocationsResponses];
-
-export type ApiV1AccessLogsFacetsGetAccessLogFacetsData = {
-  body?: never;
-  path?: never;
-  query?: never;
-  url: "/api/v1/access-logs/facets";
-};
-
-export type ApiV1AccessLogsFacetsGetAccessLogFacetsResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: AccessLogFacets;
-};
-
-export type ApiV1AccessLogsFacetsGetAccessLogFacetsResponse =
-  ApiV1AccessLogsFacetsGetAccessLogFacetsResponses[keyof ApiV1AccessLogsFacetsGetAccessLogFacetsResponses];
+export type ApiV1AccessLogDebugListAccessLogDebugsResponse =
+  ApiV1AccessLogDebugListAccessLogDebugsResponses[keyof ApiV1AccessLogDebugListAccessLogDebugsResponses];
 
 export type ApiV1AccessLogsListAccessLogsData = {
   body?: never;
@@ -844,7 +572,6 @@ export type ApiV1AccessLogsListAccessLogsErrors = {
    * Validation Exception
    */
   400: {
-    status_code: number;
     detail: string;
     extra?:
       | null
@@ -852,6 +579,7 @@ export type ApiV1AccessLogsListAccessLogsErrors = {
           [key: string]: unknown;
         }
       | Array<unknown>;
+    status_code: number;
   };
 };
 
@@ -882,104 +610,22 @@ export type ApiV1AccessLogsListAccessLogsResponses = {
 export type ApiV1AccessLogsListAccessLogsResponse =
   ApiV1AccessLogsListAccessLogsResponses[keyof ApiV1AccessLogsListAccessLogsResponses];
 
-export type ApiV1AccessLogDebugListAccessLogDebugsData = {
+export type ApiV1AccessLogsFacetsGetAccessLogFacetsData = {
   body?: never;
   path?: never;
-  query?: {
-    currentPage?: number;
-    pageSize?: number;
-  };
-  url: "/api/v1/access-log-debug";
+  query?: never;
+  url: "/api/v1/access-logs/facets";
 };
 
-export type ApiV1AccessLogDebugListAccessLogDebugsErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    status_code: number;
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-  };
-};
-
-export type ApiV1AccessLogDebugListAccessLogDebugsError =
-  ApiV1AccessLogDebugListAccessLogDebugsErrors[keyof ApiV1AccessLogDebugListAccessLogDebugsErrors];
-
-export type ApiV1AccessLogDebugListAccessLogDebugsResponses = {
+export type ApiV1AccessLogsFacetsGetAccessLogFacetsResponses = {
   /**
    * Request fulfilled, document follows
    */
-  200: {
-    items?: Array<ListAccessLogDebugsAccessLogDebugResponseBody>;
-    /**
-     * Maximal number of items to send.
-     */
-    limit?: number;
-    /**
-     * Offset from the beginning of the query.
-     */
-    offset?: number;
-    /**
-     * Total number of items.
-     */
-    total?: number;
-  };
+  200: AccessLogFacets;
 };
 
-export type ApiV1AccessLogDebugListAccessLogDebugsResponse =
-  ApiV1AccessLogDebugListAccessLogDebugsResponses[keyof ApiV1AccessLogDebugListAccessLogDebugsResponses];
-
-export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesData = {
-  body?: never;
-  path?: never;
-  query: {
-    /**
-     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
-     */
-    start_date: string;
-    /**
-     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
-     */
-    end_date: string;
-  };
-  url: "/api/v1/analytics/time-series/cumulative";
-};
-
-export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    status_code: number;
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-  };
-};
-
-export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesError =
-  ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesErrors[keyof ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesErrors];
-
-export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses =
-  {
-    /**
-     * Request fulfilled, document follows
-     */
-    200: CumulativeTimeSeriesResponse;
-  };
-
-export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponse =
-  ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses[keyof ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses];
+export type ApiV1AccessLogsFacetsGetAccessLogFacetsResponse =
+  ApiV1AccessLogsFacetsGetAccessLogFacetsResponses[keyof ApiV1AccessLogsFacetsGetAccessLogFacetsResponses];
 
 export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesData = {
   body?: never;
@@ -1006,7 +652,6 @@ export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesErrors = {
    * Validation Exception
    */
   400: {
-    status_code: number;
     detail: string;
     extra?:
       | null
@@ -1014,6 +659,7 @@ export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesErrors = {
           [key: string]: unknown;
         }
       | Array<unknown>;
+    status_code: number;
   };
 };
 
@@ -1055,7 +701,6 @@ export type ApiV1AnalyticsLiveSummaryGetLiveSummaryErrors = {
    * Validation Exception
    */
   400: {
-    status_code: number;
     detail: string;
     extra?:
       | null
@@ -1063,6 +708,7 @@ export type ApiV1AnalyticsLiveSummaryGetLiveSummaryErrors = {
           [key: string]: unknown;
         }
       | Array<unknown>;
+    status_code: number;
   };
 };
 
@@ -1104,7 +750,6 @@ export type ApiV1AnalyticsSummaryGetSummaryErrors = {
    * Validation Exception
    */
   400: {
-    status_code: number;
     detail: string;
     extra?:
       | null
@@ -1112,6 +757,7 @@ export type ApiV1AnalyticsSummaryGetSummaryErrors = {
           [key: string]: unknown;
         }
       | Array<unknown>;
+    status_code: number;
   };
 };
 
@@ -1165,7 +811,6 @@ export type ApiV1AnalyticsTimeSeriesGetTimeSeriesErrors = {
    * Validation Exception
    */
   400: {
-    status_code: number;
     detail: string;
     extra?:
       | null
@@ -1173,6 +818,7 @@ export type ApiV1AnalyticsTimeSeriesGetTimeSeriesErrors = {
           [key: string]: unknown;
         }
       | Array<unknown>;
+    status_code: number;
   };
 };
 
@@ -1188,6 +834,52 @@ export type ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses = {
 
 export type ApiV1AnalyticsTimeSeriesGetTimeSeriesResponse =
   ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses[keyof ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses];
+
+export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
+     */
+    start_date: string;
+    /**
+     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
+     */
+    end_date: string;
+  };
+  url: "/api/v1/analytics/time-series/cumulative";
+};
+
+export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+    status_code: number;
+  };
+};
+
+export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesError =
+  ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesErrors[keyof ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesErrors];
+
+export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses =
+  {
+    /**
+     * Request fulfilled, document follows
+     */
+    200: CumulativeTimeSeriesResponse;
+  };
+
+export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponse =
+  ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses[keyof ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses];
 
 export type ApiV1AnalyticsTopCitiesGetTopCitiesData = {
   body?: never;
@@ -1226,7 +918,6 @@ export type ApiV1AnalyticsTopCitiesGetTopCitiesErrors = {
    * Validation Exception
    */
   400: {
-    status_code: number;
     detail: string;
     extra?:
       | null
@@ -1234,6 +925,7 @@ export type ApiV1AnalyticsTopCitiesGetTopCitiesErrors = {
           [key: string]: unknown;
         }
       | Array<unknown>;
+    status_code: number;
   };
 };
 
@@ -1287,7 +979,6 @@ export type ApiV1AnalyticsTopCountriesGetTopCountriesErrors = {
    * Validation Exception
    */
   400: {
-    status_code: number;
     detail: string;
     extra?:
       | null
@@ -1295,6 +986,7 @@ export type ApiV1AnalyticsTopCountriesGetTopCountriesErrors = {
           [key: string]: unknown;
         }
       | Array<unknown>;
+    status_code: number;
   };
 };
 
@@ -1348,7 +1040,6 @@ export type ApiV1AnalyticsTopIpsGetTopIpsErrors = {
    * Validation Exception
    */
   400: {
-    status_code: number;
     detail: string;
     extra?:
       | null
@@ -1356,6 +1047,7 @@ export type ApiV1AnalyticsTopIpsGetTopIpsErrors = {
           [key: string]: unknown;
         }
       | Array<unknown>;
+    status_code: number;
   };
 };
 
@@ -1409,7 +1101,6 @@ export type ApiV1AnalyticsTopUrlsGetTopUrlsErrors = {
    * Validation Exception
    */
   400: {
-    status_code: number;
     detail: string;
     extra?:
       | null
@@ -1417,6 +1108,7 @@ export type ApiV1AnalyticsTopUrlsGetTopUrlsErrors = {
           [key: string]: unknown;
         }
       | Array<unknown>;
+    status_code: number;
   };
 };
 
@@ -1470,7 +1162,6 @@ export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsErrors = {
    * Validation Exception
    */
   400: {
-    status_code: number;
     detail: string;
     extra?:
       | null
@@ -1478,6 +1169,7 @@ export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsErrors = {
           [key: string]: unknown;
         }
       | Array<unknown>;
+    status_code: number;
   };
 };
 
@@ -1493,6 +1185,384 @@ export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponses = {
 
 export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponse =
   ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponses[keyof ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponses];
+
+export type ApiV1AuthLoginLoginData = {
+  body: LoginPayload;
+  path?: never;
+  query?: never;
+  url: "/api/v1/auth/login";
+};
+
+export type ApiV1AuthLoginLoginErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+    status_code: number;
+  };
+};
+
+export type ApiV1AuthLoginLoginError =
+  ApiV1AuthLoginLoginErrors[keyof ApiV1AuthLoginLoginErrors];
+
+export type ApiV1AuthLoginLoginResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: MeResponse;
+};
+
+export type ApiV1AuthLoginLoginResponse =
+  ApiV1AuthLoginLoginResponses[keyof ApiV1AuthLoginLoginResponses];
+
+export type ApiV1AuthLogoutLogoutData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: "/api/v1/auth/logout";
+};
+
+export type ApiV1AuthLogoutLogoutResponses = {
+  /**
+   * Request fulfilled, nothing follows
+   */
+  204: void;
+};
+
+export type ApiV1AuthLogoutLogoutResponse =
+  ApiV1AuthLogoutLogoutResponses[keyof ApiV1AuthLogoutLogoutResponses];
+
+export type ApiV1AuthMeMeData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: "/api/v1/auth/me";
+};
+
+export type ApiV1AuthMeMeResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: MeResponse;
+};
+
+export type ApiV1AuthMeMeResponse =
+  ApiV1AuthMeMeResponses[keyof ApiV1AuthMeMeResponses];
+
+export type ApiV1GeoEventsListGeoEventsData = {
+  body?: never;
+  path?: never;
+  query?: {
+    currentPage?: number;
+    pageSize?: number;
+  };
+  url: "/api/v1/geo-events";
+};
+
+export type ApiV1GeoEventsListGeoEventsErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+    status_code: number;
+  };
+};
+
+export type ApiV1GeoEventsListGeoEventsError =
+  ApiV1GeoEventsListGeoEventsErrors[keyof ApiV1GeoEventsListGeoEventsErrors];
+
+export type ApiV1GeoEventsListGeoEventsResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: {
+    items?: Array<ListGeoEventsGeoEventResponseBody>;
+    /**
+     * Maximal number of items to send.
+     */
+    limit?: number;
+    /**
+     * Offset from the beginning of the query.
+     */
+    offset?: number;
+    /**
+     * Total number of items.
+     */
+    total?: number;
+  };
+};
+
+export type ApiV1GeoEventsListGeoEventsResponse =
+  ApiV1GeoEventsListGeoEventsResponses[keyof ApiV1GeoEventsListGeoEventsResponses];
+
+export type ApiV1GeoLocationsListGeoLocationsData = {
+  body?: never;
+  path?: never;
+  query?: {
+    currentPage?: number;
+    pageSize?: number;
+  };
+  url: "/api/v1/geo-locations";
+};
+
+export type ApiV1GeoLocationsListGeoLocationsErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+    status_code: number;
+  };
+};
+
+export type ApiV1GeoLocationsListGeoLocationsError =
+  ApiV1GeoLocationsListGeoLocationsErrors[keyof ApiV1GeoLocationsListGeoLocationsErrors];
+
+export type ApiV1GeoLocationsListGeoLocationsResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: {
+    items?: Array<ListGeoLocationsGeoLocationResponseBody>;
+    /**
+     * Maximal number of items to send.
+     */
+    limit?: number;
+    /**
+     * Offset from the beginning of the query.
+     */
+    offset?: number;
+    /**
+     * Total number of items.
+     */
+    total?: number;
+  };
+};
+
+export type ApiV1GeoLocationsListGeoLocationsResponse =
+  ApiV1GeoLocationsListGeoLocationsResponses[keyof ApiV1GeoLocationsListGeoLocationsResponses];
+
+export type ApiV1GeoLocationsGeojsonGetGeojsonData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
+     */
+    from_timestamp: string;
+    /**
+     * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
+     */
+    to_timestamp: string;
+    /**
+     * Filter to these ISO country codes (repeatable)
+     */
+    country_code?: Array<string> | null;
+    /**
+     * Filter to these city names (repeatable)
+     */
+    city?: Array<string> | null;
+  };
+  url: "/api/v1/geo-locations/geojson";
+};
+
+export type ApiV1GeoLocationsGeojsonGetGeojsonErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+    status_code: number;
+  };
+};
+
+export type ApiV1GeoLocationsGeojsonGetGeojsonError =
+  ApiV1GeoLocationsGeojsonGetGeojsonErrors[keyof ApiV1GeoLocationsGeojsonGetGeojsonErrors];
+
+export type ApiV1GeoLocationsGeojsonGetGeojsonResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: GeoJsonFeatureCollection;
+};
+
+export type ApiV1GeoLocationsGeojsonGetGeojsonResponse =
+  ApiV1GeoLocationsGeojsonGetGeojsonResponses[keyof ApiV1GeoLocationsGeojsonGetGeojsonResponses];
+
+export type ApiV1GeoLocationsTopCountriesGetTopCountriesData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
+     */
+    from_timestamp: string;
+    /**
+     * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
+     */
+    to_timestamp: string;
+    /**
+     * Maximum number of countries to return
+     */
+    limit?: number;
+  };
+  url: "/api/v1/geo-locations/top-countries";
+};
+
+export type ApiV1GeoLocationsTopCountriesGetTopCountriesErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+    status_code: number;
+  };
+};
+
+export type ApiV1GeoLocationsTopCountriesGetTopCountriesError =
+  ApiV1GeoLocationsTopCountriesGetTopCountriesErrors[keyof ApiV1GeoLocationsTopCountriesGetTopCountriesErrors];
+
+export type ApiV1GeoLocationsTopCountriesGetTopCountriesResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: TopCountriesResponse;
+};
+
+export type ApiV1GeoLocationsTopCountriesGetTopCountriesResponse =
+  ApiV1GeoLocationsTopCountriesGetTopCountriesResponses[keyof ApiV1GeoLocationsTopCountriesGetTopCountriesResponses];
+
+export type ApiV1GeoLocationsTopIpsGetGlobalTopIpsData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
+     */
+    from_timestamp: string;
+    /**
+     * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
+     */
+    to_timestamp: string;
+    /**
+     * Maximum number of IPs to return
+     */
+    limit?: number;
+  };
+  url: "/api/v1/geo-locations/top-ips";
+};
+
+export type ApiV1GeoLocationsTopIpsGetGlobalTopIpsErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+    status_code: number;
+  };
+};
+
+export type ApiV1GeoLocationsTopIpsGetGlobalTopIpsError =
+  ApiV1GeoLocationsTopIpsGetGlobalTopIpsErrors[keyof ApiV1GeoLocationsTopIpsGetGlobalTopIpsErrors];
+
+export type ApiV1GeoLocationsTopIpsGetGlobalTopIpsResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: GlobalTopIpsResponse;
+};
+
+export type ApiV1GeoLocationsTopIpsGetGlobalTopIpsResponse =
+  ApiV1GeoLocationsTopIpsGetGlobalTopIpsResponses[keyof ApiV1GeoLocationsTopIpsGetGlobalTopIpsResponses];
+
+export type ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsData = {
+  body?: never;
+  path: {
+    location_id: number;
+  };
+  query: {
+    /**
+     * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
+     */
+    from_timestamp: string;
+    /**
+     * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
+     */
+    to_timestamp: string;
+    /**
+     * Maximum number of IPs to return
+     */
+    limit?: number;
+  };
+  url: "/api/v1/geo-locations/{location_id}/top-ips";
+};
+
+export type ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+    status_code: number;
+  };
+};
+
+export type ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsError =
+  ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsErrors[keyof ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsErrors];
+
+export type ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: LocationTopIpsResponse;
+};
+
+export type ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponse =
+  ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponses[keyof ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponses];
 
 export type ApiV1SettingsReadSettingsData = {
   body?: never;
@@ -1567,73 +1637,3 @@ export type HealthReadyHealthReadyResponses = {
 
 export type HealthReadyHealthReadyResponse =
   HealthReadyHealthReadyResponses[keyof HealthReadyHealthReadyResponses];
-
-export type ApiV1AuthLoginLoginData = {
-  body: LoginPayload;
-  path?: never;
-  query?: never;
-  url: "/api/v1/auth/login";
-};
-
-export type ApiV1AuthLoginLoginErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    status_code: number;
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-  };
-};
-
-export type ApiV1AuthLoginLoginError =
-  ApiV1AuthLoginLoginErrors[keyof ApiV1AuthLoginLoginErrors];
-
-export type ApiV1AuthLoginLoginResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: MeResponse;
-};
-
-export type ApiV1AuthLoginLoginResponse =
-  ApiV1AuthLoginLoginResponses[keyof ApiV1AuthLoginLoginResponses];
-
-export type ApiV1AuthLogoutLogoutData = {
-  body?: never;
-  path?: never;
-  query?: never;
-  url: "/api/v1/auth/logout";
-};
-
-export type ApiV1AuthLogoutLogoutResponses = {
-  /**
-   * Request fulfilled, nothing follows
-   */
-  204: void;
-};
-
-export type ApiV1AuthLogoutLogoutResponse =
-  ApiV1AuthLogoutLogoutResponses[keyof ApiV1AuthLogoutLogoutResponses];
-
-export type ApiV1AuthMeMeData = {
-  body?: never;
-  path?: never;
-  query?: never;
-  url: "/api/v1/auth/me";
-};
-
-export type ApiV1AuthMeMeResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: MeResponse;
-};
-
-export type ApiV1AuthMeMeResponse =
-  ApiV1AuthMeMeResponses[keyof ApiV1AuthMeMeResponses];

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -8,18 +8,18 @@ export type ClientOptions = {
  * AccessLogFacets
  */
 export type AccessLogFacets = {
-  cities: Array<string>;
   countries: Array<CountryFacet>;
+  cities: Array<string>;
 };
 
 /**
  * AnalyticsSettingsView
  */
 export type AnalyticsSettingsView = {
-  compression_after_days: number;
+  raw_retention_days: number;
   debug_retention_days: number;
   hourly_retention_days: number;
-  raw_retention_days: number;
+  compression_after_days: number;
 };
 
 /**
@@ -34,32 +34,32 @@ export type CountryFacet = {
  * CumulativeDataPoint
  */
 export type CumulativeDataPoint = {
+  timestamp: string;
+  cumulative_geo_events: number;
   cumulative_access_logs: number;
   cumulative_bytes: number;
-  cumulative_geo_events: number;
-  timestamp: string;
 };
 
 /**
  * CumulativeTimeSeriesResponse
  */
 export type CumulativeTimeSeriesResponse = {
-  data?: Array<CumulativeDataPoint>;
-  end_date: string;
   granularity: string;
   start_date: string;
+  end_date: string;
+  data?: Array<CumulativeDataPoint>;
 };
 
 /**
  * EmbeddedLocationDTO
  */
 export type EmbeddedLocationDto = {
-  city?: string | null;
-  country_code?: string | null;
-  country_name?: string | null;
   id: number;
   latitude: number;
   longitude: number;
+  city?: string | null;
+  country_code?: string | null;
+  country_name?: string | null;
 };
 
 /**
@@ -68,54 +68,54 @@ export type EmbeddedLocationDto = {
 export type GeoEventsDataPoint = {
   timestamp: string;
   total_geo_events: number;
-  unique_cities: number;
-  unique_countries: number;
   unique_ips: number;
+  unique_countries: number;
+  unique_cities: number;
 };
 
 /**
  * GeoEventsTimeSeriesResponse
  */
 export type GeoEventsTimeSeriesResponse = {
-  data: Array<GeoEventsDataPoint>;
-  end_date: string;
   granularity: string;
   start_date: string;
+  end_date: string;
+  data: Array<GeoEventsDataPoint>;
 };
 
 /**
  * GeoJSONFeature
  */
 export type GeoJsonFeature = {
+  type: string;
   geometry: GeoJsonPointGeometry;
   properties: GeoJsonFeatureProperties;
-  type: string;
 };
 
 /**
  * GeoJSONFeatureCollection
  */
 export type GeoJsonFeatureCollection = {
+  type: string;
   features: Array<GeoJsonFeature>;
   stats: GeoJsonFeatureStats;
-  type: string;
 };
 
 /**
  * GeoJSONFeatureProperties
  */
 export type GeoJsonFeatureProperties = {
-  city: string | null;
+  id: number;
+  geohash: string;
   country_code: string;
   country_name: string;
-  event_count: number;
-  geohash: string;
-  id: number;
   last_hit: string | null;
-  postal_code: string | null;
   state: string | null;
   state_code: string | null;
+  city: string | null;
+  postal_code: string | null;
   timezone: string | null;
+  event_count: number;
   top_ips?: Array<TopIpdto>;
 };
 
@@ -123,9 +123,9 @@ export type GeoJsonFeatureProperties = {
  * GeoJSONFeatureStats
  */
 export type GeoJsonFeatureStats = {
-  cities: number;
-  countries: number;
   events: number;
+  countries: number;
+  cities: number;
   locations: number;
 };
 
@@ -133,8 +133,8 @@ export type GeoJsonFeatureStats = {
  * GeoJSONPointGeometry
  */
 export type GeoJsonPointGeometry = {
-  coordinates: [number, number];
   type: string;
+  coordinates: [number, number];
 };
 
 /**
@@ -150,87 +150,87 @@ export type GlobalTopIpsResponse = {
 export type ListAccessLogDebugsAccessLogDebugResponseBody = {
   accessLogId?: number | null;
   createdAt?: string;
-  id: number;
+  rawLine: string;
   isMalformed?: boolean;
   parseError?: string | null;
-  rawLine: string;
+  id: number;
 };
 
 /**
  * ListAccessLogsAccessLogResponseBody
  */
 export type ListAccessLogsAccessLogResponseBody = {
+  timestamp: string;
+  ipAddress: string;
+  remoteUser?: string;
+  method?: string | null;
+  url?: string | null;
+  httpVersion?: string | null;
+  statusCode: number;
   bytesSent?: number;
-  city?: string | null;
+  referrer?: string | null;
+  userAgent?: string | null;
+  requestTime?: number;
+  upstreamResponseTime?: number | null;
+  host?: string | null;
   countryCode?: string | null;
   countryName?: string | null;
-  host?: string | null;
-  httpVersion?: string | null;
+  city?: string | null;
   id: number;
-  ipAddress: string;
-  method?: string | null;
-  referrer?: string | null;
-  remoteUser?: string;
-  requestTime?: number;
-  statusCode: number;
-  timestamp: string;
-  upstreamResponseTime?: number | null;
-  url?: string | null;
-  userAgent?: string | null;
 };
 
 /**
  * ListGeoEventsGeoEventGeoLocationResponseBody
  */
 export type ListGeoEventsGeoEventGeoLocationResponseBody = {
-  city?: string | null;
-  countryCode: string;
-  countryName: string;
-  createdAt?: string;
-  geographicPoint: string;
-  geohash: string;
-  id: number;
-  lastHit?: string | null;
   latitude: number;
   longitude: number;
-  postalCode?: string | null;
+  geohash: string;
+  geographicPoint: string;
+  countryCode: string;
+  countryName: string;
   state?: string | null;
   stateCode?: string | null;
+  city?: string | null;
+  postalCode?: string | null;
   timezone?: string | null;
+  lastHit?: string | null;
+  createdAt?: string;
   updatedAt?: string;
+  id: number;
 };
 
 /**
  * ListGeoEventsGeoEventResponseBody
  */
 export type ListGeoEventsGeoEventResponseBody = {
-  hostname: string;
-  id: number;
-  ipAddress: string;
-  location: ListGeoEventsGeoEventGeoLocationResponseBody;
-  locationId: number;
   timestamp?: string;
+  ipAddress: string;
+  hostname: string;
+  locationId: number;
+  location: ListGeoEventsGeoEventGeoLocationResponseBody;
+  id: number;
 };
 
 /**
  * ListGeoLocationsGeoLocationResponseBody
  */
 export type ListGeoLocationsGeoLocationResponseBody = {
-  city?: string | null;
-  countryCode: string;
-  countryName: string;
-  createdAt?: string;
-  geographicPoint: string;
-  geohash: string;
-  id: number;
-  lastHit?: string | null;
   latitude: number;
   longitude: number;
-  postalCode?: string | null;
+  geohash: string;
+  geographicPoint: string;
+  countryCode: string;
+  countryName: string;
   state?: string | null;
   stateCode?: string | null;
+  city?: string | null;
+  postalCode?: string | null;
   timezone?: string | null;
+  lastHit?: string | null;
+  createdAt?: string;
   updatedAt?: string;
+  id: number;
 };
 
 /**
@@ -245,8 +245,8 @@ export type LocationTopIpsResponse = {
  * LoginPayload
  */
 export type LoginPayload = {
-  password: string;
   username: string;
+  password: string;
 };
 
 /**
@@ -278,85 +278,85 @@ export type MeResponse = {
  * PercentChange
  */
 export type PercentChange = {
-  avg_request_time?: number | null;
-  bytes_sent?: number | null;
-  error_rate?: number | null;
-  geo_records?: number | null;
   log_records?: number | null;
-  malformed_rate?: number | null;
+  geo_records?: number | null;
   unique_ips?: number | null;
+  bytes_sent?: number | null;
+  avg_request_time?: number | null;
+  error_rate?: number | null;
+  malformed_rate?: number | null;
 };
 
 /**
  * PeriodSummary
  */
 export type PeriodSummary = {
+  total_requests: number;
+  total_geo_events: number;
+  unique_ips: number;
+  unique_countries: number;
+  total_bytes_sent: number;
   avg_bytes_per_request: number;
-  avg_request_time: number;
-  error_rate: number;
-  malformed_requests: number;
-  max_request_time: number;
   status_2xx: number;
   status_3xx: number;
   status_4xx: number;
   status_5xx: number;
-  total_bytes_sent: number;
-  total_geo_events: number;
-  total_requests: number;
-  unique_countries: number;
-  unique_ips: number;
+  avg_request_time: number;
+  max_request_time: number;
+  malformed_requests: number;
+  error_rate: number;
 };
 
 /**
  * SafeSettingsResponse
  */
 export type SafeSettingsResponse = {
-  analytics: AnalyticsSettingsView;
-  environment: string;
-  logparser: LogparserSettingsView;
-  map: MapSettingsView;
   name: string;
   version: string;
+  environment: string;
+  logparser: LogparserSettingsView;
+  analytics: AnalyticsSettingsView;
+  map: MapSettingsView;
 };
 
 /**
  * SummaryResponse
  */
 export type SummaryResponse = {
-  current_period: PeriodSummary;
-  end_date: string;
-  percent_changes?: PercentChange | null;
-  previous_period?: PeriodSummary | null;
   start_date: string;
+  end_date: string;
+  current_period: PeriodSummary;
+  previous_period?: PeriodSummary | null;
+  percent_changes?: PercentChange | null;
 };
 
 /**
  * TimeSeriesDataPoint
  */
 export type TimeSeriesDataPoint = {
-  avg_request_time: number;
-  error_rate: number;
-  p50_request_time: number;
-  p95_request_time: number;
-  p99_request_time: number;
+  timestamp: string;
+  total_requests: number;
+  total_geo_events: number;
+  total_bytes_sent: number;
   status_2xx: number;
   status_3xx: number;
   status_4xx: number;
   status_5xx: number;
-  timestamp: string;
-  total_bytes_sent: number;
-  total_geo_events: number;
-  total_requests: number;
+  error_rate: number;
+  avg_request_time: number;
+  p50_request_time: number;
+  p95_request_time: number;
+  p99_request_time: number;
 };
 
 /**
  * TimeSeriesResponse
  */
 export type TimeSeriesResponse = {
-  data: Array<TimeSeriesDataPoint>;
-  end_date: string;
   granularity: string;
   start_date: string;
+  end_date: string;
+  data: Array<TimeSeriesDataPoint>;
 };
 
 /**
@@ -379,8 +379,8 @@ export type TopCountryDto = {
  * TopIPDTO
  */
 export type TopIpdto = {
-  event_count: number;
   ip_address: string;
+  event_count: number;
   location?: EmbeddedLocationDto | null;
 };
 
@@ -388,587 +388,38 @@ export type TopIpdto = {
  * TopUrlDTO
  */
 export type TopUrlDto = {
-  avg_request_time: number;
-  error_hits: number;
-  hits: number;
-  total_bytes: number;
   url: string;
+  hits: number;
+  error_hits: number;
+  total_bytes: number;
+  avg_request_time: number;
 };
 
 /**
  * TopUrlsResponse
  */
 export type TopUrlsResponse = {
+  start_date: string;
   end_date: string;
   items: Array<TopUrlDto>;
-  start_date: string;
 };
 
 /**
  * TopUserAgentDTO
  */
 export type TopUserAgentDto = {
-  hits: number;
   user_agent: string;
+  hits: number;
 };
 
 /**
  * TopUserAgentsResponse
  */
 export type TopUserAgentsResponse = {
+  start_date: string;
   end_date: string;
   items: Array<TopUserAgentDto>;
-  start_date: string;
 };
-
-export type ApiV1AccessLogDebugListAccessLogDebugsData = {
-  body?: never;
-  path?: never;
-  query?: {
-    currentPage?: number;
-    pageSize?: number;
-  };
-  url: "/api/v1/access-log-debug";
-};
-
-export type ApiV1AccessLogDebugListAccessLogDebugsErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-    status_code: number;
-  };
-};
-
-export type ApiV1AccessLogDebugListAccessLogDebugsError =
-  ApiV1AccessLogDebugListAccessLogDebugsErrors[keyof ApiV1AccessLogDebugListAccessLogDebugsErrors];
-
-export type ApiV1AccessLogDebugListAccessLogDebugsResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: {
-    items?: Array<ListAccessLogDebugsAccessLogDebugResponseBody>;
-    /**
-     * Maximal number of items to send.
-     */
-    limit?: number;
-    /**
-     * Offset from the beginning of the query.
-     */
-    offset?: number;
-    /**
-     * Total number of items.
-     */
-    total?: number;
-  };
-};
-
-export type ApiV1AccessLogDebugListAccessLogDebugsResponse =
-  ApiV1AccessLogDebugListAccessLogDebugsResponses[keyof ApiV1AccessLogDebugListAccessLogDebugsResponses];
-
-export type ApiV1AccessLogsListAccessLogsData = {
-  body?: never;
-  path?: never;
-  query?: {
-    /**
-     * Field to search
-     */
-    searchString?: string | null;
-    /**
-     * Search should be case sensitive
-     */
-    searchIgnoreCase?: boolean | null;
-    currentPage?: number;
-    pageSize?: number;
-    /**
-     * Order by field
-     */
-    orderBy?: string | null;
-    /**
-     * Field to search
-     */
-    sortOrder?: "asc" | "desc" | null;
-    from_timestamp?: string | null;
-    to_timestamp?: string | null;
-    host?: string | null;
-    methodIn?: Array<string> | null;
-    ipAddressIn?: Array<string> | null;
-    cityIn?: Array<string> | null;
-    countryCodeIn?: Array<string> | null;
-    statusIn?: Array<number> | null;
-  };
-  url: "/api/v1/access-logs";
-};
-
-export type ApiV1AccessLogsListAccessLogsErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-    status_code: number;
-  };
-};
-
-export type ApiV1AccessLogsListAccessLogsError =
-  ApiV1AccessLogsListAccessLogsErrors[keyof ApiV1AccessLogsListAccessLogsErrors];
-
-export type ApiV1AccessLogsListAccessLogsResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: {
-    items?: Array<ListAccessLogsAccessLogResponseBody>;
-    /**
-     * Maximal number of items to send.
-     */
-    limit?: number;
-    /**
-     * Offset from the beginning of the query.
-     */
-    offset?: number;
-    /**
-     * Total number of items.
-     */
-    total?: number;
-  };
-};
-
-export type ApiV1AccessLogsListAccessLogsResponse =
-  ApiV1AccessLogsListAccessLogsResponses[keyof ApiV1AccessLogsListAccessLogsResponses];
-
-export type ApiV1AccessLogsFacetsGetAccessLogFacetsData = {
-  body?: never;
-  path?: never;
-  query?: never;
-  url: "/api/v1/access-logs/facets";
-};
-
-export type ApiV1AccessLogsFacetsGetAccessLogFacetsResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: AccessLogFacets;
-};
-
-export type ApiV1AccessLogsFacetsGetAccessLogFacetsResponse =
-  ApiV1AccessLogsFacetsGetAccessLogFacetsResponses[keyof ApiV1AccessLogsFacetsGetAccessLogFacetsResponses];
-
-export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesData = {
-  body?: never;
-  path?: never;
-  query: {
-    /**
-     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
-     */
-    start_date: string;
-    /**
-     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
-     */
-    end_date: string;
-  };
-  url: "/api/v1/analytics/geo-time-series";
-};
-
-export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-    status_code: number;
-  };
-};
-
-export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesError =
-  ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesErrors[keyof ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesErrors];
-
-export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: GeoEventsTimeSeriesResponse;
-};
-
-export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesResponse =
-  ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesResponses[keyof ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesResponses];
-
-export type ApiV1AnalyticsLiveSummaryGetLiveSummaryData = {
-  body?: never;
-  path?: never;
-  query: {
-    /**
-     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
-     */
-    start_date: string;
-    /**
-     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
-     */
-    end_date: string;
-    /**
-     * Include comparison with previous period of same length
-     */
-    compare_previous?: boolean;
-  };
-  url: "/api/v1/analytics/live-summary";
-};
-
-export type ApiV1AnalyticsLiveSummaryGetLiveSummaryErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-    status_code: number;
-  };
-};
-
-export type ApiV1AnalyticsLiveSummaryGetLiveSummaryError =
-  ApiV1AnalyticsLiveSummaryGetLiveSummaryErrors[keyof ApiV1AnalyticsLiveSummaryGetLiveSummaryErrors];
-
-export type ApiV1AnalyticsLiveSummaryGetLiveSummaryResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: SummaryResponse;
-};
-
-export type ApiV1AnalyticsLiveSummaryGetLiveSummaryResponse =
-  ApiV1AnalyticsLiveSummaryGetLiveSummaryResponses[keyof ApiV1AnalyticsLiveSummaryGetLiveSummaryResponses];
-
-export type ApiV1AnalyticsSummaryGetSummaryData = {
-  body?: never;
-  path?: never;
-  query: {
-    /**
-     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
-     */
-    start_date: string;
-    /**
-     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
-     */
-    end_date: string;
-    /**
-     * Include comparison with previous period of same length
-     */
-    compare_previous?: boolean;
-  };
-  url: "/api/v1/analytics/summary";
-};
-
-export type ApiV1AnalyticsSummaryGetSummaryErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-    status_code: number;
-  };
-};
-
-export type ApiV1AnalyticsSummaryGetSummaryError =
-  ApiV1AnalyticsSummaryGetSummaryErrors[keyof ApiV1AnalyticsSummaryGetSummaryErrors];
-
-export type ApiV1AnalyticsSummaryGetSummaryResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: SummaryResponse;
-};
-
-export type ApiV1AnalyticsSummaryGetSummaryResponse =
-  ApiV1AnalyticsSummaryGetSummaryResponses[keyof ApiV1AnalyticsSummaryGetSummaryResponses];
-
-export type ApiV1AnalyticsTimeSeriesGetTimeSeriesData = {
-  body?: never;
-  path?: never;
-  query: {
-    /**
-     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
-     */
-    start_date: string;
-    /**
-     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
-     */
-    end_date: string;
-  };
-  url: "/api/v1/analytics/time-series";
-};
-
-export type ApiV1AnalyticsTimeSeriesGetTimeSeriesErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-    status_code: number;
-  };
-};
-
-export type ApiV1AnalyticsTimeSeriesGetTimeSeriesError =
-  ApiV1AnalyticsTimeSeriesGetTimeSeriesErrors[keyof ApiV1AnalyticsTimeSeriesGetTimeSeriesErrors];
-
-export type ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: TimeSeriesResponse;
-};
-
-export type ApiV1AnalyticsTimeSeriesGetTimeSeriesResponse =
-  ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses[keyof ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses];
-
-export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesData = {
-  body?: never;
-  path?: never;
-  query: {
-    /**
-     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
-     */
-    start_date: string;
-    /**
-     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
-     */
-    end_date: string;
-  };
-  url: "/api/v1/analytics/time-series/cumulative";
-};
-
-export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-    status_code: number;
-  };
-};
-
-export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesError =
-  ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesErrors[keyof ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesErrors];
-
-export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses =
-  {
-    /**
-     * Request fulfilled, document follows
-     */
-    200: CumulativeTimeSeriesResponse;
-  };
-
-export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponse =
-  ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses[keyof ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses];
-
-export type ApiV1AnalyticsTopUrlsGetTopUrlsData = {
-  body?: never;
-  path?: never;
-  query: {
-    /**
-     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
-     */
-    start_date: string;
-    /**
-     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
-     */
-    end_date: string;
-    /**
-     * Maximum number of URLs to return
-     */
-    limit?: number;
-  };
-  url: "/api/v1/analytics/top-urls";
-};
-
-export type ApiV1AnalyticsTopUrlsGetTopUrlsErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-    status_code: number;
-  };
-};
-
-export type ApiV1AnalyticsTopUrlsGetTopUrlsError =
-  ApiV1AnalyticsTopUrlsGetTopUrlsErrors[keyof ApiV1AnalyticsTopUrlsGetTopUrlsErrors];
-
-export type ApiV1AnalyticsTopUrlsGetTopUrlsResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: TopUrlsResponse;
-};
-
-export type ApiV1AnalyticsTopUrlsGetTopUrlsResponse =
-  ApiV1AnalyticsTopUrlsGetTopUrlsResponses[keyof ApiV1AnalyticsTopUrlsGetTopUrlsResponses];
-
-export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsData = {
-  body?: never;
-  path?: never;
-  query: {
-    /**
-     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
-     */
-    start_date: string;
-    /**
-     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
-     */
-    end_date: string;
-    /**
-     * Maximum number of user agents to return
-     */
-    limit?: number;
-  };
-  url: "/api/v1/analytics/top-user-agents";
-};
-
-export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-    status_code: number;
-  };
-};
-
-export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsError =
-  ApiV1AnalyticsTopUserAgentsGetTopUserAgentsErrors[keyof ApiV1AnalyticsTopUserAgentsGetTopUserAgentsErrors];
-
-export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: TopUserAgentsResponse;
-};
-
-export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponse =
-  ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponses[keyof ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponses];
-
-export type ApiV1AuthLoginLoginData = {
-  body: LoginPayload;
-  path?: never;
-  query?: never;
-  url: "/api/v1/auth/login";
-};
-
-export type ApiV1AuthLoginLoginErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-    status_code: number;
-  };
-};
-
-export type ApiV1AuthLoginLoginError =
-  ApiV1AuthLoginLoginErrors[keyof ApiV1AuthLoginLoginErrors];
-
-export type ApiV1AuthLoginLoginResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: MeResponse;
-};
-
-export type ApiV1AuthLoginLoginResponse =
-  ApiV1AuthLoginLoginResponses[keyof ApiV1AuthLoginLoginResponses];
-
-export type ApiV1AuthLogoutLogoutData = {
-  body?: never;
-  path?: never;
-  query?: never;
-  url: "/api/v1/auth/logout";
-};
-
-export type ApiV1AuthLogoutLogoutResponses = {
-  /**
-   * Request fulfilled, nothing follows
-   */
-  204: void;
-};
-
-export type ApiV1AuthLogoutLogoutResponse =
-  ApiV1AuthLogoutLogoutResponses[keyof ApiV1AuthLogoutLogoutResponses];
-
-export type ApiV1AuthMeMeData = {
-  body?: never;
-  path?: never;
-  query?: never;
-  url: "/api/v1/auth/me";
-};
-
-export type ApiV1AuthMeMeResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: MeResponse;
-};
-
-export type ApiV1AuthMeMeResponse =
-  ApiV1AuthMeMeResponses[keyof ApiV1AuthMeMeResponses];
 
 export type ApiV1GeoEventsListGeoEventsData = {
   body?: never;
@@ -985,6 +436,7 @@ export type ApiV1GeoEventsListGeoEventsErrors = {
    * Validation Exception
    */
   400: {
+    status_code: number;
     detail: string;
     extra?:
       | null
@@ -992,7 +444,6 @@ export type ApiV1GeoEventsListGeoEventsErrors = {
           [key: string]: unknown;
         }
       | Array<unknown>;
-    status_code: number;
   };
 };
 
@@ -1023,59 +474,6 @@ export type ApiV1GeoEventsListGeoEventsResponses = {
 export type ApiV1GeoEventsListGeoEventsResponse =
   ApiV1GeoEventsListGeoEventsResponses[keyof ApiV1GeoEventsListGeoEventsResponses];
 
-export type ApiV1GeoLocationsListGeoLocationsData = {
-  body?: never;
-  path?: never;
-  query?: {
-    currentPage?: number;
-    pageSize?: number;
-  };
-  url: "/api/v1/geo-locations";
-};
-
-export type ApiV1GeoLocationsListGeoLocationsErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-    status_code: number;
-  };
-};
-
-export type ApiV1GeoLocationsListGeoLocationsError =
-  ApiV1GeoLocationsListGeoLocationsErrors[keyof ApiV1GeoLocationsListGeoLocationsErrors];
-
-export type ApiV1GeoLocationsListGeoLocationsResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: {
-    items?: Array<ListGeoLocationsGeoLocationResponseBody>;
-    /**
-     * Maximal number of items to send.
-     */
-    limit?: number;
-    /**
-     * Offset from the beginning of the query.
-     */
-    offset?: number;
-    /**
-     * Total number of items.
-     */
-    total?: number;
-  };
-};
-
-export type ApiV1GeoLocationsListGeoLocationsResponse =
-  ApiV1GeoLocationsListGeoLocationsResponses[keyof ApiV1GeoLocationsListGeoLocationsResponses];
-
 export type ApiV1GeoLocationsGeojsonGetGeojsonData = {
   body?: never;
   path?: never;
@@ -1105,6 +503,7 @@ export type ApiV1GeoLocationsGeojsonGetGeojsonErrors = {
    * Validation Exception
    */
   400: {
+    status_code: number;
     detail: string;
     extra?:
       | null
@@ -1112,7 +511,6 @@ export type ApiV1GeoLocationsGeojsonGetGeojsonErrors = {
           [key: string]: unknown;
         }
       | Array<unknown>;
-    status_code: number;
   };
 };
 
@@ -1128,55 +526,6 @@ export type ApiV1GeoLocationsGeojsonGetGeojsonResponses = {
 
 export type ApiV1GeoLocationsGeojsonGetGeojsonResponse =
   ApiV1GeoLocationsGeojsonGetGeojsonResponses[keyof ApiV1GeoLocationsGeojsonGetGeojsonResponses];
-
-export type ApiV1GeoLocationsTopCountriesGetTopCountriesData = {
-  body?: never;
-  path?: never;
-  query: {
-    /**
-     * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
-     */
-    from_timestamp: string;
-    /**
-     * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
-     */
-    to_timestamp: string;
-    /**
-     * Maximum number of countries to return
-     */
-    limit?: number;
-  };
-  url: "/api/v1/geo-locations/top-countries";
-};
-
-export type ApiV1GeoLocationsTopCountriesGetTopCountriesErrors = {
-  /**
-   * Validation Exception
-   */
-  400: {
-    detail: string;
-    extra?:
-      | null
-      | {
-          [key: string]: unknown;
-        }
-      | Array<unknown>;
-    status_code: number;
-  };
-};
-
-export type ApiV1GeoLocationsTopCountriesGetTopCountriesError =
-  ApiV1GeoLocationsTopCountriesGetTopCountriesErrors[keyof ApiV1GeoLocationsTopCountriesGetTopCountriesErrors];
-
-export type ApiV1GeoLocationsTopCountriesGetTopCountriesResponses = {
-  /**
-   * Request fulfilled, document follows
-   */
-  200: TopCountriesResponse;
-};
-
-export type ApiV1GeoLocationsTopCountriesGetTopCountriesResponse =
-  ApiV1GeoLocationsTopCountriesGetTopCountriesResponses[keyof ApiV1GeoLocationsTopCountriesGetTopCountriesResponses];
 
 export type ApiV1GeoLocationsTopIpsGetGlobalTopIpsData = {
   body?: never;
@@ -1203,6 +552,7 @@ export type ApiV1GeoLocationsTopIpsGetGlobalTopIpsErrors = {
    * Validation Exception
    */
   400: {
+    status_code: number;
     detail: string;
     extra?:
       | null
@@ -1210,7 +560,6 @@ export type ApiV1GeoLocationsTopIpsGetGlobalTopIpsErrors = {
           [key: string]: unknown;
         }
       | Array<unknown>;
-    status_code: number;
   };
 };
 
@@ -1254,6 +603,7 @@ export type ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsErrors = {
    * Validation Exception
    */
   400: {
+    status_code: number;
     detail: string;
     extra?:
       | null
@@ -1261,7 +611,6 @@ export type ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsErrors = {
           [key: string]: unknown;
         }
       | Array<unknown>;
-    status_code: number;
   };
 };
 
@@ -1277,6 +626,595 @@ export type ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponses = {
 
 export type ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponse =
   ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponses[keyof ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponses];
+
+export type ApiV1GeoLocationsTopCountriesGetTopCountriesData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
+     */
+    from_timestamp: string;
+    /**
+     * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
+     */
+    to_timestamp: string;
+    /**
+     * Maximum number of countries to return
+     */
+    limit?: number;
+  };
+  url: "/api/v1/geo-locations/top-countries";
+};
+
+export type ApiV1GeoLocationsTopCountriesGetTopCountriesErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    status_code: number;
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+  };
+};
+
+export type ApiV1GeoLocationsTopCountriesGetTopCountriesError =
+  ApiV1GeoLocationsTopCountriesGetTopCountriesErrors[keyof ApiV1GeoLocationsTopCountriesGetTopCountriesErrors];
+
+export type ApiV1GeoLocationsTopCountriesGetTopCountriesResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: TopCountriesResponse;
+};
+
+export type ApiV1GeoLocationsTopCountriesGetTopCountriesResponse =
+  ApiV1GeoLocationsTopCountriesGetTopCountriesResponses[keyof ApiV1GeoLocationsTopCountriesGetTopCountriesResponses];
+
+export type ApiV1GeoLocationsListGeoLocationsData = {
+  body?: never;
+  path?: never;
+  query?: {
+    currentPage?: number;
+    pageSize?: number;
+  };
+  url: "/api/v1/geo-locations";
+};
+
+export type ApiV1GeoLocationsListGeoLocationsErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    status_code: number;
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+  };
+};
+
+export type ApiV1GeoLocationsListGeoLocationsError =
+  ApiV1GeoLocationsListGeoLocationsErrors[keyof ApiV1GeoLocationsListGeoLocationsErrors];
+
+export type ApiV1GeoLocationsListGeoLocationsResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: {
+    items?: Array<ListGeoLocationsGeoLocationResponseBody>;
+    /**
+     * Maximal number of items to send.
+     */
+    limit?: number;
+    /**
+     * Offset from the beginning of the query.
+     */
+    offset?: number;
+    /**
+     * Total number of items.
+     */
+    total?: number;
+  };
+};
+
+export type ApiV1GeoLocationsListGeoLocationsResponse =
+  ApiV1GeoLocationsListGeoLocationsResponses[keyof ApiV1GeoLocationsListGeoLocationsResponses];
+
+export type ApiV1AccessLogsFacetsGetAccessLogFacetsData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: "/api/v1/access-logs/facets";
+};
+
+export type ApiV1AccessLogsFacetsGetAccessLogFacetsResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: AccessLogFacets;
+};
+
+export type ApiV1AccessLogsFacetsGetAccessLogFacetsResponse =
+  ApiV1AccessLogsFacetsGetAccessLogFacetsResponses[keyof ApiV1AccessLogsFacetsGetAccessLogFacetsResponses];
+
+export type ApiV1AccessLogsListAccessLogsData = {
+  body?: never;
+  path?: never;
+  query?: {
+    /**
+     * Field to search
+     */
+    searchString?: string | null;
+    /**
+     * Search should be case sensitive
+     */
+    searchIgnoreCase?: boolean | null;
+    currentPage?: number;
+    pageSize?: number;
+    /**
+     * Order by field
+     */
+    orderBy?: string | null;
+    /**
+     * Field to search
+     */
+    sortOrder?: "asc" | "desc" | null;
+    from_timestamp?: string | null;
+    to_timestamp?: string | null;
+    host?: string | null;
+    methodIn?: Array<string> | null;
+    ipAddressIn?: Array<string> | null;
+    cityIn?: Array<string> | null;
+    countryCodeIn?: Array<string> | null;
+    statusIn?: Array<number> | null;
+  };
+  url: "/api/v1/access-logs";
+};
+
+export type ApiV1AccessLogsListAccessLogsErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    status_code: number;
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+  };
+};
+
+export type ApiV1AccessLogsListAccessLogsError =
+  ApiV1AccessLogsListAccessLogsErrors[keyof ApiV1AccessLogsListAccessLogsErrors];
+
+export type ApiV1AccessLogsListAccessLogsResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: {
+    items?: Array<ListAccessLogsAccessLogResponseBody>;
+    /**
+     * Maximal number of items to send.
+     */
+    limit?: number;
+    /**
+     * Offset from the beginning of the query.
+     */
+    offset?: number;
+    /**
+     * Total number of items.
+     */
+    total?: number;
+  };
+};
+
+export type ApiV1AccessLogsListAccessLogsResponse =
+  ApiV1AccessLogsListAccessLogsResponses[keyof ApiV1AccessLogsListAccessLogsResponses];
+
+export type ApiV1AccessLogDebugListAccessLogDebugsData = {
+  body?: never;
+  path?: never;
+  query?: {
+    currentPage?: number;
+    pageSize?: number;
+  };
+  url: "/api/v1/access-log-debug";
+};
+
+export type ApiV1AccessLogDebugListAccessLogDebugsErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    status_code: number;
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+  };
+};
+
+export type ApiV1AccessLogDebugListAccessLogDebugsError =
+  ApiV1AccessLogDebugListAccessLogDebugsErrors[keyof ApiV1AccessLogDebugListAccessLogDebugsErrors];
+
+export type ApiV1AccessLogDebugListAccessLogDebugsResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: {
+    items?: Array<ListAccessLogDebugsAccessLogDebugResponseBody>;
+    /**
+     * Maximal number of items to send.
+     */
+    limit?: number;
+    /**
+     * Offset from the beginning of the query.
+     */
+    offset?: number;
+    /**
+     * Total number of items.
+     */
+    total?: number;
+  };
+};
+
+export type ApiV1AccessLogDebugListAccessLogDebugsResponse =
+  ApiV1AccessLogDebugListAccessLogDebugsResponses[keyof ApiV1AccessLogDebugListAccessLogDebugsResponses];
+
+export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
+     */
+    start_date: string;
+    /**
+     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
+     */
+    end_date: string;
+  };
+  url: "/api/v1/analytics/time-series/cumulative";
+};
+
+export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    status_code: number;
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+  };
+};
+
+export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesError =
+  ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesErrors[keyof ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesErrors];
+
+export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses =
+  {
+    /**
+     * Request fulfilled, document follows
+     */
+    200: CumulativeTimeSeriesResponse;
+  };
+
+export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponse =
+  ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses[keyof ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesResponses];
+
+export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
+     */
+    start_date: string;
+    /**
+     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
+     */
+    end_date: string;
+    /**
+     * Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available.
+     */
+    granularity?: "hourly" | "daily" | null;
+  };
+  url: "/api/v1/analytics/geo-time-series";
+};
+
+export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    status_code: number;
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+  };
+};
+
+export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesError =
+  ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesErrors[keyof ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesErrors];
+
+export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: GeoEventsTimeSeriesResponse;
+};
+
+export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesResponse =
+  ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesResponses[keyof ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesResponses];
+
+export type ApiV1AnalyticsLiveSummaryGetLiveSummaryData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
+     */
+    start_date: string;
+    /**
+     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
+     */
+    end_date: string;
+    /**
+     * Include comparison with previous period of same length
+     */
+    compare_previous?: boolean;
+  };
+  url: "/api/v1/analytics/live-summary";
+};
+
+export type ApiV1AnalyticsLiveSummaryGetLiveSummaryErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    status_code: number;
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+  };
+};
+
+export type ApiV1AnalyticsLiveSummaryGetLiveSummaryError =
+  ApiV1AnalyticsLiveSummaryGetLiveSummaryErrors[keyof ApiV1AnalyticsLiveSummaryGetLiveSummaryErrors];
+
+export type ApiV1AnalyticsLiveSummaryGetLiveSummaryResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: SummaryResponse;
+};
+
+export type ApiV1AnalyticsLiveSummaryGetLiveSummaryResponse =
+  ApiV1AnalyticsLiveSummaryGetLiveSummaryResponses[keyof ApiV1AnalyticsLiveSummaryGetLiveSummaryResponses];
+
+export type ApiV1AnalyticsSummaryGetSummaryData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
+     */
+    start_date: string;
+    /**
+     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
+     */
+    end_date: string;
+    /**
+     * Include comparison with previous period of same length
+     */
+    compare_previous?: boolean;
+  };
+  url: "/api/v1/analytics/summary";
+};
+
+export type ApiV1AnalyticsSummaryGetSummaryErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    status_code: number;
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+  };
+};
+
+export type ApiV1AnalyticsSummaryGetSummaryError =
+  ApiV1AnalyticsSummaryGetSummaryErrors[keyof ApiV1AnalyticsSummaryGetSummaryErrors];
+
+export type ApiV1AnalyticsSummaryGetSummaryResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: SummaryResponse;
+};
+
+export type ApiV1AnalyticsSummaryGetSummaryResponse =
+  ApiV1AnalyticsSummaryGetSummaryResponses[keyof ApiV1AnalyticsSummaryGetSummaryResponses];
+
+export type ApiV1AnalyticsTimeSeriesGetTimeSeriesData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
+     */
+    start_date: string;
+    /**
+     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
+     */
+    end_date: string;
+    /**
+     * Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available.
+     */
+    granularity?: "hourly" | "daily" | null;
+  };
+  url: "/api/v1/analytics/time-series";
+};
+
+export type ApiV1AnalyticsTimeSeriesGetTimeSeriesErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    status_code: number;
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+  };
+};
+
+export type ApiV1AnalyticsTimeSeriesGetTimeSeriesError =
+  ApiV1AnalyticsTimeSeriesGetTimeSeriesErrors[keyof ApiV1AnalyticsTimeSeriesGetTimeSeriesErrors];
+
+export type ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: TimeSeriesResponse;
+};
+
+export type ApiV1AnalyticsTimeSeriesGetTimeSeriesResponse =
+  ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses[keyof ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses];
+
+export type ApiV1AnalyticsTopUrlsGetTopUrlsData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
+     */
+    start_date: string;
+    /**
+     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
+     */
+    end_date: string;
+    /**
+     * Maximum number of URLs to return
+     */
+    limit?: number;
+  };
+  url: "/api/v1/analytics/top-urls";
+};
+
+export type ApiV1AnalyticsTopUrlsGetTopUrlsErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    status_code: number;
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+  };
+};
+
+export type ApiV1AnalyticsTopUrlsGetTopUrlsError =
+  ApiV1AnalyticsTopUrlsGetTopUrlsErrors[keyof ApiV1AnalyticsTopUrlsGetTopUrlsErrors];
+
+export type ApiV1AnalyticsTopUrlsGetTopUrlsResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: TopUrlsResponse;
+};
+
+export type ApiV1AnalyticsTopUrlsGetTopUrlsResponse =
+  ApiV1AnalyticsTopUrlsGetTopUrlsResponses[keyof ApiV1AnalyticsTopUrlsGetTopUrlsResponses];
+
+export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)
+     */
+    start_date: string;
+    /**
+     * End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)
+     */
+    end_date: string;
+    /**
+     * Maximum number of user agents to return
+     */
+    limit?: number;
+  };
+  url: "/api/v1/analytics/top-user-agents";
+};
+
+export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    status_code: number;
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+  };
+};
+
+export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsError =
+  ApiV1AnalyticsTopUserAgentsGetTopUserAgentsErrors[keyof ApiV1AnalyticsTopUserAgentsGetTopUserAgentsErrors];
+
+export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: TopUserAgentsResponse;
+};
+
+export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponse =
+  ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponses[keyof ApiV1AnalyticsTopUserAgentsGetTopUserAgentsResponses];
 
 export type ApiV1SettingsReadSettingsData = {
   body?: never;
@@ -1351,3 +1289,73 @@ export type HealthReadyHealthReadyResponses = {
 
 export type HealthReadyHealthReadyResponse =
   HealthReadyHealthReadyResponses[keyof HealthReadyHealthReadyResponses];
+
+export type ApiV1AuthLoginLoginData = {
+  body: LoginPayload;
+  path?: never;
+  query?: never;
+  url: "/api/v1/auth/login";
+};
+
+export type ApiV1AuthLoginLoginErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    status_code: number;
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+  };
+};
+
+export type ApiV1AuthLoginLoginError =
+  ApiV1AuthLoginLoginErrors[keyof ApiV1AuthLoginLoginErrors];
+
+export type ApiV1AuthLoginLoginResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: MeResponse;
+};
+
+export type ApiV1AuthLoginLoginResponse =
+  ApiV1AuthLoginLoginResponses[keyof ApiV1AuthLoginLoginResponses];
+
+export type ApiV1AuthLogoutLogoutData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: "/api/v1/auth/logout";
+};
+
+export type ApiV1AuthLogoutLogoutResponses = {
+  /**
+   * Request fulfilled, nothing follows
+   */
+  204: void;
+};
+
+export type ApiV1AuthLogoutLogoutResponse =
+  ApiV1AuthLogoutLogoutResponses[keyof ApiV1AuthLogoutLogoutResponses];
+
+export type ApiV1AuthMeMeData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: "/api/v1/auth/me";
+};
+
+export type ApiV1AuthMeMeResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: MeResponse;
+};
+
+export type ApiV1AuthMeMeResponse =
+  ApiV1AuthMeMeResponses[keyof ApiV1AuthMeMeResponses];

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -1144,6 +1144,18 @@ export type ApiV1AnalyticsTimeSeriesGetTimeSeriesData = {
      * Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available.
      */
     granularity?: "hourly" | "daily" | null;
+    /**
+     * Filter to these ISO country codes (repeatable)
+     */
+    country_code?: Array<string> | null;
+    /**
+     * Filter to these city names (repeatable)
+     */
+    city?: Array<string> | null;
+    /**
+     * Filter to these client IPs (repeatable)
+     */
+    ip_address?: Array<string> | null;
   };
   url: "/api/v1/analytics/time-series";
 };
@@ -1193,6 +1205,18 @@ export type ApiV1AnalyticsTopCitiesGetTopCitiesData = {
      * Maximum number of cities
      */
     limit?: number;
+    /**
+     * Filter to these ISO country codes (repeatable)
+     */
+    country_code?: Array<string> | null;
+    /**
+     * Filter to these city names (repeatable)
+     */
+    city?: Array<string> | null;
+    /**
+     * Filter to these client IPs (repeatable)
+     */
+    ip_address?: Array<string> | null;
   };
   url: "/api/v1/analytics/top-cities";
 };
@@ -1242,6 +1266,18 @@ export type ApiV1AnalyticsTopCountriesGetTopCountriesData = {
      * Maximum number of countries
      */
     limit?: number;
+    /**
+     * Filter to these ISO country codes (repeatable)
+     */
+    country_code?: Array<string> | null;
+    /**
+     * Filter to these city names (repeatable)
+     */
+    city?: Array<string> | null;
+    /**
+     * Filter to these client IPs (repeatable)
+     */
+    ip_address?: Array<string> | null;
   };
   url: "/api/v1/analytics/top-countries";
 };
@@ -1291,6 +1327,18 @@ export type ApiV1AnalyticsTopIpsGetTopIpsData = {
      * Maximum number of IPs
      */
     limit?: number;
+    /**
+     * Filter to these ISO country codes (repeatable)
+     */
+    country_code?: Array<string> | null;
+    /**
+     * Filter to these city names (repeatable)
+     */
+    city?: Array<string> | null;
+    /**
+     * Filter to these client IPs (repeatable)
+     */
+    ip_address?: Array<string> | null;
   };
   url: "/api/v1/analytics/top-ips";
 };
@@ -1340,6 +1388,18 @@ export type ApiV1AnalyticsTopUrlsGetTopUrlsData = {
      * Maximum number of URLs to return
      */
     limit?: number;
+    /**
+     * Filter to these ISO country codes (repeatable)
+     */
+    country_code?: Array<string> | null;
+    /**
+     * Filter to these city names (repeatable)
+     */
+    city?: Array<string> | null;
+    /**
+     * Filter to these client IPs (repeatable)
+     */
+    ip_address?: Array<string> | null;
   };
   url: "/api/v1/analytics/top-urls";
 };
@@ -1389,6 +1449,18 @@ export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsData = {
      * Maximum number of user agents to return
      */
     limit?: number;
+    /**
+     * Filter to these ISO country codes (repeatable)
+     */
+    country_code?: Array<string> | null;
+    /**
+     * Filter to these city names (repeatable)
+     */
+    city?: Array<string> | null;
+    /**
+     * Filter to these client IPs (repeatable)
+     */
+    ip_address?: Array<string> | null;
   };
   url: "/api/v1/analytics/top-user-agents";
 };

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -360,10 +360,38 @@ export type TimeSeriesResponse = {
 };
 
 /**
+ * TopCitiesResponse
+ */
+export type TopCitiesResponse = {
+  start_date: string;
+  end_date: string;
+  items: Array<TopCityStatsDto>;
+};
+
+/**
+ * TopCityStatsDTO
+ */
+export type TopCityStatsDto = {
+  city: string;
+  country_code: string | null;
+  hits: number;
+  unique_ips: number;
+};
+
+/**
  * TopCountriesResponse
  */
 export type TopCountriesResponse = {
   top_countries?: Array<TopCountryDto>;
+};
+
+/**
+ * TopCountriesStatsResponse
+ */
+export type TopCountriesStatsResponse = {
+  start_date: string;
+  end_date: string;
+  items: Array<TopCountryStatsDto>;
 };
 
 /**
@@ -376,12 +404,43 @@ export type TopCountryDto = {
 };
 
 /**
+ * TopCountryStatsDTO
+ */
+export type TopCountryStatsDto = {
+  country_code: string;
+  country_name: string | null;
+  hits: number;
+  unique_ips: number;
+};
+
+/**
  * TopIPDTO
  */
 export type TopIpdto = {
   ip_address: string;
   event_count: number;
   location?: EmbeddedLocationDto | null;
+};
+
+/**
+ * TopIpDTO
+ */
+export type TopIpDto = {
+  ip_address: string;
+  hits: number;
+  error_hits: number;
+  total_bytes: number;
+  country_code: string | null;
+  city: string | null;
+};
+
+/**
+ * TopIpsResponse
+ */
+export type TopIpsResponse = {
+  start_date: string;
+  end_date: string;
+  items: Array<TopIpDto>;
 };
 
 /**
@@ -1117,6 +1176,153 @@ export type ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses = {
 
 export type ApiV1AnalyticsTimeSeriesGetTimeSeriesResponse =
   ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses[keyof ApiV1AnalyticsTimeSeriesGetTimeSeriesResponses];
+
+export type ApiV1AnalyticsTopCitiesGetTopCitiesData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start date (ISO 8601)
+     */
+    start_date: string;
+    /**
+     * End date (ISO 8601)
+     */
+    end_date: string;
+    /**
+     * Maximum number of cities
+     */
+    limit?: number;
+  };
+  url: "/api/v1/analytics/top-cities";
+};
+
+export type ApiV1AnalyticsTopCitiesGetTopCitiesErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    status_code: number;
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+  };
+};
+
+export type ApiV1AnalyticsTopCitiesGetTopCitiesError =
+  ApiV1AnalyticsTopCitiesGetTopCitiesErrors[keyof ApiV1AnalyticsTopCitiesGetTopCitiesErrors];
+
+export type ApiV1AnalyticsTopCitiesGetTopCitiesResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: TopCitiesResponse;
+};
+
+export type ApiV1AnalyticsTopCitiesGetTopCitiesResponse =
+  ApiV1AnalyticsTopCitiesGetTopCitiesResponses[keyof ApiV1AnalyticsTopCitiesGetTopCitiesResponses];
+
+export type ApiV1AnalyticsTopCountriesGetTopCountriesData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start date (ISO 8601)
+     */
+    start_date: string;
+    /**
+     * End date (ISO 8601)
+     */
+    end_date: string;
+    /**
+     * Maximum number of countries
+     */
+    limit?: number;
+  };
+  url: "/api/v1/analytics/top-countries";
+};
+
+export type ApiV1AnalyticsTopCountriesGetTopCountriesErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    status_code: number;
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+  };
+};
+
+export type ApiV1AnalyticsTopCountriesGetTopCountriesError =
+  ApiV1AnalyticsTopCountriesGetTopCountriesErrors[keyof ApiV1AnalyticsTopCountriesGetTopCountriesErrors];
+
+export type ApiV1AnalyticsTopCountriesGetTopCountriesResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: TopCountriesStatsResponse;
+};
+
+export type ApiV1AnalyticsTopCountriesGetTopCountriesResponse =
+  ApiV1AnalyticsTopCountriesGetTopCountriesResponses[keyof ApiV1AnalyticsTopCountriesGetTopCountriesResponses];
+
+export type ApiV1AnalyticsTopIpsGetTopIpsData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Start date (ISO 8601)
+     */
+    start_date: string;
+    /**
+     * End date (ISO 8601)
+     */
+    end_date: string;
+    /**
+     * Maximum number of IPs
+     */
+    limit?: number;
+  };
+  url: "/api/v1/analytics/top-ips";
+};
+
+export type ApiV1AnalyticsTopIpsGetTopIpsErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    status_code: number;
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+  };
+};
+
+export type ApiV1AnalyticsTopIpsGetTopIpsError =
+  ApiV1AnalyticsTopIpsGetTopIpsErrors[keyof ApiV1AnalyticsTopIpsGetTopIpsErrors];
+
+export type ApiV1AnalyticsTopIpsGetTopIpsResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: TopIpsResponse;
+};
+
+export type ApiV1AnalyticsTopIpsGetTopIpsResponse =
+  ApiV1AnalyticsTopIpsGetTopIpsResponses[keyof ApiV1AnalyticsTopIpsGetTopIpsResponses];
 
 export type ApiV1AnalyticsTopUrlsGetTopUrlsData = {
   body?: never;

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -1,4658 +1,4658 @@
 {
-    "info": {
-        "title": "GeoMetrikks API",
-        "version": "0.1.0",
-        "description": "Real-time GeoIP lookups and traffic analytics API"
+  "components": {
+    "schemas": {
+      "AccessLogFacets": {
+        "properties": {
+          "cities": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "countries": {
+            "items": {
+              "$ref": "#/components/schemas/CountryFacet"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cities",
+          "countries"
+        ],
+        "title": "AccessLogFacets",
+        "type": "object"
+      },
+      "AnalyticsSettingsView": {
+        "properties": {
+          "compression_after_days": {
+            "type": "integer"
+          },
+          "debug_retention_days": {
+            "type": "integer"
+          },
+          "hourly_retention_days": {
+            "type": "integer"
+          },
+          "raw_retention_days": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "compression_after_days",
+          "debug_retention_days",
+          "hourly_retention_days",
+          "raw_retention_days"
+        ],
+        "title": "AnalyticsSettingsView",
+        "type": "object"
+      },
+      "CountryFacet": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "name"
+        ],
+        "title": "CountryFacet",
+        "type": "object"
+      },
+      "CumulativeDataPoint": {
+        "properties": {
+          "cumulative_access_logs": {
+            "type": "integer"
+          },
+          "cumulative_bytes": {
+            "type": "integer"
+          },
+          "cumulative_geo_events": {
+            "type": "integer"
+          },
+          "timestamp": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cumulative_access_logs",
+          "cumulative_bytes",
+          "cumulative_geo_events",
+          "timestamp"
+        ],
+        "title": "CumulativeDataPoint",
+        "type": "object"
+      },
+      "CumulativeTimeSeriesResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/CumulativeDataPoint"
+            },
+            "type": "array"
+          },
+          "end_date": {
+            "type": "string"
+          },
+          "granularity": {
+            "type": "string"
+          },
+          "start_date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "end_date",
+          "granularity",
+          "start_date"
+        ],
+        "title": "CumulativeTimeSeriesResponse",
+        "type": "object"
+      },
+      "EmbeddedLocationDTO": {
+        "properties": {
+          "city": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "country_code": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "country_name": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "id": {
+            "type": "integer"
+          },
+          "latitude": {
+            "type": "number"
+          },
+          "longitude": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "latitude",
+          "longitude"
+        ],
+        "title": "EmbeddedLocationDTO",
+        "type": "object"
+      },
+      "GeoEventsDataPoint": {
+        "properties": {
+          "timestamp": {
+            "type": "string"
+          },
+          "total_geo_events": {
+            "type": "integer"
+          },
+          "unique_cities": {
+            "type": "integer"
+          },
+          "unique_countries": {
+            "type": "integer"
+          },
+          "unique_ips": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "timestamp",
+          "total_geo_events",
+          "unique_cities",
+          "unique_countries",
+          "unique_ips"
+        ],
+        "title": "GeoEventsDataPoint",
+        "type": "object"
+      },
+      "GeoEventsTimeSeriesResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/GeoEventsDataPoint"
+            },
+            "type": "array"
+          },
+          "end_date": {
+            "type": "string"
+          },
+          "granularity": {
+            "type": "string"
+          },
+          "start_date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "data",
+          "end_date",
+          "granularity",
+          "start_date"
+        ],
+        "title": "GeoEventsTimeSeriesResponse",
+        "type": "object"
+      },
+      "GeoJSONFeature": {
+        "properties": {
+          "geometry": {
+            "$ref": "#/components/schemas/GeoJSONPointGeometry"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/GeoJSONFeatureProperties"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "geometry",
+          "properties",
+          "type"
+        ],
+        "title": "GeoJSONFeature",
+        "type": "object"
+      },
+      "GeoJSONFeatureCollection": {
+        "properties": {
+          "features": {
+            "items": {
+              "$ref": "#/components/schemas/GeoJSONFeature"
+            },
+            "type": "array"
+          },
+          "stats": {
+            "$ref": "#/components/schemas/GeoJSONFeatureStats"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "features",
+          "stats",
+          "type"
+        ],
+        "title": "GeoJSONFeatureCollection",
+        "type": "object"
+      },
+      "GeoJSONFeatureProperties": {
+        "properties": {
+          "city": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "country_code": {
+            "type": "string"
+          },
+          "country_name": {
+            "type": "string"
+          },
+          "event_count": {
+            "type": "integer"
+          },
+          "geohash": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_hit": {
+            "oneOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "postal_code": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "state": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "state_code": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "timezone": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "top_ips": {
+            "items": {
+              "$ref": "#/components/schemas/TopIPDTO"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "city",
+          "country_code",
+          "country_name",
+          "event_count",
+          "geohash",
+          "id",
+          "last_hit",
+          "postal_code",
+          "state",
+          "state_code",
+          "timezone"
+        ],
+        "title": "GeoJSONFeatureProperties",
+        "type": "object"
+      },
+      "GeoJSONFeatureStats": {
+        "properties": {
+          "cities": {
+            "type": "integer"
+          },
+          "countries": {
+            "type": "integer"
+          },
+          "events": {
+            "type": "integer"
+          },
+          "locations": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "cities",
+          "countries",
+          "events",
+          "locations"
+        ],
+        "title": "GeoJSONFeatureStats",
+        "type": "object"
+      },
+      "GeoJSONPointGeometry": {
+        "properties": {
+          "coordinates": {
+            "prefixItems": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "type": "array"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "coordinates",
+          "type"
+        ],
+        "title": "GeoJSONPointGeometry",
+        "type": "object"
+      },
+      "GlobalTopIPsResponse": {
+        "properties": {
+          "top_ips": {
+            "items": {
+              "$ref": "#/components/schemas/TopIPDTO"
+            },
+            "type": "array"
+          }
+        },
+        "required": [],
+        "title": "GlobalTopIPsResponse",
+        "type": "object"
+      },
+      "ListAccessLogDebugsAccessLogDebugResponseBody": {
+        "properties": {
+          "accessLogId": {
+            "oneOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "isMalformed": {
+            "default": false,
+            "type": "boolean"
+          },
+          "parseError": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "rawLine": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "rawLine"
+        ],
+        "title": "ListAccessLogDebugsAccessLogDebugResponseBody",
+        "type": "object"
+      },
+      "ListAccessLogsAccessLogResponseBody": {
+        "properties": {
+          "bytesSent": {
+            "default": 0,
+            "type": "integer"
+          },
+          "city": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "countryCode": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "countryName": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "host": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "httpVersion": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "id": {
+            "type": "integer"
+          },
+          "ipAddress": {
+            "type": "string"
+          },
+          "method": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "referrer": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "remoteUser": {
+            "type": "string"
+          },
+          "requestTime": {
+            "default": 0.0,
+            "type": "number"
+          },
+          "statusCode": {
+            "type": "integer"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "upstreamResponseTime": {
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "url": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "userAgent": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "ipAddress",
+          "statusCode",
+          "timestamp"
+        ],
+        "title": "ListAccessLogsAccessLogResponseBody",
+        "type": "object"
+      },
+      "ListGeoEventsGeoEventGeoLocationResponseBody": {
+        "properties": {
+          "city": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "countryCode": {
+            "type": "string"
+          },
+          "countryName": {
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "geographicPoint": {
+            "type": "string"
+          },
+          "geohash": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "lastHit": {
+            "oneOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "latitude": {
+            "type": "number"
+          },
+          "longitude": {
+            "type": "number"
+          },
+          "postalCode": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "state": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "stateCode": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "timezone": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "countryCode",
+          "countryName",
+          "geographicPoint",
+          "geohash",
+          "id",
+          "latitude",
+          "longitude"
+        ],
+        "title": "ListGeoEventsGeoEventGeoLocationResponseBody",
+        "type": "object"
+      },
+      "ListGeoEventsGeoEventResponseBody": {
+        "properties": {
+          "hostname": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "ipAddress": {
+            "type": "string"
+          },
+          "location": {
+            "$ref": "#/components/schemas/ListGeoEventsGeoEventGeoLocationResponseBody"
+          },
+          "locationId": {
+            "type": "integer"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "hostname",
+          "id",
+          "ipAddress",
+          "location",
+          "locationId"
+        ],
+        "title": "ListGeoEventsGeoEventResponseBody",
+        "type": "object"
+      },
+      "ListGeoLocationsGeoLocationResponseBody": {
+        "properties": {
+          "city": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "countryCode": {
+            "type": "string"
+          },
+          "countryName": {
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "geographicPoint": {
+            "type": "string"
+          },
+          "geohash": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "lastHit": {
+            "oneOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "latitude": {
+            "type": "number"
+          },
+          "longitude": {
+            "type": "number"
+          },
+          "postalCode": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "state": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "stateCode": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "timezone": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "countryCode",
+          "countryName",
+          "geographicPoint",
+          "geohash",
+          "id",
+          "latitude",
+          "longitude"
+        ],
+        "title": "ListGeoLocationsGeoLocationResponseBody",
+        "type": "object"
+      },
+      "LocationTopIPsResponse": {
+        "properties": {
+          "location_id": {
+            "type": "integer"
+          },
+          "top_ips": {
+            "items": {
+              "$ref": "#/components/schemas/TopIPDTO"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "location_id"
+        ],
+        "title": "LocationTopIPsResponse",
+        "type": "object"
+      },
+      "LoginPayload": {
+        "properties": {
+          "password": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "password",
+          "username"
+        ],
+        "title": "LoginPayload",
+        "type": "object"
+      },
+      "LogparserSettingsView": {
+        "properties": {
+          "log_paths": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "send_logs": {
+            "type": "boolean"
+          },
+          "store_debug_lines": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "log_paths",
+          "send_logs",
+          "store_debug_lines"
+        ],
+        "title": "LogparserSettingsView",
+        "type": "object"
+      },
+      "MapSettingsView": {
+        "properties": {
+          "home_latitude": {
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "home_longitude": {
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "home_source": {
+            "enum": [
+              "configured",
+              "external_ip",
+              null
+            ],
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "required": [
+          "home_latitude",
+          "home_longitude",
+          "home_source"
+        ],
+        "title": "MapSettingsView",
+        "type": "object"
+      },
+      "MeResponse": {
+        "properties": {
+          "username": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "username"
+        ],
+        "title": "MeResponse",
+        "type": "object"
+      },
+      "PercentChange": {
+        "properties": {
+          "avg_request_time": {
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "bytes_sent": {
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error_rate": {
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "geo_records": {
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "log_records": {
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "malformed_rate": {
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "unique_ips": {
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [],
+        "title": "PercentChange",
+        "type": "object"
+      },
+      "PeriodSummary": {
+        "properties": {
+          "avg_bytes_per_request": {
+            "type": "number"
+          },
+          "avg_request_time": {
+            "type": "number"
+          },
+          "error_rate": {
+            "type": "number"
+          },
+          "malformed_requests": {
+            "type": "integer"
+          },
+          "max_request_time": {
+            "type": "number"
+          },
+          "status_2xx": {
+            "type": "integer"
+          },
+          "status_3xx": {
+            "type": "integer"
+          },
+          "status_4xx": {
+            "type": "integer"
+          },
+          "status_5xx": {
+            "type": "integer"
+          },
+          "total_bytes_sent": {
+            "type": "integer"
+          },
+          "total_geo_events": {
+            "type": "integer"
+          },
+          "total_requests": {
+            "type": "integer"
+          },
+          "unique_countries": {
+            "type": "integer"
+          },
+          "unique_ips": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "avg_bytes_per_request",
+          "avg_request_time",
+          "error_rate",
+          "malformed_requests",
+          "max_request_time",
+          "status_2xx",
+          "status_3xx",
+          "status_4xx",
+          "status_5xx",
+          "total_bytes_sent",
+          "total_geo_events",
+          "total_requests",
+          "unique_countries",
+          "unique_ips"
+        ],
+        "title": "PeriodSummary",
+        "type": "object"
+      },
+      "SafeSettingsResponse": {
+        "properties": {
+          "analytics": {
+            "$ref": "#/components/schemas/AnalyticsSettingsView"
+          },
+          "environment": {
+            "type": "string"
+          },
+          "logparser": {
+            "$ref": "#/components/schemas/LogparserSettingsView"
+          },
+          "map": {
+            "$ref": "#/components/schemas/MapSettingsView"
+          },
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "analytics",
+          "environment",
+          "logparser",
+          "map",
+          "name",
+          "version"
+        ],
+        "title": "SafeSettingsResponse",
+        "type": "object"
+      },
+      "SummaryResponse": {
+        "properties": {
+          "current_period": {
+            "$ref": "#/components/schemas/PeriodSummary"
+          },
+          "end_date": {
+            "type": "string"
+          },
+          "percent_changes": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/PercentChange"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "previous_period": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/PeriodSummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "start_date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "current_period",
+          "end_date",
+          "start_date"
+        ],
+        "title": "SummaryResponse",
+        "type": "object"
+      },
+      "TimeSeriesDataPoint": {
+        "properties": {
+          "avg_request_time": {
+            "type": "number"
+          },
+          "error_rate": {
+            "type": "number"
+          },
+          "p50_request_time": {
+            "type": "number"
+          },
+          "p95_request_time": {
+            "type": "number"
+          },
+          "p99_request_time": {
+            "type": "number"
+          },
+          "status_2xx": {
+            "type": "integer"
+          },
+          "status_3xx": {
+            "type": "integer"
+          },
+          "status_4xx": {
+            "type": "integer"
+          },
+          "status_5xx": {
+            "type": "integer"
+          },
+          "timestamp": {
+            "type": "string"
+          },
+          "total_bytes_sent": {
+            "type": "integer"
+          },
+          "total_geo_events": {
+            "type": "integer"
+          },
+          "total_requests": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "avg_request_time",
+          "error_rate",
+          "p50_request_time",
+          "p95_request_time",
+          "p99_request_time",
+          "status_2xx",
+          "status_3xx",
+          "status_4xx",
+          "status_5xx",
+          "timestamp",
+          "total_bytes_sent",
+          "total_geo_events",
+          "total_requests"
+        ],
+        "title": "TimeSeriesDataPoint",
+        "type": "object"
+      },
+      "TimeSeriesResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/TimeSeriesDataPoint"
+            },
+            "type": "array"
+          },
+          "end_date": {
+            "type": "string"
+          },
+          "granularity": {
+            "type": "string"
+          },
+          "start_date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "data",
+          "end_date",
+          "granularity",
+          "start_date"
+        ],
+        "title": "TimeSeriesResponse",
+        "type": "object"
+      },
+      "TopCitiesResponse": {
+        "properties": {
+          "end_date": {
+            "type": "string"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TopCityStatsDTO"
+            },
+            "type": "array"
+          },
+          "start_date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "end_date",
+          "items",
+          "start_date"
+        ],
+        "title": "TopCitiesResponse",
+        "type": "object"
+      },
+      "TopCityStatsDTO": {
+        "properties": {
+          "city": {
+            "type": "string"
+          },
+          "country_code": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "hits": {
+            "type": "integer"
+          },
+          "unique_ips": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "city",
+          "country_code",
+          "hits",
+          "unique_ips"
+        ],
+        "title": "TopCityStatsDTO",
+        "type": "object"
+      },
+      "TopCountriesResponse": {
+        "properties": {
+          "top_countries": {
+            "items": {
+              "$ref": "#/components/schemas/TopCountryDTO"
+            },
+            "type": "array"
+          }
+        },
+        "required": [],
+        "title": "TopCountriesResponse",
+        "type": "object"
+      },
+      "TopCountriesStatsResponse": {
+        "properties": {
+          "end_date": {
+            "type": "string"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TopCountryStatsDTO"
+            },
+            "type": "array"
+          },
+          "start_date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "end_date",
+          "items",
+          "start_date"
+        ],
+        "title": "TopCountriesStatsResponse",
+        "type": "object"
+      },
+      "TopCountryDTO": {
+        "properties": {
+          "country_code": {
+            "type": "string"
+          },
+          "country_name": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "event_count": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "country_code",
+          "country_name",
+          "event_count"
+        ],
+        "title": "TopCountryDTO",
+        "type": "object"
+      },
+      "TopCountryStatsDTO": {
+        "properties": {
+          "country_code": {
+            "type": "string"
+          },
+          "country_name": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "hits": {
+            "type": "integer"
+          },
+          "unique_ips": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "country_code",
+          "country_name",
+          "hits",
+          "unique_ips"
+        ],
+        "title": "TopCountryStatsDTO",
+        "type": "object"
+      },
+      "TopIPDTO": {
+        "properties": {
+          "event_count": {
+            "type": "integer"
+          },
+          "ip_address": {
+            "type": "string"
+          },
+          "location": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/EmbeddedLocationDTO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "event_count",
+          "ip_address"
+        ],
+        "title": "TopIPDTO",
+        "type": "object"
+      },
+      "TopIpDTO": {
+        "properties": {
+          "city": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "country_code": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error_hits": {
+            "type": "integer"
+          },
+          "hits": {
+            "type": "integer"
+          },
+          "ip_address": {
+            "type": "string"
+          },
+          "total_bytes": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "city",
+          "country_code",
+          "error_hits",
+          "hits",
+          "ip_address",
+          "total_bytes"
+        ],
+        "title": "TopIpDTO",
+        "type": "object"
+      },
+      "TopIpsResponse": {
+        "properties": {
+          "end_date": {
+            "type": "string"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TopIpDTO"
+            },
+            "type": "array"
+          },
+          "start_date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "end_date",
+          "items",
+          "start_date"
+        ],
+        "title": "TopIpsResponse",
+        "type": "object"
+      },
+      "TopUrlDTO": {
+        "properties": {
+          "avg_request_time": {
+            "type": "number"
+          },
+          "error_hits": {
+            "type": "integer"
+          },
+          "hits": {
+            "type": "integer"
+          },
+          "total_bytes": {
+            "type": "integer"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "avg_request_time",
+          "error_hits",
+          "hits",
+          "total_bytes",
+          "url"
+        ],
+        "title": "TopUrlDTO",
+        "type": "object"
+      },
+      "TopUrlsResponse": {
+        "properties": {
+          "end_date": {
+            "type": "string"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TopUrlDTO"
+            },
+            "type": "array"
+          },
+          "start_date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "end_date",
+          "items",
+          "start_date"
+        ],
+        "title": "TopUrlsResponse",
+        "type": "object"
+      },
+      "TopUserAgentDTO": {
+        "properties": {
+          "hits": {
+            "type": "integer"
+          },
+          "user_agent": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "hits",
+          "user_agent"
+        ],
+        "title": "TopUserAgentDTO",
+        "type": "object"
+      },
+      "TopUserAgentsResponse": {
+        "properties": {
+          "end_date": {
+            "type": "string"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TopUserAgentDTO"
+            },
+            "type": "array"
+          },
+          "start_date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "end_date",
+          "items",
+          "start_date"
+        ],
+        "title": "TopUserAgentsResponse",
+        "type": "object"
+      }
     },
-    "openapi": "3.1.0",
-    "servers": [
-        {
-            "url": "/"
-        }
-    ],
-    "paths": {
-        "/api/v1/geo-events": {
-            "get": {
-                "tags": [
-                    "Geo Events"
-                ],
-                "summary": "ListGeoEvents",
-                "operationId": "ApiV1GeoEventsListGeoEvents",
-                "parameters": [
-                    {
-                        "name": "currentPage",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "minimum": 1.0,
-                            "default": 1
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "pageSize",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "minimum": 1.0,
-                            "default": 10
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "items": {
-                                            "items": {
-                                                "$ref": "#/components/schemas/ListGeoEventsGeoEventResponseBody"
-                                            },
-                                            "type": "array"
-                                        },
-                                        "limit": {
-                                            "type": "integer",
-                                            "description": "Maximal number of items to send."
-                                        },
-                                        "offset": {
-                                            "type": "integer",
-                                            "description": "Offset from the beginning of the query."
-                                        },
-                                        "total": {
-                                            "type": "integer",
-                                            "description": "Total number of items."
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
+    "securitySchemes": {
+      "sessionCookie": {
+        "description": "Session cookie authentication.",
+        "in": "cookie",
+        "name": "session",
+        "type": "apiKey"
+      }
+    }
+  },
+  "info": {
+    "description": "Real-time GeoIP lookups and traffic analytics API",
+    "title": "GeoMetrikks API",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/v1/access-log-debug": {
+      "get": {
+        "deprecated": false,
+        "operationId": "ApiV1AccessLogDebugListAccessLogDebugs",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "currentPage",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1.0,
+              "type": "integer"
             }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "minimum": 1.0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "$ref": "#/components/schemas/ListAccessLogDebugsAccessLogDebugResponseBody"
+                      },
+                      "type": "array"
+                    },
+                    "limit": {
+                      "description": "Maximal number of items to send.",
+                      "type": "integer"
+                    },
+                    "offset": {
+                      "description": "Offset from the beginning of the query.",
+                      "type": "integer"
+                    },
+                    "total": {
+                      "description": "Total number of items.",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
         },
-        "/api/v1/geo-locations/geojson": {
-            "get": {
-                "tags": [
-                    "Geo Locations"
-                ],
-                "summary": "GetGeojson",
-                "description": "Get all locations with event counts as GeoJSON FeatureCollection.",
-                "operationId": "ApiV1GeoLocationsGeojsonGetGeojson",
-                "parameters": [
-                    {
-                        "name": "from_timestamp",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
-                            "examples": [
-                                "2024-01-01T00:00:00Z"
-                            ]
-                        },
-                        "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "from_timestamp-example-1": {
-                                "value": "2024-01-01T00:00:00Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "to_timestamp",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
-                            "examples": [
-                                "2024-12-31T23:59:59Z"
-                            ]
-                        },
-                        "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "to_timestamp-example-1": {
-                                "value": "2024-12-31T23:59:59Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "country_code",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these ISO country codes (repeatable)"
-                        },
-                        "description": "Filter to these ISO country codes (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "city",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these city names (repeatable)"
-                        },
-                        "description": "Filter to these city names (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GeoJSONFeatureCollection"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/geo-locations/top-ips": {
-            "get": {
-                "tags": [
-                    "Geo Locations"
-                ],
-                "summary": "GetGlobalTopIps",
-                "description": "Get global top IPs by event count with their primary locations.",
-                "operationId": "ApiV1GeoLocationsTopIpsGetGlobalTopIps",
-                "parameters": [
-                    {
-                        "name": "from_timestamp",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
-                            "examples": [
-                                "2024-01-01T00:00:00Z"
-                            ]
-                        },
-                        "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "from_timestamp-example-1": {
-                                "value": "2024-01-01T00:00:00Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "to_timestamp",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
-                            "examples": [
-                                "2024-12-31T23:59:59Z"
-                            ]
-                        },
-                        "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "to_timestamp-example-1": {
-                                "value": "2024-12-31T23:59:59Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "maximum": 20.0,
-                            "minimum": 1.0,
-                            "description": "Maximum number of IPs to return",
-                            "default": 5
-                        },
-                        "description": "Maximum number of IPs to return",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GlobalTopIPsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/geo-locations/{location_id}/top-ips": {
-            "get": {
-                "tags": [
-                    "Geo Locations"
-                ],
-                "summary": "GetLocationTopIps",
-                "description": "Get top IPs for a specific location.",
-                "operationId": "ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIps",
-                "parameters": [
-                    {
-                        "name": "location_id",
-                        "in": "path",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "required": true,
-                        "deprecated": false
-                    },
-                    {
-                        "name": "from_timestamp",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
-                            "examples": [
-                                "2024-01-01T00:00:00Z"
-                            ]
-                        },
-                        "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "from_timestamp-example-1": {
-                                "value": "2024-01-01T00:00:00Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "to_timestamp",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
-                            "examples": [
-                                "2024-12-31T23:59:59Z"
-                            ]
-                        },
-                        "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "to_timestamp-example-1": {
-                                "value": "2024-12-31T23:59:59Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "maximum": 20.0,
-                            "minimum": 1.0,
-                            "description": "Maximum number of IPs to return",
-                            "default": 5
-                        },
-                        "description": "Maximum number of IPs to return",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/LocationTopIPsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/geo-locations/top-countries": {
-            "get": {
-                "tags": [
-                    "Geo Locations"
-                ],
-                "summary": "GetTopCountries",
-                "description": "Get top countries by event count.",
-                "operationId": "ApiV1GeoLocationsTopCountriesGetTopCountries",
-                "parameters": [
-                    {
-                        "name": "from_timestamp",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
-                            "examples": [
-                                "2024-01-01T00:00:00Z"
-                            ]
-                        },
-                        "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "from_timestamp-example-1": {
-                                "value": "2024-01-01T00:00:00Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "to_timestamp",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
-                            "examples": [
-                                "2024-12-31T23:59:59Z"
-                            ]
-                        },
-                        "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "to_timestamp-example-1": {
-                                "value": "2024-12-31T23:59:59Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "maximum": 50.0,
-                            "minimum": 1.0,
-                            "description": "Maximum number of countries to return",
-                            "default": 10
-                        },
-                        "description": "Maximum number of countries to return",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TopCountriesResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/geo-locations": {
-            "get": {
-                "tags": [
-                    "Geo Locations"
-                ],
-                "summary": "ListGeoLocations",
-                "operationId": "ApiV1GeoLocationsListGeoLocations",
-                "parameters": [
-                    {
-                        "name": "currentPage",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "minimum": 1.0,
-                            "default": 1
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "pageSize",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "minimum": 1.0,
-                            "default": 10
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "items": {
-                                            "items": {
-                                                "$ref": "#/components/schemas/ListGeoLocationsGeoLocationResponseBody"
-                                            },
-                                            "type": "array"
-                                        },
-                                        "limit": {
-                                            "type": "integer",
-                                            "description": "Maximal number of items to send."
-                                        },
-                                        "offset": {
-                                            "type": "integer",
-                                            "description": "Offset from the beginning of the query."
-                                        },
-                                        "total": {
-                                            "type": "integer",
-                                            "description": "Total number of items."
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/access-logs/facets": {
-            "get": {
-                "tags": [
-                    "Access Logs"
-                ],
-                "summary": "GetAccessLogFacets",
-                "operationId": "ApiV1AccessLogsFacetsGetAccessLogFacets",
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AccessLogFacets"
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/access-logs": {
-            "get": {
-                "tags": [
-                    "Access Logs"
-                ],
-                "summary": "ListAccessLogs",
-                "operationId": "ApiV1AccessLogsListAccessLogs",
-                "parameters": [
-                    {
-                        "name": "searchString",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "Field to search"
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "searchIgnoreCase",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "type": "boolean",
-                                    "default": true
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "Search should be case sensitive",
-                            "default": true
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "currentPage",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "minimum": 1.0,
-                            "default": 1
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "pageSize",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "minimum": 1.0,
-                            "default": 50
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "orderBy",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "default": "timestamp"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "Order by field",
-                            "default": "timestamp"
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "sortOrder",
-                        "in": "query",
-                        "schema": {
-                            "type": [
-                                "null",
-                                "string"
-                            ],
-                            "enum": [
-                                "asc",
-                                "desc",
-                                null
-                            ],
-                            "title": "Field to search",
-                            "default": "desc"
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "from_timestamp",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "format": "date-time"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ]
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "to_timestamp",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "type": "string",
-                                    "format": "date-time"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ]
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "host",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ]
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "methodIn",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ]
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "ipAddressIn",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ]
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "cityIn",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ]
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "countryCodeIn",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ]
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "statusIn",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "integer"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ]
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "items": {
-                                            "items": {
-                                                "$ref": "#/components/schemas/ListAccessLogsAccessLogResponseBody"
-                                            },
-                                            "type": "array"
-                                        },
-                                        "limit": {
-                                            "type": "integer",
-                                            "description": "Maximal number of items to send."
-                                        },
-                                        "offset": {
-                                            "type": "integer",
-                                            "description": "Offset from the beginning of the query."
-                                        },
-                                        "total": {
-                                            "type": "integer",
-                                            "description": "Total number of items."
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/access-log-debug": {
-            "get": {
-                "tags": [
-                    "Access Log Debug"
-                ],
-                "summary": "ListAccessLogDebugs",
-                "operationId": "ApiV1AccessLogDebugListAccessLogDebugs",
-                "parameters": [
-                    {
-                        "name": "currentPage",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "minimum": 1.0,
-                            "default": 1
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "pageSize",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "minimum": 1.0,
-                            "default": 10
-                        },
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "items": {
-                                            "items": {
-                                                "$ref": "#/components/schemas/ListAccessLogDebugsAccessLogDebugResponseBody"
-                                            },
-                                            "type": "array"
-                                        },
-                                        "limit": {
-                                            "type": "integer",
-                                            "description": "Maximal number of items to send."
-                                        },
-                                        "offset": {
-                                            "type": "integer",
-                                            "description": "Offset from the beginning of the query."
-                                        },
-                                        "total": {
-                                            "type": "integer",
-                                            "description": "Total number of items."
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/analytics/time-series/cumulative": {
-            "get": {
-                "tags": [
-                    "Analytics"
-                ],
-                "summary": "GetCumulativeTimeSeries",
-                "description": "Get cumulative time series data for area charts.",
-                "operationId": "ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeries",
-                "parameters": [
-                    {
-                        "name": "start_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-                            "examples": [
-                                "2024-01-01T00:00:00Z"
-                            ]
-                        },
-                        "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "start_date-example-1": {
-                                "value": "2024-01-01T00:00:00Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "end_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-                            "examples": [
-                                "2024-12-31T23:59:59Z"
-                            ]
-                        },
-                        "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "end_date-example-1": {
-                                "value": "2024-12-31T23:59:59Z"
-                            }
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CumulativeTimeSeriesResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/analytics/geo-time-series": {
-            "get": {
-                "tags": [
-                    "Analytics"
-                ],
-                "summary": "GetGeoTimeSeries",
-                "description": "Per-bucket geo-event metrics for charts.",
-                "operationId": "ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeries",
-                "parameters": [
-                    {
-                        "name": "start_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-                            "examples": [
-                                "2024-01-01T00:00:00Z"
-                            ]
-                        },
-                        "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "start_date-example-1": {
-                                "value": "2024-01-01T00:00:00Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "end_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-                            "examples": [
-                                "2024-12-31T23:59:59Z"
-                            ]
-                        },
-                        "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "end_date-example-1": {
-                                "value": "2024-12-31T23:59:59Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "granularity",
-                        "in": "query",
-                        "schema": {
-                            "type": [
-                                "null",
-                                "string"
-                            ],
-                            "enum": [
-                                "hourly",
-                                "daily",
-                                null
-                            ],
-                            "description": "Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available."
-                        },
-                        "description": "Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available.",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GeoEventsTimeSeriesResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/analytics/live-summary": {
-            "get": {
-                "tags": [
-                    "Analytics"
-                ],
-                "summary": "GetLiveSummary",
-                "description": "Get live summary statistics by querying raw data tables.",
-                "operationId": "ApiV1AnalyticsLiveSummaryGetLiveSummary",
-                "parameters": [
-                    {
-                        "name": "start_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-                            "examples": [
-                                "2024-01-01T00:00:00Z"
-                            ]
-                        },
-                        "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "start_date-example-1": {
-                                "value": "2024-01-01T00:00:00Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "end_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-                            "examples": [
-                                "2024-12-31T23:59:59Z"
-                            ]
-                        },
-                        "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "end_date-example-1": {
-                                "value": "2024-12-31T23:59:59Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "compare_previous",
-                        "in": "query",
-                        "schema": {
-                            "type": "boolean",
-                            "description": "Include comparison with previous period of same length",
-                            "default": false
-                        },
-                        "description": "Include comparison with previous period of same length",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SummaryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/analytics/summary": {
-            "get": {
-                "tags": [
-                    "Analytics"
-                ],
-                "summary": "GetSummary",
-                "description": "Get summary statistics for dashboard header cards.",
-                "operationId": "ApiV1AnalyticsSummaryGetSummary",
-                "parameters": [
-                    {
-                        "name": "start_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-                            "examples": [
-                                "2024-01-01T00:00:00Z"
-                            ]
-                        },
-                        "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "start_date-example-1": {
-                                "value": "2024-01-01T00:00:00Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "end_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-                            "examples": [
-                                "2024-12-31T23:59:59Z"
-                            ]
-                        },
-                        "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "end_date-example-1": {
-                                "value": "2024-12-31T23:59:59Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "compare_previous",
-                        "in": "query",
-                        "schema": {
-                            "type": "boolean",
-                            "description": "Include comparison with previous period of same length",
-                            "default": false
-                        },
-                        "description": "Include comparison with previous period of same length",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SummaryResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/analytics/time-series": {
-            "get": {
-                "tags": [
-                    "Analytics"
-                ],
-                "summary": "GetTimeSeries",
-                "description": "Per-bucket access-log metrics for charts.",
-                "operationId": "ApiV1AnalyticsTimeSeriesGetTimeSeries",
-                "parameters": [
-                    {
-                        "name": "start_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-                            "examples": [
-                                "2024-01-01T00:00:00Z"
-                            ]
-                        },
-                        "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "start_date-example-1": {
-                                "value": "2024-01-01T00:00:00Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "end_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-                            "examples": [
-                                "2024-12-31T23:59:59Z"
-                            ]
-                        },
-                        "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "end_date-example-1": {
-                                "value": "2024-12-31T23:59:59Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "granularity",
-                        "in": "query",
-                        "schema": {
-                            "type": [
-                                "null",
-                                "string"
-                            ],
-                            "enum": [
-                                "hourly",
-                                "daily",
-                                null
-                            ],
-                            "description": "Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available."
-                        },
-                        "description": "Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available.",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "country_code",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these ISO country codes (repeatable)"
-                        },
-                        "description": "Filter to these ISO country codes (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "city",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these city names (repeatable)"
-                        },
-                        "description": "Filter to these city names (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "ip_address",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these client IPs (repeatable)"
-                        },
-                        "description": "Filter to these client IPs (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TimeSeriesResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/analytics/top-cities": {
-            "get": {
-                "tags": [
-                    "Analytics"
-                ],
-                "summary": "GetTopCities",
-                "description": "Top cities by hits from raw access logs (time-bounded).",
-                "operationId": "ApiV1AnalyticsTopCitiesGetTopCities",
-                "parameters": [
-                    {
-                        "name": "start_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "Start date (ISO 8601)"
-                        },
-                        "description": "Start date (ISO 8601)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "end_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "End date (ISO 8601)"
-                        },
-                        "description": "End date (ISO 8601)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "maximum": 100.0,
-                            "minimum": 1.0,
-                            "description": "Maximum number of cities",
-                            "default": 25
-                        },
-                        "description": "Maximum number of cities",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "country_code",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these ISO country codes (repeatable)"
-                        },
-                        "description": "Filter to these ISO country codes (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "city",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these city names (repeatable)"
-                        },
-                        "description": "Filter to these city names (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "ip_address",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these client IPs (repeatable)"
-                        },
-                        "description": "Filter to these client IPs (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TopCitiesResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/analytics/top-countries": {
-            "get": {
-                "tags": [
-                    "Analytics"
-                ],
-                "summary": "GetTopCountries",
-                "description": "Top countries by hits from raw access logs (time-bounded).",
-                "operationId": "ApiV1AnalyticsTopCountriesGetTopCountries",
-                "parameters": [
-                    {
-                        "name": "start_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "Start date (ISO 8601)"
-                        },
-                        "description": "Start date (ISO 8601)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "end_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "End date (ISO 8601)"
-                        },
-                        "description": "End date (ISO 8601)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "maximum": 100.0,
-                            "minimum": 1.0,
-                            "description": "Maximum number of countries",
-                            "default": 25
-                        },
-                        "description": "Maximum number of countries",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "country_code",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these ISO country codes (repeatable)"
-                        },
-                        "description": "Filter to these ISO country codes (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "city",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these city names (repeatable)"
-                        },
-                        "description": "Filter to these city names (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "ip_address",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these client IPs (repeatable)"
-                        },
-                        "description": "Filter to these client IPs (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TopCountriesStatsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/analytics/top-ips": {
-            "get": {
-                "tags": [
-                    "Analytics"
-                ],
-                "summary": "GetTopIps",
-                "description": "Top client IPs by hits from raw access logs (time-bounded).",
-                "operationId": "ApiV1AnalyticsTopIpsGetTopIps",
-                "parameters": [
-                    {
-                        "name": "start_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "Start date (ISO 8601)"
-                        },
-                        "description": "Start date (ISO 8601)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "end_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "End date (ISO 8601)"
-                        },
-                        "description": "End date (ISO 8601)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "maximum": 100.0,
-                            "minimum": 1.0,
-                            "description": "Maximum number of IPs",
-                            "default": 25
-                        },
-                        "description": "Maximum number of IPs",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "country_code",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these ISO country codes (repeatable)"
-                        },
-                        "description": "Filter to these ISO country codes (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "city",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these city names (repeatable)"
-                        },
-                        "description": "Filter to these city names (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "ip_address",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these client IPs (repeatable)"
-                        },
-                        "description": "Filter to these client IPs (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TopIpsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/analytics/top-urls": {
-            "get": {
-                "tags": [
-                    "Analytics"
-                ],
-                "summary": "GetTopUrls",
-                "description": "Top URLs by hits from raw access logs (time-bounded).",
-                "operationId": "ApiV1AnalyticsTopUrlsGetTopUrls",
-                "parameters": [
-                    {
-                        "name": "start_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-                            "examples": [
-                                "2024-01-01T00:00:00Z"
-                            ]
-                        },
-                        "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "start_date-example-1": {
-                                "value": "2024-01-01T00:00:00Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "end_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-                            "examples": [
-                                "2024-12-31T23:59:59Z"
-                            ]
-                        },
-                        "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "end_date-example-1": {
-                                "value": "2024-12-31T23:59:59Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "maximum": 100.0,
-                            "minimum": 1.0,
-                            "description": "Maximum number of URLs to return",
-                            "default": 25
-                        },
-                        "description": "Maximum number of URLs to return",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "country_code",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these ISO country codes (repeatable)"
-                        },
-                        "description": "Filter to these ISO country codes (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "city",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these city names (repeatable)"
-                        },
-                        "description": "Filter to these city names (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "ip_address",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these client IPs (repeatable)"
-                        },
-                        "description": "Filter to these client IPs (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TopUrlsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/analytics/top-user-agents": {
-            "get": {
-                "tags": [
-                    "Analytics"
-                ],
-                "summary": "GetTopUserAgents",
-                "description": "Top user agents by hits from raw access logs.",
-                "operationId": "ApiV1AnalyticsTopUserAgentsGetTopUserAgents",
-                "parameters": [
-                    {
-                        "name": "start_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-                            "examples": [
-                                "2024-01-01T00:00:00Z"
-                            ]
-                        },
-                        "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "start_date-example-1": {
-                                "value": "2024-01-01T00:00:00Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "end_date",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-                            "examples": [
-                                "2024-12-31T23:59:59Z"
-                            ]
-                        },
-                        "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-                        "required": true,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false,
-                        "examples": {
-                            "end_date-example-1": {
-                                "value": "2024-12-31T23:59:59Z"
-                            }
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "maximum": 100.0,
-                            "minimum": 1.0,
-                            "description": "Maximum number of user agents to return",
-                            "default": 25
-                        },
-                        "description": "Maximum number of user agents to return",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "country_code",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these ISO country codes (repeatable)"
-                        },
-                        "description": "Filter to these ISO country codes (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "city",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these city names (repeatable)"
-                        },
-                        "description": "Filter to these city names (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    },
-                    {
-                        "name": "ip_address",
-                        "in": "query",
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Filter to these client IPs (repeatable)"
-                        },
-                        "description": "Filter to these client IPs (repeatable)",
-                        "required": false,
-                        "deprecated": false,
-                        "allowEmptyValue": false,
-                        "allowReserved": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TopUserAgentsResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/settings": {
-            "get": {
-                "tags": [
-                    "Settings"
-                ],
-                "summary": "ReadSettings",
-                "operationId": "ApiV1SettingsReadSettings",
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SafeSettingsResponse"
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/stats": {
-            "get": {
-                "tags": [
-                    "Analytics"
-                ],
-                "summary": "Stats",
-                "operationId": "ApiV1StatsStats",
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {},
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/health": {
-            "get": {
-                "tags": [
-                    "Health"
-                ],
-                "summary": "Health",
-                "operationId": "HealthHealth",
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {},
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/health/ready": {
-            "get": {
-                "tags": [
-                    "Health"
-                ],
-                "summary": "HealthReady",
-                "operationId": "HealthReadyHealthReady",
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {},
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/auth/login": {
-            "post": {
-                "tags": [
-                    "Auth"
-                ],
-                "summary": "Login",
-                "operationId": "ApiV1AuthLoginLogin",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/LoginPayload"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/MeResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request syntax or unsupported method",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "status_code": {
-                                            "type": "integer"
-                                        },
-                                        "detail": {
-                                            "type": "string"
-                                        },
-                                        "extra": {
-                                            "additionalProperties": {},
-                                            "type": [
-                                                "null",
-                                                "object",
-                                                "array"
-                                            ]
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "detail",
-                                        "status_code"
-                                    ],
-                                    "description": "Validation Exception",
-                                    "examples": [
-                                        {
-                                            "status_code": 400,
-                                            "detail": "Bad Request",
-                                            "extra": {}
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/auth/logout": {
-            "post": {
-                "tags": [
-                    "Auth"
-                ],
-                "summary": "Logout",
-                "operationId": "ApiV1AuthLogoutLogout",
-                "responses": {
-                    "204": {
-                        "description": "Request fulfilled, nothing follows",
-                        "headers": {}
-                    }
-                },
-                "deprecated": false
-            }
-        },
-        "/api/v1/auth/me": {
-            "get": {
-                "tags": [
-                    "Auth"
-                ],
-                "summary": "Me",
-                "operationId": "ApiV1AuthMeMe",
-                "responses": {
-                    "200": {
-                        "description": "Request fulfilled, document follows",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/MeResponse"
-                                }
-                            }
-                        }
-                    }
-                },
-                "deprecated": false
-            }
-        }
+        "summary": "ListAccessLogDebugs",
+        "tags": [
+          "Access Log Debug"
+        ]
+      }
     },
-    "components": {
-        "schemas": {
-            "AccessLogFacets": {
-                "properties": {
-                    "countries": {
-                        "items": {
-                            "$ref": "#/components/schemas/CountryFacet"
-                        },
-                        "type": "array"
-                    },
-                    "cities": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    }
+    "/api/v1/access-logs": {
+      "get": {
+        "deprecated": false,
+        "operationId": "ApiV1AccessLogsListAccessLogs",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "searchString",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
                 },
-                "type": "object",
-                "required": [
-                    "cities",
-                    "countries"
-                ],
-                "title": "AccessLogFacets"
-            },
-            "AnalyticsSettingsView": {
-                "properties": {
-                    "raw_retention_days": {
-                        "type": "integer"
-                    },
-                    "debug_retention_days": {
-                        "type": "integer"
-                    },
-                    "hourly_retention_days": {
-                        "type": "integer"
-                    },
-                    "compression_after_days": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "compression_after_days",
-                    "debug_retention_days",
-                    "hourly_retention_days",
-                    "raw_retention_days"
-                ],
-                "title": "AnalyticsSettingsView"
-            },
-            "CountryFacet": {
-                "properties": {
-                    "code": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "code",
-                    "name"
-                ],
-                "title": "CountryFacet"
-            },
-            "CumulativeDataPoint": {
-                "properties": {
-                    "timestamp": {
-                        "type": "string"
-                    },
-                    "cumulative_geo_events": {
-                        "type": "integer"
-                    },
-                    "cumulative_access_logs": {
-                        "type": "integer"
-                    },
-                    "cumulative_bytes": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "cumulative_access_logs",
-                    "cumulative_bytes",
-                    "cumulative_geo_events",
-                    "timestamp"
-                ],
-                "title": "CumulativeDataPoint"
-            },
-            "CumulativeTimeSeriesResponse": {
-                "properties": {
-                    "granularity": {
-                        "type": "string"
-                    },
-                    "start_date": {
-                        "type": "string"
-                    },
-                    "end_date": {
-                        "type": "string"
-                    },
-                    "data": {
-                        "items": {
-                            "$ref": "#/components/schemas/CumulativeDataPoint"
-                        },
-                        "type": "array"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "end_date",
-                    "granularity",
-                    "start_date"
-                ],
-                "title": "CumulativeTimeSeriesResponse"
-            },
-            "EmbeddedLocationDTO": {
-                "properties": {
-                    "id": {
-                        "type": "integer"
-                    },
-                    "latitude": {
-                        "type": "number"
-                    },
-                    "longitude": {
-                        "type": "number"
-                    },
-                    "city": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "country_code": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "country_name": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "id",
-                    "latitude",
-                    "longitude"
-                ],
-                "title": "EmbeddedLocationDTO"
-            },
-            "GeoEventsDataPoint": {
-                "properties": {
-                    "timestamp": {
-                        "type": "string"
-                    },
-                    "total_geo_events": {
-                        "type": "integer"
-                    },
-                    "unique_ips": {
-                        "type": "integer"
-                    },
-                    "unique_countries": {
-                        "type": "integer"
-                    },
-                    "unique_cities": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "timestamp",
-                    "total_geo_events",
-                    "unique_cities",
-                    "unique_countries",
-                    "unique_ips"
-                ],
-                "title": "GeoEventsDataPoint"
-            },
-            "GeoEventsTimeSeriesResponse": {
-                "properties": {
-                    "granularity": {
-                        "type": "string"
-                    },
-                    "start_date": {
-                        "type": "string"
-                    },
-                    "end_date": {
-                        "type": "string"
-                    },
-                    "data": {
-                        "items": {
-                            "$ref": "#/components/schemas/GeoEventsDataPoint"
-                        },
-                        "type": "array"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "data",
-                    "end_date",
-                    "granularity",
-                    "start_date"
-                ],
-                "title": "GeoEventsTimeSeriesResponse"
-            },
-            "GeoJSONFeature": {
-                "properties": {
-                    "type": {
-                        "type": "string"
-                    },
-                    "geometry": {
-                        "$ref": "#/components/schemas/GeoJSONPointGeometry"
-                    },
-                    "properties": {
-                        "$ref": "#/components/schemas/GeoJSONFeatureProperties"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "geometry",
-                    "properties",
-                    "type"
-                ],
-                "title": "GeoJSONFeature"
-            },
-            "GeoJSONFeatureCollection": {
-                "properties": {
-                    "type": {
-                        "type": "string"
-                    },
-                    "features": {
-                        "items": {
-                            "$ref": "#/components/schemas/GeoJSONFeature"
-                        },
-                        "type": "array"
-                    },
-                    "stats": {
-                        "$ref": "#/components/schemas/GeoJSONFeatureStats"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "features",
-                    "stats",
-                    "type"
-                ],
-                "title": "GeoJSONFeatureCollection"
-            },
-            "GeoJSONFeatureProperties": {
-                "properties": {
-                    "id": {
-                        "type": "integer"
-                    },
-                    "geohash": {
-                        "type": "string"
-                    },
-                    "country_code": {
-                        "type": "string"
-                    },
-                    "country_name": {
-                        "type": "string"
-                    },
-                    "last_hit": {
-                        "oneOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "state": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "state_code": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "city": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "postal_code": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "timezone": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "event_count": {
-                        "type": "integer"
-                    },
-                    "top_ips": {
-                        "items": {
-                            "$ref": "#/components/schemas/TopIPDTO"
-                        },
-                        "type": "array"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "city",
-                    "country_code",
-                    "country_name",
-                    "event_count",
-                    "geohash",
-                    "id",
-                    "last_hit",
-                    "postal_code",
-                    "state",
-                    "state_code",
-                    "timezone"
-                ],
-                "title": "GeoJSONFeatureProperties"
-            },
-            "GeoJSONFeatureStats": {
-                "properties": {
-                    "events": {
-                        "type": "integer"
-                    },
-                    "countries": {
-                        "type": "integer"
-                    },
-                    "cities": {
-                        "type": "integer"
-                    },
-                    "locations": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "cities",
-                    "countries",
-                    "events",
-                    "locations"
-                ],
-                "title": "GeoJSONFeatureStats"
-            },
-            "GeoJSONPointGeometry": {
-                "properties": {
-                    "type": {
-                        "type": "string"
-                    },
-                    "coordinates": {
-                        "prefixItems": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "number"
-                            }
-                        ],
-                        "type": "array"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "coordinates",
-                    "type"
-                ],
-                "title": "GeoJSONPointGeometry"
-            },
-            "GlobalTopIPsResponse": {
-                "properties": {
-                    "top_ips": {
-                        "items": {
-                            "$ref": "#/components/schemas/TopIPDTO"
-                        },
-                        "type": "array"
-                    }
-                },
-                "type": "object",
-                "required": [],
-                "title": "GlobalTopIPsResponse"
-            },
-            "ListAccessLogDebugsAccessLogDebugResponseBody": {
-                "properties": {
-                    "accessLogId": {
-                        "oneOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "rawLine": {
-                        "type": "string"
-                    },
-                    "isMalformed": {
-                        "type": "boolean",
-                        "default": false
-                    },
-                    "parseError": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "id": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "id",
-                    "rawLine"
-                ],
-                "title": "ListAccessLogDebugsAccessLogDebugResponseBody"
-            },
-            "ListAccessLogsAccessLogResponseBody": {
-                "properties": {
-                    "timestamp": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "ipAddress": {
-                        "type": "string"
-                    },
-                    "remoteUser": {
-                        "type": "string"
-                    },
-                    "method": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "url": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "httpVersion": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "statusCode": {
-                        "type": "integer"
-                    },
-                    "bytesSent": {
-                        "type": "integer",
-                        "default": 0
-                    },
-                    "referrer": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "userAgent": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "requestTime": {
-                        "type": "number",
-                        "default": 0.0
-                    },
-                    "upstreamResponseTime": {
-                        "oneOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "host": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "countryCode": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "countryName": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "city": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "id": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "id",
-                    "ipAddress",
-                    "statusCode",
-                    "timestamp"
-                ],
-                "title": "ListAccessLogsAccessLogResponseBody"
-            },
-            "ListGeoEventsGeoEventGeoLocationResponseBody": {
-                "properties": {
-                    "latitude": {
-                        "type": "number"
-                    },
-                    "longitude": {
-                        "type": "number"
-                    },
-                    "geohash": {
-                        "type": "string"
-                    },
-                    "geographicPoint": {
-                        "type": "string"
-                    },
-                    "countryCode": {
-                        "type": "string"
-                    },
-                    "countryName": {
-                        "type": "string"
-                    },
-                    "state": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "stateCode": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "city": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "postalCode": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "timezone": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "lastHit": {
-                        "oneOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "id": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "countryCode",
-                    "countryName",
-                    "geographicPoint",
-                    "geohash",
-                    "id",
-                    "latitude",
-                    "longitude"
-                ],
-                "title": "ListGeoEventsGeoEventGeoLocationResponseBody"
-            },
-            "ListGeoEventsGeoEventResponseBody": {
-                "properties": {
-                    "timestamp": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "ipAddress": {
-                        "type": "string"
-                    },
-                    "hostname": {
-                        "type": "string"
-                    },
-                    "locationId": {
-                        "type": "integer"
-                    },
-                    "location": {
-                        "$ref": "#/components/schemas/ListGeoEventsGeoEventGeoLocationResponseBody"
-                    },
-                    "id": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "hostname",
-                    "id",
-                    "ipAddress",
-                    "location",
-                    "locationId"
-                ],
-                "title": "ListGeoEventsGeoEventResponseBody"
-            },
-            "ListGeoLocationsGeoLocationResponseBody": {
-                "properties": {
-                    "latitude": {
-                        "type": "number"
-                    },
-                    "longitude": {
-                        "type": "number"
-                    },
-                    "geohash": {
-                        "type": "string"
-                    },
-                    "geographicPoint": {
-                        "type": "string"
-                    },
-                    "countryCode": {
-                        "type": "string"
-                    },
-                    "countryName": {
-                        "type": "string"
-                    },
-                    "state": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "stateCode": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "city": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "postalCode": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "timezone": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "lastHit": {
-                        "oneOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "id": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "countryCode",
-                    "countryName",
-                    "geographicPoint",
-                    "geohash",
-                    "id",
-                    "latitude",
-                    "longitude"
-                ],
-                "title": "ListGeoLocationsGeoLocationResponseBody"
-            },
-            "LocationTopIPsResponse": {
-                "properties": {
-                    "location_id": {
-                        "type": "integer"
-                    },
-                    "top_ips": {
-                        "items": {
-                            "$ref": "#/components/schemas/TopIPDTO"
-                        },
-                        "type": "array"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "location_id"
-                ],
-                "title": "LocationTopIPsResponse"
-            },
-            "LoginPayload": {
-                "properties": {
-                    "username": {
-                        "type": "string"
-                    },
-                    "password": {
-                        "type": "string"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "password",
-                    "username"
-                ],
-                "title": "LoginPayload"
-            },
-            "LogparserSettingsView": {
-                "properties": {
-                    "log_paths": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "send_logs": {
-                        "type": "boolean"
-                    },
-                    "store_debug_lines": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "log_paths",
-                    "send_logs",
-                    "store_debug_lines"
-                ],
-                "title": "LogparserSettingsView"
-            },
-            "MapSettingsView": {
-                "properties": {
-                    "home_latitude": {
-                        "oneOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "home_longitude": {
-                        "oneOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "home_source": {
-                        "type": [
-                            "null",
-                            "string"
-                        ],
-                        "enum": [
-                            "configured",
-                            "external_ip",
-                            null
-                        ]
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "home_latitude",
-                    "home_longitude",
-                    "home_source"
-                ],
-                "title": "MapSettingsView"
-            },
-            "MeResponse": {
-                "properties": {
-                    "username": {
-                        "type": "string"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "username"
-                ],
-                "title": "MeResponse"
-            },
-            "PercentChange": {
-                "properties": {
-                    "log_records": {
-                        "oneOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "geo_records": {
-                        "oneOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "unique_ips": {
-                        "oneOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "bytes_sent": {
-                        "oneOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "avg_request_time": {
-                        "oneOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "error_rate": {
-                        "oneOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "malformed_rate": {
-                        "oneOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    }
-                },
-                "type": "object",
-                "required": [],
-                "title": "PercentChange"
-            },
-            "PeriodSummary": {
-                "properties": {
-                    "total_requests": {
-                        "type": "integer"
-                    },
-                    "total_geo_events": {
-                        "type": "integer"
-                    },
-                    "unique_ips": {
-                        "type": "integer"
-                    },
-                    "unique_countries": {
-                        "type": "integer"
-                    },
-                    "total_bytes_sent": {
-                        "type": "integer"
-                    },
-                    "avg_bytes_per_request": {
-                        "type": "number"
-                    },
-                    "status_2xx": {
-                        "type": "integer"
-                    },
-                    "status_3xx": {
-                        "type": "integer"
-                    },
-                    "status_4xx": {
-                        "type": "integer"
-                    },
-                    "status_5xx": {
-                        "type": "integer"
-                    },
-                    "avg_request_time": {
-                        "type": "number"
-                    },
-                    "max_request_time": {
-                        "type": "number"
-                    },
-                    "malformed_requests": {
-                        "type": "integer"
-                    },
-                    "error_rate": {
-                        "type": "number"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "avg_bytes_per_request",
-                    "avg_request_time",
-                    "error_rate",
-                    "malformed_requests",
-                    "max_request_time",
-                    "status_2xx",
-                    "status_3xx",
-                    "status_4xx",
-                    "status_5xx",
-                    "total_bytes_sent",
-                    "total_geo_events",
-                    "total_requests",
-                    "unique_countries",
-                    "unique_ips"
-                ],
-                "title": "PeriodSummary"
-            },
-            "SafeSettingsResponse": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "version": {
-                        "type": "string"
-                    },
-                    "environment": {
-                        "type": "string"
-                    },
-                    "logparser": {
-                        "$ref": "#/components/schemas/LogparserSettingsView"
-                    },
-                    "analytics": {
-                        "$ref": "#/components/schemas/AnalyticsSettingsView"
-                    },
-                    "map": {
-                        "$ref": "#/components/schemas/MapSettingsView"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "analytics",
-                    "environment",
-                    "logparser",
-                    "map",
-                    "name",
-                    "version"
-                ],
-                "title": "SafeSettingsResponse"
-            },
-            "SummaryResponse": {
-                "properties": {
-                    "start_date": {
-                        "type": "string"
-                    },
-                    "end_date": {
-                        "type": "string"
-                    },
-                    "current_period": {
-                        "$ref": "#/components/schemas/PeriodSummary"
-                    },
-                    "previous_period": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/PeriodSummary"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "percent_changes": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/PercentChange"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "current_period",
-                    "end_date",
-                    "start_date"
-                ],
-                "title": "SummaryResponse"
-            },
-            "TimeSeriesDataPoint": {
-                "properties": {
-                    "timestamp": {
-                        "type": "string"
-                    },
-                    "total_requests": {
-                        "type": "integer"
-                    },
-                    "total_geo_events": {
-                        "type": "integer"
-                    },
-                    "total_bytes_sent": {
-                        "type": "integer"
-                    },
-                    "status_2xx": {
-                        "type": "integer"
-                    },
-                    "status_3xx": {
-                        "type": "integer"
-                    },
-                    "status_4xx": {
-                        "type": "integer"
-                    },
-                    "status_5xx": {
-                        "type": "integer"
-                    },
-                    "error_rate": {
-                        "type": "number"
-                    },
-                    "avg_request_time": {
-                        "type": "number"
-                    },
-                    "p50_request_time": {
-                        "type": "number"
-                    },
-                    "p95_request_time": {
-                        "type": "number"
-                    },
-                    "p99_request_time": {
-                        "type": "number"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "avg_request_time",
-                    "error_rate",
-                    "p50_request_time",
-                    "p95_request_time",
-                    "p99_request_time",
-                    "status_2xx",
-                    "status_3xx",
-                    "status_4xx",
-                    "status_5xx",
-                    "timestamp",
-                    "total_bytes_sent",
-                    "total_geo_events",
-                    "total_requests"
-                ],
-                "title": "TimeSeriesDataPoint"
-            },
-            "TimeSeriesResponse": {
-                "properties": {
-                    "granularity": {
-                        "type": "string"
-                    },
-                    "start_date": {
-                        "type": "string"
-                    },
-                    "end_date": {
-                        "type": "string"
-                    },
-                    "data": {
-                        "items": {
-                            "$ref": "#/components/schemas/TimeSeriesDataPoint"
-                        },
-                        "type": "array"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "data",
-                    "end_date",
-                    "granularity",
-                    "start_date"
-                ],
-                "title": "TimeSeriesResponse"
-            },
-            "TopCitiesResponse": {
-                "properties": {
-                    "start_date": {
-                        "type": "string"
-                    },
-                    "end_date": {
-                        "type": "string"
-                    },
-                    "items": {
-                        "items": {
-                            "$ref": "#/components/schemas/TopCityStatsDTO"
-                        },
-                        "type": "array"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "end_date",
-                    "items",
-                    "start_date"
-                ],
-                "title": "TopCitiesResponse"
-            },
-            "TopCityStatsDTO": {
-                "properties": {
-                    "city": {
-                        "type": "string"
-                    },
-                    "country_code": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "hits": {
-                        "type": "integer"
-                    },
-                    "unique_ips": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "city",
-                    "country_code",
-                    "hits",
-                    "unique_ips"
-                ],
-                "title": "TopCityStatsDTO"
-            },
-            "TopCountriesResponse": {
-                "properties": {
-                    "top_countries": {
-                        "items": {
-                            "$ref": "#/components/schemas/TopCountryDTO"
-                        },
-                        "type": "array"
-                    }
-                },
-                "type": "object",
-                "required": [],
-                "title": "TopCountriesResponse"
-            },
-            "TopCountriesStatsResponse": {
-                "properties": {
-                    "start_date": {
-                        "type": "string"
-                    },
-                    "end_date": {
-                        "type": "string"
-                    },
-                    "items": {
-                        "items": {
-                            "$ref": "#/components/schemas/TopCountryStatsDTO"
-                        },
-                        "type": "array"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "end_date",
-                    "items",
-                    "start_date"
-                ],
-                "title": "TopCountriesStatsResponse"
-            },
-            "TopCountryDTO": {
-                "properties": {
-                    "country_code": {
-                        "type": "string"
-                    },
-                    "country_name": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "event_count": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "country_code",
-                    "country_name",
-                    "event_count"
-                ],
-                "title": "TopCountryDTO"
-            },
-            "TopCountryStatsDTO": {
-                "properties": {
-                    "country_code": {
-                        "type": "string"
-                    },
-                    "country_name": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "hits": {
-                        "type": "integer"
-                    },
-                    "unique_ips": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "country_code",
-                    "country_name",
-                    "hits",
-                    "unique_ips"
-                ],
-                "title": "TopCountryStatsDTO"
-            },
-            "TopIPDTO": {
-                "properties": {
-                    "ip_address": {
-                        "type": "string"
-                    },
-                    "event_count": {
-                        "type": "integer"
-                    },
-                    "location": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/EmbeddedLocationDTO"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "event_count",
-                    "ip_address"
-                ],
-                "title": "TopIPDTO"
-            },
-            "TopIpDTO": {
-                "properties": {
-                    "ip_address": {
-                        "type": "string"
-                    },
-                    "hits": {
-                        "type": "integer"
-                    },
-                    "error_hits": {
-                        "type": "integer"
-                    },
-                    "total_bytes": {
-                        "type": "integer"
-                    },
-                    "country_code": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "city": {
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "city",
-                    "country_code",
-                    "error_hits",
-                    "hits",
-                    "ip_address",
-                    "total_bytes"
-                ],
-                "title": "TopIpDTO"
-            },
-            "TopIpsResponse": {
-                "properties": {
-                    "start_date": {
-                        "type": "string"
-                    },
-                    "end_date": {
-                        "type": "string"
-                    },
-                    "items": {
-                        "items": {
-                            "$ref": "#/components/schemas/TopIpDTO"
-                        },
-                        "type": "array"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "end_date",
-                    "items",
-                    "start_date"
-                ],
-                "title": "TopIpsResponse"
-            },
-            "TopUrlDTO": {
-                "properties": {
-                    "url": {
-                        "type": "string"
-                    },
-                    "hits": {
-                        "type": "integer"
-                    },
-                    "error_hits": {
-                        "type": "integer"
-                    },
-                    "total_bytes": {
-                        "type": "integer"
-                    },
-                    "avg_request_time": {
-                        "type": "number"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "avg_request_time",
-                    "error_hits",
-                    "hits",
-                    "total_bytes",
-                    "url"
-                ],
-                "title": "TopUrlDTO"
-            },
-            "TopUrlsResponse": {
-                "properties": {
-                    "start_date": {
-                        "type": "string"
-                    },
-                    "end_date": {
-                        "type": "string"
-                    },
-                    "items": {
-                        "items": {
-                            "$ref": "#/components/schemas/TopUrlDTO"
-                        },
-                        "type": "array"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "end_date",
-                    "items",
-                    "start_date"
-                ],
-                "title": "TopUrlsResponse"
-            },
-            "TopUserAgentDTO": {
-                "properties": {
-                    "user_agent": {
-                        "type": "string"
-                    },
-                    "hits": {
-                        "type": "integer"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "hits",
-                    "user_agent"
-                ],
-                "title": "TopUserAgentDTO"
-            },
-            "TopUserAgentsResponse": {
-                "properties": {
-                    "start_date": {
-                        "type": "string"
-                    },
-                    "end_date": {
-                        "type": "string"
-                    },
-                    "items": {
-                        "items": {
-                            "$ref": "#/components/schemas/TopUserAgentDTO"
-                        },
-                        "type": "array"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "end_date",
-                    "items",
-                    "start_date"
-                ],
-                "title": "TopUserAgentsResponse"
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Field to search"
             }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "searchIgnoreCase",
+            "required": false,
+            "schema": {
+              "default": true,
+              "oneOf": [
+                {
+                  "default": true,
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search should be case sensitive"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "currentPage",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1.0,
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "minimum": 1.0,
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "orderBy",
+            "required": false,
+            "schema": {
+              "default": "timestamp",
+              "oneOf": [
+                {
+                  "default": "timestamp",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Order by field"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "sortOrder",
+            "required": false,
+            "schema": {
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc",
+                null
+              ],
+              "title": "Field to search",
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "from_timestamp",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "to_timestamp",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "host",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "methodIn",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "ipAddressIn",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "cityIn",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "countryCodeIn",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "statusIn",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "$ref": "#/components/schemas/ListAccessLogsAccessLogResponseBody"
+                      },
+                      "type": "array"
+                    },
+                    "limit": {
+                      "description": "Maximal number of items to send.",
+                      "type": "integer"
+                    },
+                    "offset": {
+                      "description": "Offset from the beginning of the query.",
+                      "type": "integer"
+                    },
+                    "total": {
+                      "description": "Total number of items.",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
         },
-        "securitySchemes": {
-            "sessionCookie": {
-                "type": "apiKey",
-                "description": "Session cookie authentication.",
-                "name": "session",
-                "in": "cookie"
-            }
-        }
+        "summary": "ListAccessLogs",
+        "tags": [
+          "Access Logs"
+        ]
+      }
     },
-    "security": [
-        {
-            "sessionCookie": []
-        }
-    ]
+    "/api/v1/access-logs/facets": {
+      "get": {
+        "deprecated": false,
+        "operationId": "ApiV1AccessLogsFacetsGetAccessLogFacets",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccessLogFacets"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          }
+        },
+        "summary": "GetAccessLogFacets",
+        "tags": [
+          "Access Logs"
+        ]
+      }
+    },
+    "/api/v1/analytics/geo-time-series": {
+      "get": {
+        "deprecated": false,
+        "description": "Per-bucket geo-event metrics for charts.",
+        "operationId": "ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeries",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+            "examples": {
+              "start_date-example-1": {
+                "value": "2024-01-01T00:00:00Z"
+              }
+            },
+            "in": "query",
+            "name": "start_date",
+            "required": true,
+            "schema": {
+              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+              "examples": [
+                "2024-01-01T00:00:00Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+            "examples": {
+              "end_date-example-1": {
+                "value": "2024-12-31T23:59:59Z"
+              }
+            },
+            "in": "query",
+            "name": "end_date",
+            "required": true,
+            "schema": {
+              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+              "examples": [
+                "2024-12-31T23:59:59Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available.",
+            "in": "query",
+            "name": "granularity",
+            "required": false,
+            "schema": {
+              "description": "Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available.",
+              "enum": [
+                "hourly",
+                "daily",
+                null
+              ],
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeoEventsTimeSeriesResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetGeoTimeSeries",
+        "tags": [
+          "Analytics"
+        ]
+      }
+    },
+    "/api/v1/analytics/live-summary": {
+      "get": {
+        "deprecated": false,
+        "description": "Get live summary statistics by querying raw data tables.",
+        "operationId": "ApiV1AnalyticsLiveSummaryGetLiveSummary",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+            "examples": {
+              "start_date-example-1": {
+                "value": "2024-01-01T00:00:00Z"
+              }
+            },
+            "in": "query",
+            "name": "start_date",
+            "required": true,
+            "schema": {
+              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+              "examples": [
+                "2024-01-01T00:00:00Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+            "examples": {
+              "end_date-example-1": {
+                "value": "2024-12-31T23:59:59Z"
+              }
+            },
+            "in": "query",
+            "name": "end_date",
+            "required": true,
+            "schema": {
+              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+              "examples": [
+                "2024-12-31T23:59:59Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Include comparison with previous period of same length",
+            "in": "query",
+            "name": "compare_previous",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Include comparison with previous period of same length",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SummaryResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetLiveSummary",
+        "tags": [
+          "Analytics"
+        ]
+      }
+    },
+    "/api/v1/analytics/summary": {
+      "get": {
+        "deprecated": false,
+        "description": "Get summary statistics for dashboard header cards.",
+        "operationId": "ApiV1AnalyticsSummaryGetSummary",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+            "examples": {
+              "start_date-example-1": {
+                "value": "2024-01-01T00:00:00Z"
+              }
+            },
+            "in": "query",
+            "name": "start_date",
+            "required": true,
+            "schema": {
+              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+              "examples": [
+                "2024-01-01T00:00:00Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+            "examples": {
+              "end_date-example-1": {
+                "value": "2024-12-31T23:59:59Z"
+              }
+            },
+            "in": "query",
+            "name": "end_date",
+            "required": true,
+            "schema": {
+              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+              "examples": [
+                "2024-12-31T23:59:59Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Include comparison with previous period of same length",
+            "in": "query",
+            "name": "compare_previous",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Include comparison with previous period of same length",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SummaryResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetSummary",
+        "tags": [
+          "Analytics"
+        ]
+      }
+    },
+    "/api/v1/analytics/time-series": {
+      "get": {
+        "deprecated": false,
+        "description": "Per-bucket access-log metrics for charts.",
+        "operationId": "ApiV1AnalyticsTimeSeriesGetTimeSeries",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+            "examples": {
+              "start_date-example-1": {
+                "value": "2024-01-01T00:00:00Z"
+              }
+            },
+            "in": "query",
+            "name": "start_date",
+            "required": true,
+            "schema": {
+              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+              "examples": [
+                "2024-01-01T00:00:00Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+            "examples": {
+              "end_date-example-1": {
+                "value": "2024-12-31T23:59:59Z"
+              }
+            },
+            "in": "query",
+            "name": "end_date",
+            "required": true,
+            "schema": {
+              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+              "examples": [
+                "2024-12-31T23:59:59Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available.",
+            "in": "query",
+            "name": "granularity",
+            "required": false,
+            "schema": {
+              "description": "Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available.",
+              "enum": [
+                "hourly",
+                "daily",
+                null
+              ],
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these ISO country codes (repeatable)",
+            "in": "query",
+            "name": "country_code",
+            "required": false,
+            "schema": {
+              "description": "Filter to these ISO country codes (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these city names (repeatable)",
+            "in": "query",
+            "name": "city",
+            "required": false,
+            "schema": {
+              "description": "Filter to these city names (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these client IPs (repeatable)",
+            "in": "query",
+            "name": "ip_address",
+            "required": false,
+            "schema": {
+              "description": "Filter to these client IPs (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimeSeriesResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetTimeSeries",
+        "tags": [
+          "Analytics"
+        ]
+      }
+    },
+    "/api/v1/analytics/time-series/cumulative": {
+      "get": {
+        "deprecated": false,
+        "description": "Get cumulative time series data for area charts.",
+        "operationId": "ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeries",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+            "examples": {
+              "start_date-example-1": {
+                "value": "2024-01-01T00:00:00Z"
+              }
+            },
+            "in": "query",
+            "name": "start_date",
+            "required": true,
+            "schema": {
+              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+              "examples": [
+                "2024-01-01T00:00:00Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+            "examples": {
+              "end_date-example-1": {
+                "value": "2024-12-31T23:59:59Z"
+              }
+            },
+            "in": "query",
+            "name": "end_date",
+            "required": true,
+            "schema": {
+              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+              "examples": [
+                "2024-12-31T23:59:59Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CumulativeTimeSeriesResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetCumulativeTimeSeries",
+        "tags": [
+          "Analytics"
+        ]
+      }
+    },
+    "/api/v1/analytics/top-cities": {
+      "get": {
+        "deprecated": false,
+        "description": "Top cities by hits from raw access logs (time-bounded).",
+        "operationId": "ApiV1AnalyticsTopCitiesGetTopCities",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start date (ISO 8601)",
+            "in": "query",
+            "name": "start_date",
+            "required": true,
+            "schema": {
+              "description": "Start date (ISO 8601)",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End date (ISO 8601)",
+            "in": "query",
+            "name": "end_date",
+            "required": true,
+            "schema": {
+              "description": "End date (ISO 8601)",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Maximum number of cities",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "description": "Maximum number of cities",
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these ISO country codes (repeatable)",
+            "in": "query",
+            "name": "country_code",
+            "required": false,
+            "schema": {
+              "description": "Filter to these ISO country codes (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these city names (repeatable)",
+            "in": "query",
+            "name": "city",
+            "required": false,
+            "schema": {
+              "description": "Filter to these city names (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these client IPs (repeatable)",
+            "in": "query",
+            "name": "ip_address",
+            "required": false,
+            "schema": {
+              "description": "Filter to these client IPs (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopCitiesResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetTopCities",
+        "tags": [
+          "Analytics"
+        ]
+      }
+    },
+    "/api/v1/analytics/top-countries": {
+      "get": {
+        "deprecated": false,
+        "description": "Top countries by hits from raw access logs (time-bounded).",
+        "operationId": "ApiV1AnalyticsTopCountriesGetTopCountries",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start date (ISO 8601)",
+            "in": "query",
+            "name": "start_date",
+            "required": true,
+            "schema": {
+              "description": "Start date (ISO 8601)",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End date (ISO 8601)",
+            "in": "query",
+            "name": "end_date",
+            "required": true,
+            "schema": {
+              "description": "End date (ISO 8601)",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Maximum number of countries",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "description": "Maximum number of countries",
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these ISO country codes (repeatable)",
+            "in": "query",
+            "name": "country_code",
+            "required": false,
+            "schema": {
+              "description": "Filter to these ISO country codes (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these city names (repeatable)",
+            "in": "query",
+            "name": "city",
+            "required": false,
+            "schema": {
+              "description": "Filter to these city names (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these client IPs (repeatable)",
+            "in": "query",
+            "name": "ip_address",
+            "required": false,
+            "schema": {
+              "description": "Filter to these client IPs (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopCountriesStatsResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetTopCountries",
+        "tags": [
+          "Analytics"
+        ]
+      }
+    },
+    "/api/v1/analytics/top-ips": {
+      "get": {
+        "deprecated": false,
+        "description": "Top client IPs by hits from raw access logs (time-bounded).",
+        "operationId": "ApiV1AnalyticsTopIpsGetTopIps",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start date (ISO 8601)",
+            "in": "query",
+            "name": "start_date",
+            "required": true,
+            "schema": {
+              "description": "Start date (ISO 8601)",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End date (ISO 8601)",
+            "in": "query",
+            "name": "end_date",
+            "required": true,
+            "schema": {
+              "description": "End date (ISO 8601)",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Maximum number of IPs",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "description": "Maximum number of IPs",
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these ISO country codes (repeatable)",
+            "in": "query",
+            "name": "country_code",
+            "required": false,
+            "schema": {
+              "description": "Filter to these ISO country codes (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these city names (repeatable)",
+            "in": "query",
+            "name": "city",
+            "required": false,
+            "schema": {
+              "description": "Filter to these city names (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these client IPs (repeatable)",
+            "in": "query",
+            "name": "ip_address",
+            "required": false,
+            "schema": {
+              "description": "Filter to these client IPs (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopIpsResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetTopIps",
+        "tags": [
+          "Analytics"
+        ]
+      }
+    },
+    "/api/v1/analytics/top-urls": {
+      "get": {
+        "deprecated": false,
+        "description": "Top URLs by hits from raw access logs (time-bounded).",
+        "operationId": "ApiV1AnalyticsTopUrlsGetTopUrls",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+            "examples": {
+              "start_date-example-1": {
+                "value": "2024-01-01T00:00:00Z"
+              }
+            },
+            "in": "query",
+            "name": "start_date",
+            "required": true,
+            "schema": {
+              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+              "examples": [
+                "2024-01-01T00:00:00Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+            "examples": {
+              "end_date-example-1": {
+                "value": "2024-12-31T23:59:59Z"
+              }
+            },
+            "in": "query",
+            "name": "end_date",
+            "required": true,
+            "schema": {
+              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+              "examples": [
+                "2024-12-31T23:59:59Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Maximum number of URLs to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "description": "Maximum number of URLs to return",
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these ISO country codes (repeatable)",
+            "in": "query",
+            "name": "country_code",
+            "required": false,
+            "schema": {
+              "description": "Filter to these ISO country codes (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these city names (repeatable)",
+            "in": "query",
+            "name": "city",
+            "required": false,
+            "schema": {
+              "description": "Filter to these city names (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these client IPs (repeatable)",
+            "in": "query",
+            "name": "ip_address",
+            "required": false,
+            "schema": {
+              "description": "Filter to these client IPs (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopUrlsResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetTopUrls",
+        "tags": [
+          "Analytics"
+        ]
+      }
+    },
+    "/api/v1/analytics/top-user-agents": {
+      "get": {
+        "deprecated": false,
+        "description": "Top user agents by hits from raw access logs.",
+        "operationId": "ApiV1AnalyticsTopUserAgentsGetTopUserAgents",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+            "examples": {
+              "start_date-example-1": {
+                "value": "2024-01-01T00:00:00Z"
+              }
+            },
+            "in": "query",
+            "name": "start_date",
+            "required": true,
+            "schema": {
+              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+              "examples": [
+                "2024-01-01T00:00:00Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+            "examples": {
+              "end_date-example-1": {
+                "value": "2024-12-31T23:59:59Z"
+              }
+            },
+            "in": "query",
+            "name": "end_date",
+            "required": true,
+            "schema": {
+              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+              "examples": [
+                "2024-12-31T23:59:59Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Maximum number of user agents to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "description": "Maximum number of user agents to return",
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these ISO country codes (repeatable)",
+            "in": "query",
+            "name": "country_code",
+            "required": false,
+            "schema": {
+              "description": "Filter to these ISO country codes (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these city names (repeatable)",
+            "in": "query",
+            "name": "city",
+            "required": false,
+            "schema": {
+              "description": "Filter to these city names (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these client IPs (repeatable)",
+            "in": "query",
+            "name": "ip_address",
+            "required": false,
+            "schema": {
+              "description": "Filter to these client IPs (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopUserAgentsResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetTopUserAgents",
+        "tags": [
+          "Analytics"
+        ]
+      }
+    },
+    "/api/v1/auth/login": {
+      "post": {
+        "deprecated": false,
+        "operationId": "ApiV1AuthLoginLogin",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "Login",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/api/v1/auth/logout": {
+      "post": {
+        "deprecated": false,
+        "operationId": "ApiV1AuthLogoutLogout",
+        "responses": {
+          "204": {
+            "description": "Request fulfilled, nothing follows",
+            "headers": {}
+          }
+        },
+        "summary": "Logout",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/api/v1/auth/me": {
+      "get": {
+        "deprecated": false,
+        "operationId": "ApiV1AuthMeMe",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          }
+        },
+        "summary": "Me",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/api/v1/geo-events": {
+      "get": {
+        "deprecated": false,
+        "operationId": "ApiV1GeoEventsListGeoEvents",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "currentPage",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1.0,
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "minimum": 1.0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "$ref": "#/components/schemas/ListGeoEventsGeoEventResponseBody"
+                      },
+                      "type": "array"
+                    },
+                    "limit": {
+                      "description": "Maximal number of items to send.",
+                      "type": "integer"
+                    },
+                    "offset": {
+                      "description": "Offset from the beginning of the query.",
+                      "type": "integer"
+                    },
+                    "total": {
+                      "description": "Total number of items.",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "ListGeoEvents",
+        "tags": [
+          "Geo Events"
+        ]
+      }
+    },
+    "/api/v1/geo-locations": {
+      "get": {
+        "deprecated": false,
+        "operationId": "ApiV1GeoLocationsListGeoLocations",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "currentPage",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1.0,
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "minimum": 1.0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "items": {
+                      "items": {
+                        "$ref": "#/components/schemas/ListGeoLocationsGeoLocationResponseBody"
+                      },
+                      "type": "array"
+                    },
+                    "limit": {
+                      "description": "Maximal number of items to send.",
+                      "type": "integer"
+                    },
+                    "offset": {
+                      "description": "Offset from the beginning of the query.",
+                      "type": "integer"
+                    },
+                    "total": {
+                      "description": "Total number of items.",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "ListGeoLocations",
+        "tags": [
+          "Geo Locations"
+        ]
+      }
+    },
+    "/api/v1/geo-locations/geojson": {
+      "get": {
+        "deprecated": false,
+        "description": "Get all locations with event counts as GeoJSON FeatureCollection.",
+        "operationId": "ApiV1GeoLocationsGeojsonGetGeojson",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
+            "examples": {
+              "from_timestamp-example-1": {
+                "value": "2024-01-01T00:00:00Z"
+              }
+            },
+            "in": "query",
+            "name": "from_timestamp",
+            "required": true,
+            "schema": {
+              "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
+              "examples": [
+                "2024-01-01T00:00:00Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
+            "examples": {
+              "to_timestamp-example-1": {
+                "value": "2024-12-31T23:59:59Z"
+              }
+            },
+            "in": "query",
+            "name": "to_timestamp",
+            "required": true,
+            "schema": {
+              "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
+              "examples": [
+                "2024-12-31T23:59:59Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these ISO country codes (repeatable)",
+            "in": "query",
+            "name": "country_code",
+            "required": false,
+            "schema": {
+              "description": "Filter to these ISO country codes (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Filter to these city names (repeatable)",
+            "in": "query",
+            "name": "city",
+            "required": false,
+            "schema": {
+              "description": "Filter to these city names (repeatable)",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeoJSONFeatureCollection"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetGeojson",
+        "tags": [
+          "Geo Locations"
+        ]
+      }
+    },
+    "/api/v1/geo-locations/top-countries": {
+      "get": {
+        "deprecated": false,
+        "description": "Get top countries by event count.",
+        "operationId": "ApiV1GeoLocationsTopCountriesGetTopCountries",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
+            "examples": {
+              "from_timestamp-example-1": {
+                "value": "2024-01-01T00:00:00Z"
+              }
+            },
+            "in": "query",
+            "name": "from_timestamp",
+            "required": true,
+            "schema": {
+              "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
+              "examples": [
+                "2024-01-01T00:00:00Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
+            "examples": {
+              "to_timestamp-example-1": {
+                "value": "2024-12-31T23:59:59Z"
+              }
+            },
+            "in": "query",
+            "name": "to_timestamp",
+            "required": true,
+            "schema": {
+              "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
+              "examples": [
+                "2024-12-31T23:59:59Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Maximum number of countries to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Maximum number of countries to return",
+              "maximum": 50.0,
+              "minimum": 1.0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopCountriesResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetTopCountries",
+        "tags": [
+          "Geo Locations"
+        ]
+      }
+    },
+    "/api/v1/geo-locations/top-ips": {
+      "get": {
+        "deprecated": false,
+        "description": "Get global top IPs by event count with their primary locations.",
+        "operationId": "ApiV1GeoLocationsTopIpsGetGlobalTopIps",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
+            "examples": {
+              "from_timestamp-example-1": {
+                "value": "2024-01-01T00:00:00Z"
+              }
+            },
+            "in": "query",
+            "name": "from_timestamp",
+            "required": true,
+            "schema": {
+              "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
+              "examples": [
+                "2024-01-01T00:00:00Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
+            "examples": {
+              "to_timestamp-example-1": {
+                "value": "2024-12-31T23:59:59Z"
+              }
+            },
+            "in": "query",
+            "name": "to_timestamp",
+            "required": true,
+            "schema": {
+              "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
+              "examples": [
+                "2024-12-31T23:59:59Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Maximum number of IPs to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 5,
+              "description": "Maximum number of IPs to return",
+              "maximum": 20.0,
+              "minimum": 1.0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GlobalTopIPsResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetGlobalTopIps",
+        "tags": [
+          "Geo Locations"
+        ]
+      }
+    },
+    "/api/v1/geo-locations/{location_id}/top-ips": {
+      "get": {
+        "deprecated": false,
+        "description": "Get top IPs for a specific location.",
+        "operationId": "ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIps",
+        "parameters": [
+          {
+            "deprecated": false,
+            "in": "path",
+            "name": "location_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
+            "examples": {
+              "from_timestamp-example-1": {
+                "value": "2024-01-01T00:00:00Z"
+              }
+            },
+            "in": "query",
+            "name": "from_timestamp",
+            "required": true,
+            "schema": {
+              "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
+              "examples": [
+                "2024-01-01T00:00:00Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
+            "examples": {
+              "to_timestamp-example-1": {
+                "value": "2024-12-31T23:59:59Z"
+              }
+            },
+            "in": "query",
+            "name": "to_timestamp",
+            "required": true,
+            "schema": {
+              "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
+              "examples": [
+                "2024-12-31T23:59:59Z"
+              ],
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "Maximum number of IPs to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 5,
+              "description": "Maximum number of IPs to return",
+              "maximum": 20.0,
+              "minimum": 1.0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocationTopIPsResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "GetLocationTopIps",
+        "tags": [
+          "Geo Locations"
+        ]
+      }
+    },
+    "/api/v1/settings": {
+      "get": {
+        "deprecated": false,
+        "operationId": "ApiV1SettingsReadSettings",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SafeSettingsResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          }
+        },
+        "summary": "ReadSettings",
+        "tags": [
+          "Settings"
+        ]
+      }
+    },
+    "/api/v1/stats": {
+      "get": {
+        "deprecated": false,
+        "operationId": "ApiV1StatsStats",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          }
+        },
+        "summary": "Stats",
+        "tags": [
+          "Analytics"
+        ]
+      }
+    },
+    "/health": {
+      "get": {
+        "deprecated": false,
+        "operationId": "HealthHealth",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          }
+        },
+        "summary": "Health",
+        "tags": [
+          "Health"
+        ]
+      }
+    },
+    "/health/ready": {
+      "get": {
+        "deprecated": false,
+        "operationId": "HealthReadyHealthReady",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          }
+        },
+        "summary": "HealthReady",
+        "tags": [
+          "Health"
+        ]
+      }
+    }
+  },
+  "security": [
+    {
+      "sessionCookie": []
+    }
+  ],
+  "servers": [
+    {
+      "url": "/"
+    }
+  ]
 }

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -1,3701 +1,3743 @@
 {
-  "components": {
-    "schemas": {
-      "AccessLogFacets": {
-        "properties": {
-          "cities": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "countries": {
-            "items": {
-              "$ref": "#/components/schemas/CountryFacet"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "cities",
-          "countries"
-        ],
-        "title": "AccessLogFacets",
-        "type": "object"
-      },
-      "AnalyticsSettingsView": {
-        "properties": {
-          "compression_after_days": {
-            "type": "integer"
-          },
-          "debug_retention_days": {
-            "type": "integer"
-          },
-          "hourly_retention_days": {
-            "type": "integer"
-          },
-          "raw_retention_days": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "compression_after_days",
-          "debug_retention_days",
-          "hourly_retention_days",
-          "raw_retention_days"
-        ],
-        "title": "AnalyticsSettingsView",
-        "type": "object"
-      },
-      "CountryFacet": {
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "code",
-          "name"
-        ],
-        "title": "CountryFacet",
-        "type": "object"
-      },
-      "CumulativeDataPoint": {
-        "properties": {
-          "cumulative_access_logs": {
-            "type": "integer"
-          },
-          "cumulative_bytes": {
-            "type": "integer"
-          },
-          "cumulative_geo_events": {
-            "type": "integer"
-          },
-          "timestamp": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "cumulative_access_logs",
-          "cumulative_bytes",
-          "cumulative_geo_events",
-          "timestamp"
-        ],
-        "title": "CumulativeDataPoint",
-        "type": "object"
-      },
-      "CumulativeTimeSeriesResponse": {
-        "properties": {
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/CumulativeDataPoint"
-            },
-            "type": "array"
-          },
-          "end_date": {
-            "type": "string"
-          },
-          "granularity": {
-            "type": "string"
-          },
-          "start_date": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "end_date",
-          "granularity",
-          "start_date"
-        ],
-        "title": "CumulativeTimeSeriesResponse",
-        "type": "object"
-      },
-      "EmbeddedLocationDTO": {
-        "properties": {
-          "city": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "country_code": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "country_name": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "id": {
-            "type": "integer"
-          },
-          "latitude": {
-            "type": "number"
-          },
-          "longitude": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "id",
-          "latitude",
-          "longitude"
-        ],
-        "title": "EmbeddedLocationDTO",
-        "type": "object"
-      },
-      "GeoEventsDataPoint": {
-        "properties": {
-          "timestamp": {
-            "type": "string"
-          },
-          "total_geo_events": {
-            "type": "integer"
-          },
-          "unique_cities": {
-            "type": "integer"
-          },
-          "unique_countries": {
-            "type": "integer"
-          },
-          "unique_ips": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "timestamp",
-          "total_geo_events",
-          "unique_cities",
-          "unique_countries",
-          "unique_ips"
-        ],
-        "title": "GeoEventsDataPoint",
-        "type": "object"
-      },
-      "GeoEventsTimeSeriesResponse": {
-        "properties": {
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/GeoEventsDataPoint"
-            },
-            "type": "array"
-          },
-          "end_date": {
-            "type": "string"
-          },
-          "granularity": {
-            "type": "string"
-          },
-          "start_date": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "data",
-          "end_date",
-          "granularity",
-          "start_date"
-        ],
-        "title": "GeoEventsTimeSeriesResponse",
-        "type": "object"
-      },
-      "GeoJSONFeature": {
-        "properties": {
-          "geometry": {
-            "$ref": "#/components/schemas/GeoJSONPointGeometry"
-          },
-          "properties": {
-            "$ref": "#/components/schemas/GeoJSONFeatureProperties"
-          },
-          "type": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "geometry",
-          "properties",
-          "type"
-        ],
-        "title": "GeoJSONFeature",
-        "type": "object"
-      },
-      "GeoJSONFeatureCollection": {
-        "properties": {
-          "features": {
-            "items": {
-              "$ref": "#/components/schemas/GeoJSONFeature"
-            },
-            "type": "array"
-          },
-          "stats": {
-            "$ref": "#/components/schemas/GeoJSONFeatureStats"
-          },
-          "type": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "features",
-          "stats",
-          "type"
-        ],
-        "title": "GeoJSONFeatureCollection",
-        "type": "object"
-      },
-      "GeoJSONFeatureProperties": {
-        "properties": {
-          "city": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "country_code": {
-            "type": "string"
-          },
-          "country_name": {
-            "type": "string"
-          },
-          "event_count": {
-            "type": "integer"
-          },
-          "geohash": {
-            "type": "string"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "last_hit": {
-            "oneOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "postal_code": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "state": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "state_code": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "timezone": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "top_ips": {
-            "items": {
-              "$ref": "#/components/schemas/TopIPDTO"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "city",
-          "country_code",
-          "country_name",
-          "event_count",
-          "geohash",
-          "id",
-          "last_hit",
-          "postal_code",
-          "state",
-          "state_code",
-          "timezone"
-        ],
-        "title": "GeoJSONFeatureProperties",
-        "type": "object"
-      },
-      "GeoJSONFeatureStats": {
-        "properties": {
-          "cities": {
-            "type": "integer"
-          },
-          "countries": {
-            "type": "integer"
-          },
-          "events": {
-            "type": "integer"
-          },
-          "locations": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "cities",
-          "countries",
-          "events",
-          "locations"
-        ],
-        "title": "GeoJSONFeatureStats",
-        "type": "object"
-      },
-      "GeoJSONPointGeometry": {
-        "properties": {
-          "coordinates": {
-            "prefixItems": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "number"
-              }
-            ],
-            "type": "array"
-          },
-          "type": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "coordinates",
-          "type"
-        ],
-        "title": "GeoJSONPointGeometry",
-        "type": "object"
-      },
-      "GlobalTopIPsResponse": {
-        "properties": {
-          "top_ips": {
-            "items": {
-              "$ref": "#/components/schemas/TopIPDTO"
-            },
-            "type": "array"
-          }
-        },
-        "required": [],
-        "title": "GlobalTopIPsResponse",
-        "type": "object"
-      },
-      "ListAccessLogDebugsAccessLogDebugResponseBody": {
-        "properties": {
-          "accessLogId": {
-            "oneOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "createdAt": {
-            "format": "date-time",
-            "type": "string"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "isMalformed": {
-            "default": false,
-            "type": "boolean"
-          },
-          "parseError": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "rawLine": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "rawLine"
-        ],
-        "title": "ListAccessLogDebugsAccessLogDebugResponseBody",
-        "type": "object"
-      },
-      "ListAccessLogsAccessLogResponseBody": {
-        "properties": {
-          "bytesSent": {
-            "default": 0,
-            "type": "integer"
-          },
-          "city": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "countryCode": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "countryName": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "host": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "httpVersion": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "id": {
-            "type": "integer"
-          },
-          "ipAddress": {
-            "type": "string"
-          },
-          "method": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "referrer": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "remoteUser": {
-            "type": "string"
-          },
-          "requestTime": {
-            "default": 0.0,
-            "type": "number"
-          },
-          "statusCode": {
-            "type": "integer"
-          },
-          "timestamp": {
-            "format": "date-time",
-            "type": "string"
-          },
-          "upstreamResponseTime": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "url": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "userAgent": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "required": [
-          "id",
-          "ipAddress",
-          "statusCode",
-          "timestamp"
-        ],
-        "title": "ListAccessLogsAccessLogResponseBody",
-        "type": "object"
-      },
-      "ListGeoEventsGeoEventGeoLocationResponseBody": {
-        "properties": {
-          "city": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "countryCode": {
-            "type": "string"
-          },
-          "countryName": {
-            "type": "string"
-          },
-          "createdAt": {
-            "format": "date-time",
-            "type": "string"
-          },
-          "geographicPoint": {
-            "type": "string"
-          },
-          "geohash": {
-            "type": "string"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "lastHit": {
-            "oneOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "latitude": {
-            "type": "number"
-          },
-          "longitude": {
-            "type": "number"
-          },
-          "postalCode": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "state": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "stateCode": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "timezone": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "updatedAt": {
-            "format": "date-time",
-            "type": "string"
-          }
-        },
-        "required": [
-          "countryCode",
-          "countryName",
-          "geographicPoint",
-          "geohash",
-          "id",
-          "latitude",
-          "longitude"
-        ],
-        "title": "ListGeoEventsGeoEventGeoLocationResponseBody",
-        "type": "object"
-      },
-      "ListGeoEventsGeoEventResponseBody": {
-        "properties": {
-          "hostname": {
-            "type": "string"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "ipAddress": {
-            "type": "string"
-          },
-          "location": {
-            "$ref": "#/components/schemas/ListGeoEventsGeoEventGeoLocationResponseBody"
-          },
-          "locationId": {
-            "type": "integer"
-          },
-          "timestamp": {
-            "format": "date-time",
-            "type": "string"
-          }
-        },
-        "required": [
-          "hostname",
-          "id",
-          "ipAddress",
-          "location",
-          "locationId"
-        ],
-        "title": "ListGeoEventsGeoEventResponseBody",
-        "type": "object"
-      },
-      "ListGeoLocationsGeoLocationResponseBody": {
-        "properties": {
-          "city": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "countryCode": {
-            "type": "string"
-          },
-          "countryName": {
-            "type": "string"
-          },
-          "createdAt": {
-            "format": "date-time",
-            "type": "string"
-          },
-          "geographicPoint": {
-            "type": "string"
-          },
-          "geohash": {
-            "type": "string"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "lastHit": {
-            "oneOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "latitude": {
-            "type": "number"
-          },
-          "longitude": {
-            "type": "number"
-          },
-          "postalCode": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "state": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "stateCode": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "timezone": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "updatedAt": {
-            "format": "date-time",
-            "type": "string"
-          }
-        },
-        "required": [
-          "countryCode",
-          "countryName",
-          "geographicPoint",
-          "geohash",
-          "id",
-          "latitude",
-          "longitude"
-        ],
-        "title": "ListGeoLocationsGeoLocationResponseBody",
-        "type": "object"
-      },
-      "LocationTopIPsResponse": {
-        "properties": {
-          "location_id": {
-            "type": "integer"
-          },
-          "top_ips": {
-            "items": {
-              "$ref": "#/components/schemas/TopIPDTO"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "location_id"
-        ],
-        "title": "LocationTopIPsResponse",
-        "type": "object"
-      },
-      "LoginPayload": {
-        "properties": {
-          "password": {
-            "type": "string"
-          },
-          "username": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "password",
-          "username"
-        ],
-        "title": "LoginPayload",
-        "type": "object"
-      },
-      "LogparserSettingsView": {
-        "properties": {
-          "log_paths": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "send_logs": {
-            "type": "boolean"
-          },
-          "store_debug_lines": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "log_paths",
-          "send_logs",
-          "store_debug_lines"
-        ],
-        "title": "LogparserSettingsView",
-        "type": "object"
-      },
-      "MapSettingsView": {
-        "properties": {
-          "home_latitude": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "home_longitude": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "home_source": {
-            "enum": [
-              "configured",
-              "external_ip",
-              null
-            ],
-            "type": [
-              "null",
-              "string"
-            ]
-          }
-        },
-        "required": [
-          "home_latitude",
-          "home_longitude",
-          "home_source"
-        ],
-        "title": "MapSettingsView",
-        "type": "object"
-      },
-      "MeResponse": {
-        "properties": {
-          "username": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "username"
-        ],
-        "title": "MeResponse",
-        "type": "object"
-      },
-      "PercentChange": {
-        "properties": {
-          "avg_request_time": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "bytes_sent": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "error_rate": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "geo_records": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "log_records": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "malformed_rate": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "unique_ips": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "required": [],
-        "title": "PercentChange",
-        "type": "object"
-      },
-      "PeriodSummary": {
-        "properties": {
-          "avg_bytes_per_request": {
-            "type": "number"
-          },
-          "avg_request_time": {
-            "type": "number"
-          },
-          "error_rate": {
-            "type": "number"
-          },
-          "malformed_requests": {
-            "type": "integer"
-          },
-          "max_request_time": {
-            "type": "number"
-          },
-          "status_2xx": {
-            "type": "integer"
-          },
-          "status_3xx": {
-            "type": "integer"
-          },
-          "status_4xx": {
-            "type": "integer"
-          },
-          "status_5xx": {
-            "type": "integer"
-          },
-          "total_bytes_sent": {
-            "type": "integer"
-          },
-          "total_geo_events": {
-            "type": "integer"
-          },
-          "total_requests": {
-            "type": "integer"
-          },
-          "unique_countries": {
-            "type": "integer"
-          },
-          "unique_ips": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "avg_bytes_per_request",
-          "avg_request_time",
-          "error_rate",
-          "malformed_requests",
-          "max_request_time",
-          "status_2xx",
-          "status_3xx",
-          "status_4xx",
-          "status_5xx",
-          "total_bytes_sent",
-          "total_geo_events",
-          "total_requests",
-          "unique_countries",
-          "unique_ips"
-        ],
-        "title": "PeriodSummary",
-        "type": "object"
-      },
-      "SafeSettingsResponse": {
-        "properties": {
-          "analytics": {
-            "$ref": "#/components/schemas/AnalyticsSettingsView"
-          },
-          "environment": {
-            "type": "string"
-          },
-          "logparser": {
-            "$ref": "#/components/schemas/LogparserSettingsView"
-          },
-          "map": {
-            "$ref": "#/components/schemas/MapSettingsView"
-          },
-          "name": {
-            "type": "string"
-          },
-          "version": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "analytics",
-          "environment",
-          "logparser",
-          "map",
-          "name",
-          "version"
-        ],
-        "title": "SafeSettingsResponse",
-        "type": "object"
-      },
-      "SummaryResponse": {
-        "properties": {
-          "current_period": {
-            "$ref": "#/components/schemas/PeriodSummary"
-          },
-          "end_date": {
-            "type": "string"
-          },
-          "percent_changes": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/PercentChange"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "previous_period": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/PeriodSummary"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "start_date": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "current_period",
-          "end_date",
-          "start_date"
-        ],
-        "title": "SummaryResponse",
-        "type": "object"
-      },
-      "TimeSeriesDataPoint": {
-        "properties": {
-          "avg_request_time": {
-            "type": "number"
-          },
-          "error_rate": {
-            "type": "number"
-          },
-          "p50_request_time": {
-            "type": "number"
-          },
-          "p95_request_time": {
-            "type": "number"
-          },
-          "p99_request_time": {
-            "type": "number"
-          },
-          "status_2xx": {
-            "type": "integer"
-          },
-          "status_3xx": {
-            "type": "integer"
-          },
-          "status_4xx": {
-            "type": "integer"
-          },
-          "status_5xx": {
-            "type": "integer"
-          },
-          "timestamp": {
-            "type": "string"
-          },
-          "total_bytes_sent": {
-            "type": "integer"
-          },
-          "total_geo_events": {
-            "type": "integer"
-          },
-          "total_requests": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "avg_request_time",
-          "error_rate",
-          "p50_request_time",
-          "p95_request_time",
-          "p99_request_time",
-          "status_2xx",
-          "status_3xx",
-          "status_4xx",
-          "status_5xx",
-          "timestamp",
-          "total_bytes_sent",
-          "total_geo_events",
-          "total_requests"
-        ],
-        "title": "TimeSeriesDataPoint",
-        "type": "object"
-      },
-      "TimeSeriesResponse": {
-        "properties": {
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/TimeSeriesDataPoint"
-            },
-            "type": "array"
-          },
-          "end_date": {
-            "type": "string"
-          },
-          "granularity": {
-            "type": "string"
-          },
-          "start_date": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "data",
-          "end_date",
-          "granularity",
-          "start_date"
-        ],
-        "title": "TimeSeriesResponse",
-        "type": "object"
-      },
-      "TopCountriesResponse": {
-        "properties": {
-          "top_countries": {
-            "items": {
-              "$ref": "#/components/schemas/TopCountryDTO"
-            },
-            "type": "array"
-          }
-        },
-        "required": [],
-        "title": "TopCountriesResponse",
-        "type": "object"
-      },
-      "TopCountryDTO": {
-        "properties": {
-          "country_code": {
-            "type": "string"
-          },
-          "country_name": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "event_count": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "country_code",
-          "country_name",
-          "event_count"
-        ],
-        "title": "TopCountryDTO",
-        "type": "object"
-      },
-      "TopIPDTO": {
-        "properties": {
-          "event_count": {
-            "type": "integer"
-          },
-          "ip_address": {
-            "type": "string"
-          },
-          "location": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/EmbeddedLocationDTO"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "required": [
-          "event_count",
-          "ip_address"
-        ],
-        "title": "TopIPDTO",
-        "type": "object"
-      },
-      "TopUrlDTO": {
-        "properties": {
-          "avg_request_time": {
-            "type": "number"
-          },
-          "error_hits": {
-            "type": "integer"
-          },
-          "hits": {
-            "type": "integer"
-          },
-          "total_bytes": {
-            "type": "integer"
-          },
-          "url": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "avg_request_time",
-          "error_hits",
-          "hits",
-          "total_bytes",
-          "url"
-        ],
-        "title": "TopUrlDTO",
-        "type": "object"
-      },
-      "TopUrlsResponse": {
-        "properties": {
-          "end_date": {
-            "type": "string"
-          },
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/TopUrlDTO"
-            },
-            "type": "array"
-          },
-          "start_date": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "end_date",
-          "items",
-          "start_date"
-        ],
-        "title": "TopUrlsResponse",
-        "type": "object"
-      },
-      "TopUserAgentDTO": {
-        "properties": {
-          "hits": {
-            "type": "integer"
-          },
-          "user_agent": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "hits",
-          "user_agent"
-        ],
-        "title": "TopUserAgentDTO",
-        "type": "object"
-      },
-      "TopUserAgentsResponse": {
-        "properties": {
-          "end_date": {
-            "type": "string"
-          },
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/TopUserAgentDTO"
-            },
-            "type": "array"
-          },
-          "start_date": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "end_date",
-          "items",
-          "start_date"
-        ],
-        "title": "TopUserAgentsResponse",
-        "type": "object"
-      }
+    "info": {
+        "title": "GeoMetrikks API",
+        "version": "0.1.0",
+        "description": "Real-time GeoIP lookups and traffic analytics API"
     },
-    "securitySchemes": {
-      "sessionCookie": {
-        "description": "Session cookie authentication.",
-        "in": "cookie",
-        "name": "session",
-        "type": "apiKey"
-      }
-    }
-  },
-  "info": {
-    "description": "Real-time GeoIP lookups and traffic analytics API",
-    "title": "GeoMetrikks API",
-    "version": "0.1.0"
-  },
-  "openapi": "3.1.0",
-  "paths": {
-    "/api/v1/access-log-debug": {
-      "get": {
-        "deprecated": false,
-        "operationId": "ApiV1AccessLogDebugListAccessLogDebugs",
-        "parameters": [
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "currentPage",
-            "required": false,
-            "schema": {
-              "default": 1,
-              "minimum": 1.0,
-              "type": "integer"
+    "openapi": "3.1.0",
+    "servers": [
+        {
+            "url": "/"
+        }
+    ],
+    "paths": {
+        "/api/v1/geo-events": {
+            "get": {
+                "tags": [
+                    "Geo Events"
+                ],
+                "summary": "ListGeoEvents",
+                "operationId": "ApiV1GeoEventsListGeoEvents",
+                "parameters": [
+                    {
+                        "name": "currentPage",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1.0,
+                            "default": 1
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1.0,
+                            "default": 10
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "items": {
+                                            "items": {
+                                                "$ref": "#/components/schemas/ListGeoEventsGeoEventResponseBody"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "limit": {
+                                            "type": "integer",
+                                            "description": "Maximal number of items to send."
+                                        },
+                                        "offset": {
+                                            "type": "integer",
+                                            "description": "Offset from the beginning of the query."
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "description": "Total number of items."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
             }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "pageSize",
-            "required": false,
-            "schema": {
-              "default": 10,
-              "minimum": 1.0,
-              "type": "integer"
+        },
+        "/api/v1/geo-locations/geojson": {
+            "get": {
+                "tags": [
+                    "Geo Locations"
+                ],
+                "summary": "GetGeojson",
+                "description": "Get all locations with event counts as GeoJSON FeatureCollection.",
+                "operationId": "ApiV1GeoLocationsGeojsonGetGeojson",
+                "parameters": [
+                    {
+                        "name": "from_timestamp",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
+                            "examples": [
+                                "2024-01-01T00:00:00Z"
+                            ]
+                        },
+                        "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "from_timestamp-example-1": {
+                                "value": "2024-01-01T00:00:00Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "to_timestamp",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
+                            "examples": [
+                                "2024-12-31T23:59:59Z"
+                            ]
+                        },
+                        "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "to_timestamp-example-1": {
+                                "value": "2024-12-31T23:59:59Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "country_code",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these ISO country codes (repeatable)"
+                        },
+                        "description": "Filter to these ISO country codes (repeatable)",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "city",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these city names (repeatable)"
+                        },
+                        "description": "Filter to these city names (repeatable)",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GeoJSONFeatureCollection"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
+        },
+        "/api/v1/geo-locations/top-ips": {
+            "get": {
+                "tags": [
+                    "Geo Locations"
+                ],
+                "summary": "GetGlobalTopIps",
+                "description": "Get global top IPs by event count with their primary locations.",
+                "operationId": "ApiV1GeoLocationsTopIpsGetGlobalTopIps",
+                "parameters": [
+                    {
+                        "name": "from_timestamp",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
+                            "examples": [
+                                "2024-01-01T00:00:00Z"
+                            ]
+                        },
+                        "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "from_timestamp-example-1": {
+                                "value": "2024-01-01T00:00:00Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "to_timestamp",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
+                            "examples": [
+                                "2024-12-31T23:59:59Z"
+                            ]
+                        },
+                        "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "to_timestamp-example-1": {
+                                "value": "2024-12-31T23:59:59Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 20.0,
+                            "minimum": 1.0,
+                            "description": "Maximum number of IPs to return",
+                            "default": 5
+                        },
+                        "description": "Maximum number of IPs to return",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GlobalTopIPsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/geo-locations/{location_id}/top-ips": {
+            "get": {
+                "tags": [
+                    "Geo Locations"
+                ],
+                "summary": "GetLocationTopIps",
+                "description": "Get top IPs for a specific location.",
+                "operationId": "ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIps",
+                "parameters": [
+                    {
+                        "name": "location_id",
+                        "in": "path",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "required": true,
+                        "deprecated": false
+                    },
+                    {
+                        "name": "from_timestamp",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
+                            "examples": [
+                                "2024-01-01T00:00:00Z"
+                            ]
+                        },
+                        "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "from_timestamp-example-1": {
+                                "value": "2024-01-01T00:00:00Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "to_timestamp",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
+                            "examples": [
+                                "2024-12-31T23:59:59Z"
+                            ]
+                        },
+                        "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "to_timestamp-example-1": {
+                                "value": "2024-12-31T23:59:59Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 20.0,
+                            "minimum": 1.0,
+                            "description": "Maximum number of IPs to return",
+                            "default": 5
+                        },
+                        "description": "Maximum number of IPs to return",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/LocationTopIPsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/geo-locations/top-countries": {
+            "get": {
+                "tags": [
+                    "Geo Locations"
+                ],
+                "summary": "GetTopCountries",
+                "description": "Get top countries by event count.",
+                "operationId": "ApiV1GeoLocationsTopCountriesGetTopCountries",
+                "parameters": [
+                    {
+                        "name": "from_timestamp",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
+                            "examples": [
+                                "2024-01-01T00:00:00Z"
+                            ]
+                        },
+                        "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "from_timestamp-example-1": {
+                                "value": "2024-01-01T00:00:00Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "to_timestamp",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
+                            "examples": [
+                                "2024-12-31T23:59:59Z"
+                            ]
+                        },
+                        "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "to_timestamp-example-1": {
+                                "value": "2024-12-31T23:59:59Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 50.0,
+                            "minimum": 1.0,
+                            "description": "Maximum number of countries to return",
+                            "default": 10
+                        },
+                        "description": "Maximum number of countries to return",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TopCountriesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/geo-locations": {
+            "get": {
+                "tags": [
+                    "Geo Locations"
+                ],
+                "summary": "ListGeoLocations",
+                "operationId": "ApiV1GeoLocationsListGeoLocations",
+                "parameters": [
+                    {
+                        "name": "currentPage",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1.0,
+                            "default": 1
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1.0,
+                            "default": 10
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "items": {
+                                            "items": {
+                                                "$ref": "#/components/schemas/ListGeoLocationsGeoLocationResponseBody"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "limit": {
+                                            "type": "integer",
+                                            "description": "Maximal number of items to send."
+                                        },
+                                        "offset": {
+                                            "type": "integer",
+                                            "description": "Offset from the beginning of the query."
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "description": "Total number of items."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/access-logs/facets": {
+            "get": {
+                "tags": [
+                    "Access Logs"
+                ],
+                "summary": "GetAccessLogFacets",
+                "operationId": "ApiV1AccessLogsFacetsGetAccessLogFacets",
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AccessLogFacets"
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/access-logs": {
+            "get": {
+                "tags": [
+                    "Access Logs"
+                ],
+                "summary": "ListAccessLogs",
+                "operationId": "ApiV1AccessLogsListAccessLogs",
+                "parameters": [
+                    {
+                        "name": "searchString",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Field to search"
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "searchIgnoreCase",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "type": "boolean",
+                                    "default": true
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Search should be case sensitive",
+                            "default": true
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "currentPage",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1.0,
+                            "default": 1
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1.0,
+                            "default": 50
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "orderBy",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "type": "string",
+                                    "default": "timestamp"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Order by field",
+                            "default": "timestamp"
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "sortOrder",
+                        "in": "query",
+                        "schema": {
+                            "type": [
+                                "null",
+                                "string"
+                            ],
+                            "enum": [
+                                "asc",
+                                "desc",
+                                null
+                            ],
+                            "title": "Field to search",
+                            "default": "desc"
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "from_timestamp",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "type": "string",
+                                    "format": "date-time"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "to_timestamp",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "type": "string",
+                                    "format": "date-time"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "host",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "methodIn",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "ipAddressIn",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "cityIn",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "countryCodeIn",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "statusIn",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "integer"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "items": {
+                                            "items": {
+                                                "$ref": "#/components/schemas/ListAccessLogsAccessLogResponseBody"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "limit": {
+                                            "type": "integer",
+                                            "description": "Maximal number of items to send."
+                                        },
+                                        "offset": {
+                                            "type": "integer",
+                                            "description": "Offset from the beginning of the query."
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "description": "Total number of items."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/access-log-debug": {
+            "get": {
+                "tags": [
+                    "Access Log Debug"
+                ],
+                "summary": "ListAccessLogDebugs",
+                "operationId": "ApiV1AccessLogDebugListAccessLogDebugs",
+                "parameters": [
+                    {
+                        "name": "currentPage",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1.0,
+                            "default": 1
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1.0,
+                            "default": 10
+                        },
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "items": {
+                                            "items": {
+                                                "$ref": "#/components/schemas/ListAccessLogDebugsAccessLogDebugResponseBody"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "limit": {
+                                            "type": "integer",
+                                            "description": "Maximal number of items to send."
+                                        },
+                                        "offset": {
+                                            "type": "integer",
+                                            "description": "Offset from the beginning of the query."
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "description": "Total number of items."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/analytics/time-series/cumulative": {
+            "get": {
+                "tags": [
+                    "Analytics"
+                ],
+                "summary": "GetCumulativeTimeSeries",
+                "description": "Get cumulative time series data for area charts.",
+                "operationId": "ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeries",
+                "parameters": [
+                    {
+                        "name": "start_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                            "examples": [
+                                "2024-01-01T00:00:00Z"
+                            ]
+                        },
+                        "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "start_date-example-1": {
+                                "value": "2024-01-01T00:00:00Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "end_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                            "examples": [
+                                "2024-12-31T23:59:59Z"
+                            ]
+                        },
+                        "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "end_date-example-1": {
+                                "value": "2024-12-31T23:59:59Z"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CumulativeTimeSeriesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/analytics/geo-time-series": {
+            "get": {
+                "tags": [
+                    "Analytics"
+                ],
+                "summary": "GetGeoTimeSeries",
+                "description": "Per-bucket geo-event metrics for charts.",
+                "operationId": "ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeries",
+                "parameters": [
+                    {
+                        "name": "start_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                            "examples": [
+                                "2024-01-01T00:00:00Z"
+                            ]
+                        },
+                        "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "start_date-example-1": {
+                                "value": "2024-01-01T00:00:00Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "end_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                            "examples": [
+                                "2024-12-31T23:59:59Z"
+                            ]
+                        },
+                        "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "end_date-example-1": {
+                                "value": "2024-12-31T23:59:59Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "granularity",
+                        "in": "query",
+                        "schema": {
+                            "type": [
+                                "null",
+                                "string"
+                            ],
+                            "enum": [
+                                "hourly",
+                                "daily",
+                                null
+                            ],
+                            "description": "Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available."
+                        },
+                        "description": "Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available.",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GeoEventsTimeSeriesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/analytics/live-summary": {
+            "get": {
+                "tags": [
+                    "Analytics"
+                ],
+                "summary": "GetLiveSummary",
+                "description": "Get live summary statistics by querying raw data tables.",
+                "operationId": "ApiV1AnalyticsLiveSummaryGetLiveSummary",
+                "parameters": [
+                    {
+                        "name": "start_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                            "examples": [
+                                "2024-01-01T00:00:00Z"
+                            ]
+                        },
+                        "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "start_date-example-1": {
+                                "value": "2024-01-01T00:00:00Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "end_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                            "examples": [
+                                "2024-12-31T23:59:59Z"
+                            ]
+                        },
+                        "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "end_date-example-1": {
+                                "value": "2024-12-31T23:59:59Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "compare_previous",
+                        "in": "query",
+                        "schema": {
+                            "type": "boolean",
+                            "description": "Include comparison with previous period of same length",
+                            "default": false
+                        },
+                        "description": "Include comparison with previous period of same length",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SummaryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/analytics/summary": {
+            "get": {
+                "tags": [
+                    "Analytics"
+                ],
+                "summary": "GetSummary",
+                "description": "Get summary statistics for dashboard header cards.",
+                "operationId": "ApiV1AnalyticsSummaryGetSummary",
+                "parameters": [
+                    {
+                        "name": "start_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                            "examples": [
+                                "2024-01-01T00:00:00Z"
+                            ]
+                        },
+                        "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "start_date-example-1": {
+                                "value": "2024-01-01T00:00:00Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "end_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                            "examples": [
+                                "2024-12-31T23:59:59Z"
+                            ]
+                        },
+                        "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "end_date-example-1": {
+                                "value": "2024-12-31T23:59:59Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "compare_previous",
+                        "in": "query",
+                        "schema": {
+                            "type": "boolean",
+                            "description": "Include comparison with previous period of same length",
+                            "default": false
+                        },
+                        "description": "Include comparison with previous period of same length",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SummaryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/analytics/time-series": {
+            "get": {
+                "tags": [
+                    "Analytics"
+                ],
+                "summary": "GetTimeSeries",
+                "description": "Per-bucket access-log metrics for charts.",
+                "operationId": "ApiV1AnalyticsTimeSeriesGetTimeSeries",
+                "parameters": [
+                    {
+                        "name": "start_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                            "examples": [
+                                "2024-01-01T00:00:00Z"
+                            ]
+                        },
+                        "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "start_date-example-1": {
+                                "value": "2024-01-01T00:00:00Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "end_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                            "examples": [
+                                "2024-12-31T23:59:59Z"
+                            ]
+                        },
+                        "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "end_date-example-1": {
+                                "value": "2024-12-31T23:59:59Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "granularity",
+                        "in": "query",
+                        "schema": {
+                            "type": [
+                                "null",
+                                "string"
+                            ],
+                            "enum": [
+                                "hourly",
+                                "daily",
+                                null
+                            ],
+                            "description": "Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available."
+                        },
+                        "description": "Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available.",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TimeSeriesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/analytics/top-urls": {
+            "get": {
+                "tags": [
+                    "Analytics"
+                ],
+                "summary": "GetTopUrls",
+                "description": "Top URLs by hits from raw access logs (time-bounded).",
+                "operationId": "ApiV1AnalyticsTopUrlsGetTopUrls",
+                "parameters": [
+                    {
+                        "name": "start_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                            "examples": [
+                                "2024-01-01T00:00:00Z"
+                            ]
+                        },
+                        "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "start_date-example-1": {
+                                "value": "2024-01-01T00:00:00Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "end_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                            "examples": [
+                                "2024-12-31T23:59:59Z"
+                            ]
+                        },
+                        "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "end_date-example-1": {
+                                "value": "2024-12-31T23:59:59Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100.0,
+                            "minimum": 1.0,
+                            "description": "Maximum number of URLs to return",
+                            "default": 25
+                        },
+                        "description": "Maximum number of URLs to return",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TopUrlsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/analytics/top-user-agents": {
+            "get": {
+                "tags": [
+                    "Analytics"
+                ],
+                "summary": "GetTopUserAgents",
+                "description": "Top user agents by hits from raw access logs.",
+                "operationId": "ApiV1AnalyticsTopUserAgentsGetTopUserAgents",
+                "parameters": [
+                    {
+                        "name": "start_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                            "examples": [
+                                "2024-01-01T00:00:00Z"
+                            ]
+                        },
+                        "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "start_date-example-1": {
+                                "value": "2024-01-01T00:00:00Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "end_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                            "examples": [
+                                "2024-12-31T23:59:59Z"
+                            ]
+                        },
+                        "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false,
+                        "examples": {
+                            "end_date-example-1": {
+                                "value": "2024-12-31T23:59:59Z"
+                            }
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100.0,
+                            "minimum": 1.0,
+                            "description": "Maximum number of user agents to return",
+                            "default": 25
+                        },
+                        "description": "Maximum number of user agents to return",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TopUserAgentsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/settings": {
+            "get": {
+                "tags": [
+                    "Settings"
+                ],
+                "summary": "ReadSettings",
+                "operationId": "ApiV1SettingsReadSettings",
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SafeSettingsResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/stats": {
+            "get": {
+                "tags": [
+                    "Analytics"
+                ],
+                "summary": "Stats",
+                "operationId": "ApiV1StatsStats",
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {},
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/health": {
+            "get": {
+                "tags": [
+                    "Health"
+                ],
+                "summary": "Health",
+                "operationId": "HealthHealth",
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {},
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/health/ready": {
+            "get": {
+                "tags": [
+                    "Health"
+                ],
+                "summary": "HealthReady",
+                "operationId": "HealthReadyHealthReady",
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": {},
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/auth/login": {
+            "post": {
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Login",
+                "operationId": "ApiV1AuthLoginLogin",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/LoginPayload"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MeResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/auth/logout": {
+            "post": {
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Logout",
+                "operationId": "ApiV1AuthLogoutLogout",
+                "responses": {
+                    "204": {
+                        "description": "Request fulfilled, nothing follows",
+                        "headers": {}
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/auth/me": {
+            "get": {
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Me",
+                "operationId": "ApiV1AuthMeMe",
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MeResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "AccessLogFacets": {
+                "properties": {
+                    "countries": {
+                        "items": {
+                            "$ref": "#/components/schemas/CountryFacet"
+                        },
+                        "type": "array"
+                    },
+                    "cities": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "cities",
+                    "countries"
+                ],
+                "title": "AccessLogFacets"
+            },
+            "AnalyticsSettingsView": {
+                "properties": {
+                    "raw_retention_days": {
+                        "type": "integer"
+                    },
+                    "debug_retention_days": {
+                        "type": "integer"
+                    },
+                    "hourly_retention_days": {
+                        "type": "integer"
+                    },
+                    "compression_after_days": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "compression_after_days",
+                    "debug_retention_days",
+                    "hourly_retention_days",
+                    "raw_retention_days"
+                ],
+                "title": "AnalyticsSettingsView"
+            },
+            "CountryFacet": {
+                "properties": {
+                    "code": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "code",
+                    "name"
+                ],
+                "title": "CountryFacet"
+            },
+            "CumulativeDataPoint": {
+                "properties": {
+                    "timestamp": {
+                        "type": "string"
+                    },
+                    "cumulative_geo_events": {
+                        "type": "integer"
+                    },
+                    "cumulative_access_logs": {
+                        "type": "integer"
+                    },
+                    "cumulative_bytes": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "cumulative_access_logs",
+                    "cumulative_bytes",
+                    "cumulative_geo_events",
+                    "timestamp"
+                ],
+                "title": "CumulativeDataPoint"
+            },
+            "CumulativeTimeSeriesResponse": {
+                "properties": {
+                    "granularity": {
+                        "type": "string"
+                    },
+                    "start_date": {
+                        "type": "string"
+                    },
+                    "end_date": {
+                        "type": "string"
+                    },
+                    "data": {
+                        "items": {
+                            "$ref": "#/components/schemas/CumulativeDataPoint"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "end_date",
+                    "granularity",
+                    "start_date"
+                ],
+                "title": "CumulativeTimeSeriesResponse"
+            },
+            "EmbeddedLocationDTO": {
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "latitude": {
+                        "type": "number"
+                    },
+                    "longitude": {
+                        "type": "number"
+                    },
+                    "city": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "country_code": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "country_name": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "latitude",
+                    "longitude"
+                ],
+                "title": "EmbeddedLocationDTO"
+            },
+            "GeoEventsDataPoint": {
+                "properties": {
+                    "timestamp": {
+                        "type": "string"
+                    },
+                    "total_geo_events": {
+                        "type": "integer"
+                    },
+                    "unique_ips": {
+                        "type": "integer"
+                    },
+                    "unique_countries": {
+                        "type": "integer"
+                    },
+                    "unique_cities": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "timestamp",
+                    "total_geo_events",
+                    "unique_cities",
+                    "unique_countries",
+                    "unique_ips"
+                ],
+                "title": "GeoEventsDataPoint"
+            },
+            "GeoEventsTimeSeriesResponse": {
+                "properties": {
+                    "granularity": {
+                        "type": "string"
+                    },
+                    "start_date": {
+                        "type": "string"
+                    },
+                    "end_date": {
+                        "type": "string"
+                    },
+                    "data": {
+                        "items": {
+                            "$ref": "#/components/schemas/GeoEventsDataPoint"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "data",
+                    "end_date",
+                    "granularity",
+                    "start_date"
+                ],
+                "title": "GeoEventsTimeSeriesResponse"
+            },
+            "GeoJSONFeature": {
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "geometry": {
+                        "$ref": "#/components/schemas/GeoJSONPointGeometry"
+                    },
+                    "properties": {
+                        "$ref": "#/components/schemas/GeoJSONFeatureProperties"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "geometry",
+                    "properties",
+                    "type"
+                ],
+                "title": "GeoJSONFeature"
+            },
+            "GeoJSONFeatureCollection": {
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "features": {
+                        "items": {
+                            "$ref": "#/components/schemas/GeoJSONFeature"
+                        },
+                        "type": "array"
+                    },
+                    "stats": {
+                        "$ref": "#/components/schemas/GeoJSONFeatureStats"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "features",
+                    "stats",
+                    "type"
+                ],
+                "title": "GeoJSONFeatureCollection"
+            },
+            "GeoJSONFeatureProperties": {
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "geohash": {
+                        "type": "string"
+                    },
+                    "country_code": {
+                        "type": "string"
+                    },
+                    "country_name": {
+                        "type": "string"
+                    },
+                    "last_hit": {
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "state": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "state_code": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "city": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "postal_code": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "timezone": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "event_count": {
+                        "type": "integer"
+                    },
+                    "top_ips": {
+                        "items": {
+                            "$ref": "#/components/schemas/TopIPDTO"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "city",
+                    "country_code",
+                    "country_name",
+                    "event_count",
+                    "geohash",
+                    "id",
+                    "last_hit",
+                    "postal_code",
+                    "state",
+                    "state_code",
+                    "timezone"
+                ],
+                "title": "GeoJSONFeatureProperties"
+            },
+            "GeoJSONFeatureStats": {
+                "properties": {
+                    "events": {
+                        "type": "integer"
+                    },
+                    "countries": {
+                        "type": "integer"
+                    },
+                    "cities": {
+                        "type": "integer"
+                    },
+                    "locations": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "cities",
+                    "countries",
+                    "events",
+                    "locations"
+                ],
+                "title": "GeoJSONFeatureStats"
+            },
+            "GeoJSONPointGeometry": {
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "coordinates": {
+                        "prefixItems": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ],
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "coordinates",
+                    "type"
+                ],
+                "title": "GeoJSONPointGeometry"
+            },
+            "GlobalTopIPsResponse": {
+                "properties": {
+                    "top_ips": {
+                        "items": {
+                            "$ref": "#/components/schemas/TopIPDTO"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "required": [],
+                "title": "GlobalTopIPsResponse"
+            },
+            "ListAccessLogDebugsAccessLogDebugResponseBody": {
+                "properties": {
+                    "accessLogId": {
+                        "oneOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "rawLine": {
+                        "type": "string"
+                    },
+                    "isMalformed": {
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "parseError": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "id": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "rawLine"
+                ],
+                "title": "ListAccessLogDebugsAccessLogDebugResponseBody"
+            },
+            "ListAccessLogsAccessLogResponseBody": {
+                "properties": {
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "ipAddress": {
+                        "type": "string"
+                    },
+                    "remoteUser": {
+                        "type": "string"
+                    },
+                    "method": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "url": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "httpVersion": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "statusCode": {
+                        "type": "integer"
+                    },
+                    "bytesSent": {
+                        "type": "integer",
+                        "default": 0
+                    },
+                    "referrer": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "userAgent": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "requestTime": {
+                        "type": "number",
+                        "default": 0.0
+                    },
+                    "upstreamResponseTime": {
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "host": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "countryCode": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "countryName": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "city": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "id": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "ipAddress",
+                    "statusCode",
+                    "timestamp"
+                ],
+                "title": "ListAccessLogsAccessLogResponseBody"
+            },
+            "ListGeoEventsGeoEventGeoLocationResponseBody": {
+                "properties": {
+                    "latitude": {
+                        "type": "number"
+                    },
+                    "longitude": {
+                        "type": "number"
+                    },
+                    "geohash": {
+                        "type": "string"
+                    },
+                    "geographicPoint": {
+                        "type": "string"
+                    },
+                    "countryCode": {
+                        "type": "string"
+                    },
+                    "countryName": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "stateCode": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "city": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "postalCode": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "timezone": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "lastHit": {
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "id": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "countryCode",
+                    "countryName",
+                    "geographicPoint",
+                    "geohash",
+                    "id",
+                    "latitude",
+                    "longitude"
+                ],
+                "title": "ListGeoEventsGeoEventGeoLocationResponseBody"
+            },
+            "ListGeoEventsGeoEventResponseBody": {
+                "properties": {
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "ipAddress": {
+                        "type": "string"
+                    },
+                    "hostname": {
+                        "type": "string"
+                    },
+                    "locationId": {
+                        "type": "integer"
+                    },
+                    "location": {
+                        "$ref": "#/components/schemas/ListGeoEventsGeoEventGeoLocationResponseBody"
+                    },
+                    "id": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "hostname",
+                    "id",
+                    "ipAddress",
+                    "location",
+                    "locationId"
+                ],
+                "title": "ListGeoEventsGeoEventResponseBody"
+            },
+            "ListGeoLocationsGeoLocationResponseBody": {
+                "properties": {
+                    "latitude": {
+                        "type": "number"
+                    },
+                    "longitude": {
+                        "type": "number"
+                    },
+                    "geohash": {
+                        "type": "string"
+                    },
+                    "geographicPoint": {
+                        "type": "string"
+                    },
+                    "countryCode": {
+                        "type": "string"
+                    },
+                    "countryName": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "stateCode": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "city": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "postalCode": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "timezone": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "lastHit": {
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "id": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "countryCode",
+                    "countryName",
+                    "geographicPoint",
+                    "geohash",
+                    "id",
+                    "latitude",
+                    "longitude"
+                ],
+                "title": "ListGeoLocationsGeoLocationResponseBody"
+            },
+            "LocationTopIPsResponse": {
+                "properties": {
+                    "location_id": {
+                        "type": "integer"
+                    },
+                    "top_ips": {
+                        "items": {
+                            "$ref": "#/components/schemas/TopIPDTO"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "location_id"
+                ],
+                "title": "LocationTopIPsResponse"
+            },
+            "LoginPayload": {
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    },
+                    "password": {
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "password",
+                    "username"
+                ],
+                "title": "LoginPayload"
+            },
+            "LogparserSettingsView": {
+                "properties": {
+                    "log_paths": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "send_logs": {
+                        "type": "boolean"
+                    },
+                    "store_debug_lines": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "log_paths",
+                    "send_logs",
+                    "store_debug_lines"
+                ],
+                "title": "LogparserSettingsView"
+            },
+            "MapSettingsView": {
+                "properties": {
+                    "home_latitude": {
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "home_longitude": {
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "home_source": {
+                        "type": [
+                            "null",
+                            "string"
+                        ],
+                        "enum": [
+                            "configured",
+                            "external_ip",
+                            null
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "home_latitude",
+                    "home_longitude",
+                    "home_source"
+                ],
+                "title": "MapSettingsView"
+            },
+            "MeResponse": {
+                "properties": {
+                    "username": {
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "username"
+                ],
+                "title": "MeResponse"
+            },
+            "PercentChange": {
+                "properties": {
+                    "log_records": {
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "geo_records": {
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "unique_ips": {
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "bytes_sent": {
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "avg_request_time": {
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "error_rate": {
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "malformed_rate": {
+                        "oneOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [],
+                "title": "PercentChange"
+            },
+            "PeriodSummary": {
+                "properties": {
+                    "total_requests": {
+                        "type": "integer"
+                    },
+                    "total_geo_events": {
+                        "type": "integer"
+                    },
+                    "unique_ips": {
+                        "type": "integer"
+                    },
+                    "unique_countries": {
+                        "type": "integer"
+                    },
+                    "total_bytes_sent": {
+                        "type": "integer"
+                    },
+                    "avg_bytes_per_request": {
+                        "type": "number"
+                    },
+                    "status_2xx": {
+                        "type": "integer"
+                    },
+                    "status_3xx": {
+                        "type": "integer"
+                    },
+                    "status_4xx": {
+                        "type": "integer"
+                    },
+                    "status_5xx": {
+                        "type": "integer"
+                    },
+                    "avg_request_time": {
+                        "type": "number"
+                    },
+                    "max_request_time": {
+                        "type": "number"
+                    },
+                    "malformed_requests": {
+                        "type": "integer"
+                    },
+                    "error_rate": {
+                        "type": "number"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "avg_bytes_per_request",
+                    "avg_request_time",
+                    "error_rate",
+                    "malformed_requests",
+                    "max_request_time",
+                    "status_2xx",
+                    "status_3xx",
+                    "status_4xx",
+                    "status_5xx",
+                    "total_bytes_sent",
+                    "total_geo_events",
+                    "total_requests",
+                    "unique_countries",
+                    "unique_ips"
+                ],
+                "title": "PeriodSummary"
+            },
+            "SafeSettingsResponse": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "version": {
+                        "type": "string"
+                    },
+                    "environment": {
+                        "type": "string"
+                    },
+                    "logparser": {
+                        "$ref": "#/components/schemas/LogparserSettingsView"
+                    },
+                    "analytics": {
+                        "$ref": "#/components/schemas/AnalyticsSettingsView"
+                    },
+                    "map": {
+                        "$ref": "#/components/schemas/MapSettingsView"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "analytics",
+                    "environment",
+                    "logparser",
+                    "map",
+                    "name",
+                    "version"
+                ],
+                "title": "SafeSettingsResponse"
+            },
+            "SummaryResponse": {
+                "properties": {
+                    "start_date": {
+                        "type": "string"
+                    },
+                    "end_date": {
+                        "type": "string"
+                    },
+                    "current_period": {
+                        "$ref": "#/components/schemas/PeriodSummary"
+                    },
+                    "previous_period": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/PeriodSummary"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "percent_changes": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/PercentChange"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "current_period",
+                    "end_date",
+                    "start_date"
+                ],
+                "title": "SummaryResponse"
+            },
+            "TimeSeriesDataPoint": {
+                "properties": {
+                    "timestamp": {
+                        "type": "string"
+                    },
+                    "total_requests": {
+                        "type": "integer"
+                    },
+                    "total_geo_events": {
+                        "type": "integer"
+                    },
+                    "total_bytes_sent": {
+                        "type": "integer"
+                    },
+                    "status_2xx": {
+                        "type": "integer"
+                    },
+                    "status_3xx": {
+                        "type": "integer"
+                    },
+                    "status_4xx": {
+                        "type": "integer"
+                    },
+                    "status_5xx": {
+                        "type": "integer"
+                    },
+                    "error_rate": {
+                        "type": "number"
+                    },
+                    "avg_request_time": {
+                        "type": "number"
+                    },
+                    "p50_request_time": {
+                        "type": "number"
+                    },
+                    "p95_request_time": {
+                        "type": "number"
+                    },
+                    "p99_request_time": {
+                        "type": "number"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "avg_request_time",
+                    "error_rate",
+                    "p50_request_time",
+                    "p95_request_time",
+                    "p99_request_time",
+                    "status_2xx",
+                    "status_3xx",
+                    "status_4xx",
+                    "status_5xx",
+                    "timestamp",
+                    "total_bytes_sent",
+                    "total_geo_events",
+                    "total_requests"
+                ],
+                "title": "TimeSeriesDataPoint"
+            },
+            "TimeSeriesResponse": {
+                "properties": {
+                    "granularity": {
+                        "type": "string"
+                    },
+                    "start_date": {
+                        "type": "string"
+                    },
+                    "end_date": {
+                        "type": "string"
+                    },
+                    "data": {
+                        "items": {
+                            "$ref": "#/components/schemas/TimeSeriesDataPoint"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "data",
+                    "end_date",
+                    "granularity",
+                    "start_date"
+                ],
+                "title": "TimeSeriesResponse"
+            },
+            "TopCountriesResponse": {
+                "properties": {
+                    "top_countries": {
+                        "items": {
+                            "$ref": "#/components/schemas/TopCountryDTO"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "required": [],
+                "title": "TopCountriesResponse"
+            },
+            "TopCountryDTO": {
+                "properties": {
+                    "country_code": {
+                        "type": "string"
+                    },
+                    "country_name": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "event_count": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "country_code",
+                    "country_name",
+                    "event_count"
+                ],
+                "title": "TopCountryDTO"
+            },
+            "TopIPDTO": {
+                "properties": {
+                    "ip_address": {
+                        "type": "string"
+                    },
+                    "event_count": {
+                        "type": "integer"
+                    },
+                    "location": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/EmbeddedLocationDTO"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "event_count",
+                    "ip_address"
+                ],
+                "title": "TopIPDTO"
+            },
+            "TopUrlDTO": {
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "hits": {
+                        "type": "integer"
+                    },
+                    "error_hits": {
+                        "type": "integer"
+                    },
+                    "total_bytes": {
+                        "type": "integer"
+                    },
+                    "avg_request_time": {
+                        "type": "number"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "avg_request_time",
+                    "error_hits",
+                    "hits",
+                    "total_bytes",
+                    "url"
+                ],
+                "title": "TopUrlDTO"
+            },
+            "TopUrlsResponse": {
+                "properties": {
+                    "start_date": {
+                        "type": "string"
+                    },
+                    "end_date": {
+                        "type": "string"
+                    },
                     "items": {
-                      "items": {
-                        "$ref": "#/components/schemas/ListAccessLogDebugsAccessLogDebugResponseBody"
-                      },
-                      "type": "array"
-                    },
-                    "limit": {
-                      "description": "Maximal number of items to send.",
-                      "type": "integer"
-                    },
-                    "offset": {
-                      "description": "Offset from the beginning of the query.",
-                      "type": "integer"
-                    },
-                    "total": {
-                      "description": "Total number of items.",
-                      "type": "integer"
+                        "items": {
+                            "$ref": "#/components/schemas/TopUrlDTO"
+                        },
+                        "type": "array"
                     }
-                  },
-                  "type": "object"
-                }
-              }
+                },
+                "type": "object",
+                "required": [
+                    "end_date",
+                    "items",
+                    "start_date"
+                ],
+                "title": "TopUrlsResponse"
             },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Validation Exception",
-                  "examples": [
-                    {
-                      "detail": "Bad Request",
-                      "extra": {},
-                      "status_code": 400
-                    }
-                  ],
-                  "properties": {
-                    "detail": {
-                      "type": "string"
+            "TopUserAgentDTO": {
+                "properties": {
+                    "user_agent": {
+                        "type": "string"
                     },
-                    "extra": {
-                      "additionalProperties": {},
-                      "type": [
-                        "null",
-                        "object",
-                        "array"
-                      ]
-                    },
-                    "status_code": {
-                      "type": "integer"
+                    "hits": {
+                        "type": "integer"
                     }
-                  },
-                  "required": [
-                    "detail",
-                    "status_code"
-                  ],
-                  "type": "object"
-                }
-              }
+                },
+                "type": "object",
+                "required": [
+                    "hits",
+                    "user_agent"
+                ],
+                "title": "TopUserAgentDTO"
             },
-            "description": "Bad request syntax or unsupported method"
-          }
-        },
-        "summary": "ListAccessLogDebugs",
-        "tags": [
-          "Access Log Debug"
-        ]
-      }
-    },
-    "/api/v1/access-logs": {
-      "get": {
-        "deprecated": false,
-        "operationId": "ApiV1AccessLogsListAccessLogs",
-        "parameters": [
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "searchString",
-            "required": false,
-            "schema": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Field to search"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "searchIgnoreCase",
-            "required": false,
-            "schema": {
-              "default": true,
-              "oneOf": [
-                {
-                  "default": true,
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Search should be case sensitive"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "currentPage",
-            "required": false,
-            "schema": {
-              "default": 1,
-              "minimum": 1.0,
-              "type": "integer"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "pageSize",
-            "required": false,
-            "schema": {
-              "default": 50,
-              "minimum": 1.0,
-              "type": "integer"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "orderBy",
-            "required": false,
-            "schema": {
-              "default": "timestamp",
-              "oneOf": [
-                {
-                  "default": "timestamp",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Order by field"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "sortOrder",
-            "required": false,
-            "schema": {
-              "default": "desc",
-              "enum": [
-                "asc",
-                "desc",
-                null
-              ],
-              "title": "Field to search",
-              "type": [
-                "null",
-                "string"
-              ]
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "from_timestamp",
-            "required": false,
-            "schema": {
-              "oneOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "to_timestamp",
-            "required": false,
-            "schema": {
-              "oneOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "host",
-            "required": false,
-            "schema": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "methodIn",
-            "required": false,
-            "schema": {
-              "oneOf": [
-                {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "ipAddressIn",
-            "required": false,
-            "schema": {
-              "oneOf": [
-                {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "cityIn",
-            "required": false,
-            "schema": {
-              "oneOf": [
-                {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "countryCodeIn",
-            "required": false,
-            "schema": {
-              "oneOf": [
-                {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "statusIn",
-            "required": false,
-            "schema": {
-              "oneOf": [
-                {
-                  "items": {
-                    "type": "integer"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
+            "TopUserAgentsResponse": {
+                "properties": {
+                    "start_date": {
+                        "type": "string"
+                    },
+                    "end_date": {
+                        "type": "string"
+                    },
                     "items": {
-                      "items": {
-                        "$ref": "#/components/schemas/ListAccessLogsAccessLogResponseBody"
-                      },
-                      "type": "array"
-                    },
-                    "limit": {
-                      "description": "Maximal number of items to send.",
-                      "type": "integer"
-                    },
-                    "offset": {
-                      "description": "Offset from the beginning of the query.",
-                      "type": "integer"
-                    },
-                    "total": {
-                      "description": "Total number of items.",
-                      "type": "integer"
+                        "items": {
+                            "$ref": "#/components/schemas/TopUserAgentDTO"
+                        },
+                        "type": "array"
                     }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Validation Exception",
-                  "examples": [
-                    {
-                      "detail": "Bad Request",
-                      "extra": {},
-                      "status_code": 400
-                    }
-                  ],
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    },
-                    "extra": {
-                      "additionalProperties": {},
-                      "type": [
-                        "null",
-                        "object",
-                        "array"
-                      ]
-                    },
-                    "status_code": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "detail",
-                    "status_code"
-                  ],
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Bad request syntax or unsupported method"
-          }
-        },
-        "summary": "ListAccessLogs",
-        "tags": [
-          "Access Logs"
-        ]
-      }
-    },
-    "/api/v1/access-logs/facets": {
-      "get": {
-        "deprecated": false,
-        "operationId": "ApiV1AccessLogsFacetsGetAccessLogFacets",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AccessLogFacets"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          }
-        },
-        "summary": "GetAccessLogFacets",
-        "tags": [
-          "Access Logs"
-        ]
-      }
-    },
-    "/api/v1/analytics/geo-time-series": {
-      "get": {
-        "deprecated": false,
-        "description": "Per-bucket geo-event metrics for charts.",
-        "operationId": "ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeries",
-        "parameters": [
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-            "examples": {
-              "start_date-example-1": {
-                "value": "2024-01-01T00:00:00Z"
-              }
-            },
-            "in": "query",
-            "name": "start_date",
-            "required": true,
-            "schema": {
-              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-              "examples": [
-                "2024-01-01T00:00:00Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-            "examples": {
-              "end_date-example-1": {
-                "value": "2024-12-31T23:59:59Z"
-              }
-            },
-            "in": "query",
-            "name": "end_date",
-            "required": true,
-            "schema": {
-              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-              "examples": [
-                "2024-12-31T23:59:59Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GeoEventsTimeSeriesResponse"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Validation Exception",
-                  "examples": [
-                    {
-                      "detail": "Bad Request",
-                      "extra": {},
-                      "status_code": 400
-                    }
-                  ],
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    },
-                    "extra": {
-                      "additionalProperties": {},
-                      "type": [
-                        "null",
-                        "object",
-                        "array"
-                      ]
-                    },
-                    "status_code": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "detail",
-                    "status_code"
-                  ],
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Bad request syntax or unsupported method"
-          }
-        },
-        "summary": "GetGeoTimeSeries",
-        "tags": [
-          "Analytics"
-        ]
-      }
-    },
-    "/api/v1/analytics/live-summary": {
-      "get": {
-        "deprecated": false,
-        "description": "Get live summary statistics by querying raw data tables.",
-        "operationId": "ApiV1AnalyticsLiveSummaryGetLiveSummary",
-        "parameters": [
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-            "examples": {
-              "start_date-example-1": {
-                "value": "2024-01-01T00:00:00Z"
-              }
-            },
-            "in": "query",
-            "name": "start_date",
-            "required": true,
-            "schema": {
-              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-              "examples": [
-                "2024-01-01T00:00:00Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-            "examples": {
-              "end_date-example-1": {
-                "value": "2024-12-31T23:59:59Z"
-              }
-            },
-            "in": "query",
-            "name": "end_date",
-            "required": true,
-            "schema": {
-              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-              "examples": [
-                "2024-12-31T23:59:59Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Include comparison with previous period of same length",
-            "in": "query",
-            "name": "compare_previous",
-            "required": false,
-            "schema": {
-              "default": false,
-              "description": "Include comparison with previous period of same length",
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SummaryResponse"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Validation Exception",
-                  "examples": [
-                    {
-                      "detail": "Bad Request",
-                      "extra": {},
-                      "status_code": 400
-                    }
-                  ],
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    },
-                    "extra": {
-                      "additionalProperties": {},
-                      "type": [
-                        "null",
-                        "object",
-                        "array"
-                      ]
-                    },
-                    "status_code": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "detail",
-                    "status_code"
-                  ],
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Bad request syntax or unsupported method"
-          }
-        },
-        "summary": "GetLiveSummary",
-        "tags": [
-          "Analytics"
-        ]
-      }
-    },
-    "/api/v1/analytics/summary": {
-      "get": {
-        "deprecated": false,
-        "description": "Get summary statistics for dashboard header cards.",
-        "operationId": "ApiV1AnalyticsSummaryGetSummary",
-        "parameters": [
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-            "examples": {
-              "start_date-example-1": {
-                "value": "2024-01-01T00:00:00Z"
-              }
-            },
-            "in": "query",
-            "name": "start_date",
-            "required": true,
-            "schema": {
-              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-              "examples": [
-                "2024-01-01T00:00:00Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-            "examples": {
-              "end_date-example-1": {
-                "value": "2024-12-31T23:59:59Z"
-              }
-            },
-            "in": "query",
-            "name": "end_date",
-            "required": true,
-            "schema": {
-              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-              "examples": [
-                "2024-12-31T23:59:59Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Include comparison with previous period of same length",
-            "in": "query",
-            "name": "compare_previous",
-            "required": false,
-            "schema": {
-              "default": false,
-              "description": "Include comparison with previous period of same length",
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SummaryResponse"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Validation Exception",
-                  "examples": [
-                    {
-                      "detail": "Bad Request",
-                      "extra": {},
-                      "status_code": 400
-                    }
-                  ],
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    },
-                    "extra": {
-                      "additionalProperties": {},
-                      "type": [
-                        "null",
-                        "object",
-                        "array"
-                      ]
-                    },
-                    "status_code": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "detail",
-                    "status_code"
-                  ],
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Bad request syntax or unsupported method"
-          }
-        },
-        "summary": "GetSummary",
-        "tags": [
-          "Analytics"
-        ]
-      }
-    },
-    "/api/v1/analytics/time-series": {
-      "get": {
-        "deprecated": false,
-        "description": "Per-bucket access-log metrics for charts.",
-        "operationId": "ApiV1AnalyticsTimeSeriesGetTimeSeries",
-        "parameters": [
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-            "examples": {
-              "start_date-example-1": {
-                "value": "2024-01-01T00:00:00Z"
-              }
-            },
-            "in": "query",
-            "name": "start_date",
-            "required": true,
-            "schema": {
-              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-              "examples": [
-                "2024-01-01T00:00:00Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-            "examples": {
-              "end_date-example-1": {
-                "value": "2024-12-31T23:59:59Z"
-              }
-            },
-            "in": "query",
-            "name": "end_date",
-            "required": true,
-            "schema": {
-              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-              "examples": [
-                "2024-12-31T23:59:59Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TimeSeriesResponse"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Validation Exception",
-                  "examples": [
-                    {
-                      "detail": "Bad Request",
-                      "extra": {},
-                      "status_code": 400
-                    }
-                  ],
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    },
-                    "extra": {
-                      "additionalProperties": {},
-                      "type": [
-                        "null",
-                        "object",
-                        "array"
-                      ]
-                    },
-                    "status_code": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "detail",
-                    "status_code"
-                  ],
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Bad request syntax or unsupported method"
-          }
-        },
-        "summary": "GetTimeSeries",
-        "tags": [
-          "Analytics"
-        ]
-      }
-    },
-    "/api/v1/analytics/time-series/cumulative": {
-      "get": {
-        "deprecated": false,
-        "description": "Get cumulative time series data for area charts.",
-        "operationId": "ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeries",
-        "parameters": [
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-            "examples": {
-              "start_date-example-1": {
-                "value": "2024-01-01T00:00:00Z"
-              }
-            },
-            "in": "query",
-            "name": "start_date",
-            "required": true,
-            "schema": {
-              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-              "examples": [
-                "2024-01-01T00:00:00Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-            "examples": {
-              "end_date-example-1": {
-                "value": "2024-12-31T23:59:59Z"
-              }
-            },
-            "in": "query",
-            "name": "end_date",
-            "required": true,
-            "schema": {
-              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-              "examples": [
-                "2024-12-31T23:59:59Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CumulativeTimeSeriesResponse"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Validation Exception",
-                  "examples": [
-                    {
-                      "detail": "Bad Request",
-                      "extra": {},
-                      "status_code": 400
-                    }
-                  ],
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    },
-                    "extra": {
-                      "additionalProperties": {},
-                      "type": [
-                        "null",
-                        "object",
-                        "array"
-                      ]
-                    },
-                    "status_code": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "detail",
-                    "status_code"
-                  ],
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Bad request syntax or unsupported method"
-          }
-        },
-        "summary": "GetCumulativeTimeSeries",
-        "tags": [
-          "Analytics"
-        ]
-      }
-    },
-    "/api/v1/analytics/top-urls": {
-      "get": {
-        "deprecated": false,
-        "description": "Top URLs by hits from raw access logs (time-bounded).",
-        "operationId": "ApiV1AnalyticsTopUrlsGetTopUrls",
-        "parameters": [
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-            "examples": {
-              "start_date-example-1": {
-                "value": "2024-01-01T00:00:00Z"
-              }
-            },
-            "in": "query",
-            "name": "start_date",
-            "required": true,
-            "schema": {
-              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-              "examples": [
-                "2024-01-01T00:00:00Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-            "examples": {
-              "end_date-example-1": {
-                "value": "2024-12-31T23:59:59Z"
-              }
-            },
-            "in": "query",
-            "name": "end_date",
-            "required": true,
-            "schema": {
-              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-              "examples": [
-                "2024-12-31T23:59:59Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Maximum number of URLs to return",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 25,
-              "description": "Maximum number of URLs to return",
-              "maximum": 100.0,
-              "minimum": 1.0,
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TopUrlsResponse"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Validation Exception",
-                  "examples": [
-                    {
-                      "detail": "Bad Request",
-                      "extra": {},
-                      "status_code": 400
-                    }
-                  ],
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    },
-                    "extra": {
-                      "additionalProperties": {},
-                      "type": [
-                        "null",
-                        "object",
-                        "array"
-                      ]
-                    },
-                    "status_code": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "detail",
-                    "status_code"
-                  ],
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Bad request syntax or unsupported method"
-          }
-        },
-        "summary": "GetTopUrls",
-        "tags": [
-          "Analytics"
-        ]
-      }
-    },
-    "/api/v1/analytics/top-user-agents": {
-      "get": {
-        "deprecated": false,
-        "description": "Top user agents by hits from raw access logs.",
-        "operationId": "ApiV1AnalyticsTopUserAgentsGetTopUserAgents",
-        "parameters": [
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-            "examples": {
-              "start_date-example-1": {
-                "value": "2024-01-01T00:00:00Z"
-              }
-            },
-            "in": "query",
-            "name": "start_date",
-            "required": true,
-            "schema": {
-              "description": "Start date (ISO 8601, e.g., 2024-01-01T00:00:00Z)",
-              "examples": [
-                "2024-01-01T00:00:00Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-            "examples": {
-              "end_date-example-1": {
-                "value": "2024-12-31T23:59:59Z"
-              }
-            },
-            "in": "query",
-            "name": "end_date",
-            "required": true,
-            "schema": {
-              "description": "End date (ISO 8601, e.g., 2024-12-31T23:59:59Z)",
-              "examples": [
-                "2024-12-31T23:59:59Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Maximum number of user agents to return",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 25,
-              "description": "Maximum number of user agents to return",
-              "maximum": 100.0,
-              "minimum": 1.0,
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TopUserAgentsResponse"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Validation Exception",
-                  "examples": [
-                    {
-                      "detail": "Bad Request",
-                      "extra": {},
-                      "status_code": 400
-                    }
-                  ],
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    },
-                    "extra": {
-                      "additionalProperties": {},
-                      "type": [
-                        "null",
-                        "object",
-                        "array"
-                      ]
-                    },
-                    "status_code": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "detail",
-                    "status_code"
-                  ],
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Bad request syntax or unsupported method"
-          }
-        },
-        "summary": "GetTopUserAgents",
-        "tags": [
-          "Analytics"
-        ]
-      }
-    },
-    "/api/v1/auth/login": {
-      "post": {
-        "deprecated": false,
-        "operationId": "ApiV1AuthLoginLogin",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/LoginPayload"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MeResponse"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Validation Exception",
-                  "examples": [
-                    {
-                      "detail": "Bad Request",
-                      "extra": {},
-                      "status_code": 400
-                    }
-                  ],
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    },
-                    "extra": {
-                      "additionalProperties": {},
-                      "type": [
-                        "null",
-                        "object",
-                        "array"
-                      ]
-                    },
-                    "status_code": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "detail",
-                    "status_code"
-                  ],
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Bad request syntax or unsupported method"
-          }
-        },
-        "summary": "Login",
-        "tags": [
-          "Auth"
-        ]
-      }
-    },
-    "/api/v1/auth/logout": {
-      "post": {
-        "deprecated": false,
-        "operationId": "ApiV1AuthLogoutLogout",
-        "responses": {
-          "204": {
-            "description": "Request fulfilled, nothing follows",
-            "headers": {}
-          }
-        },
-        "summary": "Logout",
-        "tags": [
-          "Auth"
-        ]
-      }
-    },
-    "/api/v1/auth/me": {
-      "get": {
-        "deprecated": false,
-        "operationId": "ApiV1AuthMeMe",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MeResponse"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          }
-        },
-        "summary": "Me",
-        "tags": [
-          "Auth"
-        ]
-      }
-    },
-    "/api/v1/geo-events": {
-      "get": {
-        "deprecated": false,
-        "operationId": "ApiV1GeoEventsListGeoEvents",
-        "parameters": [
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "currentPage",
-            "required": false,
-            "schema": {
-              "default": 1,
-              "minimum": 1.0,
-              "type": "integer"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "pageSize",
-            "required": false,
-            "schema": {
-              "default": 10,
-              "minimum": 1.0,
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "items": {
-                      "items": {
-                        "$ref": "#/components/schemas/ListGeoEventsGeoEventResponseBody"
-                      },
-                      "type": "array"
-                    },
-                    "limit": {
-                      "description": "Maximal number of items to send.",
-                      "type": "integer"
-                    },
-                    "offset": {
-                      "description": "Offset from the beginning of the query.",
-                      "type": "integer"
-                    },
-                    "total": {
-                      "description": "Total number of items.",
-                      "type": "integer"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Validation Exception",
-                  "examples": [
-                    {
-                      "detail": "Bad Request",
-                      "extra": {},
-                      "status_code": 400
-                    }
-                  ],
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    },
-                    "extra": {
-                      "additionalProperties": {},
-                      "type": [
-                        "null",
-                        "object",
-                        "array"
-                      ]
-                    },
-                    "status_code": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "detail",
-                    "status_code"
-                  ],
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Bad request syntax or unsupported method"
-          }
-        },
-        "summary": "ListGeoEvents",
-        "tags": [
-          "Geo Events"
-        ]
-      }
-    },
-    "/api/v1/geo-locations": {
-      "get": {
-        "deprecated": false,
-        "operationId": "ApiV1GeoLocationsListGeoLocations",
-        "parameters": [
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "currentPage",
-            "required": false,
-            "schema": {
-              "default": 1,
-              "minimum": 1.0,
-              "type": "integer"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "in": "query",
-            "name": "pageSize",
-            "required": false,
-            "schema": {
-              "default": 10,
-              "minimum": 1.0,
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "items": {
-                      "items": {
-                        "$ref": "#/components/schemas/ListGeoLocationsGeoLocationResponseBody"
-                      },
-                      "type": "array"
-                    },
-                    "limit": {
-                      "description": "Maximal number of items to send.",
-                      "type": "integer"
-                    },
-                    "offset": {
-                      "description": "Offset from the beginning of the query.",
-                      "type": "integer"
-                    },
-                    "total": {
-                      "description": "Total number of items.",
-                      "type": "integer"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Validation Exception",
-                  "examples": [
-                    {
-                      "detail": "Bad Request",
-                      "extra": {},
-                      "status_code": 400
-                    }
-                  ],
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    },
-                    "extra": {
-                      "additionalProperties": {},
-                      "type": [
-                        "null",
-                        "object",
-                        "array"
-                      ]
-                    },
-                    "status_code": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "detail",
-                    "status_code"
-                  ],
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Bad request syntax or unsupported method"
-          }
-        },
-        "summary": "ListGeoLocations",
-        "tags": [
-          "Geo Locations"
-        ]
-      }
-    },
-    "/api/v1/geo-locations/geojson": {
-      "get": {
-        "deprecated": false,
-        "description": "Get all locations with event counts as GeoJSON FeatureCollection.",
-        "operationId": "ApiV1GeoLocationsGeojsonGetGeojson",
-        "parameters": [
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
-            "examples": {
-              "from_timestamp-example-1": {
-                "value": "2024-01-01T00:00:00Z"
-              }
-            },
-            "in": "query",
-            "name": "from_timestamp",
-            "required": true,
-            "schema": {
-              "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
-              "examples": [
-                "2024-01-01T00:00:00Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
-            "examples": {
-              "to_timestamp-example-1": {
-                "value": "2024-12-31T23:59:59Z"
-              }
-            },
-            "in": "query",
-            "name": "to_timestamp",
-            "required": true,
-            "schema": {
-              "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
-              "examples": [
-                "2024-12-31T23:59:59Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Filter to these ISO country codes (repeatable)",
-            "in": "query",
-            "name": "country_code",
-            "required": false,
-            "schema": {
-              "description": "Filter to these ISO country codes (repeatable)",
-              "oneOf": [
-                {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
                 },
-                {
-                  "type": "null"
-                }
-              ]
+                "type": "object",
+                "required": [
+                    "end_date",
+                    "items",
+                    "start_date"
+                ],
+                "title": "TopUserAgentsResponse"
             }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Filter to these city names (repeatable)",
-            "in": "query",
-            "name": "city",
-            "required": false,
-            "schema": {
-              "description": "Filter to these city names (repeatable)",
-              "oneOf": [
-                {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GeoJSONFeatureCollection"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Validation Exception",
-                  "examples": [
-                    {
-                      "detail": "Bad Request",
-                      "extra": {},
-                      "status_code": 400
-                    }
-                  ],
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    },
-                    "extra": {
-                      "additionalProperties": {},
-                      "type": [
-                        "null",
-                        "object",
-                        "array"
-                      ]
-                    },
-                    "status_code": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "detail",
-                    "status_code"
-                  ],
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Bad request syntax or unsupported method"
-          }
         },
-        "summary": "GetGeojson",
-        "tags": [
-          "Geo Locations"
-        ]
-      }
+        "securitySchemes": {
+            "sessionCookie": {
+                "type": "apiKey",
+                "description": "Session cookie authentication.",
+                "name": "session",
+                "in": "cookie"
+            }
+        }
     },
-    "/api/v1/geo-locations/top-countries": {
-      "get": {
-        "deprecated": false,
-        "description": "Get top countries by event count.",
-        "operationId": "ApiV1GeoLocationsTopCountriesGetTopCountries",
-        "parameters": [
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
-            "examples": {
-              "from_timestamp-example-1": {
-                "value": "2024-01-01T00:00:00Z"
-              }
-            },
-            "in": "query",
-            "name": "from_timestamp",
-            "required": true,
-            "schema": {
-              "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
-              "examples": [
-                "2024-01-01T00:00:00Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
-            "examples": {
-              "to_timestamp-example-1": {
-                "value": "2024-12-31T23:59:59Z"
-              }
-            },
-            "in": "query",
-            "name": "to_timestamp",
-            "required": true,
-            "schema": {
-              "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
-              "examples": [
-                "2024-12-31T23:59:59Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Maximum number of countries to return",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 10,
-              "description": "Maximum number of countries to return",
-              "maximum": 50.0,
-              "minimum": 1.0,
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TopCountriesResponse"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Validation Exception",
-                  "examples": [
-                    {
-                      "detail": "Bad Request",
-                      "extra": {},
-                      "status_code": 400
-                    }
-                  ],
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    },
-                    "extra": {
-                      "additionalProperties": {},
-                      "type": [
-                        "null",
-                        "object",
-                        "array"
-                      ]
-                    },
-                    "status_code": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "detail",
-                    "status_code"
-                  ],
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Bad request syntax or unsupported method"
-          }
-        },
-        "summary": "GetTopCountries",
-        "tags": [
-          "Geo Locations"
-        ]
-      }
-    },
-    "/api/v1/geo-locations/top-ips": {
-      "get": {
-        "deprecated": false,
-        "description": "Get global top IPs by event count with their primary locations.",
-        "operationId": "ApiV1GeoLocationsTopIpsGetGlobalTopIps",
-        "parameters": [
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
-            "examples": {
-              "from_timestamp-example-1": {
-                "value": "2024-01-01T00:00:00Z"
-              }
-            },
-            "in": "query",
-            "name": "from_timestamp",
-            "required": true,
-            "schema": {
-              "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
-              "examples": [
-                "2024-01-01T00:00:00Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
-            "examples": {
-              "to_timestamp-example-1": {
-                "value": "2024-12-31T23:59:59Z"
-              }
-            },
-            "in": "query",
-            "name": "to_timestamp",
-            "required": true,
-            "schema": {
-              "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
-              "examples": [
-                "2024-12-31T23:59:59Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Maximum number of IPs to return",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 5,
-              "description": "Maximum number of IPs to return",
-              "maximum": 20.0,
-              "minimum": 1.0,
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GlobalTopIPsResponse"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Validation Exception",
-                  "examples": [
-                    {
-                      "detail": "Bad Request",
-                      "extra": {},
-                      "status_code": 400
-                    }
-                  ],
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    },
-                    "extra": {
-                      "additionalProperties": {},
-                      "type": [
-                        "null",
-                        "object",
-                        "array"
-                      ]
-                    },
-                    "status_code": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "detail",
-                    "status_code"
-                  ],
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Bad request syntax or unsupported method"
-          }
-        },
-        "summary": "GetGlobalTopIps",
-        "tags": [
-          "Geo Locations"
-        ]
-      }
-    },
-    "/api/v1/geo-locations/{location_id}/top-ips": {
-      "get": {
-        "deprecated": false,
-        "description": "Get top IPs for a specific location.",
-        "operationId": "ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIps",
-        "parameters": [
-          {
-            "deprecated": false,
-            "in": "path",
-            "name": "location_id",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
-            "examples": {
-              "from_timestamp-example-1": {
-                "value": "2024-01-01T00:00:00Z"
-              }
-            },
-            "in": "query",
-            "name": "from_timestamp",
-            "required": true,
-            "schema": {
-              "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
-              "examples": [
-                "2024-01-01T00:00:00Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
-            "examples": {
-              "to_timestamp-example-1": {
-                "value": "2024-12-31T23:59:59Z"
-              }
-            },
-            "in": "query",
-            "name": "to_timestamp",
-            "required": true,
-            "schema": {
-              "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
-              "examples": [
-                "2024-12-31T23:59:59Z"
-              ],
-              "format": "date-time",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": false,
-            "allowReserved": false,
-            "deprecated": false,
-            "description": "Maximum number of IPs to return",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 5,
-              "description": "Maximum number of IPs to return",
-              "maximum": 20.0,
-              "minimum": 1.0,
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LocationTopIPsResponse"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Validation Exception",
-                  "examples": [
-                    {
-                      "detail": "Bad Request",
-                      "extra": {},
-                      "status_code": 400
-                    }
-                  ],
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    },
-                    "extra": {
-                      "additionalProperties": {},
-                      "type": [
-                        "null",
-                        "object",
-                        "array"
-                      ]
-                    },
-                    "status_code": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "detail",
-                    "status_code"
-                  ],
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Bad request syntax or unsupported method"
-          }
-        },
-        "summary": "GetLocationTopIps",
-        "tags": [
-          "Geo Locations"
-        ]
-      }
-    },
-    "/api/v1/settings": {
-      "get": {
-        "deprecated": false,
-        "operationId": "ApiV1SettingsReadSettings",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SafeSettingsResponse"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          }
-        },
-        "summary": "ReadSettings",
-        "tags": [
-          "Settings"
-        ]
-      }
-    },
-    "/api/v1/stats": {
-      "get": {
-        "deprecated": false,
-        "operationId": "ApiV1StatsStats",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {},
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          }
-        },
-        "summary": "Stats",
-        "tags": [
-          "Analytics"
-        ]
-      }
-    },
-    "/health": {
-      "get": {
-        "deprecated": false,
-        "operationId": "HealthHealth",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {},
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          }
-        },
-        "summary": "Health",
-        "tags": [
-          "Health"
-        ]
-      }
-    },
-    "/health/ready": {
-      "get": {
-        "deprecated": false,
-        "operationId": "HealthReadyHealthReady",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {},
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Request fulfilled, document follows",
-            "headers": {}
-          }
-        },
-        "summary": "HealthReady",
-        "tags": [
-          "Health"
-        ]
-      }
-    }
-  },
-  "security": [
-    {
-      "sessionCookie": []
-    }
-  ],
-  "servers": [
-    {
-      "url": "/"
-    }
-  ]
+    "security": [
+        {
+            "sessionCookie": []
+        }
+    ]
 }

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -1858,6 +1858,330 @@
                 "deprecated": false
             }
         },
+        "/api/v1/analytics/top-cities": {
+            "get": {
+                "tags": [
+                    "Analytics"
+                ],
+                "summary": "GetTopCities",
+                "description": "Top cities by hits from raw access logs (time-bounded).",
+                "operationId": "ApiV1AnalyticsTopCitiesGetTopCities",
+                "parameters": [
+                    {
+                        "name": "start_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Start date (ISO 8601)"
+                        },
+                        "description": "Start date (ISO 8601)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "end_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "End date (ISO 8601)"
+                        },
+                        "description": "End date (ISO 8601)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100.0,
+                            "minimum": 1.0,
+                            "description": "Maximum number of cities",
+                            "default": 25
+                        },
+                        "description": "Maximum number of cities",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TopCitiesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/analytics/top-countries": {
+            "get": {
+                "tags": [
+                    "Analytics"
+                ],
+                "summary": "GetTopCountries",
+                "description": "Top countries by hits from raw access logs (time-bounded).",
+                "operationId": "ApiV1AnalyticsTopCountriesGetTopCountries",
+                "parameters": [
+                    {
+                        "name": "start_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Start date (ISO 8601)"
+                        },
+                        "description": "Start date (ISO 8601)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "end_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "End date (ISO 8601)"
+                        },
+                        "description": "End date (ISO 8601)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100.0,
+                            "minimum": 1.0,
+                            "description": "Maximum number of countries",
+                            "default": 25
+                        },
+                        "description": "Maximum number of countries",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TopCountriesStatsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/api/v1/analytics/top-ips": {
+            "get": {
+                "tags": [
+                    "Analytics"
+                ],
+                "summary": "GetTopIps",
+                "description": "Top client IPs by hits from raw access logs (time-bounded).",
+                "operationId": "ApiV1AnalyticsTopIpsGetTopIps",
+                "parameters": [
+                    {
+                        "name": "start_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Start date (ISO 8601)"
+                        },
+                        "description": "Start date (ISO 8601)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "end_date",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "End date (ISO 8601)"
+                        },
+                        "description": "End date (ISO 8601)",
+                        "required": true,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100.0,
+                            "minimum": 1.0,
+                            "description": "Maximum number of IPs",
+                            "default": 25
+                        },
+                        "description": "Maximum number of IPs",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request fulfilled, document follows",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TopIpsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request syntax or unsupported method",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status_code": {
+                                            "type": "integer"
+                                        },
+                                        "detail": {
+                                            "type": "string"
+                                        },
+                                        "extra": {
+                                            "additionalProperties": {},
+                                            "type": [
+                                                "null",
+                                                "object",
+                                                "array"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "detail",
+                                        "status_code"
+                                    ],
+                                    "description": "Validation Exception",
+                                    "examples": [
+                                        {
+                                            "status_code": 400,
+                                            "detail": "Bad Request",
+                                            "extra": {}
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
         "/api/v1/analytics/top-urls": {
             "get": {
                 "tags": [
@@ -3569,6 +3893,60 @@
                 ],
                 "title": "TimeSeriesResponse"
             },
+            "TopCitiesResponse": {
+                "properties": {
+                    "start_date": {
+                        "type": "string"
+                    },
+                    "end_date": {
+                        "type": "string"
+                    },
+                    "items": {
+                        "items": {
+                            "$ref": "#/components/schemas/TopCityStatsDTO"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "end_date",
+                    "items",
+                    "start_date"
+                ],
+                "title": "TopCitiesResponse"
+            },
+            "TopCityStatsDTO": {
+                "properties": {
+                    "city": {
+                        "type": "string"
+                    },
+                    "country_code": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "hits": {
+                        "type": "integer"
+                    },
+                    "unique_ips": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "city",
+                    "country_code",
+                    "hits",
+                    "unique_ips"
+                ],
+                "title": "TopCityStatsDTO"
+            },
             "TopCountriesResponse": {
                 "properties": {
                     "top_countries": {
@@ -3581,6 +3959,29 @@
                 "type": "object",
                 "required": [],
                 "title": "TopCountriesResponse"
+            },
+            "TopCountriesStatsResponse": {
+                "properties": {
+                    "start_date": {
+                        "type": "string"
+                    },
+                    "end_date": {
+                        "type": "string"
+                    },
+                    "items": {
+                        "items": {
+                            "$ref": "#/components/schemas/TopCountryStatsDTO"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "end_date",
+                    "items",
+                    "start_date"
+                ],
+                "title": "TopCountriesStatsResponse"
             },
             "TopCountryDTO": {
                 "properties": {
@@ -3609,6 +4010,37 @@
                 ],
                 "title": "TopCountryDTO"
             },
+            "TopCountryStatsDTO": {
+                "properties": {
+                    "country_code": {
+                        "type": "string"
+                    },
+                    "country_name": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "hits": {
+                        "type": "integer"
+                    },
+                    "unique_ips": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "country_code",
+                    "country_name",
+                    "hits",
+                    "unique_ips"
+                ],
+                "title": "TopCountryStatsDTO"
+            },
             "TopIPDTO": {
                 "properties": {
                     "ip_address": {
@@ -3634,6 +4066,75 @@
                     "ip_address"
                 ],
                 "title": "TopIPDTO"
+            },
+            "TopIpDTO": {
+                "properties": {
+                    "ip_address": {
+                        "type": "string"
+                    },
+                    "hits": {
+                        "type": "integer"
+                    },
+                    "error_hits": {
+                        "type": "integer"
+                    },
+                    "total_bytes": {
+                        "type": "integer"
+                    },
+                    "country_code": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "city": {
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "city",
+                    "country_code",
+                    "error_hits",
+                    "hits",
+                    "ip_address",
+                    "total_bytes"
+                ],
+                "title": "TopIpDTO"
+            },
+            "TopIpsResponse": {
+                "properties": {
+                    "start_date": {
+                        "type": "string"
+                    },
+                    "end_date": {
+                        "type": "string"
+                    },
+                    "items": {
+                        "items": {
+                            "$ref": "#/components/schemas/TopIpDTO"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "end_date",
+                    "items",
+                    "start_date"
+                ],
+                "title": "TopIpsResponse"
             },
             "TopUrlDTO": {
                 "properties": {

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -1802,6 +1802,75 @@
                         "deprecated": false,
                         "allowEmptyValue": false,
                         "allowReserved": false
+                    },
+                    {
+                        "name": "country_code",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these ISO country codes (repeatable)"
+                        },
+                        "description": "Filter to these ISO country codes (repeatable)",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "city",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these city names (repeatable)"
+                        },
+                        "description": "Filter to these city names (repeatable)",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "ip_address",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these client IPs (repeatable)"
+                        },
+                        "description": "Filter to these client IPs (repeatable)",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
                     }
                 ],
                 "responses": {
@@ -1906,6 +1975,75 @@
                             "default": 25
                         },
                         "description": "Maximum number of cities",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "country_code",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these ISO country codes (repeatable)"
+                        },
+                        "description": "Filter to these ISO country codes (repeatable)",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "city",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these city names (repeatable)"
+                        },
+                        "description": "Filter to these city names (repeatable)",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "ip_address",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these client IPs (repeatable)"
+                        },
+                        "description": "Filter to these client IPs (repeatable)",
                         "required": false,
                         "deprecated": false,
                         "allowEmptyValue": false,
@@ -2018,6 +2156,75 @@
                         "deprecated": false,
                         "allowEmptyValue": false,
                         "allowReserved": false
+                    },
+                    {
+                        "name": "country_code",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these ISO country codes (repeatable)"
+                        },
+                        "description": "Filter to these ISO country codes (repeatable)",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "city",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these city names (repeatable)"
+                        },
+                        "description": "Filter to these city names (repeatable)",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "ip_address",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these client IPs (repeatable)"
+                        },
+                        "description": "Filter to these client IPs (repeatable)",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
                     }
                 ],
                 "responses": {
@@ -2122,6 +2329,75 @@
                             "default": 25
                         },
                         "description": "Maximum number of IPs",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "country_code",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these ISO country codes (repeatable)"
+                        },
+                        "description": "Filter to these ISO country codes (repeatable)",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "city",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these city names (repeatable)"
+                        },
+                        "description": "Filter to these city names (repeatable)",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "ip_address",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these client IPs (repeatable)"
+                        },
+                        "description": "Filter to these client IPs (repeatable)",
                         "required": false,
                         "deprecated": false,
                         "allowEmptyValue": false,
@@ -2250,6 +2526,75 @@
                         "deprecated": false,
                         "allowEmptyValue": false,
                         "allowReserved": false
+                    },
+                    {
+                        "name": "country_code",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these ISO country codes (repeatable)"
+                        },
+                        "description": "Filter to these ISO country codes (repeatable)",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "city",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these city names (repeatable)"
+                        },
+                        "description": "Filter to these city names (repeatable)",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "ip_address",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these client IPs (repeatable)"
+                        },
+                        "description": "Filter to these client IPs (repeatable)",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
                     }
                 ],
                 "responses": {
@@ -2370,6 +2715,75 @@
                             "default": 25
                         },
                         "description": "Maximum number of user agents to return",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "country_code",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these ISO country codes (repeatable)"
+                        },
+                        "description": "Filter to these ISO country codes (repeatable)",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "city",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these city names (repeatable)"
+                        },
+                        "description": "Filter to these city names (repeatable)",
+                        "required": false,
+                        "deprecated": false,
+                        "allowEmptyValue": false,
+                        "allowReserved": false
+                    },
+                    {
+                        "name": "ip_address",
+                        "in": "query",
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter to these client IPs (repeatable)"
+                        },
+                        "description": "Filter to these client IPs (repeatable)",
                         "required": false,
                         "deprecated": false,
                         "allowEmptyValue": false,

--- a/resources/generated/routes.json
+++ b/resources/generated/routes.json
@@ -26,6 +26,7 @@
       ],
       "queryParameters": {
         "end_date": "DateTime",
+        "granularity": "\"hourly\" | \"daily\" | undefined",
         "start_date": "DateTime"
       },
       "uri": "/api/v1/analytics/geo-time-series"
@@ -103,12 +104,46 @@
         "GET"
       ],
       "queryParameters": {
+        "city": "string[] | undefined",
+        "country_code": "string[] | undefined",
         "end_date": "DateTime",
+        "granularity": "\"hourly\" | \"daily\" | undefined",
+        "ip_address": "string[] | undefined",
         "start_date": "DateTime"
       },
       "uri": "/api/v1/analytics/time-series"
     },
+    "get_top_cities": {
+      "method": "get",
+      "methods": [
+        "GET"
+      ],
+      "queryParameters": {
+        "city": "string[] | undefined",
+        "country_code": "string[] | undefined",
+        "end_date": "DateTime",
+        "ip_address": "string[] | undefined",
+        "limit": "number | undefined",
+        "start_date": "DateTime"
+      },
+      "uri": "/api/v1/analytics/top-cities"
+    },
     "get_top_countries": {
+      "method": "get",
+      "methods": [
+        "GET"
+      ],
+      "queryParameters": {
+        "city": "string[] | undefined",
+        "country_code": "string[] | undefined",
+        "end_date": "DateTime",
+        "ip_address": "string[] | undefined",
+        "limit": "number | undefined",
+        "start_date": "DateTime"
+      },
+      "uri": "/api/v1/analytics/top-countries"
+    },
+    "get_top_countries_api_v1_geo_locations_top_countries": {
       "method": "get",
       "methods": [
         "GET"
@@ -120,13 +155,31 @@
       },
       "uri": "/api/v1/geo-locations/top-countries"
     },
+    "get_top_ips": {
+      "method": "get",
+      "methods": [
+        "GET"
+      ],
+      "queryParameters": {
+        "city": "string[] | undefined",
+        "country_code": "string[] | undefined",
+        "end_date": "DateTime",
+        "ip_address": "string[] | undefined",
+        "limit": "number | undefined",
+        "start_date": "DateTime"
+      },
+      "uri": "/api/v1/analytics/top-ips"
+    },
     "get_top_urls": {
       "method": "get",
       "methods": [
         "GET"
       ],
       "queryParameters": {
+        "city": "string[] | undefined",
+        "country_code": "string[] | undefined",
         "end_date": "DateTime",
+        "ip_address": "string[] | undefined",
         "limit": "number | undefined",
         "start_date": "DateTime"
       },
@@ -138,7 +191,10 @@
         "GET"
       ],
       "queryParameters": {
+        "city": "string[] | undefined",
+        "country_code": "string[] | undefined",
         "end_date": "DateTime",
+        "ip_address": "string[] | undefined",
         "limit": "number | undefined",
         "start_date": "DateTime"
       },

--- a/resources/generated/routes.ts
+++ b/resources/generated/routes.ts
@@ -24,7 +24,10 @@ export type RouteName =
   | 'get_location_top_ips'
   | 'get_summary'
   | 'get_time_series'
+  | 'get_top_cities'
   | 'get_top_countries'
+  | 'get_top_countries_api_v1_geo_locations_top_countries'
+  | 'get_top_ips'
   | 'get_top_urls'
   | 'get_top_user_agents'
   | 'health'
@@ -57,7 +60,10 @@ export interface RoutePathParams {
   };
   'get_summary': Record<string, never>;
   'get_time_series': Record<string, never>;
+  'get_top_cities': Record<string, never>;
   'get_top_countries': Record<string, never>;
+  'get_top_countries_api_v1_geo_locations_top_countries': Record<string, never>;
+  'get_top_ips': Record<string, never>;
   'get_top_urls': Record<string, never>;
   'get_top_user_agents': Record<string, never>;
   'health': Record<string, never>;
@@ -91,6 +97,7 @@ export interface RouteQueryParams {
   };
   'get_geo_time_series': {
     end_date: DateTime;
+    granularity?: "hourly" | "daily";
     start_date: DateTime;
   };
   'get_geojson': {
@@ -120,21 +127,55 @@ export interface RouteQueryParams {
     start_date: DateTime;
   };
   'get_time_series': {
+    city?: string[];
+    country_code?: string[];
     end_date: DateTime;
+    granularity?: "hourly" | "daily";
+    ip_address?: string[];
+    start_date: DateTime;
+  };
+  'get_top_cities': {
+    city?: string[];
+    country_code?: string[];
+    end_date: DateTime;
+    ip_address?: string[];
+    limit?: number;
     start_date: DateTime;
   };
   'get_top_countries': {
+    city?: string[];
+    country_code?: string[];
+    end_date: DateTime;
+    ip_address?: string[];
+    limit?: number;
+    start_date: DateTime;
+  };
+  'get_top_countries_api_v1_geo_locations_top_countries': {
     from_timestamp: DateTime;
     limit?: number;
     to_timestamp: DateTime;
   };
-  'get_top_urls': {
+  'get_top_ips': {
+    city?: string[];
+    country_code?: string[];
     end_date: DateTime;
+    ip_address?: string[];
+    limit?: number;
+    start_date: DateTime;
+  };
+  'get_top_urls': {
+    city?: string[];
+    country_code?: string[];
+    end_date: DateTime;
+    ip_address?: string[];
     limit?: number;
     start_date: DateTime;
   };
   'get_top_user_agents': {
+    city?: string[];
+    country_code?: string[];
     end_date: DateTime;
+    ip_address?: string[];
     limit?: number;
     start_date: DateTime;
   };
@@ -208,7 +249,7 @@ export const routeDefinitions = {
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['end_date', 'start_date'] as const,
+    queryParams: ['end_date', 'granularity', 'start_date'] as const,
   },
   'get_geojson': {
     path: '/api/v1/geo-locations/geojson',
@@ -250,28 +291,49 @@ export const routeDefinitions = {
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['end_date', 'start_date'] as const,
+    queryParams: ['city', 'country_code', 'end_date', 'granularity', 'ip_address', 'start_date'] as const,
+  },
+  'get_top_cities': {
+    path: '/api/v1/analytics/top-cities',
+    methods: ['GET'] as const,
+    method: 'get',
+    pathParams: [] as const,
+    queryParams: ['city', 'country_code', 'end_date', 'ip_address', 'limit', 'start_date'] as const,
   },
   'get_top_countries': {
+    path: '/api/v1/analytics/top-countries',
+    methods: ['GET'] as const,
+    method: 'get',
+    pathParams: [] as const,
+    queryParams: ['city', 'country_code', 'end_date', 'ip_address', 'limit', 'start_date'] as const,
+  },
+  'get_top_countries_api_v1_geo_locations_top_countries': {
     path: '/api/v1/geo-locations/top-countries',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
     queryParams: ['from_timestamp', 'limit', 'to_timestamp'] as const,
   },
+  'get_top_ips': {
+    path: '/api/v1/analytics/top-ips',
+    methods: ['GET'] as const,
+    method: 'get',
+    pathParams: [] as const,
+    queryParams: ['city', 'country_code', 'end_date', 'ip_address', 'limit', 'start_date'] as const,
+  },
   'get_top_urls': {
     path: '/api/v1/analytics/top-urls',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['end_date', 'limit', 'start_date'] as const,
+    queryParams: ['city', 'country_code', 'end_date', 'ip_address', 'limit', 'start_date'] as const,
   },
   'get_top_user_agents': {
     path: '/api/v1/analytics/top-user-agents',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['end_date', 'limit', 'start_date'] as const,
+    queryParams: ['city', 'country_code', 'end_date', 'ip_address', 'limit', 'start_date'] as const,
   },
   'health': {
     path: '/health',

--- a/resources/lib/analytics-filters-context.tsx
+++ b/resources/lib/analytics-filters-context.tsx
@@ -1,0 +1,40 @@
+/**
+ * Shared country/city/IP filters for the analytics page. Threaded into the
+ * six analytics hooks (time-series, top-urls, top-user-agents, top-ips,
+ * top-country-stats, top-city-stats) so the filter bar reshapes every chart
+ * and top-list at once.
+ */
+import { createContext, useContext, useState } from "react"
+
+export interface AnalyticsFilterState {
+  countryCodes: string[]
+  cities: string[]
+  ips: string[]
+}
+
+export const EMPTY_FILTERS: AnalyticsFilterState = { countryCodes: [], cities: [], ips: [] }
+
+interface AnalyticsFiltersValue {
+  filters: AnalyticsFilterState
+  setFilters: React.Dispatch<React.SetStateAction<AnalyticsFilterState>>
+}
+
+// Default = empty filters: hooks shared with the dashboard keep working
+// outside the provider.
+const AnalyticsFiltersContext = createContext<AnalyticsFiltersValue>({
+  filters: EMPTY_FILTERS,
+  setFilters: () => {},
+})
+
+export function AnalyticsFiltersProvider({ children }: { children: React.ReactNode }) {
+  const [filters, setFilters] = useState<AnalyticsFilterState>(EMPTY_FILTERS)
+  return (
+    <AnalyticsFiltersContext.Provider value={{ filters, setFilters }}>
+      {children}
+    </AnalyticsFiltersContext.Provider>
+  )
+}
+
+export function useAnalyticsFilters() {
+  return useContext(AnalyticsFiltersContext)
+}

--- a/resources/lib/api.ts
+++ b/resources/lib/api.ts
@@ -6,6 +6,9 @@ import axios from "axios"
 import {
   apiV1AnalyticsGeoTimeSeriesGetGeoTimeSeries,
   apiV1AnalyticsTimeSeriesGetTimeSeries,
+  apiV1AnalyticsTopCitiesGetTopCities,
+  apiV1AnalyticsTopCountriesGetTopCountries,
+  apiV1AnalyticsTopIpsGetTopIps,
   apiV1AnalyticsTopUrlsGetTopUrls,
   apiV1AnalyticsTopUserAgentsGetTopUserAgents,
 } from "@/generated/api/sdk.gen"
@@ -364,6 +367,30 @@ export async function fetchTopUrls(params: TimeSeriesParams & { limit?: number }
 
 export async function fetchTopUserAgents(params: TimeSeriesParams & { limit?: number }) {
   const { data } = await apiV1AnalyticsTopUserAgentsGetTopUserAgents({
+    query: { start_date: params.startDate, end_date: params.endDate, limit: params.limit ?? 25 },
+    throwOnError: true,
+  })
+  return data
+}
+
+export async function fetchTopIpStats(params: TimeSeriesParams & { limit?: number }) {
+  const { data } = await apiV1AnalyticsTopIpsGetTopIps({
+    query: { start_date: params.startDate, end_date: params.endDate, limit: params.limit ?? 25 },
+    throwOnError: true,
+  })
+  return data
+}
+
+export async function fetchTopCountryStats(params: TimeSeriesParams & { limit?: number }) {
+  const { data } = await apiV1AnalyticsTopCountriesGetTopCountries({
+    query: { start_date: params.startDate, end_date: params.endDate, limit: params.limit ?? 25 },
+    throwOnError: true,
+  })
+  return data
+}
+
+export async function fetchTopCityStats(params: TimeSeriesParams & { limit?: number }) {
+  const { data } = await apiV1AnalyticsTopCitiesGetTopCities({
     query: { start_date: params.startDate, end_date: params.endDate, limit: params.limit ?? 25 },
     throwOnError: true,
   })

--- a/resources/lib/api.ts
+++ b/resources/lib/api.ts
@@ -341,9 +341,28 @@ export async function fetchTopCountries(params: TopIPsParams): Promise<TopCountr
 // Analytics fetchers on the generated SDK (types flow from the OpenAPI schema)
 // ============================================================================
 
-export async function fetchTimeSeries(params: TimeSeriesParams) {
+/**
+ * Country/city/IP filters shared by the analytics page's six filterable
+ * endpoints (not geo-time-series, which stays unfiltered). The generated
+ * fetch client serializes arrays as repeated keys (?country_code=NO&country_code=SE)
+ * by default, matching what Litestar expects.
+ */
+export interface AnalyticsFilterParams {
+  countryCodes?: string[]
+  cities?: string[]
+  ips?: string[]
+}
+
+export async function fetchTimeSeries(params: TimeSeriesParams & AnalyticsFilterParams) {
   const { data } = await apiV1AnalyticsTimeSeriesGetTimeSeries({
-    query: { start_date: params.startDate, end_date: params.endDate, granularity: params.granularity },
+    query: {
+      start_date: params.startDate,
+      end_date: params.endDate,
+      granularity: params.granularity,
+      country_code: params.countryCodes?.length ? params.countryCodes : undefined,
+      city: params.cities?.length ? params.cities : undefined,
+      ip_address: params.ips?.length ? params.ips : undefined,
+    },
     throwOnError: true,
   })
   return data
@@ -357,41 +376,76 @@ export async function fetchGeoTimeSeries(params: TimeSeriesParams) {
   return data
 }
 
-export async function fetchTopUrls(params: TimeSeriesParams & { limit?: number }) {
+export async function fetchTopUrls(params: TimeSeriesParams & { limit?: number } & AnalyticsFilterParams) {
   const { data } = await apiV1AnalyticsTopUrlsGetTopUrls({
-    query: { start_date: params.startDate, end_date: params.endDate, limit: params.limit ?? 25 },
+    query: {
+      start_date: params.startDate,
+      end_date: params.endDate,
+      limit: params.limit ?? 25,
+      country_code: params.countryCodes?.length ? params.countryCodes : undefined,
+      city: params.cities?.length ? params.cities : undefined,
+      ip_address: params.ips?.length ? params.ips : undefined,
+    },
     throwOnError: true,
   })
   return data
 }
 
-export async function fetchTopUserAgents(params: TimeSeriesParams & { limit?: number }) {
+export async function fetchTopUserAgents(params: TimeSeriesParams & { limit?: number } & AnalyticsFilterParams) {
   const { data } = await apiV1AnalyticsTopUserAgentsGetTopUserAgents({
-    query: { start_date: params.startDate, end_date: params.endDate, limit: params.limit ?? 25 },
+    query: {
+      start_date: params.startDate,
+      end_date: params.endDate,
+      limit: params.limit ?? 25,
+      country_code: params.countryCodes?.length ? params.countryCodes : undefined,
+      city: params.cities?.length ? params.cities : undefined,
+      ip_address: params.ips?.length ? params.ips : undefined,
+    },
     throwOnError: true,
   })
   return data
 }
 
-export async function fetchTopIpStats(params: TimeSeriesParams & { limit?: number }) {
+export async function fetchTopIpStats(params: TimeSeriesParams & { limit?: number } & AnalyticsFilterParams) {
   const { data } = await apiV1AnalyticsTopIpsGetTopIps({
-    query: { start_date: params.startDate, end_date: params.endDate, limit: params.limit ?? 25 },
+    query: {
+      start_date: params.startDate,
+      end_date: params.endDate,
+      limit: params.limit ?? 25,
+      country_code: params.countryCodes?.length ? params.countryCodes : undefined,
+      city: params.cities?.length ? params.cities : undefined,
+      ip_address: params.ips?.length ? params.ips : undefined,
+    },
     throwOnError: true,
   })
   return data
 }
 
-export async function fetchTopCountryStats(params: TimeSeriesParams & { limit?: number }) {
+export async function fetchTopCountryStats(params: TimeSeriesParams & { limit?: number } & AnalyticsFilterParams) {
   const { data } = await apiV1AnalyticsTopCountriesGetTopCountries({
-    query: { start_date: params.startDate, end_date: params.endDate, limit: params.limit ?? 25 },
+    query: {
+      start_date: params.startDate,
+      end_date: params.endDate,
+      limit: params.limit ?? 25,
+      country_code: params.countryCodes?.length ? params.countryCodes : undefined,
+      city: params.cities?.length ? params.cities : undefined,
+      ip_address: params.ips?.length ? params.ips : undefined,
+    },
     throwOnError: true,
   })
   return data
 }
 
-export async function fetchTopCityStats(params: TimeSeriesParams & { limit?: number }) {
+export async function fetchTopCityStats(params: TimeSeriesParams & { limit?: number } & AnalyticsFilterParams) {
   const { data } = await apiV1AnalyticsTopCitiesGetTopCities({
-    query: { start_date: params.startDate, end_date: params.endDate, limit: params.limit ?? 25 },
+    query: {
+      start_date: params.startDate,
+      end_date: params.endDate,
+      limit: params.limit ?? 25,
+      country_code: params.countryCodes?.length ? params.countryCodes : undefined,
+      city: params.cities?.length ? params.cities : undefined,
+      ip_address: params.ips?.length ? params.ips : undefined,
+    },
     throwOnError: true,
   })
   return data

--- a/resources/lib/api.ts
+++ b/resources/lib/api.ts
@@ -209,6 +209,8 @@ export interface TimeSeriesParams {
   granularity?: "hourly" | "daily"
 }
 
+export type ChartGranularity = "auto" | "hourly" | "daily"
+
 
 export interface GeoJSONParams {
   fromTimestamp: string // Full ISO timestamp
@@ -338,7 +340,7 @@ export async function fetchTopCountries(params: TopIPsParams): Promise<TopCountr
 
 export async function fetchTimeSeries(params: TimeSeriesParams) {
   const { data } = await apiV1AnalyticsTimeSeriesGetTimeSeries({
-    query: { start_date: params.startDate, end_date: params.endDate },
+    query: { start_date: params.startDate, end_date: params.endDate, granularity: params.granularity },
     throwOnError: true,
   })
   return data
@@ -346,7 +348,7 @@ export async function fetchTimeSeries(params: TimeSeriesParams) {
 
 export async function fetchGeoTimeSeries(params: TimeSeriesParams) {
   const { data } = await apiV1AnalyticsGeoTimeSeriesGetGeoTimeSeries({
-    query: { start_date: params.startDate, end_date: params.endDate },
+    query: { start_date: params.startDate, end_date: params.endDate, granularity: params.granularity },
     throwOnError: true,
   })
   return data
@@ -695,6 +697,17 @@ export function parseTimeRange(range: TimeRangeValue, referenceTime?: number): {
     startDate: start.toISOString(),
     endDate: now.toISOString(),
   }
+}
+
+/** Auto = hourly up to 7 days, daily above (hourly buckets beyond 7d are noise). */
+export function resolveChartGranularity(
+  granularity: ChartGranularity,
+  range: TimeRangeValue,
+): "hourly" | "daily" {
+  if (granularity !== "auto") return granularity
+  const { startDate, endDate } = parseTimeRange(range, Date.now())
+  const days = (new Date(endDate).getTime() - new Date(startDate).getTime()) / 86_400_000
+  return days > 7 ? "daily" : "hourly"
 }
 
 /**

--- a/resources/lib/api.ts
+++ b/resources/lib/api.ts
@@ -609,7 +609,12 @@ export type TimeRangeValue =
   // Grafana-style presets
   | "today" | "this_week" | "this_month"
   | "yesterday" | "last_week" | "last_month"
+  | "custom"
 
+export interface CustomTimeRange {
+  from: string // ISO timestamp
+  to: string
+}
 
 export interface TimeRangePreset {
   label: string
@@ -661,7 +666,15 @@ export const POLL_INTERVAL_OPTIONS: PollIntervalOption[] = [
  * Always returns full ISO timestamps for backend compatibility.
  * Handles both relative (5m, 7d) and Grafana-style (today, this_week) presets.
  */
-export function parseTimeRange(range: TimeRangeValue, referenceTime?: number): { startDate: string; endDate: string } {
+export function parseTimeRange(
+  range: TimeRangeValue,
+  referenceTime?: number,
+  customRange?: CustomTimeRange | null,
+): { startDate: string; endDate: string } {
+  if (range === "custom" && customRange) {
+    return { startDate: customRange.from, endDate: customRange.to }
+  }
+
   const now = referenceTime ? new Date(referenceTime) : new Date()
 
   // Handle Grafana-style computed ranges
@@ -730,9 +743,10 @@ export function parseTimeRange(range: TimeRangeValue, referenceTime?: number): {
 export function resolveChartGranularity(
   granularity: ChartGranularity,
   range: TimeRangeValue,
+  customRange?: CustomTimeRange | null,
 ): "hourly" | "daily" {
   if (granularity !== "auto") return granularity
-  const { startDate, endDate } = parseTimeRange(range, Date.now())
+  const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
   const days = (new Date(endDate).getTime() - new Date(startDate).getTime()) / 86_400_000
   return days > 7 ? "daily" : "hourly"
 }

--- a/resources/lib/queries.ts
+++ b/resources/lib/queries.ts
@@ -12,6 +12,9 @@ import {
   fetchLocationTopIPs,
   fetchTimeSeries,
   fetchTopCountries,
+  fetchTopCityStats,
+  fetchTopCountryStats,
+  fetchTopIpStats,
   fetchTopUrls,
   fetchTopUserAgents,
   fetchCumulativeTimeSeries,
@@ -54,6 +57,12 @@ export const queryKeys = {
       [...queryKeys.analytics.all, "top-urls", params, refreshKey] as const,
     topUserAgents: (params: Record<string, unknown>, refreshKey?: number) =>
       [...queryKeys.analytics.all, "top-user-agents", params, refreshKey] as const,
+    topIps: (params: Record<string, unknown>, refreshKey?: number) =>
+      [...queryKeys.analytics.all, "top-ips", params, refreshKey] as const,
+    topCountryStats: (params: Record<string, unknown>, refreshKey?: number) =>
+      [...queryKeys.analytics.all, "top-country-stats", params, refreshKey] as const,
+    topCityStats: (params: Record<string, unknown>, refreshKey?: number) =>
+      [...queryKeys.analytics.all, "top-city-stats", params, refreshKey] as const,
   },
   geo: {
     all: ["geo"] as const,
@@ -404,6 +413,66 @@ export function useTopUserAgents(options: UseTopListOptions = {}) {
     queryFn: () => {
       const { startDate, endDate } = parseTimeRange(range, Date.now())
       return fetchTopUserAgents({ startDate, endDate, limit })
+    },
+    enabled,
+    staleTime: 60 * 1000,
+    refetchInterval: pollInterval || false,
+  })
+}
+
+/**
+ * Fetch the top client IPs by hit count.
+ * Uses TimeRangeContext for time filtering.
+ */
+export function useTopIpStats(options: UseTopListOptions = {}) {
+  const { enabled = true, limit = 25 } = options
+  const { range, pollInterval, lastRefresh } = useTimeRange()
+
+  return useQuery({
+    queryKey: queryKeys.analytics.topIps({ range, limit }, lastRefresh),
+    queryFn: () => {
+      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      return fetchTopIpStats({ startDate, endDate, limit })
+    },
+    enabled,
+    staleTime: 60 * 1000,
+    refetchInterval: pollInterval || false,
+  })
+}
+
+/**
+ * Fetch the top countries by hit count.
+ * Uses TimeRangeContext for time filtering.
+ */
+export function useTopCountryStats(options: UseTopListOptions = {}) {
+  const { enabled = true, limit = 25 } = options
+  const { range, pollInterval, lastRefresh } = useTimeRange()
+
+  return useQuery({
+    queryKey: queryKeys.analytics.topCountryStats({ range, limit }, lastRefresh),
+    queryFn: () => {
+      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      return fetchTopCountryStats({ startDate, endDate, limit })
+    },
+    enabled,
+    staleTime: 60 * 1000,
+    refetchInterval: pollInterval || false,
+  })
+}
+
+/**
+ * Fetch the top cities by hit count.
+ * Uses TimeRangeContext for time filtering.
+ */
+export function useTopCityStats(options: UseTopListOptions = {}) {
+  const { enabled = true, limit = 25 } = options
+  const { range, pollInterval, lastRefresh } = useTimeRange()
+
+  return useQuery({
+    queryKey: queryKeys.analytics.topCityStats({ range, limit }, lastRefresh),
+    queryFn: () => {
+      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      return fetchTopCityStats({ startDate, endDate, limit })
     },
     enabled,
     staleTime: 60 * 1000,

--- a/resources/lib/queries.ts
+++ b/resources/lib/queries.ts
@@ -108,10 +108,10 @@ export interface UseSummaryOptions {
  */
 export function useSummary(options: UseSummaryOptions = {}) {
   const { comparePrevious = true, enabled = true } = options
-  const { range, pollInterval, lastRefresh } = useTimeRange()
+  const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
 
   // Use statsRange (hourly minimum) for summary stats queries
-  const { startDate, endDate } = parseTimeRange(range, Date.now())
+  const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
   const params: SummaryParams = {
     startDate,
     endDate,
@@ -120,7 +120,7 @@ export function useSummary(options: UseSummaryOptions = {}) {
 
   return useQuery({
     // Query key uses statsRange + lastRefresh for stability
-    queryKey: queryKeys.analytics.summary({ range, comparePrevious }, lastRefresh),
+    queryKey: queryKeys.analytics.summary({ range, customRange, comparePrevious }, lastRefresh),
     queryFn: () => fetchSummary(params),
     enabled,
     staleTime: 15 * 1000, // 15 seconds
@@ -134,10 +134,10 @@ export function useSummary(options: UseSummaryOptions = {}) {
  */
 export function useLiveSummary(options: UseSummaryOptions = {}) {
   const { comparePrevious = true, enabled = true } = options
-  const { range, pollInterval, lastRefresh } = useTimeRange()
+  const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
 
   // Use range (can be more granular) for live summary stats queries
-  const { startDate, endDate } = parseTimeRange(range, Date.now())
+  const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
   const params: SummaryParams = {
     startDate,
     endDate,
@@ -146,7 +146,7 @@ export function useLiveSummary(options: UseSummaryOptions = {}) {
 
   return useQuery({
     // Query key uses range + lastRefresh for stability
-    queryKey: queryKeys.analytics.liveSummary({ range, comparePrevious }, lastRefresh),
+    queryKey: queryKeys.analytics.liveSummary({ range, customRange, comparePrevious }, lastRefresh),
     queryFn: () => fetchLiveSummary(params),
     enabled,
     staleTime: 15 * 1000, // 15 seconds
@@ -177,14 +177,14 @@ export interface UseGeoJSONOptions {
  */
 export function useGeoJSON(options: UseGeoJSONOptions = {}) {
   const { enabled = true, countryCodes, cities } = options
-  const { range, pollInterval, lastRefresh } = useTimeRange()
+  const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
 
   return useQuery({
     // Query key uses lastRefresh for cache invalidation on manual refresh
-    queryKey: queryKeys.geo.geojson({ range, countryCodes, cities }, lastRefresh),
+    queryKey: queryKeys.geo.geojson({ range, customRange, countryCodes, cities }, lastRefresh),
     // Compute date range at fetch time so polls get fresh data
     queryFn: () => {
-      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
       return fetchGeoJSON({
         fromTimestamp: startDate,
         toTimestamp: endDate,
@@ -211,12 +211,12 @@ export interface UseGlobalTopIPsOptions {
  */
 export function useGlobalTopIPs(options: UseGlobalTopIPsOptions = {}) {
   const { enabled = true, limit = 5 } = options
-  const { range, pollInterval, lastRefresh } = useTimeRange()
+  const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
 
   return useQuery<GlobalTopIPsResponse>({
-    queryKey: queryKeys.geo.globalTopIPs({ range, limit }, lastRefresh),
+    queryKey: queryKeys.geo.globalTopIPs({ range, customRange, limit }, lastRefresh),
     queryFn: () => {
-      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
       return fetchGlobalTopIPs({
         fromTimestamp: startDate,
         toTimestamp: endDate,
@@ -242,15 +242,15 @@ export interface UseLocationTopIPsOptions {
  */
 export function useLocationTopIPs(locationId: number | null, options: UseLocationTopIPsOptions = {}) {
   const { enabled = true, limit = 5 } = options
-  const { range, lastRefresh } = useTimeRange()
+  const { range, customRange, lastRefresh } = useTimeRange()
 
   return useQuery<LocationTopIPsResponse>({
-    queryKey: queryKeys.geo.locationTopIPs(locationId ?? 0, { range, limit }, lastRefresh),
+    queryKey: queryKeys.geo.locationTopIPs(locationId ?? 0, { range, customRange, limit }, lastRefresh),
     queryFn: () => {
       if (locationId === null) {
         throw new Error("locationId is required")
       }
-      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
       return fetchLocationTopIPs({
         locationId,
         fromTimestamp: startDate,
@@ -277,12 +277,12 @@ export interface UseTopCountriesOptions {
  */
 export function useTopCountries(options: UseTopCountriesOptions = {}) {
   const { enabled = true, limit = 10 } = options
-  const { range, pollInterval, lastRefresh } = useTimeRange()
+  const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
 
   return useQuery<TopCountriesResponse>({
-    queryKey: queryKeys.geo.topCountries({ range, limit }, lastRefresh),
+    queryKey: queryKeys.geo.topCountries({ range, customRange, limit }, lastRefresh),
     queryFn: () => {
-      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
       return fetchTopCountries({
         fromTimestamp: startDate,
         toTimestamp: endDate,
@@ -306,12 +306,12 @@ export interface UseCumulativeTimeSeriesOptions {
  */
 export function useCumulativeTimeSeries(options: UseCumulativeTimeSeriesOptions = {}) {
   const { enabled = true } = options
-  const { range, pollInterval, lastRefresh } = useTimeRange()
+  const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
 
   return useQuery<CumulativeTimeSeriesResponse>({
-    queryKey: queryKeys.analytics.cumulativeTimeSeries({ range }, lastRefresh),
+    queryKey: queryKeys.analytics.cumulativeTimeSeries({ range, customRange }, lastRefresh),
     queryFn: () => {
-      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
       return fetchCumulativeTimeSeries({
         startDate,
         endDate,
@@ -344,13 +344,13 @@ export interface UseTopListOptions extends UseAnalyticsQueryOptions {
  */
 export function useTimeSeries(options: UseAnalyticsQueryOptions = {}) {
   const { enabled = true } = options
-  const { range, granularity, pollInterval, lastRefresh } = useTimeRange()
-  const resolved = resolveChartGranularity(granularity, range)
+  const { range, customRange, granularity, pollInterval, lastRefresh } = useTimeRange()
+  const resolved = resolveChartGranularity(granularity, range, customRange)
 
   return useQuery({
-    queryKey: queryKeys.analytics.timeSeries({ range, granularity: resolved }, lastRefresh),
+    queryKey: queryKeys.analytics.timeSeries({ range, customRange, granularity: resolved }, lastRefresh),
     queryFn: () => {
-      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
       return fetchTimeSeries({ startDate, endDate, granularity: resolved })
     },
     enabled,
@@ -365,13 +365,13 @@ export function useTimeSeries(options: UseAnalyticsQueryOptions = {}) {
  */
 export function useGeoTimeSeries(options: UseAnalyticsQueryOptions = {}) {
   const { enabled = true } = options
-  const { range, granularity, pollInterval, lastRefresh } = useTimeRange()
-  const resolved = resolveChartGranularity(granularity, range)
+  const { range, customRange, granularity, pollInterval, lastRefresh } = useTimeRange()
+  const resolved = resolveChartGranularity(granularity, range, customRange)
 
   return useQuery({
-    queryKey: queryKeys.analytics.geoTimeSeries({ range, granularity: resolved }, lastRefresh),
+    queryKey: queryKeys.analytics.geoTimeSeries({ range, customRange, granularity: resolved }, lastRefresh),
     queryFn: () => {
-      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
       return fetchGeoTimeSeries({ startDate, endDate, granularity: resolved })
     },
     enabled,
@@ -386,12 +386,12 @@ export function useGeoTimeSeries(options: UseAnalyticsQueryOptions = {}) {
  */
 export function useTopUrls(options: UseTopListOptions = {}) {
   const { enabled = true, limit = 25 } = options
-  const { range, pollInterval, lastRefresh } = useTimeRange()
+  const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
 
   return useQuery({
-    queryKey: queryKeys.analytics.topUrls({ range, limit }, lastRefresh),
+    queryKey: queryKeys.analytics.topUrls({ range, customRange, limit }, lastRefresh),
     queryFn: () => {
-      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
       return fetchTopUrls({ startDate, endDate, limit })
     },
     enabled,
@@ -406,12 +406,12 @@ export function useTopUrls(options: UseTopListOptions = {}) {
  */
 export function useTopUserAgents(options: UseTopListOptions = {}) {
   const { enabled = true, limit = 25 } = options
-  const { range, pollInterval, lastRefresh } = useTimeRange()
+  const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
 
   return useQuery({
-    queryKey: queryKeys.analytics.topUserAgents({ range, limit }, lastRefresh),
+    queryKey: queryKeys.analytics.topUserAgents({ range, customRange, limit }, lastRefresh),
     queryFn: () => {
-      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
       return fetchTopUserAgents({ startDate, endDate, limit })
     },
     enabled,
@@ -426,12 +426,12 @@ export function useTopUserAgents(options: UseTopListOptions = {}) {
  */
 export function useTopIpStats(options: UseTopListOptions = {}) {
   const { enabled = true, limit = 25 } = options
-  const { range, pollInterval, lastRefresh } = useTimeRange()
+  const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
 
   return useQuery({
-    queryKey: queryKeys.analytics.topIps({ range, limit }, lastRefresh),
+    queryKey: queryKeys.analytics.topIps({ range, customRange, limit }, lastRefresh),
     queryFn: () => {
-      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
       return fetchTopIpStats({ startDate, endDate, limit })
     },
     enabled,
@@ -446,12 +446,12 @@ export function useTopIpStats(options: UseTopListOptions = {}) {
  */
 export function useTopCountryStats(options: UseTopListOptions = {}) {
   const { enabled = true, limit = 25 } = options
-  const { range, pollInterval, lastRefresh } = useTimeRange()
+  const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
 
   return useQuery({
-    queryKey: queryKeys.analytics.topCountryStats({ range, limit }, lastRefresh),
+    queryKey: queryKeys.analytics.topCountryStats({ range, customRange, limit }, lastRefresh),
     queryFn: () => {
-      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
       return fetchTopCountryStats({ startDate, endDate, limit })
     },
     enabled,
@@ -466,12 +466,12 @@ export function useTopCountryStats(options: UseTopListOptions = {}) {
  */
 export function useTopCityStats(options: UseTopListOptions = {}) {
   const { enabled = true, limit = 25 } = options
-  const { range, pollInterval, lastRefresh } = useTimeRange()
+  const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
 
   return useQuery({
-    queryKey: queryKeys.analytics.topCityStats({ range, limit }, lastRefresh),
+    queryKey: queryKeys.analytics.topCityStats({ range, customRange, limit }, lastRefresh),
     queryFn: () => {
-      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
       return fetchTopCityStats({ startDate, endDate, limit })
     },
     enabled,
@@ -518,15 +518,15 @@ export function useAccessLogs(options: UseAccessLogsOptions = {}) {
     sortField,
     sortOrder,
   } = options
-  const { range, pollInterval, lastRefresh } = useTimeRange()
+  const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
 
   return useQuery<AccessLogsPage>({
     queryKey: queryKeys.accessLogs.list(
-      { range, currentPage, pageSize, searchString, ipAddressIn, methodIn, host, cityIn, countryCodeIn, statusIn, sortField, sortOrder },
+      { range, customRange, currentPage, pageSize, searchString, ipAddressIn, methodIn, host, cityIn, countryCodeIn, statusIn, sortField, sortOrder },
       lastRefresh,
     ),
     queryFn: () => {
-      const { startDate, endDate } = parseTimeRange(range, Date.now())
+      const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
       return fetchAccessLogs({
         fromTimestamp: startDate,
         toTimestamp: endDate,

--- a/resources/lib/queries.ts
+++ b/resources/lib/queries.ts
@@ -19,6 +19,7 @@ import {
   fetchAccessLogFacets,
   fetchRuntimeSettings,
   parseTimeRange,
+  resolveChartGranularity,
   type SummaryParams,
   type GlobalTopIPsResponse,
   type LocationTopIPsResponse,
@@ -334,13 +335,14 @@ export interface UseTopListOptions extends UseAnalyticsQueryOptions {
  */
 export function useTimeSeries(options: UseAnalyticsQueryOptions = {}) {
   const { enabled = true } = options
-  const { range, pollInterval, lastRefresh } = useTimeRange()
+  const { range, granularity, pollInterval, lastRefresh } = useTimeRange()
+  const resolved = resolveChartGranularity(granularity, range)
 
   return useQuery({
-    queryKey: queryKeys.analytics.timeSeries({ range }, lastRefresh),
+    queryKey: queryKeys.analytics.timeSeries({ range, granularity: resolved }, lastRefresh),
     queryFn: () => {
       const { startDate, endDate } = parseTimeRange(range, Date.now())
-      return fetchTimeSeries({ startDate, endDate })
+      return fetchTimeSeries({ startDate, endDate, granularity: resolved })
     },
     enabled,
     staleTime: 60 * 1000,
@@ -354,13 +356,14 @@ export function useTimeSeries(options: UseAnalyticsQueryOptions = {}) {
  */
 export function useGeoTimeSeries(options: UseAnalyticsQueryOptions = {}) {
   const { enabled = true } = options
-  const { range, pollInterval, lastRefresh } = useTimeRange()
+  const { range, granularity, pollInterval, lastRefresh } = useTimeRange()
+  const resolved = resolveChartGranularity(granularity, range)
 
   return useQuery({
-    queryKey: queryKeys.analytics.geoTimeSeries({ range }, lastRefresh),
+    queryKey: queryKeys.analytics.geoTimeSeries({ range, granularity: resolved }, lastRefresh),
     queryFn: () => {
       const { startDate, endDate } = parseTimeRange(range, Date.now())
-      return fetchGeoTimeSeries({ startDate, endDate })
+      return fetchGeoTimeSeries({ startDate, endDate, granularity: resolved })
     },
     enabled,
     staleTime: 60 * 1000,

--- a/resources/lib/queries.ts
+++ b/resources/lib/queries.ts
@@ -34,6 +34,7 @@ import {
   type SortOrder,
 } from "./api"
 import { useTimeRange } from "./time-range-context"
+import { useAnalyticsFilters } from "./analytics-filters-context"
 
 // ============================================================================
 // Query Keys
@@ -345,13 +346,21 @@ export interface UseTopListOptions extends UseAnalyticsQueryOptions {
 export function useTimeSeries(options: UseAnalyticsQueryOptions = {}) {
   const { enabled = true } = options
   const { range, customRange, granularity, pollInterval, lastRefresh } = useTimeRange()
+  const { filters } = useAnalyticsFilters()
   const resolved = resolveChartGranularity(granularity, range, customRange)
 
   return useQuery({
-    queryKey: queryKeys.analytics.timeSeries({ range, customRange, granularity: resolved }, lastRefresh),
+    queryKey: queryKeys.analytics.timeSeries({ range, customRange, granularity: resolved, filters }, lastRefresh),
     queryFn: () => {
       const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
-      return fetchTimeSeries({ startDate, endDate, granularity: resolved })
+      return fetchTimeSeries({
+        startDate,
+        endDate,
+        granularity: resolved,
+        countryCodes: filters.countryCodes,
+        cities: filters.cities,
+        ips: filters.ips,
+      })
     },
     enabled,
     staleTime: 60 * 1000,
@@ -387,12 +396,20 @@ export function useGeoTimeSeries(options: UseAnalyticsQueryOptions = {}) {
 export function useTopUrls(options: UseTopListOptions = {}) {
   const { enabled = true, limit = 25 } = options
   const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
+  const { filters } = useAnalyticsFilters()
 
   return useQuery({
-    queryKey: queryKeys.analytics.topUrls({ range, customRange, limit }, lastRefresh),
+    queryKey: queryKeys.analytics.topUrls({ range, customRange, limit, filters }, lastRefresh),
     queryFn: () => {
       const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
-      return fetchTopUrls({ startDate, endDate, limit })
+      return fetchTopUrls({
+        startDate,
+        endDate,
+        limit,
+        countryCodes: filters.countryCodes,
+        cities: filters.cities,
+        ips: filters.ips,
+      })
     },
     enabled,
     staleTime: 60 * 1000,
@@ -407,12 +424,20 @@ export function useTopUrls(options: UseTopListOptions = {}) {
 export function useTopUserAgents(options: UseTopListOptions = {}) {
   const { enabled = true, limit = 25 } = options
   const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
+  const { filters } = useAnalyticsFilters()
 
   return useQuery({
-    queryKey: queryKeys.analytics.topUserAgents({ range, customRange, limit }, lastRefresh),
+    queryKey: queryKeys.analytics.topUserAgents({ range, customRange, limit, filters }, lastRefresh),
     queryFn: () => {
       const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
-      return fetchTopUserAgents({ startDate, endDate, limit })
+      return fetchTopUserAgents({
+        startDate,
+        endDate,
+        limit,
+        countryCodes: filters.countryCodes,
+        cities: filters.cities,
+        ips: filters.ips,
+      })
     },
     enabled,
     staleTime: 60 * 1000,
@@ -427,12 +452,20 @@ export function useTopUserAgents(options: UseTopListOptions = {}) {
 export function useTopIpStats(options: UseTopListOptions = {}) {
   const { enabled = true, limit = 25 } = options
   const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
+  const { filters } = useAnalyticsFilters()
 
   return useQuery({
-    queryKey: queryKeys.analytics.topIps({ range, customRange, limit }, lastRefresh),
+    queryKey: queryKeys.analytics.topIps({ range, customRange, limit, filters }, lastRefresh),
     queryFn: () => {
       const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
-      return fetchTopIpStats({ startDate, endDate, limit })
+      return fetchTopIpStats({
+        startDate,
+        endDate,
+        limit,
+        countryCodes: filters.countryCodes,
+        cities: filters.cities,
+        ips: filters.ips,
+      })
     },
     enabled,
     staleTime: 60 * 1000,
@@ -447,12 +480,20 @@ export function useTopIpStats(options: UseTopListOptions = {}) {
 export function useTopCountryStats(options: UseTopListOptions = {}) {
   const { enabled = true, limit = 25 } = options
   const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
+  const { filters } = useAnalyticsFilters()
 
   return useQuery({
-    queryKey: queryKeys.analytics.topCountryStats({ range, customRange, limit }, lastRefresh),
+    queryKey: queryKeys.analytics.topCountryStats({ range, customRange, limit, filters }, lastRefresh),
     queryFn: () => {
       const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
-      return fetchTopCountryStats({ startDate, endDate, limit })
+      return fetchTopCountryStats({
+        startDate,
+        endDate,
+        limit,
+        countryCodes: filters.countryCodes,
+        cities: filters.cities,
+        ips: filters.ips,
+      })
     },
     enabled,
     staleTime: 60 * 1000,
@@ -467,12 +508,20 @@ export function useTopCountryStats(options: UseTopListOptions = {}) {
 export function useTopCityStats(options: UseTopListOptions = {}) {
   const { enabled = true, limit = 25 } = options
   const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
+  const { filters } = useAnalyticsFilters()
 
   return useQuery({
-    queryKey: queryKeys.analytics.topCityStats({ range, customRange, limit }, lastRefresh),
+    queryKey: queryKeys.analytics.topCityStats({ range, customRange, limit, filters }, lastRefresh),
     queryFn: () => {
       const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
-      return fetchTopCityStats({ startDate, endDate, limit })
+      return fetchTopCityStats({
+        startDate,
+        endDate,
+        limit,
+        countryCodes: filters.countryCodes,
+        cities: filters.cities,
+        ips: filters.ips,
+      })
     },
     enabled,
     staleTime: 60 * 1000,

--- a/resources/lib/time-range-context.tsx
+++ b/resources/lib/time-range-context.tsx
@@ -1,22 +1,25 @@
 import { createContext, useContext, useState, useCallback, useEffect } from "react"
-import type { ChartGranularity, TimeRangeValue } from "./api"
+import type { ChartGranularity, CustomTimeRange, TimeRangeValue } from "./api"
 
 const STORAGE_KEY = "geometrikks-time-range"
 const DEFAULT_RANGE: TimeRangeValue = "7d"
 const DEFAULT_POLL_INTERVAL = 30000 // 30 seconds
 const DEFAULT_GRANULARITY: ChartGranularity = "auto"
+const DEFAULT_CUSTOM_RANGE: CustomTimeRange | null = null
 
 interface TimeRangeState {
   range: TimeRangeValue
   pollInterval: number
   lastRefresh: number
   granularity: ChartGranularity
+  customRange: CustomTimeRange | null
 }
 
 interface TimeRangeContextValue extends TimeRangeState {
   setRange: (range: TimeRangeValue) => void
   setPollInterval: (interval: number) => void
   setGranularity: (granularity: ChartGranularity) => void
+  setCustomRange: (customRange: CustomTimeRange) => void
   refresh: () => void
 }
 
@@ -50,18 +53,20 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
       pollInterval: stored.pollInterval ?? DEFAULT_POLL_INTERVAL,
       lastRefresh: Date.now(),
       granularity: stored.granularity ?? DEFAULT_GRANULARITY,
+      customRange: stored.customRange ?? DEFAULT_CUSTOM_RANGE,
     }
     return initial
   })
 
-  // Persist to localStorage when range, statsRange, pollInterval, or granularity changes
+  // Persist to localStorage when range, statsRange, pollInterval, granularity, or customRange changes
   useEffect(() => {
     saveToStorage({
       range: state.range,
       pollInterval: state.pollInterval,
       granularity: state.granularity,
+      customRange: state.customRange,
     })
-  }, [state.range, state.pollInterval, state.granularity])
+  }, [state.range, state.pollInterval, state.granularity, state.customRange])
 
   const setRange = useCallback((range: TimeRangeValue) => {
     setState((prev) => ({ ...prev, range, lastRefresh: Date.now() }))
@@ -75,6 +80,10 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
     setState((prev) => ({ ...prev, granularity }))
   }, [])
 
+  const setCustomRange = useCallback((customRange: CustomTimeRange) => {
+    setState((prev) => ({ ...prev, range: "custom", customRange, lastRefresh: Date.now() }))
+  }, [])
+
   const refresh = useCallback(() => {
     setState((prev) => ({ ...prev, lastRefresh: Date.now() }))
   }, [])
@@ -86,6 +95,7 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
         setRange,
         setPollInterval,
         setGranularity,
+        setCustomRange,
         refresh,
       }}
     >

--- a/resources/lib/time-range-context.tsx
+++ b/resources/lib/time-range-context.tsx
@@ -1,19 +1,22 @@
 import { createContext, useContext, useState, useCallback, useEffect } from "react"
-import type { TimeRangeValue } from "./api"
+import type { ChartGranularity, TimeRangeValue } from "./api"
 
 const STORAGE_KEY = "geometrikks-time-range"
 const DEFAULT_RANGE: TimeRangeValue = "7d"
 const DEFAULT_POLL_INTERVAL = 30000 // 30 seconds
+const DEFAULT_GRANULARITY: ChartGranularity = "auto"
 
 interface TimeRangeState {
   range: TimeRangeValue
   pollInterval: number
   lastRefresh: number
+  granularity: ChartGranularity
 }
 
 interface TimeRangeContextValue extends TimeRangeState {
   setRange: (range: TimeRangeValue) => void
   setPollInterval: (interval: number) => void
+  setGranularity: (granularity: ChartGranularity) => void
   refresh: () => void
 }
 
@@ -46,17 +49,19 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
       range: stored.range ?? DEFAULT_RANGE,
       pollInterval: stored.pollInterval ?? DEFAULT_POLL_INTERVAL,
       lastRefresh: Date.now(),
+      granularity: stored.granularity ?? DEFAULT_GRANULARITY,
     }
     return initial
   })
 
-  // Persist to localStorage when range, statsRange, or pollInterval changes
+  // Persist to localStorage when range, statsRange, pollInterval, or granularity changes
   useEffect(() => {
     saveToStorage({
       range: state.range,
       pollInterval: state.pollInterval,
+      granularity: state.granularity,
     })
-  }, [state.range, state.pollInterval])
+  }, [state.range, state.pollInterval, state.granularity])
 
   const setRange = useCallback((range: TimeRangeValue) => {
     setState((prev) => ({ ...prev, range, lastRefresh: Date.now() }))
@@ -64,6 +69,10 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
 
   const setPollInterval = useCallback((pollInterval: number) => {
     setState((prev) => ({ ...prev, pollInterval }))
+  }, [])
+
+  const setGranularity = useCallback((granularity: ChartGranularity) => {
+    setState((prev) => ({ ...prev, granularity }))
   }, [])
 
   const refresh = useCallback(() => {
@@ -76,6 +85,7 @@ export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
         ...state,
         setRange,
         setPollInterval,
+        setGranularity,
         refresh,
       }}
     >

--- a/resources/routes/analytics.tsx
+++ b/resources/routes/analytics.tsx
@@ -7,6 +7,8 @@ import { TopUrlsTable } from "@/components/analytics/top-urls-table"
 import { TopUserAgentsTable } from "@/components/analytics/top-user-agents-table"
 import { TopIpsTable } from "@/components/analytics/top-ips-table"
 import { TopCountriesCities } from "@/components/analytics/top-countries-cities"
+import { AnalyticsFilterBar } from "@/components/analytics/analytics-filter-bar"
+import { AnalyticsFiltersProvider } from "@/lib/analytics-filters-context"
 
 export const Route = createFileRoute("/analytics")({
   component: AnalyticsPage,
@@ -14,19 +16,22 @@ export const Route = createFileRoute("/analytics")({
 
 function AnalyticsPage() {
   return (
-    <div className="p-4 space-y-4">
-      <div className="grid gap-4 md:grid-cols-2">
-        <RequestsChart />
-        <StatusChart />
-        <BytesChart />
-        <LatencyChart />
+    <AnalyticsFiltersProvider>
+      <div className="p-4 space-y-4">
+        <AnalyticsFilterBar />
+        <div className="grid gap-4 md:grid-cols-2">
+          <RequestsChart />
+          <StatusChart />
+          <BytesChart />
+          <LatencyChart />
+        </div>
+        <div className="grid gap-4 lg:grid-cols-2">
+          <TopIpsTable />
+          <TopCountriesCities />
+        </div>
+        <TopUrlsTable />
+        <TopUserAgentsTable />
       </div>
-      <div className="grid gap-4 lg:grid-cols-2">
-        <TopIpsTable />
-        <TopCountriesCities />
-      </div>
-      <TopUrlsTable />
-      <TopUserAgentsTable />
-    </div>
+    </AnalyticsFiltersProvider>
   )
 }

--- a/resources/routes/analytics.tsx
+++ b/resources/routes/analytics.tsx
@@ -5,6 +5,8 @@ import { BytesChart } from "@/components/analytics/bytes-chart"
 import { LatencyChart } from "@/components/analytics/latency-chart"
 import { TopUrlsTable } from "@/components/analytics/top-urls-table"
 import { TopUserAgentsTable } from "@/components/analytics/top-user-agents-table"
+import { TopIpsTable } from "@/components/analytics/top-ips-table"
+import { TopCountriesCities } from "@/components/analytics/top-countries-cities"
 
 export const Route = createFileRoute("/analytics")({
   component: AnalyticsPage,
@@ -18,6 +20,10 @@ function AnalyticsPage() {
         <StatusChart />
         <BytesChart />
         <LatencyChart />
+      </div>
+      <div className="grid gap-4 lg:grid-cols-2">
+        <TopIpsTable />
+        <TopCountriesCities />
       </div>
       <TopUrlsTable />
       <TopUserAgentsTable />

--- a/tests/integration/test_analytics_endpoints.py
+++ b/tests/integration/test_analytics_endpoints.py
@@ -96,6 +96,38 @@ async def test_time_series_methods_survive_sub_24h_ranges(pg_session_maker, clea
     assert isinstance(geo_series, list)
 
 
+async def test_get_time_series_granularity_override(pg_session_maker, clean_tables):
+    """Explicit granularity overrides auto-routing: same data, different bucket
+    counts (issue #14 - user-selectable chart granularity)."""
+    from geometrikks.domain.analytics.repositories import StatsGranularity, SummaryStatsRepository
+
+    # Midnight of yesterday: guaranteed in the past regardless of wall-clock hour,
+    # and both inserts stay within the same calendar day.
+    base_day = (NOW - timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    ts1 = base_day + timedelta(hours=2)
+    ts2 = base_day + timedelta(hours=4)
+
+    async with pg_session_maker() as session:
+        await _insert_log(session, ts=ts1, url="/a", user_agent="ua")
+        await _insert_log(session, ts=ts2, url="/b", user_agent="ua")
+        await session.commit()
+
+    query_start = base_day
+    query_end = base_day + timedelta(days=2)
+
+    async with pg_session_maker() as session:
+        repo = SummaryStatsRepository(session=session)
+        daily_rows = await repo.get_time_series(query_start, query_end, granularity=StatsGranularity.DAILY)
+        hourly_rows = await repo.get_time_series(query_start, query_end, granularity=StatsGranularity.HOURLY)
+
+    assert len(daily_rows) == 1
+    assert daily_rows[0].bucket == base_day
+    assert daily_rows[0].total_requests == 2
+
+    assert len(hourly_rows) == 2
+    assert {r.bucket for r in hourly_rows} == {ts1, ts2}
+
+
 async def test_time_series_total_bytes_is_int(pg_session_maker, clean_tables):
     """SUM(bigint) returns numeric/Decimal; the repo must coerce to int so
     JSON serialization emits a number, not a string (issue #14 bandwidth cap)."""

--- a/tests/integration/test_analytics_endpoints.py
+++ b/tests/integration/test_analytics_endpoints.py
@@ -15,13 +15,19 @@ from geometrikks.domain.analytics.repositories import LiveStatsRepository
 NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
 
 
-async def _insert_log(session, *, ts, url, user_agent, status=200, bytes_sent=100, rt=0.01):
+async def _insert_log(
+    session, *, ts, url, user_agent, status=200, bytes_sent=100, rt=0.01,
+    ip="10.0.0.1", country=None, country_name=None, city=None
+):
     # access_logs is an id-only base: no created_at/updated_at columns.
     await session.execute(text(
         "INSERT INTO access_logs (timestamp, ip_address, method, url, "
-        "status_code, bytes_sent, request_time, user_agent) "
-        "VALUES (:ts, '10.0.0.1', 'GET', :url, :status, :bytes, :rt, :ua)"
-    ), {"ts": ts, "url": url, "status": status, "bytes": bytes_sent, "rt": rt, "ua": user_agent})
+        "status_code, bytes_sent, request_time, user_agent, country_code, country_name, city) "
+        "VALUES (:ts, :ip, 'GET', :url, :status, :bytes, :rt, :ua, :country, :country_name, :city)"
+    ), {
+        "ts": ts, "url": url, "status": status, "bytes": bytes_sent, "rt": rt, "ua": user_agent,
+        "ip": ip, "country": country, "country_name": country_name, "city": city
+    })
 
 
 async def test_top_urls_ordering_and_math(pg_session_maker, clean_tables):
@@ -149,3 +155,49 @@ async def test_time_series_total_bytes_is_int(pg_session_maker, clean_tables):
     assert rows, "expected at least one bucket (real-time aggregation)"
     assert all(type(r.total_bytes) is int for r in rows)
     assert type(summary.total_bytes) is int
+
+
+async def test_top_ips_ordering_and_math(pg_session_maker, clean_tables):
+    ts = NOW - timedelta(hours=1)
+    async with pg_session_maker() as session:
+        for _ in range(3):
+            await _insert_log(session, ts=ts, url="/a", user_agent="x",
+                              ip="1.1.1.1", country="NO", city="Oslo", bytes_sent=100)
+        await _insert_log(session, ts=ts, url="/a", user_agent="x",
+                          ip="1.1.1.1", country="NO", city="Oslo", status=500)
+        await _insert_log(session, ts=ts, url="/b", user_agent="x",
+                          ip="2.2.2.2", country="SE", city="Umea")
+        await session.commit()
+
+    async with pg_session_maker() as session:
+        rows = await LiveStatsRepository(session=session).get_top_ips(
+            NOW - timedelta(hours=2), NOW, limit=10
+        )
+
+    assert [r.ip_address for r in rows] == ["1.1.1.1", "2.2.2.2"]
+    top = rows[0]
+    assert (top.hits, top.error_hits, top.country_code, top.city) == (4, 1, "NO", "Oslo")
+    assert type(top.total_bytes) is int
+
+
+async def test_top_countries_and_cities(pg_session_maker, clean_tables):
+    ts = NOW - timedelta(hours=1)
+    async with pg_session_maker() as session:
+        for ip in ("1.1.1.1", "1.1.1.2"):
+            await _insert_log(session, ts=ts, url="/a", user_agent="x",
+                              ip=ip, country="NO", country_name="Norway", city="Oslo")
+        await _insert_log(session, ts=ts, url="/b", user_agent="x",
+                          ip="2.2.2.2", country="SE", country_name="Sweden", city="Umea")
+        await _insert_log(session, ts=ts, url="/c", user_agent="x", ip="3.3.3.3")  # no geo
+        await session.commit()
+
+    async with pg_session_maker() as session:
+        repo = LiveStatsRepository(session=session)
+        countries = await repo.get_top_countries(NOW - timedelta(hours=2), NOW, limit=10)
+        cities = await repo.get_top_cities(NOW - timedelta(hours=2), NOW, limit=10)
+
+    assert [(c.country_code, c.hits, c.unique_ips) for c in countries] == [
+        ("NO", 2, 2), ("SE", 1, 1)
+    ]
+    assert countries[0].country_name == "Norway"
+    assert [(c.city, c.hits) for c in cities] == [("Oslo", 2), ("Umea", 1)]

--- a/tests/integration/test_analytics_endpoints.py
+++ b/tests/integration/test_analytics_endpoints.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import text
 
-from geometrikks.domain.analytics.repositories import LiveStatsRepository
+from geometrikks.domain.analytics.repositories import AnalyticsFilters, LiveStatsRepository
 
 # Wall-clock derived, hour-aligned (see test_repositories_pg.py for why).
 NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
@@ -201,9 +201,6 @@ async def test_top_countries_and_cities(pg_session_maker, clean_tables):
     ]
     assert countries[0].country_name == "Norway"
     assert [(c.city, c.hits) for c in cities] == [("Oslo", 2), ("Umea", 1)]
-
-
-from geometrikks.domain.analytics.repositories import AnalyticsFilters
 
 
 async def test_filtered_time_series_and_top_urls(pg_session_maker, clean_tables):

--- a/tests/integration/test_analytics_endpoints.py
+++ b/tests/integration/test_analytics_endpoints.py
@@ -94,3 +94,26 @@ async def test_time_series_methods_survive_sub_24h_ranges(pg_session_maker, clea
 
     assert isinstance(series, list)
     assert isinstance(geo_series, list)
+
+
+async def test_time_series_total_bytes_is_int(pg_session_maker, clean_tables):
+    """SUM(bigint) returns numeric/Decimal; the repo must coerce to int so
+    JSON serialization emits a number, not a string (issue #14 bandwidth cap)."""
+    from geometrikks.domain.analytics.repositories import SummaryStatsRepository
+
+    ts = NOW - timedelta(hours=1)
+    async with pg_session_maker() as session:
+        await _insert_log(session, ts=ts, url="/big", user_agent="x", bytes_sent=5_000_000_000)
+        await session.commit()
+
+    async with pg_session_maker() as session:
+        rows = await SummaryStatsRepository(session=session).get_time_series(
+            NOW - timedelta(days=2), NOW  # > 24h so it hits the hourly CAGG path
+        )
+        summary = await SummaryStatsRepository(session=session).get_summary(
+            NOW - timedelta(days=2), NOW
+        )
+
+    assert rows, "expected at least one bucket (real-time aggregation)"
+    assert all(type(r.total_bytes) is int for r in rows)
+    assert type(summary.total_bytes) is int

--- a/tests/integration/test_analytics_endpoints.py
+++ b/tests/integration/test_analytics_endpoints.py
@@ -201,3 +201,30 @@ async def test_top_countries_and_cities(pg_session_maker, clean_tables):
     ]
     assert countries[0].country_name == "Norway"
     assert [(c.city, c.hits) for c in cities] == [("Oslo", 2), ("Umea", 1)]
+
+
+from geometrikks.domain.analytics.repositories import AnalyticsFilters
+
+
+async def test_filtered_time_series_and_top_urls(pg_session_maker, clean_tables):
+    ts = NOW - timedelta(hours=1)
+    async with pg_session_maker() as session:
+        for _ in range(3):
+            await _insert_log(session, ts=ts, url="/no", user_agent="x",
+                              ip="1.1.1.1", country="NO", city="Oslo")
+        await _insert_log(session, ts=ts, url="/se", user_agent="x",
+                          ip="2.2.2.2", country="SE", city="Umea")
+        await session.commit()
+
+    f_country = AnalyticsFilters(country_codes=["NO"])
+    f_ip = AnalyticsFilters(ip_addresses=["2.2.2.2"])
+
+    async with pg_session_maker() as session:
+        repo = LiveStatsRepository(session=session)
+        rows = await repo.get_time_series(
+            NOW - timedelta(hours=2), NOW, bucket_interval="1 hour", filters=f_country
+        )
+        urls = await repo.get_top_urls(NOW - timedelta(hours=2), NOW, limit=10, filters=f_ip)
+
+    assert sum(r.total_requests for r in rows) == 3
+    assert [u.url for u in urls] == ["/se"]

--- a/tests/integration/test_cagg_backfill.py
+++ b/tests/integration/test_cagg_backfill.py
@@ -1,0 +1,102 @@
+"""CAGG history that predates refresh coverage must be backfilled.
+
+Reproduces the issue #14 symptom: after a narrow refresh advances the
+watermark, raw rows older than the materialized range vanish from CAGG
+queries (charts) while raw-table queries (top lists) still see them.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import text
+
+from geometrikks.domain.analytics.repositories import SummaryStatsRepository
+
+NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+OLD = NOW - timedelta(days=10)
+# Inside the simulated policy refresh window: without a row here, the
+# refresh has nothing to materialize and never advances the CAGG watermark,
+# so the "bug reproduced" precondition below would not actually hold.
+RECENT = NOW - timedelta(days=1)
+
+
+async def _refresh(engine, cagg: str, start, end) -> None:
+    # CALL cannot run inside a transaction: use the raw asyncpg connection
+    async with engine.connect() as conn:
+        raw = await conn.get_raw_connection()
+        await raw.driver_connection.execute(
+            f"CALL refresh_continuous_aggregate('{cagg}', $1::timestamptz, $2::timestamptz)",
+            start,
+            end,
+        )
+
+
+async def test_backfill_recovers_history(pg_engine, pg_session_maker, clean_tables):
+    from geometrikks.server.timescale import backfill_cagg_gaps
+
+    async with pg_session_maker() as session:
+        await session.execute(text(
+            "INSERT INTO access_logs (timestamp, ip_address, status_code, bytes_sent, request_time) "
+            "VALUES (:ts, '10.0.0.1', 200, 100, 0.01)"
+        ), {"ts": OLD})
+        await session.execute(text(
+            "INSERT INTO access_logs (timestamp, ip_address, status_code, bytes_sent, request_time) "
+            "VALUES (:ts, '10.0.0.2', 200, 100, 0.01)"
+        ), {"ts": RECENT})
+        await session.commit()
+
+    # Simulate the broken state: a policy-style refresh of only the trailing
+    # window advances the watermark past the old row without materializing it.
+    await _refresh(pg_engine, "summary_daily_stats",
+                   NOW - timedelta(days=3), NOW - timedelta(hours=1))
+
+    async with pg_session_maker() as session:
+        rows = await SummaryStatsRepository(session=session).get_time_series(
+            NOW - timedelta(days=90), NOW
+        )
+    assert all(r.bucket.date() != OLD.date() for r in rows), "precondition: bug reproduced"
+
+    await backfill_cagg_gaps(pg_engine, raw_retention_days=180)
+
+    async with pg_session_maker() as session:
+        rows = await SummaryStatsRepository(session=session).get_time_series(
+            NOW - timedelta(days=90), NOW
+        )
+    assert any(r.bucket.date() == OLD.date() for r in rows)
+
+
+async def test_one_bad_probe_does_not_cascade(pg_engine, pg_session_maker, clean_tables, monkeypatch):
+    """A probe failure for one CAGG must not skip the others.
+
+    Each CAGG is probed on its own connection: a failed statement poisons
+    only that connection's transaction, so a bad first entry must not
+    cascade to later ones (regression guard for the shared-connection bug).
+    """
+    import geometrikks.server.timescale as ts
+
+    async with pg_session_maker() as session:
+        for ts_val, ip in ((OLD, "10.0.0.1"), (RECENT, "10.0.0.2")):
+            await session.execute(text(
+                "INSERT INTO access_logs (timestamp, ip_address, status_code, bytes_sent, request_time) "
+                "VALUES (:ts, :ip, 200, 100, 0.01)"
+            ), {"ts": ts_val, "ip": ip})
+        await session.commit()
+
+    await _refresh(pg_engine, "summary_daily_stats",
+                   NOW - timedelta(days=3), NOW - timedelta(hours=1))
+
+    # Poison the FIRST probed CAGG by pointing it at a nonexistent table.
+    # A shared-connection implementation would abort the transaction and
+    # skip summary_daily_stats too, leaving the gap unfilled.
+    bad = {"broken_cagg": "table_that_does_not_exist", **ts.CAGG_SOURCE_TABLES}
+    monkeypatch.setattr(ts, "CAGG_SOURCE_TABLES", bad)
+
+    await ts.backfill_cagg_gaps(pg_engine, raw_retention_days=180)
+
+    async with pg_session_maker() as session:
+        rows = await SummaryStatsRepository(session=session).get_time_series(
+            NOW - timedelta(days=90), NOW
+        )
+    assert any(r.bucket.date() == OLD.date() for r in rows), (
+        "later CAGG was skipped: one bad probe cascaded across the shared connection"
+    )

--- a/tests/test_analytics_granularity.py
+++ b/tests/test_analytics_granularity.py
@@ -1,0 +1,28 @@
+"""Chart granularity resolution: explicit override wins, fallback is the
+existing get_stats_granularity routing, RAW is never returned."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from geometrikks.api.v1.analytics_controller import _resolve_chart_granularity
+from geometrikks.domain.analytics.repositories import StatsGranularity
+
+NOW = datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc)
+
+
+def test_explicit_override_wins():
+    start = NOW - timedelta(days=14)
+    assert _resolve_chart_granularity(start, NOW, "daily") is StatsGranularity.DAILY
+    assert _resolve_chart_granularity(start, NOW, "hourly") is StatsGranularity.HOURLY
+
+
+def test_fallback_matches_get_stats_granularity():
+    # > 30 days -> DAILY (unchanged default routing)
+    assert _resolve_chart_granularity(NOW - timedelta(days=90), NOW, None) is StatsGranularity.DAILY
+    # 24h..30d -> HOURLY (unchanged default routing)
+    assert _resolve_chart_granularity(NOW - timedelta(days=14), NOW, None) is StatsGranularity.HOURLY
+
+
+def test_raw_is_never_returned():
+    # <= 24h falls back to RAW internally but must clamp to HOURLY for charts
+    assert _resolve_chart_granularity(NOW - timedelta(hours=6), NOW, None) is StatsGranularity.HOURLY

--- a/tests/test_analytics_granularity.py
+++ b/tests/test_analytics_granularity.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-from geometrikks.api.v1.analytics_controller import _resolve_chart_granularity
+import pytest
+from litestar.exceptions import ValidationException
+
+from geometrikks.api.v1.analytics_controller import _build_filters, _resolve_chart_granularity
 from geometrikks.domain.analytics.repositories import StatsGranularity
 
 NOW = datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc)
@@ -26,3 +29,34 @@ def test_fallback_matches_get_stats_granularity():
 def test_raw_is_never_returned():
     # <= 24h falls back to RAW internally but must clamp to HOURLY for charts
     assert _resolve_chart_granularity(NOW - timedelta(hours=6), NOW, None) is StatsGranularity.HOURLY
+
+
+def test_build_filters_accepts_valid_ipv4():
+    filters = _build_filters(None, None, ["1.1.1.1", "2.2.2.2"])
+    assert filters.ip_addresses == ["1.1.1.1", "2.2.2.2"]
+
+
+def test_build_filters_accepts_valid_ipv6():
+    filters = _build_filters(None, None, ["2001:db8::1"])
+    assert filters.ip_addresses == ["2001:db8::1"]
+
+
+def test_build_filters_rejects_invalid_ip():
+    with pytest.raises(ValidationException):
+        _build_filters(None, None, ["not-an-ip"])
+
+
+def test_build_filters_all_none_is_inactive():
+    filters = _build_filters(None, None, None)
+    assert filters.is_active() is False
+    assert filters.country_codes is None
+    assert filters.cities is None
+    assert filters.ip_addresses is None
+
+
+def test_build_filters_empty_lists_behave_like_none():
+    filters = _build_filters([], [], [])
+    assert filters.is_active() is False
+    assert filters.country_codes is None
+    assert filters.cities is None
+    assert filters.ip_addresses is None

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "geometrikks"
-version = "0.1.0"
+version = "0.2.2"
 source = { virtual = "." }
 dependencies = [
     { name = "advanced-alchemy", extra = ["argon2", "cli", "passlib", "pwdlib"] },


### PR DESCRIPTION
Closes #14

## What
Analytics page improvements bundled from issue #14.

- **Bandwidth card fix** - Decimal-as-JSON-string was capping the Y-axis; now coerced to int.
- **Selectable chart granularity** - Auto / Hourly / Daily selector; never RAW above 24h, falls back to `get_stats_granularity`, avoids hourly buckets on ranges above 7d.
- **Top IPs** and **Top Countries / Cities** cards (new API endpoints + tables).
- **Custom absolute date-range picker** (mobile-friendly); fixed a UTC-vs-local off-by-offset bug and a dropdown-width clipping bug.
- **Country / City / IP filters** (multi-select + manual IP entry) wired to all charts and top-lists.
- **CAGG gap backfill** - recovers history that predates refresh coverage so charts and top-lists agree.
- **Pagination** on all top-lists (10 rows/page) so the page does not scroll far.

## Testing
- 195 passing (`uv run pytest tests -q`)
- `npm run build` clean
- Verified end-to-end on the dev DB and in the browser
