### PR TITLE
fix: sidebar tooltips and runtime metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,5 +78,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_IMAGE_TAG=${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Live map packets now complete their route before coalesced follow-up traffic
   from the same visual corridor begins.
   - Analytics page: Bandwidth card fix - Decimal-as-JSON-string was capping the Y-axis; now coerced to int.
+- Sidebar tooltips no longer appear as a side effect of collapsing the sidebar,
+  and each navigation item now owns only one tooltip.
 
-### Added 
+### Added
 
 - Add search and filter options to access logs.
 - Add more columns on the live tail access log view.
@@ -23,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added custom absolute date-range picker (mobile-friendly)
 - Analytics page: Country / City / IP filters (multi-select + manual IP entry) wired to all charts and top-lists.
 - Added CAGG gap backfill - recovers history that predates refresh coverage so charts and top-lists agree.
+- Sidebar footer now reports the installed package version and indicates when
+  the app is running in a container, including the release image tag.
+- Added `react-icons`
 
 
 ## [0.2.1] - 2026-07-13

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ WORKDIR /app
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy
 
-COPY pyproject.toml uv.lock* ./
+COPY pyproject.toml uv.lock* README.md ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-install-project
 
@@ -45,6 +45,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Stage 3: Production runtime
 # ------------------------------------------------------------------------------
 FROM python:3.13-slim-bookworm AS production
+
+ARG APP_IMAGE_TAG=local
 
 RUN groupadd --gid 1000 geometrikks \
     && useradd --uid 1000 --gid geometrikks --shell /bin/bash --create-home geometrikks
@@ -68,6 +70,8 @@ ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     APP_ENVIRONMENT=production \
+    APP_RUNTIME=container \
+    APP_IMAGE_TAG=${APP_IMAGE_TAG} \
     VITE_DEV_MODE=false \
     GEOIP_DB_PATH=/app/data/geoip/GeoLite2-City.mmdb \
     GEOIP_VALIDATE_DB_PATH=false \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,6 +4,8 @@ FROM oven/bun:latest AS bun
 
 FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
+ARG APP_IMAGE_TAG=local
+
 COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 
 WORKDIR /app
@@ -13,11 +15,17 @@ ENV UV_COMPILE_BYTECODE=1 \
     PATH="/app/.venv/bin:$PATH" \
     PYTHONUNBUFFERED=1 \
     APP_ENVIRONMENT=development \
+    APP_RUNTIME=container \
+    APP_IMAGE_TAG=${APP_IMAGE_TAG} \
     API_RELOAD=true \
     VITE_DEV_MODE=true
 
-COPY pyproject.toml uv.lock* ./
+COPY pyproject.toml uv.lock* README.md ./
 COPY package.json bun.lock ./
+
+# Install the project once so importlib.metadata can report its version. The
+# source mount used for hot reload replaces this copy at runtime.
+COPY geometrikks/ ./geometrikks/
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "radix-ui": "^1.4.3",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
+        "react-icons": "^5.7.0",
         "react-map-gl": "^8.1.0",
         "recharts": "^2.15.4",
         "shadcn": "^3.6.2",
@@ -1114,6 +1115,8 @@
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "react-icons": ["react-icons@5.7.0", "", { "peerDependencies": { "react": "*" } }, "sha512-LBLy340Rzqy6+/yVhZKT3B/QpP1BZaesGqasf09HPOBzRarcDIFH0WwXlXQfE7q7ipxK4MSiC5DIBWURCny6fw=="],
 
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,10 +10,12 @@ list most users need is in `.env.example`; everything below is available.
 | Variable | Default | Description |
 |---|---|---|
 | `APP_NAME` | `GeoMetrikks API` | Application name |
-| `APP_VERSION` | `0.1.0` | Application version |
+| `APP_VERSION` | *(computed)* | Application version (defaults to installed package metadata) |
 | `APP_DESCRIPTION` | `Real-time GeoIP lookups and traffic analytics API` | Application description |
 | `APP_DEBUG` | `false` | Enable debug mode |
 | `APP_ENVIRONMENT` | `production` | Application environment |
+| `APP_RUNTIME` | `host` | Execution runtime; container images set this to container. |
+| `APP_IMAGE_TAG` | — | Optional container image tag embedded at build time. |
 | `APP_AUTH_DISABLED` | `false` | Disable the built-in session auth entirely. Set true only when an authenticating reverse proxy (Authelia, Tailscale, ...) fronts the app. |
 | `APP_ADMIN_USER` | `admin` | Admin login username |
 | `APP_ADMIN_PASSWORD` | — | Admin login password (required unless auth_disabled=true) |

--- a/geometrikks/api/v1/settings.py
+++ b/geometrikks/api/v1/settings.py
@@ -38,10 +38,19 @@ class MapSettingsView:
 
 
 @dataclass
+class RuntimeSettingsView:
+    """Non-sensitive information about the executing application image."""
+
+    container: bool
+    image_tag: str | None
+
+
+@dataclass
 class SafeSettingsResponse:
     name: str
     version: str
     environment: str
+    runtime: RuntimeSettingsView
     logparser: LogparserSettingsView
     analytics: AnalyticsSettingsView
     map: MapSettingsView
@@ -62,6 +71,10 @@ async def read_settings(request: Request) -> SafeSettingsResponse:
         name=s.name,
         version=s.version,
         environment=s.environment,
+        runtime=RuntimeSettingsView(
+            container=s.runtime == "container",
+            image_tag=s.image_tag if s.runtime == "container" else None,
+        ),
         logparser=LogparserSettingsView(
             log_paths=[str(p) for p in s.logparser.log_paths],
             send_logs=s.logparser.send_logs,

--- a/geometrikks/config/settings.py
+++ b/geometrikks/config/settings.py
@@ -1,12 +1,26 @@
 import json
 import socket
 from functools import lru_cache
+from importlib.metadata import PackageNotFoundError, version as distribution_version
 from pathlib import Path
 from typing import Annotated, Literal
 
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 from geometrikks.services.logparser.constants import ALLOWED_GEOIP_LOCALES
+
+
+def get_installed_version() -> str:
+    """Return the version of the installed GeoMetrikks distribution.
+
+    The application is packaged during normal ``uv sync`` and image builds, so
+    distribution metadata is the single source of truth for the running
+    version. The fallback keeps direct source execution usable before install.
+    """
+    try:
+        return distribution_version("geometrikks")
+    except PackageNotFoundError:
+        return "unknown"
 
 
 class DatabaseSettings(BaseSettings):
@@ -377,7 +391,10 @@ class Settings(BaseSettings):
 
     # Application metadata
     name: str = Field(default="GeoMetrikks API", description="Application name")
-    version: str = Field(default="0.1.0", description="Application version")
+    version: str = Field(
+        default_factory=get_installed_version,
+        description="Application version (defaults to installed package metadata)",
+    )
     description: str = Field(
         default="Real-time GeoIP lookups and traffic analytics API",
         description="Application description",
@@ -386,6 +403,14 @@ class Settings(BaseSettings):
     environment: Literal["development", "staging", "production"] = Field(
         default="production",
         description="Application environment",
+    )
+    runtime: Literal["host", "container"] = Field(
+        default="host",
+        description="Execution runtime; container images set this to container.",
+    )
+    image_tag: str | None = Field(
+        default=None,
+        description="Optional container image tag embedded at build time.",
     )
 
     # Authentication (single admin user; see Phase 1c design)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "radix-ui": "^1.4.3",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "react-icons": "^5.7.0",
     "react-map-gl": "^8.1.0",
     "recharts": "^2.15.4",
     "shadcn": "^3.6.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,10 @@ dependencies = [
     "alembic>=1.18.5",
 ]
 
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [dependency-groups]
 dev = [
     "pytest>=9.1.1",

--- a/resources/components/app-sidebar.tsx
+++ b/resources/components/app-sidebar.tsx
@@ -1,5 +1,6 @@
 import { Link, useRouterState } from "@tanstack/react-router"
 import { useQuery } from "@tanstack/react-query"
+import { useState } from "react"
 import {
   Sidebar,
   SidebarContent,
@@ -35,6 +36,8 @@ import {
 import { cn } from "@/lib/utils"
 import { fetchHealth, fetchMe, logout } from "@/lib/api"
 import { useLiveFeedStatus } from "@/lib/live-feed-context"
+import { useRuntimeSettings } from "@/lib/queries"
+import { SiDocker } from "react-icons/si"
 
 const navigationItems = [
   {
@@ -132,73 +135,67 @@ function GeoLogo({ collapsed }: { collapsed: boolean }) {
 function NavItem({
   item,
   isActive,
-  collapsed,
 }: {
   item: (typeof navigationItems)[0]
   isActive: boolean
-  collapsed: boolean
 }) {
   const Icon = item.icon
 
   return (
     <SidebarMenuItem>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <SidebarMenuButton
-            asChild
-            isActive={isActive}
-            tooltip={item.title}
+      <SidebarMenuButton
+        asChild
+        isActive={isActive}
+        tooltip={{
+          children: (
+            <span className="flex items-center gap-2">
+              <span>{item.title}</span>
+              <span className="text-muted-foreground text-xs">{item.description}</span>
+            </span>
+          ),
+        }}
+        className={cn(
+          "relative group/nav-item transition-all duration-200",
+          isActive && [
+            "bg-sidebar-accent/80",
+            "before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2",
+            "before:w-[3px] before:h-5 before:rounded-r-full",
+            "before:bg-geo-cyan before:shadow-[0_0_8px_var(--geo-cyan)]",
+          ]
+        )}
+      >
+        <Link to={item.url}>
+          <div className="relative">
+            <Icon
+              className={cn(
+                "w-4 h-4 transition-colors duration-200",
+                isActive
+                  ? "text-geo-cyan"
+                  : "text-sidebar-foreground/60 group-hover/nav-item:text-sidebar-foreground"
+              )}
+            />
+            {isActive && (
+              <div className="absolute inset-0 blur-sm bg-geo-cyan/30 rounded-full" />
+            )}
+          </div>
+          <span
             className={cn(
-              "relative group/nav-item transition-all duration-200",
-              isActive && [
-                "bg-sidebar-accent/80",
-                "before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2",
-                "before:w-[3px] before:h-5 before:rounded-r-full",
-                "before:bg-geo-cyan before:shadow-[0_0_8px_var(--geo-cyan)]",
-              ]
+              "transition-colors duration-200",
+              isActive
+                ? "text-sidebar-foreground font-medium"
+                : "text-sidebar-foreground/70 group-hover/nav-item:text-sidebar-foreground"
             )}
           >
-            <Link to={item.url}>
-              <div className="relative">
-                <Icon
-                  className={cn(
-                    "w-4 h-4 transition-colors duration-200",
-                    isActive
-                      ? "text-geo-cyan"
-                      : "text-sidebar-foreground/60 group-hover/nav-item:text-sidebar-foreground"
-                  )}
-                />
-                {isActive && (
-                  <div className="absolute inset-0 blur-sm bg-geo-cyan/30 rounded-full" />
-                )}
-              </div>
-              <span
-                className={cn(
-                  "transition-colors duration-200",
-                  isActive
-                    ? "text-sidebar-foreground font-medium"
-                    : "text-sidebar-foreground/70 group-hover/nav-item:text-sidebar-foreground"
-                )}
-              >
-                {item.title}
-              </span>
-            </Link>
-          </SidebarMenuButton>
-        </TooltipTrigger>
-        {collapsed && (
-          <TooltipContent side="right" className="flex items-center gap-2">
-            <span>{item.title}</span>
-            <span className="text-muted-foreground text-xs">
-              {item.description}
-            </span>
-          </TooltipContent>
-        )}
-      </Tooltip>
+            {item.title}
+          </span>
+        </Link>
+      </SidebarMenuButton>
     </SidebarMenuItem>
   )
 }
 
 function LiveIndicator({ collapsed }: { collapsed: boolean }) {
+  const { tooltipsSuppressed, resetTooltipSuppression } = useSidebar()
   const { data: health, isError } = useQuery({
     queryKey: ["health"],
     queryFn: fetchHealth,
@@ -223,7 +220,10 @@ function LiveIndicator({ collapsed }: { collapsed: boolean }) {
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="flex items-center justify-center py-2 mx-2">
+          <div
+            className="flex items-center justify-center py-2 mx-2"
+            onPointerLeave={resetTooltipSuppression}
+          >
             <div className="relative flex items-center justify-center w-3 h-3">
               {isRunning && (
                 <span className={cn("absolute inline-flex h-full w-full animate-ping rounded-full opacity-75", color)} />
@@ -232,9 +232,11 @@ function LiveIndicator({ collapsed }: { collapsed: boolean }) {
             </div>
           </div>
         </TooltipTrigger>
-        <TooltipContent side="right">
-          <span>{tooltip}</span>
-        </TooltipContent>
+        {!tooltipsSuppressed && (
+          <TooltipContent side="right">
+            <span>{tooltip}</span>
+          </TooltipContent>
+        )}
       </Tooltip>
     )
   }
@@ -262,6 +264,7 @@ function LiveIndicator({ collapsed }: { collapsed: boolean }) {
 }
 
 function LiveFeedIndicator({ collapsed }: { collapsed: boolean }) {
+  const { tooltipsSuppressed, resetTooltipSuppression } = useSidebar()
   // WebSocket live-feed status — distinct from the ingestion-health dot above.
   // Lazy-connect: reads "Live feed off" until a consumer (map pulses or the
   // access-logs live tail) subscribes to the shared connection.
@@ -285,13 +288,18 @@ function LiveFeedIndicator({ collapsed }: { collapsed: boolean }) {
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="flex items-center justify-center py-1 mx-2">
+          <div
+            className="flex items-center justify-center py-1 mx-2"
+            onPointerLeave={resetTooltipSuppression}
+          >
             <span className={cn("inline-flex w-2 h-2 rounded-full", color)} />
           </div>
         </TooltipTrigger>
-        <TooltipContent side="right">
-          <span>{tooltip}</span>
-        </TooltipContent>
+        {!tooltipsSuppressed && (
+          <TooltipContent side="right">
+            <span>{tooltip}</span>
+          </TooltipContent>
+        )}
       </Tooltip>
     )
   }
@@ -305,7 +313,7 @@ function LiveFeedIndicator({ collapsed }: { collapsed: boolean }) {
 }
 
 function LogoutButton() {
-  const { state, isMobile } = useSidebar()
+  const { state, isMobile, tooltipsSuppressed, resetTooltipSuppression } = useSidebar()
   const collapsed = isMobile ? false : state === "collapsed"
 
   // Only render when session auth is active: /auth/me succeeds when logged
@@ -333,6 +341,7 @@ function LogoutButton() {
       <TooltipTrigger asChild>
         <button
           onClick={onLogout}
+          onPointerLeave={resetTooltipSuppression}
           className={cn(
             "flex items-center justify-center w-full py-2",
             collapsed ? "px-0" : "px-3",
@@ -351,25 +360,47 @@ function LogoutButton() {
           </span>
         </button>
       </TooltipTrigger>
-      <TooltipContent side="right">
-        <span>Log out {me.username}</span>
-      </TooltipContent>
+      {collapsed && !tooltipsSuppressed && (
+        <TooltipContent side="right">
+          <span>Log out {me.username}</span>
+        </TooltipContent>
+      )}
     </Tooltip>
   )
 }
 
 function CollapseToggle() {
-  const { toggleSidebar, state, isMobile } = useSidebar()
+  const { toggleSidebar, state, isMobile, resetTooltipSuppression } = useSidebar()
   const collapsed = state === "collapsed"
+  const [tooltipOpen, setTooltipOpen] = useState(false)
+  const [suppressTooltip, setSuppressTooltip] = useState(false)
 
   // Don't show collapse toggle on mobile - sidebar is always expanded when open
   if (isMobile) return null
 
+  function onToggle(event: React.MouseEvent<HTMLButtonElement>) {
+    // The trigger stays focused and hovered after its click. Suppress that
+    // state so collapsing cannot open its new "Expand sidebar" tooltip.
+    setSuppressTooltip(true)
+    setTooltipOpen(false)
+    event.currentTarget.blur()
+    toggleSidebar()
+  }
+
+  function onTooltipOpenChange(open: boolean) {
+    if (!suppressTooltip) setTooltipOpen(open)
+  }
+
   return (
-    <Tooltip>
+    <Tooltip open={tooltipOpen} onOpenChange={onTooltipOpenChange}>
       <TooltipTrigger asChild>
         <button
-          onClick={toggleSidebar}
+          onClick={onToggle}
+          onPointerLeave={() => {
+            setSuppressTooltip(false)
+            setTooltipOpen(false)
+            resetTooltipSuppression()
+          }}
           className={cn(
             "flex items-center justify-center w-full py-2",
             collapsed ? "px-0" : "px-3",
@@ -394,12 +425,41 @@ function CollapseToggle() {
           </span>
         </button>
       </TooltipTrigger>
-      {collapsed && (
+      {collapsed && !suppressTooltip && (
         <TooltipContent side="right">
           <span>Expand sidebar</span>
         </TooltipContent>
       )}
     </Tooltip>
+  )
+}
+
+function RuntimeMetadata({ collapsed }: { collapsed: boolean }) {
+  const { data: settings } = useRuntimeSettings()
+
+  if (collapsed || !settings) return null
+
+  const imageTag = settings.runtime.image_tag
+  const runtimeLabel = imageTag
+    ? `Container image ${imageTag}`
+    : "Running in a container"
+
+  return (
+    <div className="flex items-center justify-center gap-1.5 px-3 py-2 text-sidebar-foreground/30">
+      <span className="text-[10px] font-mono">v{settings.version}</span>
+      {settings.runtime.container && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex cursor-default" aria-label={runtimeLabel}>
+              <SiDocker aria-hidden="true" className="h-6 w-6 text-[#2560ff]" />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="right">
+            <span>{runtimeLabel}</span>
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </div>
   )
 }
 
@@ -444,7 +504,6 @@ export function AppSidebar() {
                       ? currentPath === "/"
                       : currentPath.startsWith(item.url)
                   }
-                  collapsed={collapsed}
                 />
               ))}
             </SidebarMenu>
@@ -466,7 +525,6 @@ export function AppSidebar() {
                   key={item.title}
                   item={item}
                   isActive={currentPath.startsWith(item.url)}
-                  collapsed={collapsed}
                 />
               ))}
             </SidebarMenu>
@@ -478,12 +536,7 @@ export function AppSidebar() {
         <SidebarSeparator className="opacity-50" />
         <LogoutButton />
         <CollapseToggle />
-        {/* Version tag */}
-        <div className={cn("px-3 py-2 text-center", collapsed && "hidden")}>
-          <span className="text-[10px] font-mono text-sidebar-foreground/30">
-            v0.1.0-alpha
-          </span>
-        </div>
+        <RuntimeMetadata collapsed={collapsed} />
       </SidebarFooter>
 
       <SidebarRail />

--- a/resources/components/app-sidebar.tsx
+++ b/resources/components/app-sidebar.tsx
@@ -451,7 +451,7 @@ function RuntimeMetadata({ collapsed }: { collapsed: boolean }) {
         <Tooltip>
           <TooltipTrigger asChild>
             <span className="inline-flex cursor-default" aria-label={runtimeLabel}>
-              <SiDocker aria-hidden="true" className="h-6 w-6 text-[#2560ff]" />
+              <SiDocker aria-hidden="true" className="h-4 w-4 text-[#2496ED]" />
             </span>
           </TooltipTrigger>
           <TooltipContent side="right">

--- a/resources/components/ui/sidebar.tsx
+++ b/resources/components/ui/sidebar.tsx
@@ -39,6 +39,8 @@ type SidebarContextProps = {
   setOpenMobile: (open: boolean) => void
   isMobile: boolean
   toggleSidebar: () => void
+  tooltipsSuppressed: boolean
+  resetTooltipSuppression: () => void
 }
 
 const SidebarContext = React.createContext<SidebarContextProps | null>(null)
@@ -67,6 +69,7 @@ function SidebarProvider({
 }) {
   const isMobile = useIsMobile()
   const [openMobile, setOpenMobile] = React.useState(false)
+  const [tooltipsSuppressed, setTooltipsSuppressed] = React.useState(false)
 
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.
@@ -89,8 +92,16 @@ function SidebarProvider({
 
   // Helper to toggle the sidebar.
   const toggleSidebar = React.useCallback(() => {
+    // A focused or hovered trigger can otherwise reveal a tooltip as soon as
+    // the sidebar enters collapsed state. It is re-enabled when the pointer
+    // leaves that trigger, before a normal subsequent hover.
+    setTooltipsSuppressed(true)
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
   }, [isMobile, setOpen, setOpenMobile])
+
+  const resetTooltipSuppression = React.useCallback(() => {
+    setTooltipsSuppressed(false)
+  }, [])
 
   // Adds a keyboard shortcut to toggle the sidebar.
   React.useEffect(() => {
@@ -121,8 +132,20 @@ function SidebarProvider({
       openMobile,
       setOpenMobile,
       toggleSidebar,
+      tooltipsSuppressed,
+      resetTooltipSuppression,
     }),
-    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
+    [
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+      tooltipsSuppressed,
+      resetTooltipSuppression,
+    ]
   )
 
   return (
@@ -497,6 +520,7 @@ function SidebarMenuButton({
   size = "default",
   tooltip,
   className,
+  onPointerLeave,
   ...props
 }: React.ComponentProps<"button"> & {
   asChild?: boolean
@@ -504,7 +528,7 @@ function SidebarMenuButton({
   tooltip?: string | React.ComponentProps<typeof TooltipContent>
 } & VariantProps<typeof sidebarMenuButtonVariants>) {
   const Comp = asChild ? Slot.Root : "button"
-  const { isMobile, state } = useSidebar()
+  const { isMobile, state, tooltipsSuppressed, resetTooltipSuppression } = useSidebar()
 
   const button = (
     <Comp
@@ -513,6 +537,10 @@ function SidebarMenuButton({
       data-size={size}
       data-active={isActive}
       className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+      onPointerLeave={(event) => {
+        onPointerLeave?.(event)
+        resetTooltipSuppression()
+      }}
       {...props}
     />
   )
@@ -533,7 +561,7 @@ function SidebarMenuButton({
       <TooltipContent
         side="right"
         align="center"
-        hidden={state !== "collapsed" || isMobile}
+        hidden={state !== "collapsed" || isMobile || tooltipsSuppressed}
         {...tooltip}
       />
     </Tooltip>

--- a/resources/components/ui/sidebar.tsx
+++ b/resources/components/ui/sidebar.tsx
@@ -94,8 +94,14 @@ function SidebarProvider({
   const toggleSidebar = React.useCallback(() => {
     // A focused or hovered trigger can otherwise reveal a tooltip as soon as
     // the sidebar enters collapsed state. It is re-enabled when the pointer
-    // leaves that trigger, before a normal subsequent hover.
-    setTooltipsSuppressed(true)
+    // leaves that trigger, before a normal subsequent hover. Only suppress when
+    // a sidebar element is actually focused or hovered at toggle time; otherwise
+    // (e.g. a keyboard toggle with the pointer elsewhere) the first later hover
+    // must behave normally.
+    const panel = document.querySelector('[data-slot="sidebar-inner"]')
+    const hovered = panel?.matches(":hover") ?? false
+    const focused = !!(panel && panel.contains(document.activeElement))
+    setTooltipsSuppressed(hovered || focused)
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
   }, [isMobile, setOpen, setOpenMobile])
 

--- a/resources/components/ui/tooltip.tsx
+++ b/resources/components/ui/tooltip.tsx
@@ -21,11 +21,7 @@ function TooltipProvider({
 function Tooltip({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return (
-    <TooltipProvider>
-      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
-    </TooltipProvider>
-  )
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
 }
 
 function TooltipTrigger({

--- a/resources/generated/api/schemas.gen.ts
+++ b/resources/generated/api/schemas.gen.ts
@@ -1051,6 +1051,27 @@ export const PeriodSummarySchema = {
   type: "object",
 } as const;
 
+export const RuntimeSettingsViewSchema = {
+  properties: {
+    container: {
+      type: "boolean",
+    },
+    image_tag: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+  },
+  required: ["container", "image_tag"],
+  title: "RuntimeSettingsView",
+  type: "object",
+} as const;
+
 export const SafeSettingsResponseSchema = {
   properties: {
     analytics: {
@@ -1068,11 +1089,22 @@ export const SafeSettingsResponseSchema = {
     name: {
       type: "string",
     },
+    runtime: {
+      $ref: "#/components/schemas/RuntimeSettingsView",
+    },
     version: {
       type: "string",
     },
   },
-  required: ["analytics", "environment", "logparser", "map", "name", "version"],
+  required: [
+    "analytics",
+    "environment",
+    "logparser",
+    "map",
+    "name",
+    "runtime",
+    "version",
+  ],
   title: "SafeSettingsResponse",
   type: "object",
 } as const;

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -308,6 +308,14 @@ export type PeriodSummary = {
 };
 
 /**
+ * RuntimeSettingsView
+ */
+export type RuntimeSettingsView = {
+  container: boolean;
+  image_tag: string | null;
+};
+
+/**
  * SafeSettingsResponse
  */
 export type SafeSettingsResponse = {
@@ -316,6 +324,7 @@ export type SafeSettingsResponse = {
   logparser: LogparserSettingsView;
   map: MapSettingsView;
   name: string;
+  runtime: RuntimeSettingsView;
   version: string;
 };
 

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -1097,6 +1097,29 @@
         "title": "PeriodSummary",
         "type": "object"
       },
+      "RuntimeSettingsView": {
+        "properties": {
+          "container": {
+            "type": "boolean"
+          },
+          "image_tag": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "container",
+          "image_tag"
+        ],
+        "title": "RuntimeSettingsView",
+        "type": "object"
+      },
       "SafeSettingsResponse": {
         "properties": {
           "analytics": {
@@ -1114,6 +1137,9 @@
           "name": {
             "type": "string"
           },
+          "runtime": {
+            "$ref": "#/components/schemas/RuntimeSettingsView"
+          },
           "version": {
             "type": "string"
           }
@@ -1124,6 +1150,7 @@
           "logparser",
           "map",
           "name",
+          "runtime",
           "version"
         ],
         "title": "SafeSettingsResponse",
@@ -1602,7 +1629,7 @@
   "info": {
     "description": "Real-time GeoIP lookups and traffic analytics API",
     "title": "GeoMetrikks API",
-    "version": "0.1.0"
+    "version": "0.2.2"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,6 @@ def baseline_settings_env():
     os.environ.update({
         # App
         "APP_NAME": "GeoMetrikks API",
-        "APP_VERSION": "0.1.0",
         "APP_DEBUG": "false",
         "APP_ENVIRONMENT": "production",
         # API

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from geometrikks.config import GeoIPSettings, MapSettings, Settings, get_settings
+from geometrikks.config.settings import get_installed_version
 
 
 def test_default_settings():
@@ -12,7 +13,7 @@ def test_default_settings():
     settings = Settings()
     
     assert settings.name == "GeoMetrikks API"
-    assert settings.version == "0.1.0"
+    assert settings.version == get_installed_version()
     assert settings.environment == "production"
     assert settings.debug is False
 
@@ -22,12 +23,26 @@ def test_environment_override(monkeypatch):
     monkeypatch.setenv("APP_NAME", "Custom Name")
     monkeypatch.setenv("APP_DEBUG", "true")
     monkeypatch.setenv("APP_ENVIRONMENT", "development")
+    monkeypatch.setenv("APP_VERSION", "9.9.9-test")
     
     settings = Settings()
     
     assert settings.name == "Custom Name"
     assert settings.debug is True
     assert settings.environment == "development"
+    assert settings.version == "9.9.9-test"
+
+
+def test_runtime_metadata_defaults_and_overrides(monkeypatch):
+    default_settings = Settings(_env_file=None)
+    assert default_settings.runtime == "host"
+    assert default_settings.image_tag is None
+
+    monkeypatch.setenv("APP_RUNTIME", "container")
+    monkeypatch.setenv("APP_IMAGE_TAG", "v0.2.2-dev.4")
+    container_settings = Settings(_env_file=None)
+    assert container_settings.runtime == "container"
+    assert container_settings.image_tag == "v0.2.2-dev.4"
 
 
 def test_database_settings():

--- a/tests/test_settings_endpoint.py
+++ b/tests/test_settings_endpoint.py
@@ -28,6 +28,7 @@ def test_settings_response_is_whitelisted():
     assert body["name"]
     assert body["version"]
     assert body["environment"]
+    assert body["runtime"] == {"container": False, "image_tag": None}
     assert "log_paths" in body["logparser"]
     assert "raw_retention_days" in body["analytics"]
     assert body["map"] == {
@@ -40,3 +41,16 @@ def test_settings_response_is_whitelisted():
     flat = str(body).lower()
     for forbidden in ("password", "geopass", "database", "db_", "admin"):
         assert forbidden not in flat, f"leaked: {forbidden}"
+
+
+def test_settings_reports_container_build_metadata(monkeypatch):
+    monkeypatch.setenv("APP_RUNTIME", "container")
+    monkeypatch.setenv("APP_IMAGE_TAG", "v0.2.2-dev.4")
+
+    with TestClient(app=make_app()) as client:
+        body = client.get("/api/v1/settings").json()
+
+    assert body["runtime"] == {
+        "container": True,
+        "image_tag": "v0.2.2-dev.4",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -495,7 +495,7 @@ wheels = [
 [[package]]
 name = "geometrikks"
 version = "0.2.2"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy", extra = ["argon2", "cli", "passlib", "pwdlib"] },
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- prevent sidebar tooltips from appearing when the sidebar collapses
- display installed package version plus container/image-tag metadata in the sidebar
- add reusable brand icons and use the Docker mark for containerized deployments

## Validation
- `uv run ty check geometrikks`
- `uv run pytest -q`
- `bun run build`
- Docker production/dev image build checks