### PR TITLE
Map page mobile UX overhaul (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Analytics page: Bandwidth card fix - Decimal-as-JSON-string was capping the Y-axis; now coerced to int.
 - Sidebar tooltips no longer appear as a side effect of collapsing the sidebar,
   and each navigation item now owns only one tooltip.
+- Heatmap ↔ markers toggle bug: Re-key the GeoJSON <Source> so MapLibre recreates it with the correct cluster setting; points regroup correctly on switch.
+- Fix bad mobile UI on the map page.
 
 ### Added
 

--- a/resources/components/map/GeoMap.tsx
+++ b/resources/components/map/GeoMap.tsx
@@ -317,21 +317,37 @@ export default function GeoMap() {
   // Filter options come from the last UNFILTERED result (a second query just
   // for options would be wasteful), held in a ref so the option lists don't
   // shrink to the filtered subset while a filter is active.
-  const optionsRef = useRef<{ countries: string[]; cities: string[] }>({
+  const optionsRef = useRef<{
+    countries: string[]
+    cities: string[]
+    countryLabels: Record<string, string>
+  }>({
     countries: [],
     cities: [],
+    countryLabels: {},
   })
   const filterOptions = useMemo(() => {
     if (geojson && selectedCountries.length === 0 && selectedCities.length === 0) {
-      const countries = new Set<string>()
+      const countryLabels: Record<string, string> = {}
       const cities = new Set<string>()
       for (const f of geojson.features) {
-        if (f.properties.country_code) countries.add(f.properties.country_code)
+        const code = f.properties.country_code
+        if (code) {
+          // Display "<name> (<code>)" but keep the code as the option value,
+          // since the value feeds useGeoJSON({ countryCodes }).
+          countryLabels[code] = f.properties.country_name
+            ? `${f.properties.country_name} (${code})`
+            : code
+        }
         if (f.properties.city) cities.add(f.properties.city)
       }
       optionsRef.current = {
-        countries: [...countries].sort(),
+        // Sort country codes by their display label.
+        countries: Object.keys(countryLabels).sort((a, b) =>
+          countryLabels[a].localeCompare(countryLabels[b]),
+        ),
         cities: [...cities].sort(),
+        countryLabels,
       }
     }
     return optionsRef.current
@@ -490,11 +506,16 @@ export default function GeoMap() {
         <NavigationControl position="bottom-right" showCompass={true} />
 
         {/* GeoJSON data source */}
-        {/* No key prop: react-map-gl diffs `data` and calls setData on the
-            underlying source, so data updates must not remount the Source
-            (a remount tears down and re-adds every layer). */}
+        {/* The `key` only flips when the clustering requirement changes (markers
+            need clustering, heatmap does not). MapLibre reads `cluster` only at
+            source creation, so a layer switch must recreate the source for the
+            new clustering state to take effect - otherwise flipping back to
+            markers never regroups the points. Within a single layer the key is
+            stable, so data refreshes still diff via setData without remounting
+            (which would tear down and re-add every layer). */}
         {geojson && (
           <Source
+            key={activeLayer === "markers" ? "clustered" : "plain"}
             id="geo-data"
             type="geojson"
             data={geojson as unknown as GeoJSON.FeatureCollection}
@@ -557,6 +578,7 @@ export default function GeoMap() {
         topIPs={globalTopIPs?.top_ips ?? []}
         onFlyToLocation={flyToLocation}
         countryOptions={filterOptions.countries}
+        countryLabels={filterOptions.countryLabels}
         cityOptions={filterOptions.cities}
         selectedCountries={selectedCountries}
         selectedCities={selectedCities}

--- a/resources/components/map/MapControls.tsx
+++ b/resources/components/map/MapControls.tsx
@@ -1,12 +1,23 @@
 /**
  * Map control overlay with layer toggle and utilities.
- * Collapsible on mobile for better map visibility.
+ * Desktop: a collapsible panel docked top-right.
+ * Mobile: a floating trigger button that opens a bottom drawer, keeping the
+ * map area unobstructed.
  */
 
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer"
+import { useIsMobile } from "@/hooks/use-mobile"
 import {
   Combobox,
   ComboboxChip,
@@ -21,8 +32,10 @@ import {
 } from "@/components/ui/combobox"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import {
+  Check,
   Flame,
   Globe2,
+  Layers,
   Loader2,
   MapPin,
   Maximize2,
@@ -54,6 +67,7 @@ interface MapControlsProps {
   topIPs: TopIPDTO[]
   onFlyToLocation?: (lat: number, lng: number) => void
   countryOptions: string[]
+  countryLabels?: Record<string, string>
   cityOptions: string[]
   selectedCountries: string[]
   selectedCities: string[]
@@ -66,19 +80,119 @@ function FilterCombobox({
   selected,
   onChange,
   placeholder,
+  labels,
+  native = false,
 }: {
   options: string[]
   selected: string[]
   onChange: (values: string[]) => void
   placeholder: string
+  // Optional display labels keyed by option value. The value stays the raw
+  // option (e.g. a country code); only the rendered text changes.
+  labels?: Record<string, string>
+  // On touch (mobile) render a native <select> so iOS/Android show their own
+  // picker instead of the typeahead popup, which is clunky on a touch screen.
+  native?: boolean
 }) {
+  // Called unconditionally to satisfy the rules of hooks even though the native
+  // branch below returns before using some of them.
   const anchor = useComboboxAnchor()
+  const [query, setQuery] = useState("")
+  const labelFor = (value: string) => labels?.[value] ?? value
+
+  // Mobile: an inline searchable checkbox list (a "sheet" rendered directly in
+  // the controls drawer, no nested modal). A search box filters the options and
+  // each row toggles selection, so several can be picked without scrolling a
+  // long native picker. Selected chips sit on top for a quick overview/removal.
+  if (native) {
+    const q = query.trim().toLowerCase()
+    const filtered = options.filter((o) => labelFor(o).toLowerCase().includes(q))
+    // Keep selected rows visible at the top of the filtered list.
+    const ordered = [...filtered].sort(
+      (a, b) => Number(selected.includes(b)) - Number(selected.includes(a)),
+    )
+    const toggle = (o: string) =>
+      onChange(
+        selected.includes(o)
+          ? selected.filter((x) => x !== o)
+          : [...selected, o],
+      )
+    return (
+      <div className="flex flex-col gap-1.5">
+        {selected.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {selected.map((v) => (
+              <span
+                key={v}
+                className="bg-muted text-foreground flex h-6 items-center gap-1 rounded-sm px-1.5 text-xs font-medium"
+              >
+                {labelFor(v)}
+                <button
+                  type="button"
+                  onClick={() => onChange(selected.filter((x) => x !== v))}
+                  aria-label={`Remove ${labelFor(v)}`}
+                  className="opacity-50 hover:opacity-100"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={`Search ${placeholder.toLowerCase()}`}
+          autoComplete="off"
+          // text-base (16px) keeps iOS Safari from zooming the page on focus.
+          className="border-input focus-visible:border-ring focus-visible:ring-ring/50 h-9 w-full rounded-md border bg-transparent px-2.5 text-base shadow-xs outline-none focus-visible:ring-[3px]"
+        />
+        <div className="border-input max-h-48 overflow-y-auto overscroll-contain rounded-md border">
+          {ordered.length === 0 ? (
+            <div className="text-muted-foreground px-2.5 py-2 text-xs">
+              No matches
+            </div>
+          ) : (
+            ordered.map((o) => {
+              const isSel = selected.includes(o)
+              return (
+                <button
+                  key={o}
+                  type="button"
+                  onClick={() => toggle(o)}
+                  className={cn(
+                    "flex w-full items-center gap-2 px-2.5 py-2 text-left text-sm",
+                    isSel ? "bg-geo-cyan/10 text-geo-cyan" : "hover:bg-accent/50",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "flex h-4 w-4 shrink-0 items-center justify-center rounded border",
+                      isSel
+                        ? "bg-geo-cyan border-geo-cyan text-background"
+                        : "border-input",
+                    )}
+                  >
+                    {isSel && <Check className="h-3 w-3" />}
+                  </span>
+                  <span className="truncate">{labelFor(o)}</span>
+                </button>
+              )
+            })
+          )}
+        </div>
+      </div>
+    )
+  }
+
   return (
     <Combobox
       multiple
       items={options}
       value={selected}
       onValueChange={(value) => onChange(value as string[])}
+      itemToStringLabel={labelFor}
     >
       <ComboboxChips ref={anchor} className="min-h-8 px-1.5 py-1 text-xs">
         <ComboboxValue>
@@ -86,7 +200,7 @@ function FilterCombobox({
             <>
               {value.map((v) => (
                 <ComboboxChip key={v} className="text-[10px]">
-                  {v}
+                  {labelFor(v)}
                 </ComboboxChip>
               ))}
               <ComboboxChipsInput
@@ -102,7 +216,7 @@ function FilterCombobox({
         <ComboboxList>
           {(item: string) => (
             <ComboboxItem key={item} value={item} className="text-xs">
-              {item}
+              {labelFor(item)}
             </ComboboxItem>
           )}
         </ComboboxList>
@@ -128,6 +242,7 @@ export function MapControls({
   topIPs,
   onFlyToLocation,
   countryOptions,
+  countryLabels,
   cityOptions,
   selectedCountries,
   selectedCities,
@@ -136,40 +251,13 @@ export function MapControls({
 }: MapControlsProps) {
   const { events, countries, cities, locations } = featureStats
   const [isExpanded, setIsExpanded] = useState(true)
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const isMobile = useIsMobile()
 
-  // Default collapsed on mobile (< 768px)
-  useEffect(() => {
-    const checkMobile = () => setIsExpanded(window.innerWidth >= 768)
-    checkMobile()
-    window.addEventListener('resize', checkMobile)
-    return () => window.removeEventListener('resize', checkMobile)
-  }, [])
-
-  // Collapsed state - single toggle button
-  if (!isExpanded) {
-    return (
-      <div className="absolute top-4 right-4 z-10">
-        <Button
-          size="icon"
-          variant="outline"
-          className="bg-background mt-1 cursor-pointer"
-          onClick={() => setIsExpanded(true)}
-          title="Show map controls"
-        >
-          <SlidersHorizontal className="h-4 w-4" />
-        </Button>
-      </div>
-    )
-  }
-
-  // Expanded state - full controls
-  return (
-    <div className="absolute top-4 right-4 z-10 flex gap-2 max-h-[calc(100vh-2rem)] pointer-events-auto">
-      {/* Scrollable controls area */}
-      <div
-        className="flex flex-col gap-2 p-1 overflow-y-auto overscroll-contain pointer-events-auto max-h-full max-w-[min(200px,calc(100vw-4rem))]"
-        style={{ touchAction: 'pan-y' }}
-      >
+  // The control sections are shared between the desktop top-right panel and the
+  // mobile bottom drawer so there is a single source of truth for the controls.
+  const sections = (
+    <>
       {/* Layer Toggle */}
       <Card className="p-2 shrink-0">
         <div className="flex flex-col gap-1">
@@ -282,12 +370,15 @@ export function MapControls({
           selected={selectedCountries}
           onChange={onCountriesChange}
           placeholder="Country"
+          labels={countryLabels}
+          native={isMobile}
         />
         <FilterCombobox
           options={cityOptions}
           selected={selectedCities}
           onChange={onCitiesChange}
           placeholder="City"
+          native={isMobile}
         />
       </Card>
 
@@ -355,6 +446,66 @@ export function MapControls({
           </div>
         </Card>
       )}
+    </>
+  )
+
+  // Mobile: a single floating trigger (bottom-right) opens a bottom drawer.
+  // Placed bottom-right so it clears the lifted zoom control's row and the
+  // bottom-left Event Count legend.
+  if (isMobile) {
+    return (
+      <Drawer open={drawerOpen} onOpenChange={setDrawerOpen}>
+        <DrawerTrigger asChild>
+          <Button
+            size="icon"
+            variant="outline"
+            className="absolute top-4 right-4 z-10 bg-background cursor-pointer"
+            title="Show map controls"
+          >
+            <Layers className="h-4 w-4" />
+          </Button>
+        </DrawerTrigger>
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>Map controls</DrawerTitle>
+            <DrawerDescription className="sr-only">
+              Switch map layers, filter by country and city, and view statistics.
+            </DrawerDescription>
+          </DrawerHeader>
+          <div className="flex flex-col gap-2 overflow-y-auto overscroll-contain px-4 pb-6">
+            {sections}
+          </div>
+        </DrawerContent>
+      </Drawer>
+    )
+  }
+
+  // Desktop collapsed state - single toggle button
+  if (!isExpanded) {
+    return (
+      <div className="absolute top-4 right-4 z-10">
+        <Button
+          size="icon"
+          variant="outline"
+          className="bg-background mt-1 cursor-pointer"
+          onClick={() => setIsExpanded(true)}
+          title="Show map controls"
+        >
+          <SlidersHorizontal className="h-4 w-4" />
+        </Button>
+      </div>
+    )
+  }
+
+  // Desktop expanded state - full controls docked top-right
+  return (
+    <div className="absolute top-4 right-4 z-10 flex gap-2 max-h-[calc(100vh-2rem)] pointer-events-auto">
+      {/* Scrollable controls area */}
+      <div
+        className="flex flex-col gap-2 p-1 overflow-y-auto overscroll-contain pointer-events-auto max-h-full max-w-[min(200px,calc(100vw-4rem))]"
+        style={{ touchAction: 'pan-y' }}
+      >
+        {sections}
       </div>
       {/* Collapse button - inline right */}
       <Button

--- a/resources/components/map/MapControls.tsx
+++ b/resources/components/map/MapControls.tsx
@@ -81,7 +81,7 @@ function FilterCombobox({
   onChange,
   placeholder,
   labels,
-  native = false,
+  mobile = false,
 }: {
   options: string[]
   selected: string[]
@@ -90,11 +90,11 @@ function FilterCombobox({
   // Optional display labels keyed by option value. The value stays the raw
   // option (e.g. a country code); only the rendered text changes.
   labels?: Record<string, string>
-  // On touch (mobile) render a native <select> so iOS/Android show their own
-  // picker instead of the typeahead popup, which is clunky on a touch screen.
-  native?: boolean
+  // On mobile, render an inline searchable multi-select list instead of the
+  // desktop typeahead popup, which is clunky on a touch screen.
+  mobile?: boolean
 }) {
-  // Called unconditionally to satisfy the rules of hooks even though the native
+  // Called unconditionally to satisfy the rules of hooks even though the mobile
   // branch below returns before using some of them.
   const anchor = useComboboxAnchor()
   const [query, setQuery] = useState("")
@@ -103,8 +103,8 @@ function FilterCombobox({
   // Mobile: an inline searchable checkbox list (a "sheet" rendered directly in
   // the controls drawer, no nested modal). A search box filters the options and
   // each row toggles selection, so several can be picked without scrolling a
-  // long native picker. Selected chips sit on top for a quick overview/removal.
-  if (native) {
+  // long option list. Selected chips sit on top for a quick overview/removal.
+  if (mobile) {
     const q = query.trim().toLowerCase()
     const filtered = options.filter((o) => labelFor(o).toLowerCase().includes(q))
     // Keep selected rows visible at the top of the filtered list.
@@ -144,6 +144,7 @@ function FilterCombobox({
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder={`Search ${placeholder.toLowerCase()}`}
+          aria-label={`Search ${placeholder.toLowerCase()}`}
           autoComplete="off"
           // text-base (16px) keeps iOS Safari from zooming the page on focus.
           className="border-input focus-visible:border-ring focus-visible:ring-ring/50 h-9 w-full rounded-md border bg-transparent px-2.5 text-base shadow-xs outline-none focus-visible:ring-[3px]"
@@ -161,6 +162,7 @@ function FilterCombobox({
                   key={o}
                   type="button"
                   onClick={() => toggle(o)}
+                  aria-pressed={isSel}
                   className={cn(
                     "flex w-full items-center gap-2 px-2.5 py-2 text-left text-sm",
                     isSel ? "bg-geo-cyan/10 text-geo-cyan" : "hover:bg-accent/50",
@@ -371,14 +373,14 @@ export function MapControls({
           onChange={onCountriesChange}
           placeholder="Country"
           labels={countryLabels}
-          native={isMobile}
+          mobile={isMobile}
         />
         <FilterCombobox
           options={cityOptions}
           selected={selectedCities}
           onChange={onCitiesChange}
           placeholder="City"
-          native={isMobile}
+          mobile={isMobile}
         />
       </Card>
 
@@ -459,7 +461,7 @@ export function MapControls({
           <Button
             size="icon"
             variant="outline"
-            className="absolute top-4 right-4 z-10 bg-background cursor-pointer"
+            className="absolute bottom-6 right-4 z-10 bg-background cursor-pointer"
             title="Show map controls"
           >
             <Layers className="h-4 w-4" />

--- a/resources/components/map/MapLegend.tsx
+++ b/resources/components/map/MapLegend.tsx
@@ -57,12 +57,20 @@ export function MapLegend({ maxValue, layerType }: MapLegendProps) {
         <CardTitle
           className={cn(
             "text-xs font-medium text-muted-foreground flex items-center justify-between",
-            isMobile && "cursor-pointer"
+            isMobile && "gap-2",
           )}
-          onClick={isMobile ? () => setOpen(false) : undefined}
         >
           {title}
-          {isMobile && <span className="text-muted-foreground/60">×</span>}
+          {isMobile && (
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label={`Hide ${title.toLowerCase()} legend`}
+              className="cursor-pointer text-muted-foreground/60"
+            >
+              <span aria-hidden="true">×</span>
+            </button>
+          )}
         </CardTitle>
         <div className="border-b border-border/50">
         </div>

--- a/resources/components/map/MapLegend.tsx
+++ b/resources/components/map/MapLegend.tsx
@@ -1,9 +1,14 @@
 /**
  * Map legend showing the color scale for heatmap or markers.
+ * On mobile it collapses to a small swatch button (hidden by default) that
+ * expands the full card on tap, to keep the map area uncluttered.
  */
 
+import { useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { formatNumber } from "@/lib/api"
+import { useIsMobile } from "@/hooks/use-mobile"
+import { cn } from "@/lib/utils"
 import type { LayerType } from "./GeoMap"
 
 interface MapLegendProps {
@@ -23,12 +28,41 @@ export function MapLegend({ maxValue, layerType }: MapLegendProps) {
   const isHeatmap = layerType === "heatmap"
   const title = isHeatmap ? "Event Density" : "Event Count"
   const gradient = isHeatmap ? HEATMAP_GRADIENT : MARKER_GRADIENT
+  const isMobile = useIsMobile()
+  const [open, setOpen] = useState(false)
+
+  // Mobile, collapsed: a compact swatch button that expands the legend on tap.
+  if (isMobile && !open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        title={`Show ${title.toLowerCase()} legend`}
+        className="absolute bottom-6 left-4 z-10 flex items-center gap-2 rounded-md border border-border/50 bg-card/90 px-2.5 py-1.5 shadow-sm backdrop-blur cursor-pointer"
+      >
+        <span
+          className="h-2.5 w-10 rounded-sm"
+          style={{ background: gradient }}
+        />
+        <span className="text-[10px] font-medium text-muted-foreground">
+          {title}
+        </span>
+      </button>
+    )
+  }
 
   return (
     <Card className="absolute gap-3 bottom-6 py-0 left-4 z-10 w-44">
       <CardHeader className="pb-0 pt-3 px-3">
-        <CardTitle className="text-xs font-medium text-muted-foreground">
+        <CardTitle
+          className={cn(
+            "text-xs font-medium text-muted-foreground flex items-center justify-between",
+            isMobile && "cursor-pointer"
+          )}
+          onClick={isMobile ? () => setOpen(false) : undefined}
+        >
           {title}
+          {isMobile && <span className="text-muted-foreground/60">×</span>}
         </CardTitle>
         <div className="border-b border-border/50">
         </div>

--- a/resources/components/time-range-toolbar.tsx
+++ b/resources/components/time-range-toolbar.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { useRouterState } from "@tanstack/react-router"
 import { RotateCw, Filter, SlidersHorizontal, BarChart3 } from "lucide-react"
 
 import {
@@ -12,6 +13,14 @@ import {
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu"
 
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
@@ -79,6 +88,10 @@ export function TimeRangeToolbar() {
     refresh,
   } = useTimeRange()
   const isFetching = useIsFetching()
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+  // The map page has no time-series charts, so granularity is irrelevant there.
+  const showGranularity = pathname !== "/map"
+  const [rangeDrawerOpen, setRangeDrawerOpen] = useState(false)
 
   const rangeLabel =
     range === "custom" && customRange
@@ -160,53 +173,79 @@ export function TimeRangeToolbar() {
         </Select>
 
         {/* Chart Granularity Select */}
-        <Select
-          value={granularity}
-          onValueChange={(value) => setGranularity(value as ChartGranularity)}
-        >
-          <SelectTrigger size="sm" className="w-[90px] text-xs">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {GRANULARITY_OPTIONS.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        {showGranularity && (
+          <Select
+            value={granularity}
+            onValueChange={(value) => setGranularity(value as ChartGranularity)}
+          >
+            <SelectTrigger size="sm" className="w-[90px] text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {GRANULARITY_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
       </div>
 
-      {/* Mobile Layout - 3 icon buttons */}
+      {/* Mobile Layout - icon buttons + time-range drawer */}
       <div className="md:hidden flex items-center gap-1">
-        {/* Time Range Dropdown */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
+        {/* Time Range Drawer - a bottom sheet with a preset grid, replacing the
+            cramped tall dropdown that overflowed the viewport. */}
+        <Drawer open={rangeDrawerOpen} onOpenChange={setRangeDrawerOpen}>
+          <DrawerTrigger asChild>
             <Button variant="outline" size="icon-sm" className="shrink-0">
               <Filter className="h-4 w-4" />
               <span className="sr-only">Time Range</span>
             </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-auto!">
-            <DropdownMenuLabel>Time Range</DropdownMenuLabel>
-            <DropdownMenuRadioGroup value={range} onValueChange={(value) => setRange(value as typeof range)}>
-              {TIME_RANGE_PRESETS.map((preset) => (
-                <DropdownMenuRadioItem
-                  key={preset.value}
-                  value={preset.value}
-                  className="text-xs"
-                >
-                  {preset.label}
-                </DropdownMenuRadioItem>
-              ))}
-            </DropdownMenuRadioGroup>
-            <DropdownMenuSeparator />
-            <DropdownMenuLabel className="text-xs">Custom range</DropdownMenuLabel>
-            <div onKeyDown={(e) => e.stopPropagation()}>
-              <CustomRangeFields onApply={setCustomRange} />
+          </DrawerTrigger>
+          <DrawerContent>
+            <DrawerHeader>
+              <DrawerTitle>Time Range</DrawerTitle>
+              <DrawerDescription className="sr-only">
+                Choose a preset time range or set a custom from/to range.
+              </DrawerDescription>
+            </DrawerHeader>
+            <div className="overflow-y-auto px-4 pb-6">
+              {/* Presets as a compact grid instead of a long scroll list */}
+              <div className="grid grid-cols-3 gap-2">
+                {TIME_RANGE_PRESETS.map((preset) => (
+                  <Button
+                    key={preset.value}
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setRange(preset.value)
+                      setRangeDrawerOpen(false)
+                    }}
+                    className={cn(
+                      "text-xs",
+                      range === preset.value &&
+                        "bg-geo-cyan/20 text-geo-cyan border-geo-cyan/40"
+                    )}
+                  >
+                    {preset.label}
+                  </Button>
+                ))}
+              </div>
+              <div className="mt-4 border-t border-border/50 pt-2">
+                <div className="text-xs font-medium text-muted-foreground px-2">
+                  Custom range
+                </div>
+                <CustomRangeFields
+                  onApply={(r) => {
+                    setCustomRange(r)
+                    setRangeDrawerOpen(false)
+                  }}
+                />
+              </div>
             </div>
-          </DropdownMenuContent>
-        </DropdownMenu>
+          </DrawerContent>
+        </Drawer>
 
         {/* Refresh Button */}
         <Button
@@ -253,31 +292,33 @@ export function TimeRangeToolbar() {
         </DropdownMenu>
 
         {/* Chart Granularity Dropdown */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="icon-sm" className="shrink-0">
-              <BarChart3 className="h-4 w-4" />
-              <span className="sr-only">Chart Granularity</span>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuLabel>Chart Granularity</DropdownMenuLabel>
-            <DropdownMenuRadioGroup
-              value={granularity}
-              onValueChange={(value) => setGranularity(value as ChartGranularity)}
-            >
-              {GRANULARITY_OPTIONS.map((option) => (
-                <DropdownMenuRadioItem
-                  key={option.value}
-                  value={option.value}
-                  className="text-xs"
-                >
-                  {option.label}
-                </DropdownMenuRadioItem>
-              ))}
-            </DropdownMenuRadioGroup>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        {showGranularity && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="icon-sm" className="shrink-0">
+                <BarChart3 className="h-4 w-4" />
+                <span className="sr-only">Chart Granularity</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuLabel>Chart Granularity</DropdownMenuLabel>
+              <DropdownMenuRadioGroup
+                value={granularity}
+                onValueChange={(value) => setGranularity(value as ChartGranularity)}
+              >
+                {GRANULARITY_OPTIONS.map((option) => (
+                  <DropdownMenuRadioItem
+                    key={option.value}
+                    value={option.value}
+                    className="text-xs"
+                  >
+                    {option.label}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
       </div>
     </>
   )

--- a/resources/main.css
+++ b/resources/main.css
@@ -281,7 +281,7 @@
    floating map-controls trigger. */
 @media (max-width: 767px) {
   .maplibregl-ctrl-bottom-right {
-    bottom: calc(env(safe-area-inset-bottom) + 4.5rem) !important;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 4.5rem) !important;
   }
 }
 

--- a/resources/main.css
+++ b/resources/main.css
@@ -276,6 +276,25 @@
   filter: invert(1);
 }
 
+/* On mobile the bottom-right zoom/compass control sits too low and collides
+   with the browser chrome. Lift it clear of the safe-area inset and the
+   floating map-controls trigger. */
+@media (max-width: 767px) {
+  .maplibregl-ctrl-bottom-right {
+    bottom: calc(env(safe-area-inset-bottom) + 4.5rem) !important;
+  }
+}
+
+/* iOS Safari force-zooms the page when a focused input has a font-size below
+   16px. The map filter comboboxes render at text-xs, so on touch devices bump
+   the input itself to 16px to suppress the zoom. Font size only affects the
+   text the user types; the chips/list keep their compact sizing. */
+@media (pointer: coarse) {
+  input[data-slot="combobox-chip-input"] {
+    font-size: 16px;
+  }
+}
+
 /* Legacy Mapbox GL Popup Styles (if used) */
 .mapboxgl-popup-content {
   background-color: #333;

--- a/resources/main.tsx
+++ b/resources/main.tsx
@@ -31,7 +31,7 @@ createRoot(document.getElementById("app")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
-      <ReactQueryDevtools initialIsOpen={false} />
+      <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
     </QueryClientProvider>
   </StrictMode>
 )


### PR DESCRIPTION
Closes #15.

Overhauls the map page for mobile. All seven items from the issue:

| # | Item | Change |
|---|------|--------|
| 1 | Cramped time-range toolbar | Bottom **drawer** with a preset grid + custom-range section, replacing the tall dropdown. |
| 2 | Heatmap ↔ markers toggle bug | Re-key the GeoJSON `<Source>` so MapLibre recreates it with the correct `cluster` setting; points regroup correctly on switch. |
| 3 | Zoom/bearing control too low | Mobile-only CSS lifting the control clear of the browser chrome + safe-area inset. |
| 4 | Event Count legend eats space | Collapses to a tappable gradient chip on mobile, hidden by default. |
| 5 | Granularity control irrelevant on map | Hidden on the `/map` route. |
| 6 | Country code in filter | Displays `Name (Code)`; the stored value stays the code that drives filtering. |
| 7 | MapControls not mobile-friendly | Bottom **drawer** on mobile via a single floating trigger; shared content with the desktop panel. |

### Mobile filter (country/city)

The touch-unfriendly typeahead combobox is replaced on mobile with an **inline searchable checkbox list** rendered in the controls drawer:

- Search box (16px, so iOS Safari doesn't force-zoom on focus).
- Capped-height scrollable list; each row toggles selection, selected rows stay pinned to the top.
- Removable chips above the search for a quick overview.

Desktop keeps the combobox unchanged.

### Verification

- `npx tsc -b --noEmit` and `npm run build` both pass.
- Items verified live on mobile (390×844) and desktop viewports; the mobile filter was confirmed working on iOS Safari.

🤖 Generated with [Claude Code](https://claude.com/claude-code)