### PR TITLE
Mobile UI polish: header map controls, touch targets, tab list toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Database credentials containing reserved URL characters (`@`, `:`, `/`, `%`)
   no longer produce a broken connection URL.
 - Geo-logs embedded map zoom control no longer floats mid-card on mobile; app shell sizes to the real visible viewport (dvh) so the map page fits even with the degraded banner; bottom drawers respect the iOS safe area.
+- Mobile map controls moved from a floating button over the map into the top header bar (same icon as the desktop panel toggle); the auto-refresh dropdown got its own Timer icon and the theme toggle now matches the other header buttons' touch size.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no longer produce a broken connection URL.
 - Geo-logs embedded map zoom control no longer floats mid-card on mobile; app shell sizes to the real visible viewport (dvh) so the map page fits even with the degraded banner; bottom drawers respect the iOS safe area.
 - Mobile map controls moved from a floating button over the map into the top header bar (same icon as the desktop panel toggle); the auto-refresh dropdown got its own Timer icon and the theme toggle now matches the other header buttons' touch size.
+- Access Logs History/Live tail switch now uses the same tab list style as the Top Countries/Cities card on Geo Logs.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Larger touch targets for header controls on touch devices; small mobile layout fixes on Overview and Environment pages.
+- Larger touch targets on touch devices across the app: header controls, sidebar trigger, filter/columns/clear buttons on the table pages, map controls drawer, custom-range apply, and settings page buttons; small mobile layout fixes on Overview and Environment pages.
 - Live tail no longer freezes permanently after a tap on touch devices; added an explicit pause/resume button and a narrower mobile column set.
 - Focusing any input on a touch device no longer triggers the iOS auto-zoom.
 - Mobile sidebar closes automatically after navigating.

--- a/resources/components/access-logs/access-logs-table.tsx
+++ b/resources/components/access-logs/access-logs-table.tsx
@@ -411,7 +411,7 @@ export function AccessLogsTable() {
   const columnsMenu = (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="sm" className="h-8">
+        <Button variant="outline" size="sm" className="h-8 pointer-coarse:h-10">
           <Columns3 className="mr-1 h-3.5 w-3.5" /> Columns
         </Button>
       </DropdownMenuTrigger>

--- a/resources/components/analytics/analytics-filter-bar.tsx
+++ b/resources/components/analytics/analytics-filter-bar.tsx
@@ -91,7 +91,7 @@ export function AnalyticsFilterBar() {
       ))}
 
       {hasActiveFilters && (
-        <Button variant="ghost" size="sm" className="h-8" onClick={() => setFilters(EMPTY_FILTERS)}>
+        <Button variant="ghost" size="sm" className="h-8 pointer-coarse:h-10" onClick={() => setFilters(EMPTY_FILTERS)}>
           Clear filters
         </Button>
       )}

--- a/resources/components/debug-logs/debug-log-detail-dialog.tsx
+++ b/resources/components/debug-logs/debug-log-detail-dialog.tsx
@@ -69,7 +69,7 @@ export function DebugLogDetailDialog({
             <div className="space-y-1">
               <div className="flex items-center justify-between">
                 <span className="text-xs font-medium text-muted-foreground">Raw line</span>
-                <Button variant="ghost" size="sm" className="h-7 px-2" onClick={copyRawLine}>
+                <Button variant="ghost" size="sm" className="h-7 px-2 pointer-coarse:h-10" onClick={copyRawLine}>
                   {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
                   <span className="ml-1 text-xs">{copied ? "Copied" : "Copy"}</span>
                 </Button>

--- a/resources/components/debug-logs/debug-logs-table.tsx
+++ b/resources/components/debug-logs/debug-logs-table.tsx
@@ -337,7 +337,7 @@ export function DebugLogsTable() {
             value={malformedFilter}
             onValueChange={(v) => setMalformedFilter(v as MalformedFilter)}
           >
-            <SelectTrigger size="sm" className={cn("h-8 text-xs", inDrawer ? "w-full" : "w-40")}>
+            <SelectTrigger size="sm" className={cn("h-8 text-xs pointer-coarse:h-10", inDrawer ? "w-full" : "w-40")}>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -384,7 +384,7 @@ export function DebugLogsTable() {
   const columnsMenu = (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="sm" className="h-8">
+        <Button variant="outline" size="sm" className="h-8 pointer-coarse:h-10">
           <Columns3 className="mr-1 h-3.5 w-3.5" /> Columns
         </Button>
       </DropdownMenuTrigger>

--- a/resources/components/geo-logs/geo-logs-filter-bar.tsx
+++ b/resources/components/geo-logs/geo-logs-filter-bar.tsx
@@ -85,7 +85,7 @@ export function GeoLogsFilterBar() {
 
       <DropdownMenu onOpenChange={(open) => open && setFacetsEnabled(true)}>
         <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="sm" className="h-8">
+          <Button variant="outline" size="sm" className="h-8 pointer-coarse:h-10">
             Hostname{filters.hostnames.length > 0 && ` (${filters.hostnames.length})`}
             <ChevronsUpDown className="ml-1 h-3.5 w-3.5" />
           </Button>
@@ -177,7 +177,7 @@ export function GeoLogsFilterBar() {
         <Button
           variant="ghost"
           size="sm"
-          className="h-8"
+          className="h-8 pointer-coarse:h-10"
           onClick={() => setFilters(() => EMPTY_GEO_LOG_FILTERS)}
         >
           Clear filters

--- a/resources/components/geo-logs/geo-logs-table.tsx
+++ b/resources/components/geo-logs/geo-logs-table.tsx
@@ -181,7 +181,7 @@ export function GeoLogsTable({
         <h2 className="text-sm font-medium">Geo Events by Location and IP</h2>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm" className="h-8">
+            <Button variant="outline" size="sm" className="h-8 pointer-coarse:h-10">
               <Columns3 className="mr-1 h-3.5 w-3.5" /> Columns
             </Button>
           </DropdownMenuTrigger>

--- a/resources/components/map/MapControls.tsx
+++ b/resources/components/map/MapControls.tsx
@@ -120,7 +120,7 @@ export function MapControls({
               aria-label="Heatmap view"
               variant="outline"
               className={cn(
-                "cursor-pointer w-full justify-start gap-2 px-3 data-[state=on]:bg-geo-cyan/15 data-[state=on]:text-geo-cyan data-[state=on]:border-geo-cyan/30",
+                "cursor-pointer w-full justify-start gap-2 px-3 pointer-coarse:h-10 data-[state=on]:bg-geo-cyan/15 data-[state=on]:text-geo-cyan data-[state=on]:border-geo-cyan/30",
                 activeLayer === "heatmap" && "bg-geo-cyan/15 text-geo-cyan border-geo-cyan/30"
               )}
             >
@@ -132,7 +132,7 @@ export function MapControls({
               aria-label="Marker view"
               variant="outline"
               className={cn(
-                "cursor-pointer w-full justify-start gap-2 px-3 data-[state=on]:bg-geo-cyan/15 data-[state=on]:text-geo-cyan data-[state=on]:border-geo-cyan/30",
+                "cursor-pointer w-full justify-start gap-2 px-3 pointer-coarse:h-10 data-[state=on]:bg-geo-cyan/15 data-[state=on]:text-geo-cyan data-[state=on]:border-geo-cyan/30",
                 activeLayer === "markers" && "bg-geo-cyan/15 text-geo-cyan border-geo-cyan/30"
               )}
             >
@@ -150,7 +150,7 @@ export function MapControls({
               ? "Switch to a flat Mercator map"
               : "Switch to an interactive globe"}
             className={cn(
-              "cursor-pointer w-full justify-start gap-2 px-3",
+              "cursor-pointer w-full justify-start gap-2 px-3 pointer-coarse:h-10",
               projection === "globe"
                 && "bg-geo-cyan/15 text-geo-cyan border-geo-cyan/30",
             )}
@@ -167,7 +167,7 @@ export function MapControls({
             onClick={() => onLiveModeChange(!liveMode)}
             aria-pressed={liveMode}
             className={cn(
-              "cursor-pointer w-full justify-start gap-2 px-3",
+              "cursor-pointer w-full justify-start gap-2 px-3 pointer-coarse:h-10",
               liveMode && "bg-geo-cyan/15 text-geo-cyan border-geo-cyan/30"
             )}
           >
@@ -190,7 +190,7 @@ export function MapControls({
               ? "Show or hide animated network routes"
               : "No map home location could be resolved"}
             className={cn(
-              "cursor-pointer w-full justify-start gap-2 px-3",
+              "cursor-pointer w-full justify-start gap-2 px-3 pointer-coarse:h-10",
               routeEffectsEnabled && routeHomeAvailable
                 && "bg-geo-cyan/15 text-geo-cyan border-geo-cyan/30",
             )}
@@ -236,7 +236,7 @@ export function MapControls({
           onClick={onFitBounds}
           disabled={isLoading || events === 0}
           title="Fit to data bounds"
-          className="cursor-pointer"
+          className="cursor-pointer pointer-coarse:size-10"
         >
           <Maximize2 className="h-4 w-4" />
         </Button>

--- a/resources/components/map/MapControls.tsx
+++ b/resources/components/map/MapControls.tsx
@@ -1,11 +1,13 @@
 /**
  * Map control overlay with layer toggle and utilities.
  * Desktop: a collapsible panel docked top-right.
- * Mobile: a floating trigger button that opens a bottom drawer, keeping the
- * map area unobstructed.
+ * Mobile: a trigger button portaled into the top header bar (next to the
+ * time-range toolbar) that opens a bottom drawer, keeping the map area
+ * unobstructed.
  */
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
+import { createPortal } from "react-dom"
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -23,7 +25,6 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import {
   Flame,
   Globe2,
-  Layers,
   Loader2,
   MapPin,
   Maximize2,
@@ -91,6 +92,13 @@ export function MapControls({
   const [isExpanded, setIsExpanded] = useState(true)
   const [drawerOpen, setDrawerOpen] = useState(false)
   const isMobile = useIsMobile()
+
+  // The header slot only exists after the root layout commits, so resolve it
+  // post-mount rather than during render.
+  const [headerSlot, setHeaderSlot] = useState<HTMLElement | null>(null)
+  useEffect(() => {
+    setHeaderSlot(document.getElementById("header-actions-slot"))
+  }, [])
 
   // The control sections are shared between the desktop top-right panel and the
   // mobile bottom drawer so there is a single source of truth for the controls.
@@ -287,22 +295,26 @@ export function MapControls({
     </>
   )
 
-  // Mobile: a single floating trigger (bottom-right) opens a bottom drawer.
-  // Placed bottom-right so it clears the lifted zoom control's row and the
-  // bottom-left Event Count legend.
+  // Mobile: a trigger in the top header bar (same icon as the desktop panel
+  // toggle) opens a bottom drawer. Portaled into the header's action slot so
+  // it sits with the toolbar buttons instead of floating over the map.
   if (isMobile) {
     return (
       <Drawer open={drawerOpen} onOpenChange={setDrawerOpen}>
-        <DrawerTrigger asChild>
-          <Button
-            size="icon"
-            variant="outline"
-            className="absolute bottom-6 right-4 z-10 bg-background cursor-pointer"
-            title="Show map controls"
-          >
-            <Layers className="h-4 w-4" />
-          </Button>
-        </DrawerTrigger>
+        {headerSlot && createPortal(
+          <DrawerTrigger asChild>
+            <Button
+              size="icon-sm"
+              variant="outline"
+              className="shrink-0 pointer-coarse:size-10 cursor-pointer"
+              title="Show map controls"
+            >
+              <SlidersHorizontal className="h-4 w-4" />
+              <span className="sr-only">Map Controls</span>
+            </Button>
+          </DrawerTrigger>,
+          headerSlot,
+        )}
         <DrawerContent>
           <DrawerHeader>
             <DrawerTitle>Map controls</DrawerTitle>

--- a/resources/components/mode-toggle.tsx
+++ b/resources/components/mode-toggle.tsx
@@ -15,7 +15,7 @@ export function ModeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon-sm">
+        <Button variant="outline" size="icon-sm" className="shrink-0 pointer-coarse:size-10">
           <Sun className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
           <Moon className="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
           <span className="sr-only">Toggle theme</span>

--- a/resources/components/settings/about-page.tsx
+++ b/resources/components/settings/about-page.tsx
@@ -247,13 +247,13 @@ export function AboutPage() {
 
       <Card className="md:col-span-2">
         <CardContent className="flex flex-wrap gap-2 py-4">
-          <Button variant="outline" size="sm" asChild>
+          <Button variant="outline" size="sm" className="pointer-coarse:h-10" asChild>
             <a href={data.links.repository} target="_blank" rel="noreferrer">
               <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
               GitHub repository
             </a>
           </Button>
-          <Button variant="outline" size="sm" asChild>
+          <Button variant="outline" size="sm" className="pointer-coarse:h-10" asChild>
             <a href={data.links.issues} target="_blank" rel="noreferrer">
               <Bug className="mr-1.5 h-3.5 w-3.5" />
               Issue tracker

--- a/resources/components/settings/environment-overview.tsx
+++ b/resources/components/settings/environment-overview.tsx
@@ -215,6 +215,7 @@ export function EnvironmentOverview() {
         </div>
         <Button
           size="sm"
+          className="pointer-coarse:h-10"
           variant={overriddenOnly ? "secondary" : "outline"}
           onClick={() => setOverriddenOnly((v) => !v)}
           aria-pressed={overriddenOnly}

--- a/resources/components/settings/scheduler-overview.tsx
+++ b/resources/components/settings/scheduler-overview.tsx
@@ -246,6 +246,7 @@ export function SchedulerOverview() {
                 <TableCell className="align-top">
                   <Button
                     size="sm"
+                    className="pointer-coarse:h-10"
                     variant="outline"
                     disabled={job.running || runJob.isPending}
                     onClick={() => runJob.mutate(job.id)}

--- a/resources/components/time-range-toolbar.tsx
+++ b/resources/components/time-range-toolbar.tsx
@@ -66,6 +66,7 @@ function CustomRangeFields({ onApply }: { onApply: (r: CustomTimeRange) => void 
       <Input type="datetime-local" value={to} onChange={(e) => setTo(e.target.value)} />
       <Button
         size="sm"
+        className="pointer-coarse:h-10"
         disabled={!valid}
         onClick={() => onApply({ from: new Date(from).toISOString(), to: new Date(to).toISOString() })}
       >

--- a/resources/components/time-range-toolbar.tsx
+++ b/resources/components/time-range-toolbar.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { useRouterState } from "@tanstack/react-router"
-import { RotateCw, Filter, SlidersHorizontal, BarChart3 } from "lucide-react"
+import { RotateCw, Filter, Timer, BarChart3 } from "lucide-react"
 
 import {
   DropdownMenu,
@@ -268,7 +268,7 @@ export function TimeRangeToolbar() {
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="outline" size="icon-sm" className="shrink-0 pointer-coarse:size-10">
-              <SlidersHorizontal className="h-4 w-4" />
+              <Timer className="h-4 w-4" />
               <span className="sr-only">Auto Refresh</span>
             </Button>
           </DropdownMenuTrigger>

--- a/resources/components/ui/filter-combobox.tsx
+++ b/resources/components/ui/filter-combobox.tsx
@@ -157,7 +157,7 @@ export function FilterCombobox<T extends string | number>({
     return (
       <Drawer onOpenChange={onOpenChange}>
         <DrawerTrigger asChild>
-          <Button variant="outline" size="sm" className={cn("h-8", className)}>
+          <Button variant="outline" size="sm" className={cn("h-8 pointer-coarse:h-10", className)}>
             {triggerLabel}
             <ChevronsUpDown className="ml-1 h-3.5 w-3.5" />
           </Button>
@@ -195,7 +195,7 @@ export function FilterCombobox<T extends string | number>({
       onOpenChange={onOpenChange}
     >
       <ComboboxPrimitive.Trigger
-        render={<Button variant="outline" size="sm" className={cn("h-8", className)} />}
+        render={<Button variant="outline" size="sm" className={cn("h-8 pointer-coarse:h-10", className)} />}
       >
         {triggerLabel}
         <ChevronsUpDown className="ml-1 h-3.5 w-3.5" />

--- a/resources/components/ui/sheet.tsx
+++ b/resources/components/ui/sheet.tsx
@@ -62,7 +62,7 @@ function SheetContent({
         {children}
         {showCloseButton && (
           <SheetPrimitive.Close data-slot="sheet-close" asChild>
-            <Button variant="ghost" className="absolute top-4 right-4" size="icon-sm">
+            <Button variant="ghost" className="absolute top-4 right-4 pointer-coarse:size-10" size="icon-sm">
               <XIcon
               />
               <span className="sr-only">Close</span>

--- a/resources/components/ui/sidebar.tsx
+++ b/resources/components/ui/sidebar.tsx
@@ -292,7 +292,7 @@ function SidebarTrigger({
       data-slot="sidebar-trigger"
       variant="ghost"
       size="icon-sm"
-      className={cn(className)}
+      className={cn("pointer-coarse:size-10", className)}
       onClick={(event) => {
         onClick?.(event)
         toggleSidebar()

--- a/resources/main.css
+++ b/resources/main.css
@@ -277,11 +277,11 @@
 }
 
 /* On mobile the full-page map's bottom-right zoom/compass control needs to
-   clear the safe-area inset and the floating map-controls trigger. Scoped to
-   .fullscreen-map so embedded card maps (geo-logs) are unaffected. */
+   clear the safe-area inset (home indicator). Scoped to .fullscreen-map so
+   embedded card maps (geo-logs) are unaffected. */
 @media (max-width: 767px) {
   .fullscreen-map .maplibregl-ctrl-bottom-right {
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 4.5rem) !important;
+    bottom: env(safe-area-inset-bottom, 0px) !important;
   }
 }
 

--- a/resources/routes/__root.tsx
+++ b/resources/routes/__root.tsx
@@ -141,6 +141,9 @@ function RootLayout() {
                 </div>
                 <div className="flex items-center gap-3">
                   <TimeRangeToolbar />
+                  {/* Portal target for page-specific header actions (e.g. the
+                      mobile map-controls drawer trigger in MapControls). */}
+                  <span id="header-actions-slot" className="contents" />
                   <Separator orientation="vertical" className="h-6" />
                   <ModeToggle />
                 </div>

--- a/resources/routes/access-logs.tsx
+++ b/resources/routes/access-logs.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react"
 import { createFileRoute } from "@tanstack/react-router"
 import { History, Radio } from "lucide-react"
-import { Button } from "@/components/ui/button"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { AccessLogsTable } from "@/components/access-logs/access-logs-table"
 import { LiveTail } from "@/components/access-logs/live-tail"
 
@@ -15,22 +15,16 @@ function AccessLogsPage() {
   const [mode, setMode] = useState<Mode>("history")
   return (
     <div className="p-4 space-y-4">
-      <div className="flex justify-end gap-1">
-        <Button
-          variant={mode === "history" ? "default" : "outline"}
-          size="sm"
-          onClick={() => setMode("history")}
-        >
-          <History className="h-4 w-4 mr-2" /> History
-        </Button>
-        <Button
-          variant={mode === "live" ? "default" : "outline"}
-          size="sm"
-          onClick={() => setMode("live")}
-        >
-          <Radio className="h-4 w-4 mr-2" /> Live tail
-        </Button>
-      </div>
+      <Tabs value={mode} onValueChange={(value) => setMode(value as Mode)}>
+        <TabsList>
+          <TabsTrigger value="history">
+            <History className="h-4 w-4" /> History
+          </TabsTrigger>
+          <TabsTrigger value="live">
+            <Radio className="h-4 w-4" /> Live tail
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
       {mode === "history" ? <AccessLogsTable /> : <LiveTail enabled={mode === "live"} />}
     </div>
   )

--- a/resources/routes/access-logs.tsx
+++ b/resources/routes/access-logs.tsx
@@ -16,7 +16,7 @@ function AccessLogsPage() {
   return (
     <div className="p-4 space-y-4">
       <Tabs value={mode} onValueChange={(value) => setMode(value as Mode)}>
-        <TabsList>
+        <TabsList className="pointer-coarse:h-10">
           <TabsTrigger value="history">
             <History className="h-4 w-4" /> History
           </TabsTrigger>


### PR DESCRIPTION
Follow-up polish on top of #30.

## Changes

- **Map controls in the header (mobile)**: the floating layers button over the map is gone; the map controls drawer trigger now portals into a new `header-actions-slot` in the top header bar, using the same SlidersHorizontal icon as the desktop panel toggle. The auto-refresh dropdown gets a Timer icon instead, and the theme toggle matches the other header buttons' touch size.
- **Zoom control back at the bottom**: the mobile map page's zoom/compass control drops back to the bottom edge (keeping only the safe-area inset); the 4.5rem lift only existed to clear the removed floating button.
- **40px touch targets everywhere**: extended the `pointer-coarse:h-10`/`size-10` convention to the filter comboboxes, filter/columns/clear buttons on the table pages, sidebar trigger, sheet close, map controls drawer items, custom-range apply, dialog copy button, and settings page buttons. Desktop sizing is unchanged.
- **Access Logs toggle restyled**: the History/Live tail switch is now the same Tabs list style as the Top Countries/Cities card on Geo Logs.

## Testing

- `bun run build` clean on every commit.