### PR TITLE
fix(frontend): don't reset WS reconnect backoff on open; guard /ws/crowdsec frame parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- WebSocket clients (`/ws/live`, `/ws/crowdsec`) no longer reset their
+  reconnect backoff on socket open. The server accepts and immediately closes
+  with 1013 while the poller/ingestion is down, which pinned the reconnect
+  loop at the 1s floor; the backoff now resets only after a valid frame, so
+  outages back off to the 30s cap.
+- The `/ws/crowdsec` client guards against non-string and malformed frames
+  instead of throwing inside `onmessage`.
+
 ## [0.4.0] - 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- WebSocket clients (`/ws/live`, `/ws/crowdsec`) no longer reset their
-  reconnect backoff on socket open. The server accepts and immediately closes
-  with 1013 while the poller/ingestion is down, which pinned the reconnect
-  loop at the 1s floor; the backoff now resets only after a valid frame, so
-  outages back off to the 30s cap.
-- The `/ws/crowdsec` client guards against non-string and malformed frames
-  instead of throwing inside `onmessage`.
+- WebSocket reconnect backoff (`/ws/live`, `/ws/crowdsec`) resets on a valid
+  frame instead of on open, ending the 1s reconnect loop while the server
+  closes with 1013.
+- The `/ws/crowdsec` client ignores non-string/malformed frames instead of
+  throwing.
 
 ## [0.4.0] - 2026-07-21
 

--- a/resources/lib/queries.ts
+++ b/resources/lib/queries.ts
@@ -325,12 +325,21 @@ export function useCrowdsecLiveUpdates() {
     const connect = () => {
       const proto = window.location.protocol === "https:" ? "wss" : "ws"
       ws = new WebSocket(`${proto}://${window.location.host}/ws/crowdsec`)
-      ws.onopen = () => {
-        retryMs = 1000
-      }
       ws.onmessage = (msg) => {
-        const frame = JSON.parse(msg.data) as CrowdsecDecisionsFrame
+        // The server only ever sends JSON text frames; ignore anything else
+        // (a Blob/ArrayBuffer or malformed payload) rather than throwing.
+        if (typeof msg.data !== "string") return
+        let frame: CrowdsecDecisionsFrame
+        try {
+          frame = JSON.parse(msg.data) as CrowdsecDecisionsFrame
+        } catch {
+          return
+        }
         if (frame.type !== "crowdsec_decisions") return
+        // Reset backoff only on a valid frame, not onopen: the server accepts
+        // and immediately closes 1013 while the poller is down, so an onopen
+        // reset would pin the reconnect loop at the 1s floor.
+        retryMs = 1000
         queryClient.setQueryData<string[]>(
           queryKeys.crowdsec.bannedIps,
           (ips) => {

--- a/resources/lib/websocket.ts
+++ b/resources/lib/websocket.ts
@@ -1,6 +1,6 @@
 /**
  * Reconnecting WebSocket client for /ws/live.
- * Exponential backoff (1s -> 30s cap, reset on successful open).
+ * Exponential backoff (1s -> 30s cap, reset on first valid frame).
  * The connection is lazy: first onEvents subscriber connects, last one disconnects.
  */
 
@@ -86,7 +86,6 @@ export class LiveFeedClient {
     this.setStatus("connecting")
     this.ws = new WebSocket(this.url())
     this.ws.onopen = () => {
-      this.backoffMs = 1000
       this.setStatus("connected")
     }
     this.ws.onmessage = (msg) => {
@@ -101,6 +100,10 @@ export class LiveFeedClient {
         return
       }
       if (frame.type === "batch") {
+        // Reset backoff only on a valid frame, not onopen: the server accepts
+        // and immediately closes 1013 while ingestion is down, so an onopen
+        // reset would pin the reconnect loop at the 1s floor.
+        this.backoffMs = 1000
         this.eventsListeners.forEach((cb) => cb(frame.events, frame.dropped))
       }
     }


### PR DESCRIPTION
Addresses the Copilot review comment on #35.

- Both WS clients (`/ws/live`, `/ws/crowdsec`) reset their reconnect backoff in `onopen`. The server accepts and immediately closes with 1013 while the decision-stream poller (or ingestion) is down, so the backoff never grew and the client reconnected every ~1s forever. The backoff now resets only after a valid frame, letting outages back off to the 30s cap.
- The `/ws/crowdsec` `onmessage` handler now guards `msg.data`'s type and wraps `JSON.parse` in try/catch, matching the `/ws/live` client.

Trade-off: a healthy but quiet connection that drops retries at its last backoff value (capped 30s) instead of 1s; the 60s refetch fallback covers the gap.

Verified with `tsc -b --noEmit`.