### PR TITLE
fix(ws): send idle keepalive frames on /ws/live and /ws/crowdsec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `/ws/live` and `/ws/crowdsec` now send an empty keepalive frame after 30s of
+  silence so reverse proxies (nginx `proxy_read_timeout`, 60s default / 240s in
+  SWAG) no longer cut idle live-feed connections on quiet servers.
 - WebSocket reconnect backoff (`/ws/live`, `/ws/crowdsec`) resets on a valid
   frame instead of on open, ending the 1s reconnect loop while the server
   closes with 1013.

--- a/geometrikks/api/v1/live_controller.py
+++ b/geometrikks/api/v1/live_controller.py
@@ -5,6 +5,8 @@ Protocol: one JSON frame per message —
 Events are converted from post-commit ParsedLogRecords; frames flush every
 FLUSH_INTERVAL seconds with at most MAX_EVENTS_PER_FRAME events (overflow is
 counted in `dropped` — the browser gets a rate signal instead of melting).
+When idle, an empty frame is sent every HEARTBEAT_INTERVAL seconds so reverse
+proxies don't cut the socket.
 
 Auth: /ws/ paths are NOT excluded in AUTH_EXCLUDE_PATTERNS, so the session
 middleware authenticates the handshake exactly like an API request.
@@ -26,6 +28,11 @@ logger = logging.getLogger(__name__)
 
 FLUSH_INTERVAL = 0.15          # seconds -> ~6.7 frames/s, under the ~10/s cap
 MAX_EVENTS_PER_FRAME = 100
+# Reverse proxies cut idle upstream sockets (nginx proxy_read_timeout defaults
+# to 60s; SWAG ships 240s). Both handlers are send-only and silent when no
+# events flow, so emit an empty frame of the endpoint's own type as a
+# keepalive — existing clients treat it as a no-op and reset their backoff.
+HEARTBEAT_INTERVAL = 30.0
 
 
 def record_to_events(record: ParsedLogRecord) -> list[dict[str, Any]]:
@@ -99,13 +106,21 @@ async def crowdsec_feed(socket: WebSocket) -> None:
     queue = poller.subscribe()
     watcher = asyncio.create_task(_watch_disconnect(socket))
     try:
+        loop = asyncio.get_running_loop()
+        last_send = loop.time()
         while not watcher.done():
             try:
                 frame = await asyncio.wait_for(queue.get(), timeout=0.5)
             except asyncio.TimeoutError:
+                if not watcher.done() and loop.time() - last_send >= HEARTBEAT_INTERVAL:
+                    await socket.send_json(
+                        {"type": "crowdsec_decisions", "added": [], "deleted": []}
+                    )
+                    last_send = loop.time()
                 continue
             if not watcher.done():
                 await socket.send_json(frame)
+                last_send = loop.time()
     except WebSocketDisconnect:
         pass  # client went away between the watcher check and the send
     finally:
@@ -127,13 +142,15 @@ async def live_feed(socket: WebSocket) -> None:
     queue = ingestion.subscribe()
     watcher = asyncio.create_task(_watch_disconnect(socket))
     try:
+        loop = asyncio.get_running_loop()
+        last_send = loop.time()
         pending: list[dict[str, Any]] = []
         dropped = 0
         while not watcher.done():
             # Drain until the flush deadline.
-            deadline = asyncio.get_running_loop().time() + FLUSH_INTERVAL
+            deadline = loop.time() + FLUSH_INTERVAL
             while True:
-                remaining = deadline - asyncio.get_running_loop().time()
+                remaining = deadline - loop.time()
                 if remaining <= 0:
                     break
                 try:
@@ -146,9 +163,12 @@ async def live_feed(socket: WebSocket) -> None:
                     else:
                         pending.append(event)
 
-            if (pending or dropped) and not watcher.done():
+            if watcher.done():
+                break
+            if pending or dropped or loop.time() - last_send >= HEARTBEAT_INTERVAL:
                 await socket.send_json({"type": "batch", "events": pending, "dropped": dropped})
                 pending, dropped = [], 0
+                last_send = loop.time()
     except WebSocketDisconnect:
         pass  # client went away between the watcher check and the send
     finally:

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -2960,7 +2960,7 @@
   "info": {
     "description": "Real-time GeoIP lookups and traffic analytics API",
     "title": "GeoMetrikks API",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/tests/test_crowdsec_stream.py
+++ b/tests/test_crowdsec_stream.py
@@ -188,6 +188,23 @@ def test_ws_forwards_decision_frames():
     assert poller.unsubscribed is True
 
 
+def test_ws_sends_empty_delta_heartbeat_when_idle(monkeypatch):
+    """Reverse proxies cut idle sockets (nginx proxy_read_timeout); with no
+    deltas flowing the handler must emit an empty decisions frame as a
+    keepalive. The frontend applies it as a no-op."""
+    from litestar.testing import TestClient
+
+    from geometrikks.api.v1 import live_controller
+
+    monkeypatch.setattr(live_controller, "HEARTBEAT_INTERVAL", 0.3, raising=False)
+    poller = FakePoller()
+    with TestClient(app=make_ws_app(poller)) as client:
+        with client.websocket_connect("/ws/crowdsec") as ws:
+            frame = ws.receive_json(timeout=5)
+    assert frame == {"type": "crowdsec_decisions", "added": [], "deleted": []}
+    assert poller.unsubscribed is True
+
+
 def test_ws_closes_without_poller():
     import pytest
     from litestar.exceptions import WebSocketDisconnect

--- a/tests/test_live_ws.py
+++ b/tests/test_live_ws.py
@@ -92,6 +92,19 @@ def test_ws_streams_batch_frames():
     assert ingestion.unsubscribed is True
 
 
+def test_ws_sends_empty_batch_heartbeat_when_idle(monkeypatch):
+    """Reverse proxies cut idle sockets (nginx proxy_read_timeout); with no
+    events flowing the handler must emit an empty batch frame as a keepalive."""
+    from geometrikks.api.v1 import live_controller
+
+    monkeypatch.setattr(live_controller, "HEARTBEAT_INTERVAL", 0.3, raising=False)
+    ingestion = FakeIngestion()
+    with TestClient(app=make_app(ingestion)) as client:
+        with client.websocket_connect("/ws/live") as ws:
+            frame = ws.receive_json(timeout=5)
+    assert frame == {"type": "batch", "events": [], "dropped": 0}
+
+
 def test_ws_closes_when_no_ingestion_service():
     import pytest
     from litestar.exceptions import WebSocketDisconnect  # NOT starlette — litestar has no starlette dependency

--- a/tests/test_live_ws.py
+++ b/tests/test_live_ws.py
@@ -103,6 +103,7 @@ def test_ws_sends_empty_batch_heartbeat_when_idle(monkeypatch):
         with client.websocket_connect("/ws/live") as ws:
             frame = ws.receive_json(timeout=5)
     assert frame == {"type": "batch", "events": [], "dropped": 0}
+    assert ingestion.unsubscribed is True
 
 
 def test_ws_closes_when_no_ingestion_service():

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "geometrikks"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy", extra = ["argon2", "cli", "passlib", "pwdlib"] },


### PR DESCRIPTION
## What

Both WebSocket feeds are send-only and silent when no events flow, so reverse proxies cut the socket after `proxy_read_timeout` (60s nginx default, 240s SWAG) on quiet servers. The client self-heals via reconnect backoff, but users saw the live-feed status blip "disconnected" every few minutes plus pointless reconnect churn and re-authenticated handshakes.

The server now sends an empty frame of each endpoint's own type after 30s of silence:

- `/ws/live`: `{"type": "batch", "events": [], "dropped": 0}`
- `/ws/crowdsec`: `{"type": "crowdsec_decisions", "added": [], "deleted": []}`

30s also survives a plain nginx setup with the 60s default, not just SWAG's 240s. No frontend changes needed: both clients already treat an empty frame of their own type as a no-op, and it doubles as the backoff reset since both reset on a valid typed frame rather than on open.

## Testing

- New tests in `test_live_ws.py` and `test_crowdsec_stream.py` shrink the interval via monkeypatch and assert the idle heartbeat arrives (both failed before the fix, pass after).
- Full suite green.
- Verified live against a running dev server: a raw WS client with a session cookie received the empty batch frame at exactly the configured interval.