### PR TITLE
0.4.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,14 @@ APP_ADMIN_PASSWORD=
 # Set true ONLY behind an authenticating reverse proxy (Authelia, Tailscale...)
 APP_AUTH_DISABLED=false
 
+# Mark the session cookie Secure (browsers then only send it over HTTPS).
+# Recommended when serving behind a TLS reverse proxy.
+APP_SESSION_SECURE=false
+# Reverse-proxy IPs/CIDRs allowed to supply X-Forwarded-For (used for login
+# logging). One value, comma-separated, or a JSON list. Empty = never trust
+# forwarded headers.
+APP_TRUSTED_PROXIES=
+
 # MaxMind GeoLite2 auto-download (free account: maxmind.com/en/geolite2/signup)
 MAXMINDDB_USER_ID=
 MAXMINDDB_LICENSE_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-07-22
+
 ### Added
 
 - `APP_SESSION_SECURE` (default `false`): mark the session cookie `Secure`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- WebSocket clients (`/ws/live`, `/ws/crowdsec`) no longer reset their
+  reconnect backoff on socket open. The server accepts and immediately closes
+  with 1013 while the poller/ingestion is down, which pinned the reconnect
+  loop at the 1s floor; the backoff now resets only after a valid frame, so
+  outages back off to the 30s cap.
+- The `/ws/crowdsec` client guards against non-string and malformed frames
+  instead of throwing inside `onmessage`.
+
 ## [0.4.0] - 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `/ws/live` and `/ws/crowdsec` now send an empty keepalive frame after 30s of
+  silence so reverse proxies (nginx `proxy_read_timeout`, 60s default / 240s in
+  SWAG) no longer cut idle live-feed connections on quiet servers.
 - WebSocket reconnect backoff (`/ws/live`, `/ws/crowdsec`) resets on a valid
   frame instead of on open, ending the 1s reconnect loop while the server
   closes with 1013.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `APP_SESSION_SECURE` (default `false`): mark the session cookie `Secure`;
+  recommended behind a TLS reverse proxy.
+- `APP_TRUSTED_PROXIES` (IPs/CIDRs, default empty): trust `X-Forwarded-For`
+  from these proxies so the app can resolve real client IPs.
+- Login successes and failures are now logged with username and client IP.
+- README: "Running behind a reverse proxy" section with a SWAG sample
+  config, recommended proxy settings, exposed-path notes and an edge
+  rate-limiting recommendation.
+
 ### Fixed
 
 - WebSocket reconnect backoff (`/ws/live`, `/ws/crowdsec`) resets on a valid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `APP_TRUSTED_PROXIES` (IPs/CIDRs, default empty): trust `X-Forwarded-For`
   from these proxies so the app can resolve real client IPs.
 - Login successes and failures are now logged with username and client IP.
-- README: "Running behind a reverse proxy" section with a SWAG sample
-  config, recommended proxy settings, exposed-path notes and an edge
-  rate-limiting recommendation.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- WebSocket clients (`/ws/live`, `/ws/crowdsec`) no longer reset their
-  reconnect backoff on socket open. The server accepts and immediately closes
-  with 1013 while the poller/ingestion is down, which pinned the reconnect
-  loop at the 1s floor; the backoff now resets only after a valid frame, so
-  outages back off to the 30s cap.
-- The `/ws/crowdsec` client guards against non-string and malformed frames
-  instead of throwing inside `onmessage`.
+- WebSocket reconnect backoff (`/ws/live`, `/ws/crowdsec`) resets on a valid
+  frame instead of on open, ending the 1s reconnect loop while the server
+  closes with 1013.
+- The `/ws/crowdsec` client ignores non-string/malformed frames instead of
+  throwing.
 
 ## [0.4.0] - 2026-07-21
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,76 @@ This is a reverse-proxy-only mode: with it set, `/api/v1/auth/*` is not
 registered (404s) and the WebSocket accepts anonymous connections, so only
 enable it when something else is already gating access to the app.
 
+## Running behind a reverse proxy
+
+GeoMetrikks works behind a TLS-terminating reverse proxy. Serve it on its
+own subdomain (for example `geometrikks.example.com`): the frontend is
+hard-wired to the site root, so subfolder setups
+(`example.com/geometrikks/`) are not supported.
+
+The WebSocket feeds (`/ws/live`, `/ws/crowdsec`) work through standard
+`Upgrade`/`Connection` proxy headers, and the server sends a keepalive
+frame every 30 seconds so idle connections survive proxy read timeouts.
+
+Recommended settings when proxied over HTTPS:
+
+```env
+# The session cookie is only ever sent over HTTPS.
+APP_SESSION_SECURE=true
+# Trust X-Forwarded-For from your proxy so login logging records the real
+# client IP. Use the narrowest range that covers the proxy.
+APP_TRUSTED_PROXIES=172.18.0.0/16
+```
+
+`X-Forwarded-For` is a plain header any client can send, so GeoMetrikks
+only honors it when the request arrives from an address listed in
+`APP_TRUSTED_PROXIES`; otherwise the connection's own address is used.
+Keep the range tight: everything inside it can put arbitrary addresses in
+the header.
+
+### SWAG / nginx sample
+
+For [linuxserver SWAG](https://github.com/linuxserver/docker-swag), drop
+this into `/config/nginx/proxy-confs/geometrikks.subdomain.conf` (the
+GeoMetrikks container must be named `geometrikks` and share a Docker
+network with SWAG):
+
+```nginx
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name geometrikks.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    location / {
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        include /config/nginx/proxy.conf;
+        include /config/nginx/resolver.conf;
+        set $upstream_app geometrikks;
+        set $upstream_port 8000;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    }
+}
+```
+
+Notes for exposing GeoMetrikks to the internet:
+
+- `/schema` (the interactive API docs) and `/health` do not require login.
+  If you don't want them public, protect them at the proxy (an nginx
+  `location` rule or your auth portal).
+- The login endpoint has no built-in rate limiting. Run fail2ban or
+  CrowdSec against your proxy's access logs to stop brute force at the
+  edge.
+- `APP_AUTH_DISABLED=true` must only be used when an authenticating proxy
+  (Authelia, Tailscale, ...) sits in front of the app.
+
 ## CrowdSec integration (optional)
 
 If a [CrowdSec](https://www.crowdsec.net/) instance protects your stack,

--- a/README.md
+++ b/README.md
@@ -189,10 +189,6 @@ own subdomain (for example `geometrikks.example.com`): the frontend is
 hard-wired to the site root, so subfolder setups
 (`example.com/geometrikks/`) are not supported.
 
-The WebSocket feeds (`/ws/live`, `/ws/crowdsec`) work through standard
-`Upgrade`/`Connection` proxy headers, and the server sends a keepalive
-frame every 30 seconds so idle connections survive proxy read timeouts.
-
 Recommended settings when proxied over HTTPS:
 
 ```env
@@ -209,7 +205,15 @@ only honors it when the request arrives from an address listed in
 Keep the range tight: everything inside it can put arbitrary addresses in
 the header.
 
-### SWAG / nginx sample
+The WebSocket feeds (`/ws/live`, `/ws/crowdsec`) work through the standard
+`Upgrade`/`Connection` proxy headers, and the server sends a keepalive
+frame every 30 seconds, so idle connections survive nginx's default
+`proxy_read_timeout` without extra tuning.
+
+### Sample nginx configs
+
+<details>
+<summary>SWAG (linuxserver.io)</summary>
 
 For [linuxserver SWAG](https://github.com/linuxserver/docker-swag), drop
 this into `/config/nginx/proxy-confs/geometrikks.subdomain.conf` (the
@@ -240,6 +244,56 @@ server {
     }
 }
 ```
+
+SWAG's stock `proxy.conf` already sends the WebSocket upgrade and
+`X-Forwarded-For` headers. Set `APP_TRUSTED_PROXIES` to the Docker network
+SWAG shares with the app (for example `172.18.0.0/16`).
+
+</details>
+
+<details>
+<summary>Plain nginx</summary>
+
+For a regular nginx install terminating TLS in front of the app:
+
+```nginx
+# The Connection header must be "upgrade" for WebSocket handshakes and
+# "close" otherwise; this map picks the right value per request.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ""      close;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name geometrikks.example.com;
+
+    ssl_certificate     /etc/nginx/ssl/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket upgrade for /ws/live and /ws/crowdsec
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+}
+```
+
+Adjust `proxy_pass` to wherever the app runs (container IP, another host).
+With nginx proxying from the same machine as above, set
+`APP_TRUSTED_PROXIES=127.0.0.1`.
+
+</details>
 
 Notes for exposing GeoMetrikks to the internet:
 

--- a/README.md
+++ b/README.md
@@ -221,9 +221,15 @@ GeoMetrikks container must be named `geometrikks` and share a Docker
 network with SWAG):
 
 ```nginx
+## Version 2025/07/18
+# make sure that your geometrikks container is named geometrikks
+# make sure that your dns has a cname set for geometrikks
+
 server {
     listen 443 ssl;
+#    listen 443 quic;
     listen [::]:443 ssl;
+#    listen [::]:443 quic;
 
     server_name geometrikks.*;
 
@@ -231,9 +237,34 @@ server {
 
     client_max_body_size 0;
 
+    # enable for ldap auth (requires ldap-location.conf in the location block)
+    #include /config/nginx/ldap-server.conf;
+
+    # enable for Authelia (requires authelia-location.conf in the location block)
+    #include /config/nginx/authelia-server.conf;
+
+    # enable for Authentik (requires authentik-location.conf in the location block)
+    #include /config/nginx/authentik-server.conf;
+
+    # enable for Tinyauth (requires tinyauth-location.conf in the location block)
+    #include /config/nginx/tinyauth-server.conf;
+
     location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
         # enable for Authelia (requires authelia-server.conf in the server block)
         #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        # enable for Tinyauth (requires tinyauth-server.conf in the server block)
+        #include /config/nginx/tinyauth-location.conf;
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,8 @@ list most users need is in `.env.example`; everything below is available.
 | `APP_AUTH_DISABLED` | `false` | Disable the built-in session auth entirely. Set true only when an authenticating reverse proxy (Authelia, Tailscale, ...) fronts the app. |
 | `APP_ADMIN_USER` | `admin` | Admin login username |
 | `APP_ADMIN_PASSWORD` | — | Admin login password (required unless auth_disabled=true) |
+| `APP_SESSION_SECURE` | `false` | Mark the session cookie Secure so browsers only send it over HTTPS. Recommended when serving behind a TLS reverse proxy. |
+| `APP_TRUSTED_PROXIES` | *(computed)* | Reverse-proxy IPs/CIDRs allowed to supply X-Forwarded-For. Env accepts one value, comma-separated values, or a JSON list. Empty (default): forwarded headers are never trusted. |
 
 ## API server
 

--- a/geometrikks/api/v1/auth_controller.py
+++ b/geometrikks/api/v1/auth_controller.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 from litestar import Controller, Request, get, post
 from litestar.exceptions import NotAuthorizedException
 from litestar.status_codes import HTTP_200_OK, HTTP_204_NO_CONTENT
 
+from geometrikks.lib.client_ip import resolve_client_ip
 from geometrikks.server.auth import AdminUser, AuthState
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -31,9 +36,12 @@ class AuthController(Controller):
     @post("/login", status_code=HTTP_200_OK, exclude_from_auth=True)
     async def login(self, request: Request, data: LoginPayload) -> MeResponse:
         auth_state: AuthState = request.app.state.auth_state
+        client_ip = resolve_client_ip(request)
         if not auth_state.verify(data.username, data.password):
+            logger.warning("Login failed for %r from %s", data.username, client_ip)
             raise NotAuthorizedException(detail="Invalid credentials")
         request.set_session({"username": data.username})
+        logger.info("Login succeeded for %r from %s", data.username, client_ip)
         return MeResponse(username=data.username)
 
     @post("/logout", status_code=HTTP_204_NO_CONTENT)

--- a/geometrikks/api/v1/live_controller.py
+++ b/geometrikks/api/v1/live_controller.py
@@ -5,6 +5,8 @@ Protocol: one JSON frame per message —
 Events are converted from post-commit ParsedLogRecords; frames flush every
 FLUSH_INTERVAL seconds with at most MAX_EVENTS_PER_FRAME events (overflow is
 counted in `dropped` — the browser gets a rate signal instead of melting).
+When idle, an empty frame is sent every HEARTBEAT_INTERVAL seconds so reverse
+proxies don't cut the socket.
 
 Auth: /ws/ paths are NOT excluded in AUTH_EXCLUDE_PATTERNS, so the session
 middleware authenticates the handshake exactly like an API request.
@@ -26,6 +28,11 @@ logger = logging.getLogger(__name__)
 
 FLUSH_INTERVAL = 0.15          # seconds -> ~6.7 frames/s, under the ~10/s cap
 MAX_EVENTS_PER_FRAME = 100
+# Reverse proxies cut idle upstream sockets (nginx proxy_read_timeout defaults
+# to 60s; SWAG ships 240s). Both handlers are send-only and silent when no
+# events flow, so emit an empty frame of the endpoint's own type as a
+# keepalive — existing clients treat it as a no-op and reset their backoff.
+HEARTBEAT_INTERVAL = 30.0
 
 
 def record_to_events(record: ParsedLogRecord) -> list[dict[str, Any]]:
@@ -99,13 +106,21 @@ async def crowdsec_feed(socket: WebSocket) -> None:
     queue = poller.subscribe()
     watcher = asyncio.create_task(_watch_disconnect(socket))
     try:
+        loop = asyncio.get_running_loop()
+        last_send = loop.time()
         while not watcher.done():
             try:
                 frame = await asyncio.wait_for(queue.get(), timeout=0.5)
             except asyncio.TimeoutError:
+                if not watcher.done() and loop.time() - last_send >= HEARTBEAT_INTERVAL:
+                    await socket.send_json(
+                        {"type": "crowdsec_decisions", "added": [], "deleted": []}
+                    )
+                    last_send = loop.time()
                 continue
             if not watcher.done():
                 await socket.send_json(frame)
+                last_send = loop.time()
     except WebSocketDisconnect:
         pass  # client went away between the watcher check and the send
     finally:
@@ -127,13 +142,15 @@ async def live_feed(socket: WebSocket) -> None:
     queue = ingestion.subscribe()
     watcher = asyncio.create_task(_watch_disconnect(socket))
     try:
+        loop = asyncio.get_running_loop()
+        last_send = loop.time()
         pending: list[dict[str, Any]] = []
         dropped = 0
         while not watcher.done():
             # Drain until the flush deadline.
-            deadline = asyncio.get_running_loop().time() + FLUSH_INTERVAL
+            deadline = loop.time() + FLUSH_INTERVAL
             while True:
-                remaining = deadline - asyncio.get_running_loop().time()
+                remaining = deadline - loop.time()
                 if remaining <= 0:
                     break
                 try:
@@ -146,9 +163,12 @@ async def live_feed(socket: WebSocket) -> None:
                     else:
                         pending.append(event)
 
-            if (pending or dropped) and not watcher.done():
+            if watcher.done():
+                break
+            if pending or dropped or loop.time() - last_send >= HEARTBEAT_INTERVAL:
                 await socket.send_json({"type": "batch", "events": pending, "dropped": dropped})
                 pending, dropped = [], 0
+                last_send = loop.time()
     except WebSocketDisconnect:
         pass  # client went away between the watcher check and the send
     finally:

--- a/geometrikks/config/settings.py
+++ b/geometrikks/config/settings.py
@@ -2,6 +2,7 @@ import json
 import socket
 from functools import lru_cache
 from importlib.metadata import PackageNotFoundError, version as distribution_version
+from ipaddress import ip_network
 from pathlib import Path
 from typing import Annotated, Literal
 from urllib.parse import quote
@@ -481,6 +482,47 @@ class Settings(BaseSettings):
         default=None,
         description="Admin login password (required unless auth_disabled=true)",
     )
+    session_secure: bool = Field(
+        default=False,
+        description=(
+            "Mark the session cookie Secure so browsers only send it over "
+            "HTTPS. Recommended when serving behind a TLS reverse proxy."
+        ),
+    )
+    trusted_proxies: Annotated[list[str], NoDecode] = Field(
+        default_factory=list,
+        description=(
+            "Reverse-proxy IPs/CIDRs allowed to supply X-Forwarded-For. Env "
+            "accepts one value, comma-separated values, or a JSON list. "
+            "Empty (default): forwarded headers are never trusted."
+        ),
+    )
+
+    @field_validator("trusted_proxies", mode="before")
+    @classmethod
+    def parse_trusted_proxies(cls, value: object) -> object:
+        """Accept one value, comma-separated values, or a JSON list."""
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return []
+            if stripped.startswith("["):
+                return json.loads(stripped)
+            return [part.strip() for part in stripped.split(",") if part.strip()]
+        return value
+
+    @field_validator("trusted_proxies")
+    @classmethod
+    def validate_trusted_proxies(cls, value: list[str]) -> list[str]:
+        """Fail at startup on entries that are not an IP or CIDR."""
+        for entry in value:
+            try:
+                ip_network(entry, strict=False)
+            except ValueError as exc:
+                raise ValueError(
+                    f"APP_TRUSTED_PROXIES entry {entry!r} is not an IP address or CIDR"
+                ) from exc
+        return value
 
     # Sub-configurations
     api: APISettings = Field(default_factory=APISettings)

--- a/geometrikks/lib/client_ip.py
+++ b/geometrikks/lib/client_ip.py
@@ -1,0 +1,67 @@
+"""Resolve the real client IP behind a trusted reverse proxy.
+
+X-Forwarded-For is a plain header any client can send, so it is only
+honored when the TCP peer is inside one of the configured trusted-proxy
+networks (APP_TRUSTED_PROXIES). Entries are walked right to left; the
+first address not belonging to a trusted proxy is the client as seen by
+the edge. Every failure mode falls back to the peer address.
+"""
+
+from __future__ import annotations
+
+from ipaddress import IPv4Address, IPv6Address, ip_address, ip_network
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from ipaddress import IPv4Network, IPv6Network
+
+    from litestar.connection import ASGIConnection
+
+
+def _parse_ip(value: str) -> IPv4Address | IPv6Address | None:
+    try:
+        return ip_address(value.strip().strip("[]"))
+    except ValueError:
+        return None
+
+
+def resolve_client_ip(
+    connection: ASGIConnection,
+    trusted_networks: Sequence[IPv4Network | IPv6Network] | None = None,
+) -> str | None:
+    """Return the client IP for a connection, honoring trusted proxies.
+
+    Args:
+        connection: The request or WebSocket connection.
+        trusted_networks: Networks whose X-Forwarded-For is trusted. When
+            None, built from ``get_settings().trusted_proxies``.
+
+    Returns:
+        The resolved client address, or None when the peer is unknown.
+    """
+    if trusted_networks is None:
+        from geometrikks.config.settings import get_settings
+
+        trusted_networks = [
+            ip_network(entry, strict=False) for entry in get_settings().trusted_proxies
+        ]
+
+    peer = connection.client.host if connection.client else None
+    if peer is None or not trusted_networks:
+        return peer
+
+    peer_ip = _parse_ip(peer)
+    if peer_ip is None or not any(peer_ip in net for net in trusted_networks):
+        return peer
+
+    forwarded = connection.headers.get("x-forwarded-for")
+    if not forwarded:
+        return peer
+    for entry in reversed(forwarded.split(",")):
+        entry_ip = _parse_ip(entry)
+        if entry_ip is None:
+            return peer
+        if not any(entry_ip in net for net in trusted_networks):
+            return str(entry_ip)
+    return peer

--- a/geometrikks/lib/client_ip.py
+++ b/geometrikks/lib/client_ip.py
@@ -20,6 +20,10 @@ if TYPE_CHECKING:
 
 
 def _parse_ip(value: str) -> IPv4Address | IPv6Address | None:
+    if "%" in value:
+        # IPv6 zone IDs accept arbitrary bytes (including newlines) and
+        # round-trip through str(); never legitimate in X-Forwarded-For.
+        return None
     try:
         return ip_address(value.strip().strip("[]"))
     except ValueError:
@@ -55,7 +59,11 @@ def resolve_client_ip(
     if peer_ip is None or not any(peer_ip in net for net in trusted_networks):
         return peer
 
-    forwarded = connection.headers.get("x-forwarded-for")
+    # A client can send its own X-Forwarded-For; a proxy that appends rather
+    # than merges (e.g. HAProxy's "option forwardfor") leaves that as a
+    # separate header occurrence. headers.get() only returns the first one,
+    # so every occurrence must be joined before walking right to left.
+    forwarded = ", ".join(connection.headers.getall("x-forwarded-for", []))
     if not forwarded:
         return peer
     for entry in reversed(forwarded.split(",")):

--- a/geometrikks/server/auth.py
+++ b/geometrikks/server/auth.py
@@ -94,6 +94,9 @@ def create_session_auth(settings: "Settings") -> SessionAuth[AdminUser, ServerSi
     """
     return SessionAuth[AdminUser, ServerSideSessionBackend](
         retrieve_user_handler=retrieve_user_handler,
-        session_backend_config=ServerSideSessionConfig(max_age=60 * 60 * 24 * 7),
+        session_backend_config=ServerSideSessionConfig(
+            max_age=60 * 60 * 24 * 7,
+            secure=settings.session_secure,
+        ),
         exclude=AUTH_EXCLUDE_PATTERNS,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geometrikks"
-version = "0.4.0"
+version = "0.4.1"
 description = "Geo metrics ingress service built with Litestar."
 readme = "README.md"
 requires-python = ">=3.13,<3.14"

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -2960,7 +2960,7 @@
   "info": {
     "description": "Real-time GeoIP lookups and traffic analytics API",
     "title": "GeoMetrikks API",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/resources/lib/queries.ts
+++ b/resources/lib/queries.ts
@@ -325,12 +325,21 @@ export function useCrowdsecLiveUpdates() {
     const connect = () => {
       const proto = window.location.protocol === "https:" ? "wss" : "ws"
       ws = new WebSocket(`${proto}://${window.location.host}/ws/crowdsec`)
-      ws.onopen = () => {
-        retryMs = 1000
-      }
       ws.onmessage = (msg) => {
-        const frame = JSON.parse(msg.data) as CrowdsecDecisionsFrame
+        // The server only ever sends JSON text frames; ignore anything else
+        // (a Blob/ArrayBuffer or malformed payload) rather than throwing.
+        if (typeof msg.data !== "string") return
+        let frame: CrowdsecDecisionsFrame
+        try {
+          frame = JSON.parse(msg.data) as CrowdsecDecisionsFrame
+        } catch {
+          return
+        }
         if (frame.type !== "crowdsec_decisions") return
+        // Reset backoff only on a valid frame, not onopen: the server accepts
+        // and immediately closes 1013 while the poller is down, so an onopen
+        // reset would pin the reconnect loop at the 1s floor.
+        retryMs = 1000
         queryClient.setQueryData<string[]>(
           queryKeys.crowdsec.bannedIps,
           (ips) => {

--- a/resources/lib/websocket.ts
+++ b/resources/lib/websocket.ts
@@ -1,6 +1,6 @@
 /**
  * Reconnecting WebSocket client for /ws/live.
- * Exponential backoff (1s -> 30s cap, reset on successful open).
+ * Exponential backoff (1s -> 30s cap, reset on first valid frame).
  * The connection is lazy: first onEvents subscriber connects, last one disconnects.
  */
 
@@ -86,7 +86,6 @@ export class LiveFeedClient {
     this.setStatus("connecting")
     this.ws = new WebSocket(this.url())
     this.ws.onopen = () => {
-      this.backoffMs = 1000
       this.setStatus("connected")
     }
     this.ws.onmessage = (msg) => {
@@ -101,6 +100,10 @@ export class LiveFeedClient {
         return
       }
       if (frame.type === "batch") {
+        // Reset backoff only on a valid frame, not onopen: the server accepts
+        // and immediately closes 1013 while ingestion is down, so an onopen
+        // reset would pin the reconnect loop at the 1s floor.
+        this.backoffMs = 1000
         this.eventsListeners.forEach((cb) => cb(frame.events, frame.dropped))
       }
     }

--- a/tests/test_auth_endpoints.py
+++ b/tests/test_auth_endpoints.py
@@ -1,6 +1,7 @@
 """Endpoint tests for login/logout/me and the auth middleware boundary."""
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pytest
@@ -166,3 +167,35 @@ def test_session_cookie_secure_flag_follows_setting():
             json={"username": "admin", "password": "bestpasswordintheworldnojoke"},
         )
         assert "secure" not in res.headers["set-cookie"].lower()
+
+
+def test_login_attempts_are_logged_with_client_ip(caplog):
+    records: list = []
+
+    class ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    auth_logger = logging.getLogger("geometrikks.api.v1.auth_controller")
+    handler = ListHandler(level=logging.INFO)
+    app = make_app()
+    with TestClient(app=app) as client:
+        auth_logger.addHandler(handler)
+        try:
+            client.post(
+                "/api/v1/auth/login",
+                json={"username": "admin", "password": "wrong"},
+            )
+            client.post(
+                "/api/v1/auth/login",
+                json={"username": "admin", "password": "bestpasswordintheworldnojoke"},
+            )
+        finally:
+            auth_logger.removeHandler(handler)
+    failed = [r for r in records if "Login failed" in r.getMessage()]
+    succeeded = [r for r in records if "Login succeeded" in r.getMessage()]
+    assert len(failed) == 1 and failed[0].levelno == logging.WARNING
+    assert len(succeeded) == 1 and succeeded[0].levelno == logging.INFO
+    # Both carry the username and a from-<address> clause (TestClient peer).
+    assert "'admin'" in failed[0].getMessage() and "from" in failed[0].getMessage()
+    assert "'admin'" in succeeded[0].getMessage() and "from" in succeeded[0].getMessage()

--- a/tests/test_auth_endpoints.py
+++ b/tests/test_auth_endpoints.py
@@ -149,3 +149,20 @@ def test_auth_routes_registered_when_auth_enabled(monkeypatch):
     app = create_app()
     paths = {route.path for route in app.routes}
     assert AUTH_ROUTE_PATHS <= paths
+
+
+def test_session_cookie_secure_flag_follows_setting():
+    with TestClient(app=make_app(session_secure=True)) as client:
+        res = client.post(
+            "/api/v1/auth/login",
+            json={"username": "admin", "password": "bestpasswordintheworldnojoke"},
+        )
+        assert res.status_code == 200
+        assert "secure" in res.headers["set-cookie"].lower()
+
+    with TestClient(app=make_app()) as client:
+        res = client.post(
+            "/api/v1/auth/login",
+            json={"username": "admin", "password": "bestpasswordintheworldnojoke"},
+        )
+        assert "secure" not in res.headers["set-cookie"].lower()

--- a/tests/test_auth_endpoints.py
+++ b/tests/test_auth_endpoints.py
@@ -27,7 +27,12 @@ async def fake_health() -> dict[str, Any]:
 
 
 def make_app(**settings_kwargs) -> Litestar:
-    settings = Settings(admin_user="admin", admin_password="bestpasswordintheworldnojoke", **settings_kwargs)
+    settings = Settings(
+        admin_user="admin",
+        admin_password="bestpasswordintheworldnojoke",
+        _env_file=None,
+        **settings_kwargs,
+    )
     session_auth = create_session_auth(settings)
     app = Litestar(
         route_handlers=[AuthController, protected, fake_health, live_feed],
@@ -169,7 +174,7 @@ def test_session_cookie_secure_flag_follows_setting():
         assert "secure" not in res.headers["set-cookie"].lower()
 
 
-def test_login_attempts_are_logged_with_client_ip(caplog):
+def test_login_attempts_are_logged_with_client_ip():
     records: list = []
 
     class ListHandler(logging.Handler):

--- a/tests/test_client_ip.py
+++ b/tests/test_client_ip.py
@@ -8,15 +8,30 @@ from geometrikks.lib.client_ip import resolve_client_ip
 TRUSTED = [ip_network("172.18.0.0/16"), ip_network("10.0.0.5/32")]
 
 
+class _Headers:
+    """Minimal stand-in for litestar's Headers, supporting getall()."""
+
+    def __init__(self, data: dict[str, list[str]]) -> None:
+        self._data = data
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        values = self._data.get(key.lower())
+        return values[0] if values else default
+
+    def getall(self, key: str, default: list[str] | None = None) -> list[str]:
+        return self._data.get(key.lower(), default if default is not None else [])
+
+
 class FakeConnection:
     """Duck-typed stand-in for litestar's ASGIConnection."""
 
-    def __init__(self, peer: str | None, headers: dict[str, str] | None = None) -> None:
+    def __init__(self, peer: str | None, headers: dict[str, str | list[str]] | None = None) -> None:
         class _Client:
             host = peer
 
         self.client = _Client() if peer is not None else None
-        self.headers = headers or {}
+        raw = headers or {}
+        self.headers = _Headers({k.lower(): v if isinstance(v, list) else [v] for k, v in raw.items()})
 
 
 def test_no_trusted_networks_returns_peer_and_ignores_header():
@@ -74,3 +89,27 @@ def test_non_ip_peer_is_returned_verbatim():
     # litestar's TestClient reports a hostname peer; never crash on it.
     conn = FakeConnection("testclient", {"x-forwarded-for": "203.0.113.7"})
     assert resolve_client_ip(conn, trusted_networks=TRUSTED) == "testclient"
+
+
+def test_duplicate_xff_header_occurrences_are_joined():
+    # The client sent its own X-Forwarded-For; HAProxy's "option forwardfor"
+    # appends a separate header occurrence rather than merging it in.
+    conn = FakeConnection("172.18.0.2", {"x-forwarded-for": ["8.8.8.8", "203.0.113.7"]})
+    assert resolve_client_ip(conn, trusted_networks=TRUSTED) == "203.0.113.7"
+
+
+def test_duplicate_xff_header_occurrences_with_multiple_entries_each():
+    conn = FakeConnection("172.18.0.2", {"x-forwarded-for": ["8.8.8.8, 6.6.6.6", "203.0.113.7"]})
+    assert resolve_client_ip(conn, trusted_networks=TRUSTED) == "203.0.113.7"
+
+
+def test_ipv6_zone_id_is_rejected_and_falls_back_to_peer():
+    # Zone IDs can carry arbitrary bytes, including newlines, and would
+    # otherwise round-trip through str() into log lines unfiltered.
+    conn = FakeConnection("172.18.0.2", {"x-forwarded-for": "fe80::1%eth0"})
+    assert resolve_client_ip(conn, trusted_networks=TRUSTED) == "172.18.0.2"
+
+
+def test_malformed_entry_behind_trusted_hop_falls_back_to_peer():
+    conn = FakeConnection("172.18.0.2", {"x-forwarded-for": "203.0.113.7, garbage, 10.0.0.5"})
+    assert resolve_client_ip(conn, trusted_networks=TRUSTED) == "172.18.0.2"

--- a/tests/test_client_ip.py
+++ b/tests/test_client_ip.py
@@ -1,0 +1,76 @@
+"""Trusted-proxy X-Forwarded-For resolution."""
+from __future__ import annotations
+
+from ipaddress import ip_network
+
+from geometrikks.lib.client_ip import resolve_client_ip
+
+TRUSTED = [ip_network("172.18.0.0/16"), ip_network("10.0.0.5/32")]
+
+
+class FakeConnection:
+    """Duck-typed stand-in for litestar's ASGIConnection."""
+
+    def __init__(self, peer: str | None, headers: dict[str, str] | None = None) -> None:
+        class _Client:
+            host = peer
+
+        self.client = _Client() if peer is not None else None
+        self.headers = headers or {}
+
+
+def test_no_trusted_networks_returns_peer_and_ignores_header():
+    conn = FakeConnection("203.0.113.7", {"x-forwarded-for": "8.8.8.8"})
+    assert resolve_client_ip(conn, trusted_networks=[]) == "203.0.113.7"
+
+
+def test_untrusted_peer_cannot_spoof_via_header():
+    conn = FakeConnection("203.0.113.7", {"x-forwarded-for": "8.8.8.8"})
+    assert resolve_client_ip(conn, trusted_networks=TRUSTED) == "203.0.113.7"
+
+
+def test_trusted_peer_single_forwarded_entry():
+    conn = FakeConnection("172.18.0.2", {"x-forwarded-for": "203.0.113.7"})
+    assert resolve_client_ip(conn, trusted_networks=TRUSTED) == "203.0.113.7"
+
+
+def test_trusted_chain_skips_trusted_hops():
+    # client, then an inner proxy (10.0.0.5), observed by the edge (peer).
+    conn = FakeConnection("172.18.0.2", {"x-forwarded-for": "203.0.113.7, 10.0.0.5"})
+    assert resolve_client_ip(conn, trusted_networks=TRUSTED) == "203.0.113.7"
+
+
+def test_client_supplied_garbage_left_of_real_ip_is_ignored():
+    # The attacker sent their own X-Forwarded-For; the proxy appended the truth.
+    conn = FakeConnection("172.18.0.2", {"x-forwarded-for": "8.8.8.8, 203.0.113.7"})
+    assert resolve_client_ip(conn, trusted_networks=TRUSTED) == "203.0.113.7"
+
+
+def test_missing_header_falls_back_to_peer():
+    conn = FakeConnection("172.18.0.2")
+    assert resolve_client_ip(conn, trusted_networks=TRUSTED) == "172.18.0.2"
+
+
+def test_malformed_header_falls_back_to_peer():
+    conn = FakeConnection("172.18.0.2", {"x-forwarded-for": "unknown, garbage"})
+    assert resolve_client_ip(conn, trusted_networks=TRUSTED) == "172.18.0.2"
+
+
+def test_all_entries_trusted_falls_back_to_peer():
+    conn = FakeConnection("172.18.0.2", {"x-forwarded-for": "10.0.0.5"})
+    assert resolve_client_ip(conn, trusted_networks=TRUSTED) == "172.18.0.2"
+
+
+def test_ipv6_entry_with_brackets():
+    conn = FakeConnection("172.18.0.2", {"x-forwarded-for": "[2001:db8::1]"})
+    assert resolve_client_ip(conn, trusted_networks=TRUSTED) == "2001:db8::1"
+
+
+def test_no_client_returns_none():
+    assert resolve_client_ip(FakeConnection(None), trusted_networks=TRUSTED) is None
+
+
+def test_non_ip_peer_is_returned_verbatim():
+    # litestar's TestClient reports a hostname peer; never crash on it.
+    conn = FakeConnection("testclient", {"x-forwarded-for": "203.0.113.7"})
+    assert resolve_client_ip(conn, trusted_networks=TRUSTED) == "testclient"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from geometrikks.config import GeoIPSettings, MapSettings, Settings, get_settings
 from geometrikks.config.settings import get_installed_version
@@ -365,3 +366,26 @@ def test_crowdsec_stream_poll_interval(monkeypatch):
     assert CrowdSecSettings(_env_file=None).stream_poll_interval == 15.0
     monkeypatch.setenv("CROWDSEC_STREAM_POLL_INTERVAL", "5")
     assert CrowdSecSettings(_env_file=None).stream_poll_interval == 5.0
+
+
+class TestProxySettings:
+    def test_trusted_proxies_default_empty(self):
+        assert Settings(_env_file=None).trusted_proxies == []
+
+    def test_trusted_proxies_comma_separated(self):
+        s = Settings(trusted_proxies="172.18.0.0/16, 10.0.0.5", _env_file=None)
+        assert s.trusted_proxies == ["172.18.0.0/16", "10.0.0.5"]
+
+    def test_trusted_proxies_json_list(self):
+        s = Settings(trusted_proxies='["172.18.0.0/16"]', _env_file=None)
+        assert s.trusted_proxies == ["172.18.0.0/16"]
+
+    def test_trusted_proxies_empty_string_is_empty(self):
+        assert Settings(trusted_proxies="", _env_file=None).trusted_proxies == []
+
+    def test_trusted_proxies_invalid_entry_fails_at_load(self):
+        with pytest.raises(ValidationError):
+            Settings(trusted_proxies="not-an-ip", _env_file=None)
+
+    def test_session_secure_defaults_false(self):
+        assert Settings(_env_file=None).session_secure is False

--- a/tests/test_crowdsec_stream.py
+++ b/tests/test_crowdsec_stream.py
@@ -188,6 +188,23 @@ def test_ws_forwards_decision_frames():
     assert poller.unsubscribed is True
 
 
+def test_ws_sends_empty_delta_heartbeat_when_idle(monkeypatch):
+    """Reverse proxies cut idle sockets (nginx proxy_read_timeout); with no
+    deltas flowing the handler must emit an empty decisions frame as a
+    keepalive. The frontend applies it as a no-op."""
+    from litestar.testing import TestClient
+
+    from geometrikks.api.v1 import live_controller
+
+    monkeypatch.setattr(live_controller, "HEARTBEAT_INTERVAL", 0.3, raising=False)
+    poller = FakePoller()
+    with TestClient(app=make_ws_app(poller)) as client:
+        with client.websocket_connect("/ws/crowdsec") as ws:
+            frame = ws.receive_json(timeout=5)
+    assert frame == {"type": "crowdsec_decisions", "added": [], "deleted": []}
+    assert poller.unsubscribed is True
+
+
 def test_ws_closes_without_poller():
     import pytest
     from litestar.exceptions import WebSocketDisconnect

--- a/tests/test_live_ws.py
+++ b/tests/test_live_ws.py
@@ -92,6 +92,19 @@ def test_ws_streams_batch_frames():
     assert ingestion.unsubscribed is True
 
 
+def test_ws_sends_empty_batch_heartbeat_when_idle(monkeypatch):
+    """Reverse proxies cut idle sockets (nginx proxy_read_timeout); with no
+    events flowing the handler must emit an empty batch frame as a keepalive."""
+    from geometrikks.api.v1 import live_controller
+
+    monkeypatch.setattr(live_controller, "HEARTBEAT_INTERVAL", 0.3, raising=False)
+    ingestion = FakeIngestion()
+    with TestClient(app=make_app(ingestion)) as client:
+        with client.websocket_connect("/ws/live") as ws:
+            frame = ws.receive_json(timeout=5)
+    assert frame == {"type": "batch", "events": [], "dropped": 0}
+
+
 def test_ws_closes_when_no_ingestion_service():
     import pytest
     from litestar.exceptions import WebSocketDisconnect  # NOT starlette — litestar has no starlette dependency

--- a/tests/test_live_ws.py
+++ b/tests/test_live_ws.py
@@ -103,6 +103,7 @@ def test_ws_sends_empty_batch_heartbeat_when_idle(monkeypatch):
         with client.websocket_connect("/ws/live") as ws:
             frame = ws.receive_json(timeout=5)
     assert frame == {"type": "batch", "events": [], "dropped": 0}
+    assert ingestion.unsubscribed is True
 
 
 def test_ws_closes_when_no_ingestion_service():

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "geometrikks"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy", extra = ["argon2", "cli", "passlib", "pwdlib"] },


### PR DESCRIPTION
### Added

- `APP_SESSION_SECURE` (default `false`): mark the session cookie `Secure`;
  recommended behind a TLS reverse proxy.
- `APP_TRUSTED_PROXIES` (IPs/CIDRs, default empty): trust `X-Forwarded-For`
  from these proxies so the app can resolve real client IPs.
- Login successes and failures are now logged with username and client IP.

### Fixed

- `/ws/live` and `/ws/crowdsec` now send an empty keepalive frame after 30s of
  silence so reverse proxies (nginx `proxy_read_timeout`, 60s default / 240s in
  SWAG) no longer cut idle live-feed connections on quiet servers.
- WebSocket reconnect backoff (`/ws/live`, `/ws/crowdsec`) resets on a valid
  frame instead of on open, ending the 1s reconnect loop while the server
  closes with 1013.
- The `/ws/crowdsec` client ignores non-string/malformed frames instead of
  throwing.
