### PR TITLE
v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-07-22
+
+### Fixed
+
+- The PWA manifest link now uses `crossorigin="use-credentials"` so the
+  browser sends session cookies when fetching `manifest.webmanifest`; without
+  it the fetch is credential-less and 401s behind cookie-auth reverse proxies
+  (Organizr/Authelia `auth_request`).
+
 ## [0.4.1] - 2026-07-22
 
 ### Added
@@ -301,3 +310,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.1]: https://github.com/GilbN/geometrikks/releases/tag/v0.2.1
 [0.3.0]: https://github.com/GilbN/geometrikks/releases/tag/v0.3.0
 [0.4.0]: https://github.com/GilbN/geometrikks/releases/tag/v0.4.0
+[0.4.1]: https://github.com/GilbN/geometrikks/releases/tag/v0.4.1
+[0.4.2]: https://github.com/GilbN/geometrikks/releases/tag/v0.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,7 +303,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Settings endpoint no longer exposes the full settings tree (database credentials leaked via `model_dump()`); response is now an explicit whitelist.
 - Timestamps in `CALL refresh_continuous_aggregate` are bound as asyncpg parameters instead of interpolated into SQL.
 
-[Unreleased]: https://github.com/GilbN/geometrikks/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/GilbN/geometrikks/compare/v0.4.2...HEAD
 [0.1.0]: https://github.com/GilbN/geometrikks/compare/v0.1.0-alpha.1...v0.1.0
 [0.1.0-alpha.1]: https://github.com/GilbN/geometrikks/releases/tag/v0.1.0-alpha.1
 [0.2.0]: https://github.com/GilbN/geometrikks/releases/tag/v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geometrikks"
-version = "0.4.1"
+version = "0.4.2"
 description = "Geo metrics ingress service built with Litestar."
 readme = "README.md"
 requires-python = ">=3.13,<3.14"

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -2960,7 +2960,7 @@
   "info": {
     "description": "Real-time GeoIP lookups and traffic analytics API",
     "title": "GeoMetrikks API",
-    "version": "0.4.0"
+    "version": "0.4.2"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/resources/main.tsx
+++ b/resources/main.tsx
@@ -18,6 +18,9 @@ if (import.meta.env.PROD) {
   const manifestLink = document.createElement("link")
   manifestLink.rel = "manifest"
   manifestLink.href = "/static/manifest.webmanifest"
+  // Manifest fetches omit cookies unless the link opts into credentials,
+  // which 401s behind cookie-auth proxies (Organizr/Authelia auth_request).
+  manifestLink.crossOrigin = "use-credentials"
   document.head.appendChild(manifestLink)
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "geometrikks"
-version = "0.4.0"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy", extra = ["argon2", "cli", "passlib", "pwdlib"] },


### PR DESCRIPTION
- The PWA manifest link now uses `crossorigin="use-credentials"` so the
  browser sends session cookies when fetching `manifest.webmanifest`; without
  it the fetch is credential-less and 401s behind cookie-auth reverse proxies
  (Organizr/Authelia `auth_request`).