### PR TITLE
fix(geoip): fixed broken logic in the stale check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-07-22
+
+### Fixed
+
+- Fixed the stale GeoLite database check. The database_is_stale function looked at the modified time of the file instead of the build time of the database. Moved the private _geoip_info function into /lib/utils.py, and database_is_stale uses that to check instead.
+
+
 ## [0.4.2] - 2026-07-22
 
 ### Fixed
@@ -303,7 +310,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Settings endpoint no longer exposes the full settings tree (database credentials leaked via `model_dump()`); response is now an explicit whitelist.
 - Timestamps in `CALL refresh_continuous_aggregate` are bound as asyncpg parameters instead of interpolated into SQL.
 
-[Unreleased]: https://github.com/GilbN/geometrikks/compare/v0.4.2...HEAD
+[Unreleased]: https://github.com/GilbN/geometrikks/compare/v0.4.3...HEAD
 [0.1.0]: https://github.com/GilbN/geometrikks/compare/v0.1.0-alpha.1...v0.1.0
 [0.1.0-alpha.1]: https://github.com/GilbN/geometrikks/releases/tag/v0.1.0-alpha.1
 [0.2.0]: https://github.com/GilbN/geometrikks/releases/tag/v0.2.0
@@ -312,3 +319,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.4.0]: https://github.com/GilbN/geometrikks/releases/tag/v0.4.0
 [0.4.1]: https://github.com/GilbN/geometrikks/releases/tag/v0.4.1
 [0.4.2]: https://github.com/GilbN/geometrikks/releases/tag/v0.4.2
+[0.4.3]: https://github.com/GilbN/geometrikks/releases/tag/v0.4.3

--- a/geometrikks/api/v1/system_controller.py
+++ b/geometrikks/api/v1/system_controller.py
@@ -22,6 +22,7 @@ from sqlalchemy import text
 from geometrikks.config.introspection import SystemSettingsResponse, build_settings_overview
 from geometrikks.config.settings import get_settings
 from geometrikks.server.scheduler_tracking import JobRunTracker, JobStatus
+from geometrikks.lib.utils import GeoIPInfoView, geoip_info
 
 if TYPE_CHECKING:
     from apscheduler.job import Job
@@ -76,14 +77,6 @@ class DatabaseVersionsView:
 
 
 @dataclass
-class GeoIPInfoView:
-    available: bool
-    db_path: str
-    build_date: datetime | None
-    age_days: int | None
-
-
-@dataclass
 class AboutLinksView:
     repository: str
     issues: str
@@ -134,21 +127,6 @@ async def _database_versions() -> DatabaseVersionsView:
         )
 
 
-def _geoip_info(db_path: Path) -> GeoIPInfoView:
-    """Build date and age from mmdb metadata; degrades when missing."""
-    try:
-        with maxminddb.open_database(str(db_path)) as reader:
-            build = datetime.fromtimestamp(reader.metadata().build_epoch, tz=timezone.utc)
-        age_days = (datetime.now(timezone.utc) - build).days
-        return GeoIPInfoView(
-            available=True, db_path=str(db_path), build_date=build, age_days=age_days
-        )
-    except Exception:
-        return GeoIPInfoView(
-            available=False, db_path=str(db_path), build_date=None, age_days=None
-        )
-
-
 def _job_view(job: "Job", tracker: JobRunTracker) -> SchedulerJobView:
     info = tracker.get(job.id)
     return SchedulerJobView(
@@ -194,7 +172,7 @@ class SystemController(Controller):
                 apscheduler_version=_dist_version("apscheduler"),
             ),
             database=await _database_versions(),
-            geoip=_geoip_info(s.geoip.db_path),
+            geoip=geoip_info(s.geoip.db_path),
             links=AboutLinksView(repository=REPO_URL, issues=f"{REPO_URL}/issues"),
         )
 

--- a/geometrikks/lib/utils.py
+++ b/geometrikks/lib/utils.py
@@ -5,15 +5,24 @@ import asyncio
 from functools import wraps
 from pathlib import Path
 from typing import ParamSpec, Callable
+from dataclasses import dataclass
 
 import aiofiles.os
 import aiofiles
 
+import maxminddb
+from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
 P = ParamSpec("P")
 
+@dataclass
+class GeoIPInfoView:
+    available: bool
+    db_path: str
+    build_date: datetime | None
+    age_days: int | None
 
 def wait(timeout_seconds: int = 60) -> Callable[[Callable[P, bool]], Callable[P, bool]]:
     """Factory Decorator to wait for a function to return True for a given amount of time.
@@ -82,3 +91,17 @@ async def wait_for_path(
         "Timeout of %.1f seconds reached waiting for path: %s", timeout_seconds, path
     )
     return False
+
+def geoip_info(db_path: Path) -> GeoIPInfoView:
+    """Build date and age from mmdb metadata; degrades when missing."""
+    try:
+        with maxminddb.open_database(str(db_path)) as reader:
+            build: datetime = datetime.fromtimestamp(reader.metadata().build_epoch, tz=timezone.utc)
+        age_days: int = (datetime.now(timezone.utc) - build).days
+        return GeoIPInfoView(
+            available=True, db_path=str(db_path), build_date=build, age_days=age_days
+        )
+    except Exception:
+        return GeoIPInfoView(
+            available=False, db_path=str(db_path), build_date=None, age_days=None
+        )

--- a/geometrikks/services/geoip/downloader.py
+++ b/geometrikks/services/geoip/downloader.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING
 
 import httpx
 
+from geometrikks.lib.utils import GeoIPInfoView, geoip_info
+
 if TYPE_CHECKING:
     from geometrikks.config.settings import GeoIPSettings
 
@@ -40,10 +42,21 @@ def has_credentials(settings: "GeoIPSettings") -> bool:
 
 def database_is_stale(db_path: Path, max_age_days: int) -> bool:
     """Missing or older than max_age_days."""
-    if not db_path.exists():
+    geoip_info_view: GeoIPInfoView = geoip_info(db_path)
+    if not geoip_info_view.available:
         return True
-    age_seconds = time.time() - db_path.stat().st_mtime
-    return age_seconds > max_age_days * 86400
+    if geoip_info_view.age_days is None:
+        return True
+    stale: bool = geoip_info_view.age_days > max_age_days
+    if stale:
+        logger.warning(
+            "GeoLite2 database at %s is older than %d days (age: %s days)",
+            db_path,
+            max_age_days,
+            geoip_info_view.age_days,
+        )
+    return stale
+
 
 
 async def _fetch_tarball(settings: "GeoIPSettings") -> bytes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geometrikks"
-version = "0.4.2"
+version = "0.4.3"
 description = "Geo metrics ingress service built with Litestar."
 readme = "README.md"
 requires-python = ">=3.13,<3.14"

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -2960,7 +2960,7 @@
   "info": {
     "description": "Real-time GeoIP lookups and traffic analytics API",
     "title": "GeoMetrikks API",
-    "version": "0.4.2"
+    "version": "0.4.3"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/tests/test_geoip_downloader.py
+++ b/tests/test_geoip_downloader.py
@@ -5,6 +5,7 @@ import io
 import tarfile
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -37,25 +38,70 @@ def make_tarball(mmdb_bytes: bytes) -> bytes:
     return buf.getvalue()
 
 
+class FakeMMDBReader:
+    """Stands in for maxminddb.open_database; only metadata().build_epoch is read."""
+
+    def __init__(self, build_epoch: float):
+        self._metadata = SimpleNamespace(build_epoch=build_epoch)
+
+    def metadata(self):
+        return self._metadata
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+def patch_build_epoch(monkeypatch, age_days: float) -> None:
+    """Make maxminddb report a database built age_days ago, regardless of file."""
+    epoch = time.time() - age_days * 86400
+    monkeypatch.setattr(
+        "geometrikks.lib.utils.maxminddb.open_database",
+        lambda _path: FakeMMDBReader(epoch),
+    )
+
+
 class TestStaleness:
     def test_missing_file_is_stale(self, tmp_path):
         from geometrikks.services.geoip.downloader import database_is_stale
         assert database_is_stale(tmp_path / "nope.mmdb", max_age_days=7) is True
 
-    def test_fresh_file_is_not_stale(self, tmp_path):
+    def test_unreadable_file_is_stale(self, tmp_path):
+        """Not a valid mmdb -> no build date to trust -> stale."""
         from geometrikks.services.geoip.downloader import database_is_stale
         p = tmp_path / "db.mmdb"
         p.write_bytes(b"x")
+        assert database_is_stale(p, max_age_days=7) is True
+
+    def test_fresh_build_date_is_not_stale(self, tmp_path, monkeypatch):
+        from geometrikks.services.geoip.downloader import database_is_stale
+        p = tmp_path / "db.mmdb"
+        p.write_bytes(b"x")
+        patch_build_epoch(monkeypatch, age_days=1)
         assert database_is_stale(p, max_age_days=7) is False
 
-    def test_old_file_is_stale(self, tmp_path):
-        import os
+    def test_old_build_date_is_stale_despite_fresh_mtime(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """The bug this check replaced: mtime is fresh (file just written) but
+        the database itself was built 8 days ago -> stale, with a warning."""
+        from geometrikks.services.geoip.downloader import database_is_stale
+        p = tmp_path / "db.mmdb"
+        p.write_bytes(b"x")  # mtime = now
+        patch_build_epoch(monkeypatch, age_days=8)
+        with caplog.at_level("WARNING"):
+            assert database_is_stale(p, max_age_days=7) is True
+        assert any("older than 7 days" in r.message for r in caplog.records)
+
+    def test_build_date_at_max_age_is_not_stale(self, tmp_path, monkeypatch):
+        """Staleness is strictly greater-than: exactly max_age_days is kept."""
         from geometrikks.services.geoip.downloader import database_is_stale
         p = tmp_path / "db.mmdb"
         p.write_bytes(b"x")
-        old = time.time() - 8 * 86400
-        os.utime(p, (old, old))
-        assert database_is_stale(p, max_age_days=7) is True
+        patch_build_epoch(monkeypatch, age_days=7)
+        assert database_is_stale(p, max_age_days=7) is False
 
 
 class TestEnsure:
@@ -67,11 +113,23 @@ class TestEnsure:
         assert ok is False
         assert any("MAXMINDDB_USER_ID" in r.message for r in caplog.records)
 
-    async def test_no_credentials_existing_db_returns_true(self, tmp_path):
+    async def test_no_credentials_fresh_db_returns_true(self, tmp_path, monkeypatch):
         from geometrikks.services.geoip.downloader import ensure_geoip_database
         settings = make_settings(tmp_path)
         settings.db_path.write_bytes(b"existing")
+        patch_build_epoch(monkeypatch, age_days=1)
         assert await ensure_geoip_database(settings) is True
+
+    async def test_no_credentials_stale_db_keeps_copy_and_returns_true(
+        self, tmp_path, caplog
+    ):
+        """Unreadable/old db without credentials: keep it, warn, stay usable."""
+        from geometrikks.services.geoip.downloader import ensure_geoip_database
+        settings = make_settings(tmp_path)
+        settings.db_path.write_bytes(b"existing")  # not a valid mmdb -> stale
+        with caplog.at_level("WARNING"):
+            assert await ensure_geoip_database(settings) is True
+        assert any("keeping the stale copy" in r.message for r in caplog.records)
 
     async def test_download_extracts_and_replaces_atomically(self, tmp_path, monkeypatch):
         from geometrikks.services.geoip import downloader
@@ -114,13 +172,10 @@ class TestEnsure:
         assert list(settings.db_path.parent.glob("*.tmp")) == []
 
     async def test_failed_download_keeps_existing_db_and_returns_true(self, tmp_path, monkeypatch):
-        import os
         from geometrikks.services.geoip import downloader
 
         settings = make_settings(tmp_path, account_id="1", license_key="k")
-        settings.db_path.write_bytes(b"OLD")
-        old = time.time() - 30 * 86400
-        os.utime(settings.db_path, (old, old))  # stale -> download attempted
+        settings.db_path.write_bytes(b"OLD")  # unreadable mmdb -> stale -> download attempted
 
         async def boom(s):
             raise downloader.GeoIPDownloadError("http 401")

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "geometrikks"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy", extra = ["argon2", "cli", "passlib", "pwdlib"] },


### PR DESCRIPTION
- Fixed the stale GeoLite database check. The database_is_stale function looked at the modified time of the file instead of the build time of the database. Moved the private _geoip_info function into /lib/utils.py, and database_is_stale uses that to check instead.
