### PR TITLE
fix: improve service worker handling and optimize access log queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed the stale GeoLite database check. The database_is_stale function looked at the modified time of the file instead of the build time of the database. Moved the private _geoip_info function into /lib/utils.py, and database_is_stale uses that to check instead.
+- Fixed a stale service worker breaking production loads (blank page, module
+  MIME-type errors): the app shell at `/` is no longer precached (navigations
+  are NetworkFirst with the cached shell as offline fallback), and `/sw.js`
+  404s while `VITE_DEV_MODE=true` so a dev-mode server can never install the
+  worker.
+- `/api/v1/access-logs` now runs separate page and count queries instead of a
+  `count(*) OVER ()` window function, cutting large time-range requests from
+  15+ s to ~130 ms on a 17M+ dataset.
 
 
 ## [0.4.2] - 2026-07-22

--- a/geometrikks/domain/logs/services.py
+++ b/geometrikks/domain/logs/services.py
@@ -26,6 +26,15 @@ class AccessLogService(SQLAlchemyAsyncRepositoryService[AccessLog]):
         model_type = AccessLog
 
     repository_type = Repo
+    # Two queries (page + count(*)) instead of one with count(*) OVER ().
+    # The window function forces every row in the filter window through the
+    # sort before LIMIT applies: on the compressed hypertable that
+    # decompresses all matching chunks (~15s over 365d / 17M rows), while the
+    # split queries run in milliseconds. Timescale answers the bare count(*)
+    # from compressed-batch metadata without decompressing. Must live on the
+    # service, not the Repo: the service ClassVar is passed to the repository
+    # constructor and overrides any repository-level attribute.
+    count_with_window_function = False
 
     async def get_facets(self) -> AccessLogFacets:
         """Distinct country/city values present in the data, for filter dropdowns.

--- a/geometrikks/server/routes.py
+++ b/geometrikks/server/routes.py
@@ -19,6 +19,7 @@ from geometrikks.api.v1.live_controller import crowdsec_feed, live_feed
 from geometrikks.api.v1.settings import read_settings
 from geometrikks.api.v1.stats import stats
 from geometrikks.api.health import health, health_ready
+from geometrikks.config.settings import get_settings
 
 
 @get(
@@ -30,6 +31,10 @@ from geometrikks.api.health import health, health_ready
     response_headers=[ResponseHeader(name="Cache-Control", value="no-cache")],
 )
 def service_worker() -> File:
+    # No worker in dev mode: it would cache the dev shell and break the next
+    # production run on the same origin.
+    if get_settings().vite.dev_mode:
+        raise NotFoundException(detail="Service worker is not served in dev mode")
     sw_path = Path("public/sw.js")
     if not sw_path.is_file():
         raise NotFoundException(detail="Service worker not built")

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,34 +44,46 @@ export default defineConfig({
       input: ["resources/main.tsx", "resources/main.css"],
     }),
     VitePWA({
-      // litestar-vite-plugin sets Vite's global `base` to "/static/" (asset
-      // rewriting), but vite-plugin-pwa derives its own script URL/scope from
-      // that same base by default. Override it here so /sw.js registers at
-      // root scope ("/") instead of "/static/sw.js" scope "/static/".
+      // litestar-vite-plugin sets Vite's base to "/static/"; override so
+      // /sw.js registers at root scope instead of "/static/".
       base: "/",
       registerType: "autoUpdate",
-      // No HTML entry exists in this build; registration happens in main.tsx
-      // and all links are added manually to the source index.html.
+      // Registration happens in main.tsx; there is no HTML entry to inject into.
       injectRegister: false,
-      // The manifest is a hand-written static file (resources/static/
-      // manifest.webmanifest, served at /static/manifest.webmanifest in both
-      // dev and prod via publicDir) rather than plugin-generated: the dev
-      // server has no build output, so a generated manifest 404s there and
-      // the SPA fallback's HTML triggers "Manifest: syntax error" spam.
+      // Hand-written static manifest (resources/static/manifest.webmanifest);
+      // a plugin-generated one would 404 in dev, where no build output exists.
       manifest: false,
       workbox: {
-        // Precache the app shell; never intercept live data or the API schema.
+        // Precache the built static assets; never live data or the API schema.
         globPatterns: ["**/*.{js,css,svg,png,ico,woff2}"],
-        // The SW is served from /sw.js (root) but the bundle lives under
-        // /static/, so precache entries need the prefix.
+        // The SW lives at /sw.js but the bundle is served under /static/.
         modifyURLPrefix: { "": "/static/" },
-        // No built index.html exists; precache the Litestar-transformed shell
-        // at "/" and use it as the SPA navigation fallback.
-        additionalManifestEntries: [{ url: "/", revision: String(Date.now()) }],
-        navigateFallback: "/",
-        navigateFallbackDenylist: [/^\/api\//, /^\/ws/, /^\/schema/, /^\/static\//, /^\/sw\.js/],
-        // Keep the runtime inline so sw.js has no sibling workbox-*.js import
-        // (which would resolve to a nonexistent root URL).
+        // The Litestar shell at "/" is deliberately NOT precached: a precached
+        // shell is frozen at install time, and one captured from a dev-mode
+        // server would break production loads forever. NetworkFirst below keeps
+        // it fresh, with the cached copy ("/" for all navigations) as offline
+        // fallback.
+        //
+        // Load-bearing undefined: the plugin default is "index.html", which
+        // this build doesn't emit, and the worker would throw and never install.
+        navigateFallback: undefined,
+        runtimeCaching: [
+          {
+            urlPattern: ({ request, url }) =>
+              request.mode === "navigate" &&
+              ![/^\/api\//, /^\/ws/, /^\/schema/, /^\/static\//, /^\/sw\.js/].some(
+                (denied) => denied.test(url.pathname),
+              ),
+            handler: "NetworkFirst",
+            options: {
+              cacheName: "app-shell",
+              networkTimeoutSeconds: 10,
+              cacheableResponse: { statuses: [200] },
+              plugins: [{ cacheKeyWillBeUsed: async () => "/" }],
+            },
+          },
+        ],
+        // Inline the runtime; a sibling workbox-*.js would 404 at the root.
         inlineWorkboxRuntime: true,
         maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
       },


### PR DESCRIPTION
- Fixed a stale service worker breaking production loads (blank page, module
  MIME-type errors): the app shell at `/` is no longer precached (navigations
  are NetworkFirst with the cached shell as offline fallback), and `/sw.js`
  404s while `VITE_DEV_MODE=true` so a dev-mode server can never install the
  worker.

- `/api/v1/access-logs` now runs separate page and count queries instead of a
  `count(*) OVER ()` window function, cutting large time-range requests from
  15+ s to ~130 ms on a 17M+ dataset.