### PR TITLE
v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed the stale GeoLite database check. The database_is_stale function looked at the modified time of the file instead of the build time of the database. Moved the private _geoip_info function into /lib/utils.py, and database_is_stale uses that to check instead.
+- Fixed a stale service worker breaking production loads (blank page, module
+  MIME-type errors): the app shell at `/` is no longer precached (navigations
+  are NetworkFirst with the cached shell as offline fallback), and `/sw.js`
+  404s while `VITE_DEV_MODE=true` so a dev-mode server can never install the
+  worker.
+- `/api/v1/access-logs` now runs separate page and count queries instead of a
+  `count(*) OVER ()` window function, cutting large time-range requests from
+  15+ s to ~130 ms on a 17M+ dataset.
 
 
 ## [0.4.2] - 2026-07-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-07-22
+
+### Fixed
+
+- Fixed the stale GeoLite database check. The database_is_stale function looked at the modified time of the file instead of the build time of the database. Moved the private _geoip_info function into /lib/utils.py, and database_is_stale uses that to check instead.
+
+
 ## [0.4.2] - 2026-07-22
 
 ### Fixed
@@ -303,7 +310,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Settings endpoint no longer exposes the full settings tree (database credentials leaked via `model_dump()`); response is now an explicit whitelist.
 - Timestamps in `CALL refresh_continuous_aggregate` are bound as asyncpg parameters instead of interpolated into SQL.
 
-[Unreleased]: https://github.com/GilbN/geometrikks/compare/v0.4.2...HEAD
+[Unreleased]: https://github.com/GilbN/geometrikks/compare/v0.4.3...HEAD
 [0.1.0]: https://github.com/GilbN/geometrikks/compare/v0.1.0-alpha.1...v0.1.0
 [0.1.0-alpha.1]: https://github.com/GilbN/geometrikks/releases/tag/v0.1.0-alpha.1
 [0.2.0]: https://github.com/GilbN/geometrikks/releases/tag/v0.2.0
@@ -312,3 +319,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.4.0]: https://github.com/GilbN/geometrikks/releases/tag/v0.4.0
 [0.4.1]: https://github.com/GilbN/geometrikks/releases/tag/v0.4.1
 [0.4.2]: https://github.com/GilbN/geometrikks/releases/tag/v0.4.2
+[0.4.3]: https://github.com/GilbN/geometrikks/releases/tag/v0.4.3

--- a/geometrikks/api/v1/system_controller.py
+++ b/geometrikks/api/v1/system_controller.py
@@ -22,6 +22,7 @@ from sqlalchemy import text
 from geometrikks.config.introspection import SystemSettingsResponse, build_settings_overview
 from geometrikks.config.settings import get_settings
 from geometrikks.server.scheduler_tracking import JobRunTracker, JobStatus
+from geometrikks.lib.utils import GeoIPInfoView, geoip_info
 
 if TYPE_CHECKING:
     from apscheduler.job import Job
@@ -76,14 +77,6 @@ class DatabaseVersionsView:
 
 
 @dataclass
-class GeoIPInfoView:
-    available: bool
-    db_path: str
-    build_date: datetime | None
-    age_days: int | None
-
-
-@dataclass
 class AboutLinksView:
     repository: str
     issues: str
@@ -134,21 +127,6 @@ async def _database_versions() -> DatabaseVersionsView:
         )
 
 
-def _geoip_info(db_path: Path) -> GeoIPInfoView:
-    """Build date and age from mmdb metadata; degrades when missing."""
-    try:
-        with maxminddb.open_database(str(db_path)) as reader:
-            build = datetime.fromtimestamp(reader.metadata().build_epoch, tz=timezone.utc)
-        age_days = (datetime.now(timezone.utc) - build).days
-        return GeoIPInfoView(
-            available=True, db_path=str(db_path), build_date=build, age_days=age_days
-        )
-    except Exception:
-        return GeoIPInfoView(
-            available=False, db_path=str(db_path), build_date=None, age_days=None
-        )
-
-
 def _job_view(job: "Job", tracker: JobRunTracker) -> SchedulerJobView:
     info = tracker.get(job.id)
     return SchedulerJobView(
@@ -194,7 +172,7 @@ class SystemController(Controller):
                 apscheduler_version=_dist_version("apscheduler"),
             ),
             database=await _database_versions(),
-            geoip=_geoip_info(s.geoip.db_path),
+            geoip=geoip_info(s.geoip.db_path),
             links=AboutLinksView(repository=REPO_URL, issues=f"{REPO_URL}/issues"),
         )
 

--- a/geometrikks/domain/logs/services.py
+++ b/geometrikks/domain/logs/services.py
@@ -26,6 +26,15 @@ class AccessLogService(SQLAlchemyAsyncRepositoryService[AccessLog]):
         model_type = AccessLog
 
     repository_type = Repo
+    # Two queries (page + count(*)) instead of one with count(*) OVER ().
+    # The window function forces every row in the filter window through the
+    # sort before LIMIT applies: on the compressed hypertable that
+    # decompresses all matching chunks (~15s over 365d / 17M rows), while the
+    # split queries run in milliseconds. Timescale answers the bare count(*)
+    # from compressed-batch metadata without decompressing. Must live on the
+    # service, not the Repo: the service ClassVar is passed to the repository
+    # constructor and overrides any repository-level attribute.
+    count_with_window_function = False
 
     async def get_facets(self) -> AccessLogFacets:
         """Distinct country/city values present in the data, for filter dropdowns.

--- a/geometrikks/lib/utils.py
+++ b/geometrikks/lib/utils.py
@@ -5,15 +5,24 @@ import asyncio
 from functools import wraps
 from pathlib import Path
 from typing import ParamSpec, Callable
+from dataclasses import dataclass
 
 import aiofiles.os
 import aiofiles
 
+import maxminddb
+from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
 P = ParamSpec("P")
 
+@dataclass
+class GeoIPInfoView:
+    available: bool
+    db_path: str
+    build_date: datetime | None
+    age_days: int | None
 
 def wait(timeout_seconds: int = 60) -> Callable[[Callable[P, bool]], Callable[P, bool]]:
     """Factory Decorator to wait for a function to return True for a given amount of time.
@@ -82,3 +91,17 @@ async def wait_for_path(
         "Timeout of %.1f seconds reached waiting for path: %s", timeout_seconds, path
     )
     return False
+
+def geoip_info(db_path: Path) -> GeoIPInfoView:
+    """Build date and age from mmdb metadata; degrades when missing."""
+    try:
+        with maxminddb.open_database(str(db_path)) as reader:
+            build: datetime = datetime.fromtimestamp(reader.metadata().build_epoch, tz=timezone.utc)
+        age_days: int = (datetime.now(timezone.utc) - build).days
+        return GeoIPInfoView(
+            available=True, db_path=str(db_path), build_date=build, age_days=age_days
+        )
+    except Exception:
+        return GeoIPInfoView(
+            available=False, db_path=str(db_path), build_date=None, age_days=None
+        )

--- a/geometrikks/server/routes.py
+++ b/geometrikks/server/routes.py
@@ -19,6 +19,7 @@ from geometrikks.api.v1.live_controller import crowdsec_feed, live_feed
 from geometrikks.api.v1.settings import read_settings
 from geometrikks.api.v1.stats import stats
 from geometrikks.api.health import health, health_ready
+from geometrikks.config.settings import get_settings
 
 
 @get(
@@ -30,6 +31,10 @@ from geometrikks.api.health import health, health_ready
     response_headers=[ResponseHeader(name="Cache-Control", value="no-cache")],
 )
 def service_worker() -> File:
+    # No worker in dev mode: it would cache the dev shell and break the next
+    # production run on the same origin.
+    if get_settings().vite.dev_mode:
+        raise NotFoundException(detail="Service worker is not served in dev mode")
     sw_path = Path("public/sw.js")
     if not sw_path.is_file():
         raise NotFoundException(detail="Service worker not built")

--- a/geometrikks/services/geoip/downloader.py
+++ b/geometrikks/services/geoip/downloader.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING
 
 import httpx
 
+from geometrikks.lib.utils import GeoIPInfoView, geoip_info
+
 if TYPE_CHECKING:
     from geometrikks.config.settings import GeoIPSettings
 
@@ -40,10 +42,21 @@ def has_credentials(settings: "GeoIPSettings") -> bool:
 
 def database_is_stale(db_path: Path, max_age_days: int) -> bool:
     """Missing or older than max_age_days."""
-    if not db_path.exists():
+    geoip_info_view: GeoIPInfoView = geoip_info(db_path)
+    if not geoip_info_view.available:
         return True
-    age_seconds = time.time() - db_path.stat().st_mtime
-    return age_seconds > max_age_days * 86400
+    if geoip_info_view.age_days is None:
+        return True
+    stale: bool = geoip_info_view.age_days > max_age_days
+    if stale:
+        logger.warning(
+            "GeoLite2 database at %s is older than %d days (age: %s days)",
+            db_path,
+            max_age_days,
+            geoip_info_view.age_days,
+        )
+    return stale
+
 
 
 async def _fetch_tarball(settings: "GeoIPSettings") -> bytes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geometrikks"
-version = "0.4.2"
+version = "0.4.3"
 description = "Geo metrics ingress service built with Litestar."
 readme = "README.md"
 requires-python = ">=3.13,<3.14"

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -2960,7 +2960,7 @@
   "info": {
     "description": "Real-time GeoIP lookups and traffic analytics API",
     "title": "GeoMetrikks API",
-    "version": "0.4.2"
+    "version": "0.4.3"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/tests/test_geoip_downloader.py
+++ b/tests/test_geoip_downloader.py
@@ -5,6 +5,7 @@ import io
 import tarfile
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -37,25 +38,70 @@ def make_tarball(mmdb_bytes: bytes) -> bytes:
     return buf.getvalue()
 
 
+class FakeMMDBReader:
+    """Stands in for maxminddb.open_database; only metadata().build_epoch is read."""
+
+    def __init__(self, build_epoch: float):
+        self._metadata = SimpleNamespace(build_epoch=build_epoch)
+
+    def metadata(self):
+        return self._metadata
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+def patch_build_epoch(monkeypatch, age_days: float) -> None:
+    """Make maxminddb report a database built age_days ago, regardless of file."""
+    epoch = time.time() - age_days * 86400
+    monkeypatch.setattr(
+        "geometrikks.lib.utils.maxminddb.open_database",
+        lambda _path: FakeMMDBReader(epoch),
+    )
+
+
 class TestStaleness:
     def test_missing_file_is_stale(self, tmp_path):
         from geometrikks.services.geoip.downloader import database_is_stale
         assert database_is_stale(tmp_path / "nope.mmdb", max_age_days=7) is True
 
-    def test_fresh_file_is_not_stale(self, tmp_path):
+    def test_unreadable_file_is_stale(self, tmp_path):
+        """Not a valid mmdb -> no build date to trust -> stale."""
         from geometrikks.services.geoip.downloader import database_is_stale
         p = tmp_path / "db.mmdb"
         p.write_bytes(b"x")
+        assert database_is_stale(p, max_age_days=7) is True
+
+    def test_fresh_build_date_is_not_stale(self, tmp_path, monkeypatch):
+        from geometrikks.services.geoip.downloader import database_is_stale
+        p = tmp_path / "db.mmdb"
+        p.write_bytes(b"x")
+        patch_build_epoch(monkeypatch, age_days=1)
         assert database_is_stale(p, max_age_days=7) is False
 
-    def test_old_file_is_stale(self, tmp_path):
-        import os
+    def test_old_build_date_is_stale_despite_fresh_mtime(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """The bug this check replaced: mtime is fresh (file just written) but
+        the database itself was built 8 days ago -> stale, with a warning."""
+        from geometrikks.services.geoip.downloader import database_is_stale
+        p = tmp_path / "db.mmdb"
+        p.write_bytes(b"x")  # mtime = now
+        patch_build_epoch(monkeypatch, age_days=8)
+        with caplog.at_level("WARNING"):
+            assert database_is_stale(p, max_age_days=7) is True
+        assert any("older than 7 days" in r.message for r in caplog.records)
+
+    def test_build_date_at_max_age_is_not_stale(self, tmp_path, monkeypatch):
+        """Staleness is strictly greater-than: exactly max_age_days is kept."""
         from geometrikks.services.geoip.downloader import database_is_stale
         p = tmp_path / "db.mmdb"
         p.write_bytes(b"x")
-        old = time.time() - 8 * 86400
-        os.utime(p, (old, old))
-        assert database_is_stale(p, max_age_days=7) is True
+        patch_build_epoch(monkeypatch, age_days=7)
+        assert database_is_stale(p, max_age_days=7) is False
 
 
 class TestEnsure:
@@ -67,11 +113,23 @@ class TestEnsure:
         assert ok is False
         assert any("MAXMINDDB_USER_ID" in r.message for r in caplog.records)
 
-    async def test_no_credentials_existing_db_returns_true(self, tmp_path):
+    async def test_no_credentials_fresh_db_returns_true(self, tmp_path, monkeypatch):
         from geometrikks.services.geoip.downloader import ensure_geoip_database
         settings = make_settings(tmp_path)
         settings.db_path.write_bytes(b"existing")
+        patch_build_epoch(monkeypatch, age_days=1)
         assert await ensure_geoip_database(settings) is True
+
+    async def test_no_credentials_stale_db_keeps_copy_and_returns_true(
+        self, tmp_path, caplog
+    ):
+        """Unreadable/old db without credentials: keep it, warn, stay usable."""
+        from geometrikks.services.geoip.downloader import ensure_geoip_database
+        settings = make_settings(tmp_path)
+        settings.db_path.write_bytes(b"existing")  # not a valid mmdb -> stale
+        with caplog.at_level("WARNING"):
+            assert await ensure_geoip_database(settings) is True
+        assert any("keeping the stale copy" in r.message for r in caplog.records)
 
     async def test_download_extracts_and_replaces_atomically(self, tmp_path, monkeypatch):
         from geometrikks.services.geoip import downloader
@@ -114,13 +172,10 @@ class TestEnsure:
         assert list(settings.db_path.parent.glob("*.tmp")) == []
 
     async def test_failed_download_keeps_existing_db_and_returns_true(self, tmp_path, monkeypatch):
-        import os
         from geometrikks.services.geoip import downloader
 
         settings = make_settings(tmp_path, account_id="1", license_key="k")
-        settings.db_path.write_bytes(b"OLD")
-        old = time.time() - 30 * 86400
-        os.utime(settings.db_path, (old, old))  # stale -> download attempted
+        settings.db_path.write_bytes(b"OLD")  # unreadable mmdb -> stale -> download attempted
 
         async def boom(s):
             raise downloader.GeoIPDownloadError("http 401")

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "geometrikks"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy", extra = ["argon2", "cli", "passlib", "pwdlib"] },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,34 +44,46 @@ export default defineConfig({
       input: ["resources/main.tsx", "resources/main.css"],
     }),
     VitePWA({
-      // litestar-vite-plugin sets Vite's global `base` to "/static/" (asset
-      // rewriting), but vite-plugin-pwa derives its own script URL/scope from
-      // that same base by default. Override it here so /sw.js registers at
-      // root scope ("/") instead of "/static/sw.js" scope "/static/".
+      // litestar-vite-plugin sets Vite's base to "/static/"; override so
+      // /sw.js registers at root scope instead of "/static/".
       base: "/",
       registerType: "autoUpdate",
-      // No HTML entry exists in this build; registration happens in main.tsx
-      // and all links are added manually to the source index.html.
+      // Registration happens in main.tsx; there is no HTML entry to inject into.
       injectRegister: false,
-      // The manifest is a hand-written static file (resources/static/
-      // manifest.webmanifest, served at /static/manifest.webmanifest in both
-      // dev and prod via publicDir) rather than plugin-generated: the dev
-      // server has no build output, so a generated manifest 404s there and
-      // the SPA fallback's HTML triggers "Manifest: syntax error" spam.
+      // Hand-written static manifest (resources/static/manifest.webmanifest);
+      // a plugin-generated one would 404 in dev, where no build output exists.
       manifest: false,
       workbox: {
-        // Precache the app shell; never intercept live data or the API schema.
+        // Precache the built static assets; never live data or the API schema.
         globPatterns: ["**/*.{js,css,svg,png,ico,woff2}"],
-        // The SW is served from /sw.js (root) but the bundle lives under
-        // /static/, so precache entries need the prefix.
+        // The SW lives at /sw.js but the bundle is served under /static/.
         modifyURLPrefix: { "": "/static/" },
-        // No built index.html exists; precache the Litestar-transformed shell
-        // at "/" and use it as the SPA navigation fallback.
-        additionalManifestEntries: [{ url: "/", revision: String(Date.now()) }],
-        navigateFallback: "/",
-        navigateFallbackDenylist: [/^\/api\//, /^\/ws/, /^\/schema/, /^\/static\//, /^\/sw\.js/],
-        // Keep the runtime inline so sw.js has no sibling workbox-*.js import
-        // (which would resolve to a nonexistent root URL).
+        // The Litestar shell at "/" is deliberately NOT precached: a precached
+        // shell is frozen at install time, and one captured from a dev-mode
+        // server would break production loads forever. NetworkFirst below keeps
+        // it fresh, with the cached copy ("/" for all navigations) as offline
+        // fallback.
+        //
+        // Load-bearing undefined: the plugin default is "index.html", which
+        // this build doesn't emit, and the worker would throw and never install.
+        navigateFallback: undefined,
+        runtimeCaching: [
+          {
+            urlPattern: ({ request, url }) =>
+              request.mode === "navigate" &&
+              ![/^\/api\//, /^\/ws/, /^\/schema/, /^\/static\//, /^\/sw\.js/].some(
+                (denied) => denied.test(url.pathname),
+              ),
+            handler: "NetworkFirst",
+            options: {
+              cacheName: "app-shell",
+              networkTimeoutSeconds: 10,
+              cacheableResponse: { statuses: [200] },
+              plugins: [{ cacheKeyWillBeUsed: async () => "/" }],
+            },
+          },
+        ],
+        // Inline the runtime; a sibling workbox-*.js would 404 at the root.
         inlineWorkboxRuntime: true,
         maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
       },


### PR DESCRIPTION
### Fixed

- Fixed the stale GeoLite database check. The database_is_stale function looked at the modified time of the file instead of the build time of the database. Moved the private _geoip_info function into /lib/utils.py, and database_is_stale uses that to check instead.
- Fixed a stale service worker breaking production loads (blank page, module
  MIME-type errors): the app shell at `/` is no longer precached (navigations
  are NetworkFirst with the cached shell as offline fallback), and `/sw.js`
  404s while `VITE_DEV_MODE=true` so a dev-mode server can never install the
  worker.
- `/api/v1/access-logs` now runs separate page and count queries instead of a
  `count(*) OVER ()` window function, cutting large time-range requests from
  15+ s to ~130 ms on a 17M+ dataset.