### PR TITLE
feat(logging): structured logging pipeline, login log, logs API and Logs page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ docs/superpowers/
 *.db
 .litestar.json
 /logs
+/nginx_logs
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 docs/superpowers/
 *.db
 .litestar.json
+/logs
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Login, failed login, and logout attempts now emit `login_success`,
   `login_failed`, and `logout` events through the login logger, landing
   in `logs/login.log` in the CrowdSec/fail2ban contract format.
+- Scheduler job outcomes are now logged centrally by `JobRunTracker`:
+  `scheduler_job_completed` at SUCCESS level, `scheduler_job_failed` at
+  ERROR, and `scheduler_job_missed` at WARNING, each with `job_id` and
+  `duration_seconds` where applicable, covering every APScheduler job
+  uniformly.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and ingested nginx access logs). `/ws/logs` WebSocket endpoint streams
   structured log events in real time, batched and coalesced like the other
   live feeds, with an optional `?level=` query param to filter to a minimum
-  log level.
+  log level. New `POST /api/v1/logs/rotate` endpoint forces an immediate
+  rollover of the live log file handlers, gzipping the current file and
+  starting a fresh one, and returns which files were actually rotated.
 - New Logs page at Settings -> Logs: live log stream with level/component
   filters and search, color-coded level badges (including the new SUCCESS
   level), traceback and detail dialogs, and downloads for the application
   log, login log, rotated gzip archives, and ingested nginx access logs. A
   tabs toggle above the stream switches between the system log and the
   login log, each with its own buffer, while filters, search, pause and the
-  detail dialog behave the same on both.
+  detail dialog behave the same on both. A "Rotate logs" button on the
+  downloads card triggers the manual rotation endpoint on demand and
+  refreshes the file list to show the new archive.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   controllers) now get their loggers via `get_logger` from
   `geometrikks.server.logging` instead of stdlib `logging.getLogger`, so
   their output flows through the structlog pipeline.
+- All subsystems now log lifecycle and state-change events (WS connects,
+  scheduler outcomes, CrowdSec stream state, GeoIP refreshes, imports);
+  scheduler and task completions use a new SUCCESS log level.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `API_LOG_LEVEL` is deprecated in favor of `LOG_LEVEL`. It is still honored
   as a fallback (with a `DeprecationWarning`) when `LOG_LEVEL` is unset.
 
+### Fixed
+
+- Exceptions logged with `exc_info` (including Litestar's own "Uncaught
+  exception" handler) now carry their traceback in `logs/geometrikks.log`,
+  the `/ws/logs` broadcast, and the console: the traceback was previously
+  captured too late, after the record crossed onto the background
+  queue-listener thread, and got silently dropped.
+- Console log levels are now easier to tell apart: DEBUG renders dim/grey
+  and INFO renders blue, instead of both rendering the same green as
+  SUCCESS.
+
 ## [0.4.3] - 2026-07-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ERROR, and `scheduler_job_missed` at WARNING, each with `job_id` and
   `duration_seconds` where applicable, covering every APScheduler job
   uniformly.
+- All app modules (server, services, domain repositories/services, and API
+  controllers) now get their loggers via `get_logger` from
+  `geometrikks.server.logging` instead of stdlib `logging.getLogger`, so
+  their output flows through the structlog pipeline.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New Logs page at Settings -> Logs: live log stream with level/component
   filters and search, color-coded level badges (including the new SUCCESS
   level), traceback and detail dialogs, and downloads for the application
-  log, login log, rotated gzip archives, and ingested nginx access logs.
+  log, login log, rotated gzip archives, and ingested nginx access logs. A
+  tabs toggle above the stream switches between the system log and the
+  login log, each with its own buffer, while filters, search, pause and the
+  detail dialog behave the same on both.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,75 +9,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `LOG_LEVEL` and `LOG_DIR`/`LOG_MAIN_MAX_BYTES`/`LOG_MAIN_BACKUP_COUNT`/
-  `LOG_LOGIN_MAX_BYTES`/`LOG_LOGIN_BACKUP_COUNT` settings for the upcoming
-  structured-logging pipeline.
-- Log endpoints: `/api/v1/logs/tail` and `/api/v1/logs/files` REST endpoints
-  for log retrieval and file listing, plus per-file download at
-  `/api/v1/logs/files/{kind}/{name}` (app log, login log, gzip archives,
-  and ingested nginx access logs). `/ws/logs` WebSocket endpoint streams
-  structured log events in real time, batched and coalesced like the other
-  live feeds, with an optional `?level=` query param to filter to a minimum
-  log level. New `POST /api/v1/logs/rotate` endpoint forces an immediate
-  rollover of the live log file handlers, gzipping the current file and
-  starting a fresh one, and returns which files were actually rotated.
-- New Logs page at Settings -> Logs: live log stream with level/component
-  filters and search, color-coded level badges (including the new SUCCESS
-  level), traceback and detail dialogs, and downloads for the application
-  log, login log, rotated gzip archives, and ingested nginx access logs. A
-  tabs toggle at the top of the card switches between the system log, the
-  login log, and a Downloads tab; the two log tabs each keep their own
-  buffer while filters, search, pause and the detail dialog behave the same
-  on both, and the Downloads tab holds the file list. A "Rotate logs"
-  button on the Downloads tab triggers the manual rotation endpoint on
-  demand and refreshes the file list to show the new archive.
+- New `LOG_*` settings: `LOG_LEVEL`, `LOG_DIR`, and size/backup-count
+  limits for the main and login log files.
+- Logs API: `GET /api/v1/logs/tail`, `GET /api/v1/logs/files`, per-file
+  download at `GET /api/v1/logs/files/{kind}/{name}`, and
+  `POST /api/v1/logs/rotate` for on-demand rotation. `/ws/logs` streams
+  structured log events live, with an optional `?level=` minimum-level
+  filter.
+- Logs page at Settings -> Logs: live log stream with level/component
+  filters, search, pause, and traceback/detail dialogs. Tabs switch between
+  the system log, the login log, and a Downloads tab listing the raw files
+  (app log, login log, gzip archives, ingested nginx access logs) with a
+  "Rotate logs" button.
 
 ### Changed
 
-- Swapped the `picologging` litestar extra for `structlog` in preparation
-  for structured logging.
 - Logging is now structured (structlog): colored console output, a JSONL
-  main log file (`logs/geometrikks.log`), and a separate plain-text login
-  log (`logs/login.log`) suitable for CrowdSec/fail2ban. Both files rotate
-  by size and are gzip-compressed. New `LOG_*` settings; `API_LOG_LEVEL`
-  is deprecated (still honored) in favor of `LOG_LEVEL`.
-- Login, failed login, and logout attempts now emit `login_success`,
-  `login_failed`, and `logout` events through the login logger, landing
-  in `logs/login.log` in the CrowdSec/fail2ban contract format.
-- Scheduler job outcomes are now logged centrally by `JobRunTracker`:
-  `scheduler_job_completed` at SUCCESS level, `scheduler_job_failed` at
-  ERROR, and `scheduler_job_missed` at WARNING, each with `job_id` and
-  `duration_seconds` where applicable, covering every APScheduler job
-  uniformly.
-- All app modules (server, services, domain repositories/services, and API
-  controllers) now get their loggers via `get_logger` from
-  `geometrikks.server.logging` instead of stdlib `logging.getLogger`, so
-  their output flows through the structlog pipeline.
-- All subsystems now log lifecycle and state-change events (WS connects,
-  scheduler outcomes, CrowdSec stream state, GeoIP refreshes, imports);
-  scheduler and task completions use a new SUCCESS log level.
-- `docker-compose.yml` now mounts `./logs:/app/logs` on the app service so
-  application logs persist across container recreation and `login.log` is
-  readable by host-side tools like CrowdSec/fail2ban. If that directory is
-  not writable by the container (e.g. wrong owner on a freshly created host
-  path), the app now falls back to console-only logging and prints a loud
-  startup error instead of crashing.
+  main log (`logs/geometrikks.log`), and a plain-text login log
+  (`logs/login.log`) in a CrowdSec/fail2ban-friendly format. Both rotate by
+  size and gzip their archives.
+- Logins, failed logins, and logouts now emit `login_success`,
+  `login_failed`, and `logout` events to `logs/login.log`.
+- Scheduler job outcomes are logged centrally: `scheduler_job_completed`
+  (SUCCESS), `scheduler_job_failed` (ERROR), and `scheduler_job_missed`
+  (WARNING), with `job_id` and duration.
+- All app modules log through the structlog pipeline, and subsystems emit
+  lifecycle and state-change events (WS connects, scheduler outcomes,
+  CrowdSec stream state, GeoIP refreshes, imports); completed jobs use a
+  new SUCCESS level.
+- Swapped the `picologging` litestar extra for `structlog`.
+- `docker-compose.yml` mounts `./logs:/app/logs` so logs persist across
+  container recreation and `login.log` is readable by host tools. If the
+  directory is not writable, the app falls back to console-only logging
+  with a startup error instead of crashing.
 
 ### Deprecated
 
-- `API_LOG_LEVEL` is deprecated in favor of `LOG_LEVEL`. It is still honored
-  as a fallback (with a `DeprecationWarning`) when `LOG_LEVEL` is unset.
+- `API_LOG_LEVEL` in favor of `LOG_LEVEL`; still honored as a fallback,
+  with a `DeprecationWarning`.
 
 ### Fixed
 
-- Exceptions logged with `exc_info` (including Litestar's own "Uncaught
-  exception" handler) now carry their traceback in `logs/geometrikks.log`,
-  the `/ws/logs` broadcast, and the console: the traceback was previously
-  captured too late, after the record crossed onto the background
-  queue-listener thread, and got silently dropped.
-- Console log levels are now easier to tell apart: DEBUG renders dim/grey
-  and INFO renders blue, instead of both rendering the same green as
-  SUCCESS.
+- Exceptions logged with `exc_info` (including Litestar's "Uncaught
+  exception" handler) now carry their traceback in the log file, the
+  `/ws/logs` broadcast, and the console; it was previously dropped on the
+  queue-listener thread.
+- DEBUG (dim) and INFO (blue) console output are now distinguishable from
+  SUCCESS (green).
 
 ## [0.4.3] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   log (`logs/login.log`) suitable for CrowdSec/fail2ban. Both files rotate
   by size and are gzip-compressed. New `LOG_*` settings; `API_LOG_LEVEL`
   is deprecated (still honored) in favor of `LOG_LEVEL`.
+- Login, failed login, and logout attempts now emit `login_success`,
+  `login_failed`, and `logout` events through the login logger, landing
+  in `logs/login.log` in the CrowdSec/fail2ban contract format.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All subsystems now log lifecycle and state-change events (WS connects,
   scheduler outcomes, CrowdSec stream state, GeoIP refreshes, imports);
   scheduler and task completions use a new SUCCESS log level.
+- `docker-compose.yml` now mounts `./logs:/app/logs` on the app service so
+  application logs persist across container recreation and `login.log` is
+  readable by host-side tools like CrowdSec/fail2ban.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `LOG_LEVEL` and `LOG_DIR`/`LOG_MAIN_MAX_BYTES`/`LOG_MAIN_BACKUP_COUNT`/
+  `LOG_LOGIN_MAX_BYTES`/`LOG_LOGIN_BACKUP_COUNT` settings for the upcoming
+  structured-logging pipeline.
+
+### Changed
+
+- Swapped the `picologging` litestar extra for `structlog` in preparation
+  for structured logging.
+
+### Deprecated
+
+- `API_LOG_LEVEL` is deprecated in favor of `LOG_LEVEL`. It is still honored
+  as a fallback (with a `DeprecationWarning`) when `LOG_LEVEL` is unset.
+
 ## [0.4.3] - 2026-07-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   filters and search, color-coded level badges (including the new SUCCESS
   level), traceback and detail dialogs, and downloads for the application
   log, login log, rotated gzip archives, and ingested nginx access logs. A
-  tabs toggle above the stream switches between the system log and the
-  login log, each with its own buffer, while filters, search, pause and the
-  detail dialog behave the same on both. A "Rotate logs" button on the
-  downloads card triggers the manual rotation endpoint on demand and
-  refreshes the file list to show the new archive.
+  tabs toggle at the top of the card switches between the system log, the
+  login log, and a Downloads tab; the two log tabs each keep their own
+  buffer while filters, search, pause and the detail dialog behave the same
+  on both, and the Downloads tab holds the file list. A "Rotate logs"
+  button on the Downloads tab triggers the manual rotation endpoint on
+  demand and refreshes the file list to show the new archive.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `LOG_LEVEL` and `LOG_DIR`/`LOG_MAIN_MAX_BYTES`/`LOG_MAIN_BACKUP_COUNT`/
   `LOG_LOGIN_MAX_BYTES`/`LOG_LOGIN_BACKUP_COUNT` settings for the upcoming
   structured-logging pipeline.
-- `/ws/logs` WebSocket endpoint streaming structured log events in real
-  time, batched and coalesced like the other live feeds, with an optional
-  `?level=` query param to filter to a minimum log level.
+- Log endpoints: `/api/v1/logs/tail` and `/api/v1/logs/files` REST endpoints
+  for log retrieval and file listing, plus per-file download at
+  `/api/v1/logs/files/{kind}/{name}` (app log, login log, gzip archives,
+  and ingested nginx access logs). `/ws/logs` WebSocket endpoint streams
+  structured log events in real time, batched and coalesced like the other
+  live feeds, with an optional `?level=` query param to filter to a minimum
+  log level.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `LOG_LEVEL` and `LOG_DIR`/`LOG_MAIN_MAX_BYTES`/`LOG_MAIN_BACKUP_COUNT`/
   `LOG_LOGIN_MAX_BYTES`/`LOG_LOGIN_BACKUP_COUNT` settings for the upcoming
   structured-logging pipeline.
+- `/ws/logs` WebSocket endpoint streaming structured log events in real
+  time, batched and coalesced like the other live feeds, with an optional
+  `?level=` query param to filter to a minimum log level.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scheduler and task completions use a new SUCCESS log level.
 - `docker-compose.yml` now mounts `./logs:/app/logs` on the app service so
   application logs persist across container recreation and `login.log` is
-  readable by host-side tools like CrowdSec/fail2ban.
+  readable by host-side tools like CrowdSec/fail2ban. If that directory is
+  not writable by the container (e.g. wrong owner on a freshly created host
+  path), the app now falls back to console-only logging and prints a loud
+  startup error instead of crashing.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Swapped the `picologging` litestar extra for `structlog` in preparation
   for structured logging.
+- Logging is now structured (structlog): colored console output, a JSONL
+  main log file (`logs/geometrikks.log`), and a separate plain-text login
+  log (`logs/login.log`) suitable for CrowdSec/fail2ban. Both files rotate
+  by size and are gzip-compressed. New `LOG_*` settings; `API_LOG_LEVEL`
+  is deprecated (still honored) in favor of `LOG_LEVEL`.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   structured log events in real time, batched and coalesced like the other
   live feeds, with an optional `?level=` query param to filter to a minimum
   log level.
+- New Logs page at Settings -> Logs: live log stream with level/component
+  filters and search, color-coded level badges (including the new SUCCESS
+  level), traceback and detail dialogs, and downloads for the application
+  log, login log, rotated gzip archives, and ingested nginx access logs.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,15 +48,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `API_LOG_LEVEL` in favor of `LOG_LEVEL`; still honored as a fallback,
   with a `DeprecationWarning`.
 
-### Fixed
-
-- Exceptions logged with `exc_info` (including Litestar's "Uncaught
-  exception" handler) now carry their traceback in the log file, the
-  `/ws/logs` broadcast, and the console; it was previously dropped on the
-  queue-listener thread.
-- DEBUG (dim) and INFO (blue) console output are now distinguishable from
-  SUCCESS (green).
-
 ## [0.4.3] - 2026-07-22
 
 ### Fixed

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -37,7 +37,7 @@ COPY vite.config.ts tsconfig.json components.json index.html openapi-ts.config.t
 COPY alembic.ini ./
 COPY migrations/ ./migrations/
 
-RUN mkdir -p /app/data/geoip /app/logs
+RUN mkdir -p /app/data/geoip
 
 # Note: Source code is mounted as volumes in docker-compose
 # This allows hot-reload to work
@@ -47,4 +47,4 @@ EXPOSE 8000 5173
 
 # Default command runs backend with reload
 # Frontend can be run separately or via docker-compose
-CMD ["litestar", "--app", "geometrikks.server.core:create_app", "run", "--host", "0.0.0.0", "--port", "8000", "--reload", "--reload-ignore-paths", "/app/logs/access.log", "--debug"]
+CMD ["litestar", "--app", "geometrikks.server.core:create_app", "run", "--host", "0.0.0.0", "--port", "8000", "--reload", "--debug"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -75,8 +75,10 @@ services:
       LOG_LEVEL: DEBUG
       # ./logs is mounted read-only below for nginx access log ingestion, so
       # the app's own log files (geometrikks.log, login.log) need a separate
-      # writable directory that does not collide with it.
-      LOG_DIR: /app/applogs
+      # writable directory that does not collide with it. Kept outside /app
+      # (the container runs as root here, so /var/log is writable) so app
+      # log writes cannot land inside the tree the reload watcher scans.
+      LOG_DIR: /var/log/geometrikks
       DB_HOST: timescale_db
       DB_PORT: 5432
       DB_USER: geouser

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -73,11 +73,8 @@ services:
       APP_DEBUG: "true"
       API_RELOAD: "true"
       LOG_LEVEL: DEBUG
-      # ./logs is mounted read-only below for nginx access log ingestion, so
-      # the app's own log files (geometrikks.log, login.log) need a separate
-      # writable directory that does not collide with it. Kept outside /app
-      # (the container runs as root here, so /var/log is writable) so app
-      # log writes cannot land inside the tree the reload watcher scans.
+      # Outside /app so the reload watcher never sees log writes; mounted
+      # from ./logs below, matching the prod compose and native runs.
       LOG_DIR: /var/log/geometrikks
       DB_HOST: timescale_db
       DB_PORT: 5432
@@ -85,7 +82,7 @@ services:
       DB_PASSWORD: geopass
       DB_DATABASE: geometrikks
       GEOIP_DB_PATH: /app/data/geoip/GeoLite2-City.mmdb
-      LOGPARSER_LOG_PATHS: /app/logs/access.log
+      LOGPARSER_LOG_PATHS: /var/log/nginx/access.log
       VITE_DEV_MODE: "true"
       VITE_EXECUTOR: "bun"
       VITE_HOST: "0.0.0.0"
@@ -99,8 +96,10 @@ services:
       - ./resources:/app/resources:cached
       - ./tests:/app/tests:cached
       - ./data:/app/data:cached
-      # Mount log directory
-      - ./logs:/app/logs:ro
+      # Sample nginx access logs for ingestion, same mount point as prod
+      - ./nginx_logs:/var/log/nginx:ro
+      # The app's own log files (geometrikks.log, login.log)
+      - ./logs:/var/log/geometrikks
     networks:
       - geometrikks_net
     env_file:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -72,7 +72,7 @@ services:
       APP_ENVIRONMENT: development
       APP_DEBUG: "true"
       API_RELOAD: "true"
-      API_LOG_LEVEL: DEBUG
+      LOG_LEVEL: DEBUG
       DB_HOST: timescale_db
       DB_PORT: 5432
       DB_USER: geouser

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -73,6 +73,10 @@ services:
       APP_DEBUG: "true"
       API_RELOAD: "true"
       LOG_LEVEL: DEBUG
+      # ./logs is mounted read-only below for nginx access log ingestion, so
+      # the app's own log files (geometrikks.log, login.log) need a separate
+      # writable directory that does not collide with it.
+      LOG_DIR: /app/applogs
       DB_HOST: timescale_db
       DB_PORT: 5432
       DB_USER: geouser

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,9 @@
 #   docker compose up -d
 #
 # ./logs on the host holds the application log and login.log, readable by
-# host-side tools like CrowdSec/fail2ban.
+# host-side tools like CrowdSec/fail2ban. Create it with the right owner
+# before first start: mkdir -p logs && chown 1000:1000 logs (the container
+# runs as uid 1000; without this the app falls back to console-only logging).
 #
 # Developing GeoMetrikks itself? Use docker-compose.dev.yml instead.
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@
 #   $EDITOR .env      # set APP_ADMIN_PASSWORD, MaxMind key, log path
 #   docker compose up -d
 #
+# ./logs on the host holds the application log and login.log, readable by
+# host-side tools like CrowdSec/fail2ban.
+#
 # Developing GeoMetrikks itself? Use docker-compose.dev.yml instead.
 services:
   timescale_db:
@@ -36,6 +39,9 @@ services:
     volumes:
       - geoip_data:/app/data/geoip
       - ${NGINX_LOG_DIR:-/var/log/nginx}:/var/log/nginx:ro
+      # Exposes the application log and login.log on the host for tools like
+      # CrowdSec/fail2ban, and persists them across container recreation.
+      - ./logs:/app/logs
     depends_on:
       timescale_db:
         condition: service_healthy

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,7 @@ list most users need is in `.env.example`; everything below is available.
 |---|---|---|
 | `API_HOST` | `0.0.0.0` | API server host |
 | `API_PORT` | `8000` | API server port |
-| `API_LOG_LEVEL` | `INFO` | Logging level |
+| `API_LOG_LEVEL` | — | DEPRECATED: use LOG_LEVEL. Kept as a fallback for existing deployments. |
 
 ## Database
 
@@ -60,6 +60,17 @@ list most users need is in `.env.example`; everything below is available.
 | `MAXMINDDB_USER_ID` | — | MaxMind account ID for GeoLite2 auto-download |
 | `MAXMINDDB_LICENSE_KEY` | — | MaxMind license key for GeoLite2 auto-download |
 | `GEOIP_REFRESH_DAYS` | `7` | Re-download the GeoLite2 database when older than this many days |
+
+## Logging
+
+| Variable | Default | Description |
+|---|---|---|
+| `LOG_DIR` | `logs` | Directory for application log files |
+| `LOG_LEVEL` | — | Root log level. Falls back to deprecated API_LOG_LEVEL, then INFO. |
+| `LOG_MAIN_MAX_BYTES` | `10485760` | Rotate the main JSONL log when it exceeds this size (bytes) |
+| `LOG_MAIN_BACKUP_COUNT` | `5` | Number of gzipped main-log archives to keep |
+| `LOG_LOGIN_MAX_BYTES` | `10485760` | Rotate the login log when it exceeds this size (bytes) |
+| `LOG_LOGIN_BACKUP_COUNT` | `5` | Number of gzipped login-log archives to keep |
 
 ## Log parser
 

--- a/geometrikks/api/v1/auth_controller.py
+++ b/geometrikks/api/v1/auth_controller.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 
 from litestar import Controller, Request, get, post
@@ -11,9 +10,11 @@ from litestar.status_codes import HTTP_200_OK, HTTP_204_NO_CONTENT
 
 from geometrikks.lib.client_ip import resolve_client_ip
 from geometrikks.server.auth import AdminUser, AuthState
+from geometrikks.server.logging import LOGIN_LOGGER_NAME, get_logger
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
+login_logger = get_logger(LOGIN_LOGGER_NAME)
 
 
 @dataclass
@@ -38,14 +39,16 @@ class AuthController(Controller):
         auth_state: AuthState = request.app.state.auth_state
         client_ip = resolve_client_ip(request)
         if not auth_state.verify(data.username, data.password):
-            logger.warning("Login failed for %r from %s", data.username, client_ip)
+            login_logger.warning("login_failed", user=data.username, ip=client_ip)
             raise NotAuthorizedException(detail="Invalid credentials")
         request.set_session({"username": data.username})
-        logger.info("Login succeeded for %r from %s", data.username, client_ip)
+        login_logger.info("login_success", user=data.username, ip=client_ip)
         return MeResponse(username=data.username)
 
     @post("/logout", status_code=HTTP_204_NO_CONTENT)
     async def logout(self, request: Request) -> None:
+        username = (request.session or {}).get("username", "")
+        login_logger.info("logout", user=username, ip=resolve_client_ip(request))
         request.clear_session()
 
     @get("/me")

--- a/geometrikks/api/v1/crowdsec_controller.py
+++ b/geometrikks/api/v1/crowdsec_controller.py
@@ -8,7 +8,6 @@ key) the data endpoints return 404 and the frontend hides the page.
 from __future__ import annotations
 
 import ipaddress
-import logging
 import re
 from datetime import datetime
 from collections import Counter
@@ -34,6 +33,7 @@ from geometrikks.api.dependencies import (
 from geometrikks.config.settings import get_settings
 from geometrikks.domain.security.repositories import SecurityEnrichmentRepository
 from geometrikks.domain.security.schemas import IpEnrichment, IpLocation
+from geometrikks.server.logging import get_logger
 from geometrikks.services.crowdsec import CrowdSecService, Decision
 
 # The CAPI community blocklist can hold tens of thousands of decisions; the
@@ -46,7 +46,7 @@ TOP_SCENARIO_LIMIT = 10
 # Go duration string as the LAPI accepts it, e.g. "4h", "30m", "1h30m".
 GO_DURATION_RE = re.compile(r"^(\d+h)?(\d+m)?(\d+s)?$")
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @dataclass

--- a/geometrikks/api/v1/geo_locations_controller.py
+++ b/geometrikks/api/v1/geo_locations_controller.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Annotated
-import logging
 
 from advanced_alchemy.extensions.litestar import filters
 from litestar.pagination import OffsetPagination
@@ -30,8 +29,9 @@ from geometrikks.domain.geo.dtos import (
 
 from geometrikks.api.dependencies import provide_geo_location_repo
 from geometrikks.api.v1.geo_events_controller import validate_ip_addresses
+from geometrikks.server.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 class GeoLocationController(Controller):
     """Geo-location endpoints for managing location data."""

--- a/geometrikks/api/v1/live_controller.py
+++ b/geometrikks/api/v1/live_controller.py
@@ -101,10 +101,12 @@ async def crowdsec_feed(socket: WebSocket) -> None:
     poller = getattr(socket.app.state, "crowdsec_stream_poller", None)
     await socket.accept()
     if poller is None:
+        logger.warning("ws_rejected_service_unavailable", endpoint="/ws/crowdsec")
         await socket.close(code=1013, reason="crowdsec stream not running")  # 1013 = try again later
         return
 
     queue = poller.subscribe()
+    logger.info("ws_client_connected", endpoint="/ws/crowdsec")
     watcher = asyncio.create_task(_watch_disconnect(socket))
     try:
         loop = asyncio.get_running_loop()
@@ -129,6 +131,7 @@ async def crowdsec_feed(socket: WebSocket) -> None:
         with contextlib.suppress(asyncio.CancelledError, WebSocketDisconnect):
             await watcher
         poller.unsubscribe(queue)
+        logger.info("ws_client_disconnected", endpoint="/ws/crowdsec")
 
 
 @websocket("/ws/live", tags=["Live Feed"])
@@ -137,10 +140,12 @@ async def live_feed(socket: WebSocket) -> None:
     ingestion = getattr(socket.app.state, "ingestion_service", None)
     await socket.accept()
     if ingestion is None:
+        logger.warning("ws_rejected_service_unavailable", endpoint="/ws/live")
         await socket.close(code=1013, reason="ingestion not running")  # 1013 = try again later
         return
 
     queue = ingestion.subscribe()
+    logger.info("ws_client_connected", endpoint="/ws/live")
     watcher = asyncio.create_task(_watch_disconnect(socket))
     try:
         loop = asyncio.get_running_loop()
@@ -177,6 +182,7 @@ async def live_feed(socket: WebSocket) -> None:
         with contextlib.suppress(asyncio.CancelledError, WebSocketDisconnect):
             await watcher  # retrieve its exception so no "never retrieved" warning
         ingestion.unsubscribe(queue)
+        logger.info("ws_client_disconnected", endpoint="/ws/live")
 
 
 LOG_FLUSH_INTERVAL = 0.25
@@ -206,6 +212,7 @@ async def logs_feed(socket: WebSocket) -> None:
     level_names = logging.getLevelNamesMapping()
 
     queue = log_broadcaster.subscribe()
+    logger.info("ws_client_connected", endpoint="/ws/logs")
     watcher = asyncio.create_task(_watch_disconnect(socket))
     try:
         loop = asyncio.get_running_loop()
@@ -243,3 +250,4 @@ async def logs_feed(socket: WebSocket) -> None:
         with contextlib.suppress(asyncio.CancelledError, WebSocketDisconnect):
             await watcher
         log_broadcaster.unsubscribe(queue)
+        logger.info("ws_client_disconnected", endpoint="/ws/logs")

--- a/geometrikks/api/v1/live_controller.py
+++ b/geometrikks/api/v1/live_controller.py
@@ -22,10 +22,10 @@ from typing import Any
 from litestar import WebSocket, websocket
 from litestar.exceptions import WebSocketDisconnect
 
-from geometrikks.server.logging import log_broadcaster, register_success_level
+from geometrikks.server.logging import get_logger, log_broadcaster, register_success_level
 from geometrikks.services.logparser.schemas import ParsedLogRecord
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 FLUSH_INTERVAL = 0.15          # seconds -> ~6.7 frames/s, under the ~10/s cap
 MAX_EVENTS_PER_FRAME = 100

--- a/geometrikks/api/v1/live_controller.py
+++ b/geometrikks/api/v1/live_controller.py
@@ -22,6 +22,7 @@ from typing import Any
 from litestar import WebSocket, websocket
 from litestar.exceptions import WebSocketDisconnect
 
+from geometrikks.server.logging import log_broadcaster, register_success_level
 from geometrikks.services.logparser.schemas import ParsedLogRecord
 
 logger = logging.getLogger(__name__)
@@ -176,3 +177,69 @@ async def live_feed(socket: WebSocket) -> None:
         with contextlib.suppress(asyncio.CancelledError, WebSocketDisconnect):
             await watcher  # retrieve its exception so no "never retrieved" warning
         ingestion.unsubscribe(queue)
+
+
+LOG_FLUSH_INTERVAL = 0.25
+MAX_RECORDS_PER_FRAME = 200
+
+
+def _min_levelno(level_name: str | None) -> int:
+    """Numeric threshold for the optional ?level= filter (default: everything)."""
+    if not level_name:
+        return 0
+    register_success_level()
+    mapping = logging.getLevelNamesMapping()
+    return mapping.get(level_name.upper(), 0)
+
+
+@websocket("/ws/logs", tags=["Live Feed"])
+async def logs_feed(socket: WebSocket) -> None:
+    """Stream application log events, batched and coalesced.
+
+    One JSON frame per flush: {"type": "log_batch", "records": [...], "dropped": n}
+    Auth: same session-authenticated handshake as /ws/live.
+    """
+    await socket.accept()
+    log_broadcaster.bind_loop(asyncio.get_running_loop())
+    min_levelno = _min_levelno(socket.query_params.get("level"))
+    register_success_level()
+    level_names = logging.getLevelNamesMapping()
+
+    queue = log_broadcaster.subscribe()
+    watcher = asyncio.create_task(_watch_disconnect(socket))
+    try:
+        loop = asyncio.get_running_loop()
+        last_send = loop.time()
+        pending: list[dict[str, Any]] = []
+        dropped = 0
+        while not watcher.done():
+            deadline = loop.time() + LOG_FLUSH_INTERVAL
+            while True:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    break
+                try:
+                    record = await asyncio.wait_for(queue.get(), timeout=remaining)
+                except asyncio.TimeoutError:
+                    break
+                levelno = level_names.get(str(record.get("level", "")).upper(), 0)
+                if levelno < min_levelno:
+                    continue
+                if len(pending) >= MAX_RECORDS_PER_FRAME:
+                    dropped += 1
+                else:
+                    pending.append(record)
+
+            if watcher.done():
+                break
+            if pending or dropped or loop.time() - last_send >= HEARTBEAT_INTERVAL:
+                await socket.send_json({"type": "log_batch", "records": pending, "dropped": dropped})
+                pending, dropped = [], 0
+                last_send = loop.time()
+    except WebSocketDisconnect:
+        pass  # client went away between the watcher check and the send
+    finally:
+        watcher.cancel()
+        with contextlib.suppress(asyncio.CancelledError, WebSocketDisconnect):
+            await watcher
+        log_broadcaster.unsubscribe(queue)

--- a/geometrikks/api/v1/logs_controller.py
+++ b/geometrikks/api/v1/logs_controller.py
@@ -1,0 +1,73 @@
+"""Application log endpoints: tail for the UI table, file list, downloads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from litestar import Controller, get
+from litestar.exceptions import NotFoundException
+from litestar.response import File
+
+from geometrikks.services.logfiles import LogFileKind, create_log_files_service
+
+MAX_TAIL_LINES = 2000
+
+
+@dataclass
+class LogFileView:
+    name: str
+    kind: LogFileKind
+    size_bytes: int
+    modified_at: datetime | None
+    available: bool
+
+
+@dataclass
+class LogFilesResponse:
+    files: list[LogFileView]
+
+
+@dataclass
+class LogTailResponse:
+    records: list[dict[str, Any]]
+
+
+class LogsController(Controller):
+    """Read-only access to the application's own log files."""
+
+    path = "/api/v1/logs"
+    tags = ["Logs"]
+
+    @get("/tail", sync_to_thread=True)
+    def tail(self, lines: int = 500) -> LogTailResponse:
+        clamped = max(1, min(lines, MAX_TAIL_LINES))
+        return LogTailResponse(records=create_log_files_service().tail_main(lines=clamped))
+
+    @get("/files", sync_to_thread=True)
+    def list_files(self) -> LogFilesResponse:
+        return LogFilesResponse(
+            files=[
+                LogFileView(
+                    name=e.name,
+                    kind=e.kind,
+                    size_bytes=e.size_bytes,
+                    modified_at=e.modified_at,
+                    available=e.available,
+                )
+                for e in create_log_files_service().list_files()
+            ]
+        )
+
+    @get("/files/{kind:str}/{name:str}", sync_to_thread=True)
+    def download(self, kind: str, name: str) -> File:
+        path = create_log_files_service().resolve(kind, name)
+        if path is None:
+            raise NotFoundException(detail="No such log file")
+        return File(
+            path=path,
+            filename=path.name,
+            content_disposition_type="attachment",
+            media_type="application/gzip" if path.suffix == ".gz" else "text/plain",
+        )

--- a/geometrikks/api/v1/logs_controller.py
+++ b/geometrikks/api/v1/logs_controller.py
@@ -6,10 +6,11 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Literal
 
-from litestar import Controller, get
+from litestar import Controller, get, post
 from litestar.exceptions import NotFoundException
 from litestar.response import File
 
+from geometrikks.server.logging import rotate_log_files
 from geometrikks.services.logfiles import LogFileKind, create_log_files_service
 
 MAX_TAIL_LINES = 2000
@@ -32,6 +33,11 @@ class LogFilesResponse:
 @dataclass
 class LogTailResponse:
     records: list[dict[str, Any]]
+
+
+@dataclass
+class LogRotateResponse:
+    rotated: list[str]
 
 
 class LogsController(Controller):
@@ -76,3 +82,7 @@ class LogsController(Controller):
             content_disposition_type="attachment",
             media_type="application/gzip" if path.suffix == ".gz" else "text/plain",
         )
+
+    @post("/rotate", sync_to_thread=True)
+    def rotate(self) -> LogRotateResponse:
+        return LogRotateResponse(rotated=rotate_log_files())

--- a/geometrikks/api/v1/logs_controller.py
+++ b/geometrikks/api/v1/logs_controller.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from litestar import Controller, get
 from litestar.exceptions import NotFoundException
@@ -41,9 +41,14 @@ class LogsController(Controller):
     tags = ["Logs"]
 
     @get("/tail", sync_to_thread=True)
-    def tail(self, lines: int = 500) -> LogTailResponse:
+    def tail(self, lines: int = 500, source: Literal["app", "login"] = "app") -> LogTailResponse:
         clamped = max(1, min(lines, MAX_TAIL_LINES))
-        return LogTailResponse(records=create_log_files_service().tail_main(lines=clamped))
+        service = create_log_files_service()
+        if source == "login":
+            records = service.tail_login(lines=clamped)
+        else:
+            records = service.tail_main(lines=clamped)
+        return LogTailResponse(records=records)
 
     @get("/files", sync_to_thread=True)
     def list_files(self) -> LogFilesResponse:

--- a/geometrikks/api/v1/logs_controller.py
+++ b/geometrikks/api/v1/logs_controller.py
@@ -41,7 +41,7 @@ class LogRotateResponse:
 
 
 class LogsController(Controller):
-    """Read-only access to the application's own log files."""
+    """Access to the application's own log files: tail, list, download, rotate."""
 
     path = "/api/v1/logs"
     tags = ["Logs"]

--- a/geometrikks/api/v1/system_controller.py
+++ b/geometrikks/api/v1/system_controller.py
@@ -21,12 +21,15 @@ from sqlalchemy import text
 
 from geometrikks.config.introspection import SystemSettingsResponse, build_settings_overview
 from geometrikks.config.settings import get_settings
+from geometrikks.server.logging import get_logger
 from geometrikks.server.scheduler_tracking import JobRunTracker, JobStatus
 from geometrikks.lib.utils import GeoIPInfoView, geoip_info
 
 if TYPE_CHECKING:
     from apscheduler.job import Job
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+logger = get_logger(__name__)
 
 
 @dataclass
@@ -205,6 +208,7 @@ class SystemController(Controller):
         scheduler: AsyncIOScheduler | None = getattr(request.app.state, "scheduler", None)
         if scheduler is None or scheduler.get_job(job_id) is None:
             raise NotFoundException(detail=f"Unknown scheduler job: {job_id}")
+        logger.info("scheduler_job_triggered_manually", job_id=job_id)
         scheduler.modify_job(job_id, next_run_time=datetime.now(timezone.utc))
         tracker: JobRunTracker = (
             getattr(request.app.state, "scheduler_tracker", None) or JobRunTracker()

--- a/geometrikks/config/settings.py
+++ b/geometrikks/config/settings.py
@@ -1,5 +1,6 @@
 import json
 import socket
+import warnings
 from functools import lru_cache
 from importlib.metadata import PackageNotFoundError, version as distribution_version
 from ipaddress import ip_network
@@ -154,9 +155,35 @@ class APISettings(BaseSettings):
 
     host: str = Field(default="0.0.0.0", description="API server host")
     port: int = Field(default=8000, description="API server port")
-    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(
-        default="INFO",
-        description="Logging level",
+    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] | None = Field(
+        default=None,
+        description="DEPRECATED: use LOG_LEVEL. Kept as a fallback for existing deployments.",
+    )
+
+
+class LogSettings(BaseSettings):
+    """Application logging configuration (files, rotation, level)."""
+
+    model_config = SettingsConfigDict(env_prefix="LOG_", env_file=".env", extra="ignore")
+
+    dir: Path = Field(default=Path("logs"), description="Directory for application log files")
+    level: Literal["DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL"] | None = Field(
+        default=None,
+        description="Root log level. Falls back to deprecated API_LOG_LEVEL, then INFO.",
+    )
+    main_max_bytes: int = Field(
+        default=10 * 1024 * 1024,
+        description="Rotate the main JSONL log when it exceeds this size (bytes)",
+    )
+    main_backup_count: int = Field(
+        default=5, description="Number of gzipped main-log archives to keep"
+    )
+    login_max_bytes: int = Field(
+        default=10 * 1024 * 1024,
+        description="Rotate the login log when it exceeds this size (bytes)",
+    )
+    login_backup_count: int = Field(
+        default=5, description="Number of gzipped login-log archives to keep"
     )
 
 
@@ -524,10 +551,27 @@ class Settings(BaseSettings):
                 ) from exc
         return value
 
+    @model_validator(mode="after")
+    def _resolve_log_level(self) -> "Settings":
+        """LOG_LEVEL wins; deprecated API_LOG_LEVEL is honored with a warning."""
+        if self.log.level is None:
+            if self.api.log_level is not None:
+                warnings.warn(
+                    "API_LOG_LEVEL is deprecated and will be removed in a future "
+                    "release; set LOG_LEVEL instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                self.log.level = self.api.log_level
+            else:
+                self.log.level = "INFO"
+        return self
+
     # Sub-configurations
     api: APISettings = Field(default_factory=APISettings)
     database: DatabaseSettings = Field(default_factory=DatabaseSettings)
     geoip: GeoIPSettings = Field(default_factory=GeoIPSettings)
+    log: LogSettings = Field(default_factory=LogSettings)
     logparser: LogParserSettings = Field(default_factory=LogParserSettings)
     analytics: AnalyticsSettings = Field(default_factory=AnalyticsSettings)
     scheduler: SchedulerSettings = Field(default_factory=SchedulerSettings)

--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -25,12 +25,13 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Sequence
-import logging
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-logger = logging.getLogger(__name__)
+from geometrikks.server.logging import get_logger
+
+logger = get_logger(__name__)
 
 class StatsGranularity(Enum):
     """Granularity for query routing."""

--- a/geometrikks/domain/geo/repositories.py
+++ b/geometrikks/domain/geo/repositories.py
@@ -13,7 +13,6 @@ to get exact time range results.
 """
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum
@@ -22,8 +21,9 @@ from sqlalchemy import text
 from advanced_alchemy.repository import SQLAlchemyAsyncRepository
 
 from geometrikks.domain.geo.models import GeoLocation, GeoEvent
+from geometrikks.server.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class StatsGranularity(Enum):

--- a/geometrikks/domain/geo/services.py
+++ b/geometrikks/domain/geo/services.py
@@ -12,7 +12,6 @@ Query routing follows the repository convention:
 """
 from __future__ import annotations
 
-import logging
 from datetime import datetime
 
 from advanced_alchemy.repository import SQLAlchemyAsyncRepository
@@ -32,8 +31,9 @@ from geometrikks.domain.geo.schemas import (
     TopGeoCountry,
     TopGeoIp,
 )
+from geometrikks.server.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 _IP_LOCATION_CAGGS = {

--- a/geometrikks/domain/imports/repositories.py
+++ b/geometrikks/domain/imports/repositories.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 from advanced_alchemy.repository import SQLAlchemyAsyncRepository
 
 from geometrikks.domain.imports.models import ImportJob
+from geometrikks.server.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class ImportJobRepository(SQLAlchemyAsyncRepository[ImportJob]):
     model_type = ImportJob
 
     async def get_by_checksum(self, checksum: str) -> ImportJob | None:
-        return await self.get_one_or_none(checksum=checksum)
+        job = await self.get_one_or_none(checksum=checksum)
+        logger.debug("import_job_checksum_lookup", checksum=checksum, found=job is not None)
+        return job

--- a/geometrikks/domain/logs/services.py
+++ b/geometrikks/domain/logs/services.py
@@ -17,6 +17,9 @@ from geometrikks.domain.logs.schemas import (
     CountryFacet,
     ParseErrorCount,
 )
+from geometrikks.server.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class AccessLogService(SQLAlchemyAsyncRepositoryService[AccessLog]):
@@ -172,6 +175,7 @@ class AccessLogDebugService(SQLAlchemyAsyncRepositoryService[AccessLogDebug]):
             stmt = limit_offset.append_to_statement(stmt, AccessLogDebug)
 
         rows = (await session.execute(stmt)).all()
+        logger.debug("access_log_debug_page_fetched", rows=len(rows), total=total)
         return [
             AccessLogDebugEntry(
                 id=row.id,
@@ -233,6 +237,7 @@ class AccessLogDebugService(SQLAlchemyAsyncRepositoryService[AccessLogDebug]):
             )
         ).first()
 
+        logger.debug("access_log_debug_stats_fetched", total=total, malformed=malformed)
         return AccessLogDebugStats(
             total=total,
             malformed=malformed,

--- a/geometrikks/domain/security/repositories.py
+++ b/geometrikks/domain/security/repositories.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import ipaddress
-import logging
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import bindparam, text
@@ -11,8 +10,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from geometrikks.domain.geo.repositories import StatsGranularity, get_stats_granularity
 from geometrikks.domain.security.schemas import IpEnrichment, IpLocation
+from geometrikks.server.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Latest-geo lookback: bounds chunk scans on the access_logs hypertable while
 # still finding geo data for IPs whose last request predates the 24h window.

--- a/geometrikks/lib/utils.py
+++ b/geometrikks/lib/utils.py
@@ -1,6 +1,5 @@
 import os
 import time
-import logging
 import asyncio
 from functools import wraps
 from pathlib import Path
@@ -13,7 +12,9 @@ import aiofiles
 import maxminddb
 from datetime import datetime, timezone
 
-logger = logging.getLogger(__name__)
+from geometrikks.server.logging import get_logger
+
+logger = get_logger(__name__)
 
 P = ParamSpec("P")
 

--- a/geometrikks/server/auth.py
+++ b/geometrikks/server/auth.py
@@ -17,10 +17,14 @@ from litestar.middleware.session.server_side import (
 from litestar.security.session_auth import SessionAuth
 from pwdlib import PasswordHash
 
+from geometrikks.server.logging import get_logger
+
 if TYPE_CHECKING:
     from litestar.connection import ASGIConnection
 
     from geometrikks.config.settings import Settings
+
+logger = get_logger(__name__)
 
 # Paths that never require a session:
 # - "^/(?!api(/|$)|ws(/|$))" — everything that is not /api, /ws, or under them
@@ -71,9 +75,21 @@ def build_auth_state(settings: "Settings") -> AuthState:
             "Set APP_ADMIN_PASSWORD, or set APP_AUTH_DISABLED=true if an "
             "authenticating reverse proxy fronts this app."
         )
-    return AuthState(
+    auth_state = AuthState(
         username=settings.admin_user,
         password_hash=_hasher.hash(settings.admin_password.get_secret_value()),
+    )
+    logger.info("auth_state_built", user=settings.admin_user)
+    return auth_state
+
+
+def warn_auth_disabled() -> None:
+    logger.warning(
+        "auth_disabled",
+        detail=(
+            "APP_AUTH_DISABLED=true: API is unauthenticated. Only run this "
+            "behind an authenticating reverse proxy."
+        ),
     )
 
 
@@ -92,7 +108,7 @@ def create_session_auth(settings: "Settings") -> SessionAuth[AdminUser, ServerSi
     invalidates all sessions (users just log in again) — fine for a
     single-admin homelab tool and avoids a signing-secret setting.
     """
-    return SessionAuth[AdminUser, ServerSideSessionBackend](
+    session_auth = SessionAuth[AdminUser, ServerSideSessionBackend](
         retrieve_user_handler=retrieve_user_handler,
         session_backend_config=ServerSideSessionConfig(
             max_age=60 * 60 * 24 * 7,
@@ -100,3 +116,5 @@ def create_session_auth(settings: "Settings") -> SessionAuth[AdminUser, ServerSi
         ),
         exclude=AUTH_EXCLUDE_PATTERNS,
     )
+    logger.debug("session_auth_configured")
+    return session_auth

--- a/geometrikks/server/core.py
+++ b/geometrikks/server/core.py
@@ -7,7 +7,6 @@ from litestar import Litestar
 from litestar.di import Provide
 from litestar.openapi import OpenAPIConfig
 from litestar.config.compression import CompressionConfig
-from litestar.middleware.logging import LoggingMiddlewareConfig
 
 from geometrikks.config.settings import get_settings
 from geometrikks.server import plugins
@@ -64,16 +63,6 @@ def create_app() -> Litestar:
         ],
     )
     
-    logging_middleware_config = LoggingMiddlewareConfig(
-        response_log_fields=("status_code",),
-        request_log_fields=(
-                "path",
-                "method",
-                "query",
-                "path_params",
-            ),
-    )
-
     # Create app with configuration
     app = Litestar(
         debug=settings.debug,
@@ -85,11 +74,9 @@ def create_app() -> Litestar:
             "limit_offset": Provide(provide_limit_offset_pagination, sync_to_thread=False),
             "transaction": provide_transaction,
         },
-        logging_config=plugins.create_logging_config(settings),
         openapi_config=openapi_config,
         compression_config=compression_config,
         exception_handlers=CROWDSEC_EXCEPTION_HANDLERS,
-        middleware=[logging_middleware_config.middleware],
         on_app_init=on_app_init,
     )
     app.state.auth_state = auth_state

--- a/geometrikks/server/core.py
+++ b/geometrikks/server/core.py
@@ -31,17 +31,13 @@ def create_app() -> Litestar:
     # Load settings once at app creation
     settings = get_settings()
 
-    from geometrikks.server.auth import build_auth_state, create_session_auth
+    from geometrikks.server.auth import build_auth_state, create_session_auth, warn_auth_disabled
 
     on_app_init = []
     auth_state = None
     if settings.auth_disabled:
         # Documented reverse-proxy mode (Authelia/Tailscale in front).
-        import logging
-        logging.getLogger(__name__).warning(
-            "APP_AUTH_DISABLED=true: API is unauthenticated. Only run this "
-            "behind an authenticating reverse proxy."
-        )
+        warn_auth_disabled()
     else:
         auth_state = build_auth_state(settings)
         on_app_init.append(create_session_auth(settings).on_app_init)

--- a/geometrikks/server/exceptions.py
+++ b/geometrikks/server/exceptions.py
@@ -1,15 +1,14 @@
 """App-level exception handlers translating domain errors to HTTP responses."""
 from __future__ import annotations
 
-import logging
-
 from litestar import MediaType, Request, Response
 from litestar.status_codes import HTTP_500_INTERNAL_SERVER_ERROR, HTTP_502_BAD_GATEWAY
 from litestar.types import ExceptionHandlersMap
 
+from geometrikks.server.logging import get_logger
 from geometrikks.services.crowdsec import CrowdSecAuthError, CrowdSecUnavailableError
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def handle_crowdsec_unavailable(request: Request, exc: Exception) -> Response:

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Callable
 
@@ -12,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from geometrikks.config.settings import get_settings
+from geometrikks.server.logging import get_logger
 from geometrikks.server.migrations import migrate_database
 from geometrikks.server.plugins import get_sqlalchemy_config
 from geometrikks.server.timescale import setup_timescaledb
@@ -28,7 +28,7 @@ from geometrikks.server.scheduler_tracking import JobRunTracker
 if TYPE_CHECKING:
     from litestar import Litestar
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 async def _db_available(timeout: float = 10.0) -> bool:

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -60,6 +60,12 @@ async def on_startup(app: "Litestar") -> None:
 
     settings = get_settings()
 
+    if settings.api.log_level is not None:
+        logger.warning(
+            "API_LOG_LEVEL is deprecated and will be removed in a future "
+            "release; set LOG_LEVEL instead."
+        )
+
     # GeoIP: download/refresh if credentials are configured; degrade otherwise.
     # Runs before the DB gate — geo enrichment does not need the database, and
     # /health must report geoip state accurately even in DB-degraded mode.

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -58,6 +58,9 @@ async def on_startup(app: "Litestar") -> None:
     # Set before anything else so /about reports uptime even in degraded mode.
     app.state.started_at = datetime.now(timezone.utc)
 
+    from geometrikks.server.logging import log_broadcaster
+    log_broadcaster.bind_loop(asyncio.get_running_loop())
+
     settings = get_settings()
 
     if settings.api.log_level is not None:

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -186,6 +186,38 @@ class NonBlockingQueueHandler(QueueHandler):
         return record
 
 
+def _capture_exc_info(_: Any, __: str, event_dict: dict[str, Any]) -> dict[str, Any]:
+    """Resolve a lazy ``exc_info`` (``True`` or an exception instance) into a
+    real ``(type, value, traceback)`` tuple, in place, before the record
+    leaves this thread.
+
+    structlog-native calls such as ``logger.exception(...)`` or
+    ``logger.error(..., exc_info=True)`` (this is exactly what Litestar's
+    default exception handler does) only stash ``exc_info=True`` in the
+    event dict; turning that into an actual traceback is deferred to
+    whichever processor runs ``structlog.processors.format_exc_info``. Our
+    pipeline queues every record (``NonBlockingQueueHandler``) and only
+    renders it later, on the ``LoggingQueueListener`` thread. ``exc_info``
+    is thread-local, so by the time a deferred ``format_exc_info`` called
+    ``sys.exc_info()`` there, the original ``except`` block (and thread)
+    were long gone and it silently got ``(None, None, None)`` -- the
+    traceback was lost forever and no "exception" key was ever produced.
+
+    Running this as one of the shared processors (used both as the
+    structlog-native processor chain and as ``foreign_pre_chain`` for
+    stdlib records) captures the live traceback synchronously, in the
+    original call-site thread, before the record is queued. Foreign stdlib
+    records already carry a resolved tuple on ``record.exc_info`` by the
+    time this runs, so this is a no-op for them.
+    """
+    exc_info = event_dict.get("exc_info")
+    if exc_info is True:
+        event_dict["exc_info"] = sys.exc_info()
+    elif isinstance(exc_info, BaseException):
+        event_dict["exc_info"] = (type(exc_info), exc_info, exc_info.__traceback__)
+    return event_dict
+
+
 def _shared_processors() -> list[Any]:
     return [
         structlog.contextvars.merge_contextvars,
@@ -195,13 +227,37 @@ def _shared_processors() -> list[Any]:
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.TimeStamper(fmt="iso", utc=True),
         structlog.processors.StackInfoRenderer(),
+        _capture_exc_info,
     ]
+
+
+def _console_exception_formatter() -> Any:
+    """Pretty, colorized traceback for the console, without dumping locals.
+
+    structlog.dev.ConsoleRenderer defaults to rich_traceback (show_locals=True)
+    whenever the rich package is installed, which would print every local
+    variable in every frame -- request bodies, passwords, tokens -- straight
+    to the console/container logs. We want the same frame-by-frame Rich
+    rendering, just never with locals. No plain formatted traceback string
+    is the JSONL/broadcast contract either way (see _capture_exc_info); this
+    only affects what the human-facing console shows.
+    """
+    if structlog.dev.rich is not None:
+        return structlog.dev.RichTracebackFormatter(show_locals=False)
+    return structlog.dev.plain_traceback
 
 
 def _console_renderer() -> structlog.dev.ConsoleRenderer:
     styles = structlog.dev.ConsoleRenderer.get_default_level_styles(colors=True)
     styles["success"] = "\x1b[32m"  # green, matches the UI emerald badge
-    return structlog.dev.ConsoleRenderer(colors=True, level_styles=styles)
+    styles["debug"] = "\x1b[2m"  # dim/grey, was green (indistinguishable from info)
+    styles["info"] = "\x1b[34m"  # blue, was green (indistinguishable from debug)
+    styles["critical"] = "\x1b[1m\x1b[31m"  # bold red, stands out from plain error red
+    return structlog.dev.ConsoleRenderer(
+        colors=True,
+        level_styles=styles,
+        exception_formatter=_console_exception_formatter(),
+    )
 
 
 def _log_dir_write_error(log_dir: "Path") -> str | None:
@@ -246,14 +302,19 @@ def create_logging_config(settings: "Settings") -> StructLoggingConfig:
     shared = _shared_processors()
     fmt = structlog.stdlib.ProcessorFormatter
 
-    def formatter(renderer: Any) -> dict[str, Any]:
+    def formatter(renderer: Any, *, format_exception: bool = True) -> dict[str, Any]:
+        # format_exception=False (console): exc_info reaches the renderer as a
+        # real (type, value, traceback) tuple (captured by _capture_exc_info
+        # above, shared by every formatter's foreign_pre_chain) and
+        # ConsoleRenderer formats it itself, producing a pretty, colorized
+        # traceback instead of a plain string.
+        processors: list[Any] = [fmt.remove_processors_meta]
+        if format_exception:
+            processors.append(structlog.processors.format_exc_info)
+        processors.append(renderer)
         return {
             "()": fmt,
-            "processors": [
-                fmt.remove_processors_meta,
-                structlog.processors.format_exc_info,
-                renderer,
-            ],
+            "processors": processors,
             "foreign_pre_chain": shared,
         }
 
@@ -303,7 +364,7 @@ def create_logging_config(settings: "Settings") -> StructLoggingConfig:
 
     standard_lib = LoggingConfig(
         formatters={
-            "console": formatter(_console_renderer()),
+            "console": formatter(_console_renderer(), format_exception=False),
             "json": formatter(structlog.processors.JSONRenderer()),
             "login": formatter(render_login_line),
         },

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -212,9 +212,16 @@ def _capture_exc_info(_: Any, __: str, event_dict: dict[str, Any]) -> dict[str, 
     """
     exc_info = event_dict.get("exc_info")
     if exc_info is True:
-        event_dict["exc_info"] = sys.exc_info()
+        exc_info = sys.exc_info()
+        event_dict["exc_info"] = exc_info
     elif isinstance(exc_info, BaseException):
-        event_dict["exc_info"] = (type(exc_info), exc_info, exc_info.__traceback__)
+        exc_info = (type(exc_info), exc_info, exc_info.__traceback__)
+        event_dict["exc_info"] = exc_info
+    # One-line summary next to the full traceback, e.g.
+    # "NotAuthorizedException: 401: no session data found"; setdefault so an
+    # explicit error=... kwarg (scheduler job failures) is never clobbered.
+    if isinstance(exc_info, tuple) and len(exc_info) == 3 and exc_info[1] is not None:
+        event_dict.setdefault("error", f"{type(exc_info[1]).__name__}: {exc_info[1]}")
     return event_dict
 
 

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -29,7 +29,7 @@ def register_success_level() -> None:
     if logging.getLevelName(SUCCESS_LEVEL) != "SUCCESS":
         logging.addLevelName(SUCCESS_LEVEL, "SUCCESS")
     if not hasattr(logging.Logger, "success"):
-        logging.Logger.success = _stdlib_success  # type: ignore[attr-defined]
+        logging.Logger.success = _stdlib_success  # ty: ignore[unresolved-attribute]
 
 
 class SuccessBoundLogger(structlog.stdlib.BoundLogger):

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -17,15 +17,15 @@ import logging
 import os
 import shutil
 import sys
+import weakref
 from logging.handlers import QueueHandler, RotatingFileHandler
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import structlog
 from litestar.logging.config import LoggingConfig, StructLoggingConfig
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from geometrikks.config.settings import Settings
 
 SUCCESS_LEVEL = 25  # between INFO (20) and WARNING (30)
@@ -67,10 +67,49 @@ def _gz_namer(default_name: str) -> str:
 class GzipRotatingFileHandler(RotatingFileHandler):
     """Size-based rotation that gzips archives: app.log.1.gz ... app.log.N.gz."""
 
+    _instances: ClassVar["weakref.WeakSet[GzipRotatingFileHandler]"] = weakref.WeakSet()
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.namer = _gz_namer
         self.rotator = _gzip_rotator
+        self.__class__._instances.add(self)
+
+
+def rotate_log_files() -> list[str]:
+    """Force a rollover of every live log file handler.
+
+    Skips closed handlers (reconfiguration can leave stale, closed
+    instances reachable via the weak-reference registry) and dedupes by
+    baseFilename, keeping the first live handler found for each file. A
+    handler whose current file is empty or missing is skipped too, since
+    rotating an empty file would just churn archives.
+
+    Returns the rotated base file names (e.g. ["geometrikks.log", "login.log"]).
+    """
+    rotated: list[str] = []
+    seen: set[str] = set()
+    for handler in list(GzipRotatingFileHandler._instances):
+        if handler.stream is None:  # closed by a prior reconfiguration
+            continue
+        if handler.baseFilename in seen:
+            continue
+        seen.add(handler.baseFilename)
+        try:
+            size = os.path.getsize(handler.baseFilename)
+        except OSError:
+            continue
+        if size == 0:
+            continue
+        handler.acquire()
+        try:
+            handler.doRollover()
+        finally:
+            handler.release()
+        rotated.append(Path(handler.baseFilename).name)
+    if rotated:
+        get_logger(__name__).info("logs_rotated", files=rotated)
+    return rotated
 
 
 def _sanitize_login_field(value: str) -> str:

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 from logging.handlers import QueueHandler, RotatingFileHandler
 from typing import TYPE_CHECKING, Any
 
@@ -23,6 +24,8 @@ import structlog
 from litestar.logging.config import LoggingConfig, StructLoggingConfig
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from geometrikks.config.settings import Settings
 
 SUCCESS_LEVEL = 25  # between INFO (20) and WARNING (30)
@@ -201,6 +204,22 @@ def _console_renderer() -> structlog.dev.ConsoleRenderer:
     return structlog.dev.ConsoleRenderer(colors=True, level_styles=styles)
 
 
+def _log_dir_write_error(log_dir: "Path") -> str | None:
+    """Try to create log_dir and confirm it is actually writable.
+
+    Returns None when the directory is usable, otherwise a short
+    human-readable description of the OSError that prevented it.
+    """
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        probe = log_dir / ".write_probe"
+        probe.write_text("")
+        probe.unlink()
+    except OSError as exc:
+        return f"{exc.strerror or exc} (errno={exc.errno})"
+    return None
+
+
 def create_logging_config(settings: "Settings") -> StructLoggingConfig:
     """Full pipeline: console + JSONL file + login file + WS broadcast.
 
@@ -209,7 +228,20 @@ def create_logging_config(settings: "Settings") -> StructLoggingConfig:
     """
     register_success_level()
     log_dir = settings.log.dir
-    log_dir.mkdir(parents=True, exist_ok=True)
+    write_error = _log_dir_write_error(log_dir)
+    file_logging_enabled = write_error is None
+
+    if not file_logging_enabled:
+        print(
+            f"ERROR: log directory {log_dir} is not writable ({write_error}); "
+            "file logging is DISABLED, including login.log, until this is "
+            "fixed. Console logging continues. Fix ownership/permissions "
+            "(e.g. `chown 1000:1000` for the container's geometrikks user, "
+            "or the equivalent for a non-default uid) and restart to "
+            "re-enable file logging.",
+            file=sys.stderr,
+            flush=True,
+        )
 
     shared = _shared_processors()
     fmt = structlog.stdlib.ProcessorFormatter
@@ -225,6 +257,50 @@ def create_logging_config(settings: "Settings") -> StructLoggingConfig:
             "foreign_pre_chain": shared,
         }
 
+    handlers: dict[str, Any] = {
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "DEBUG",
+            "formatter": "console",
+        },
+        "broadcast": {
+            "()": BroadcastHandler,
+            "level": "DEBUG",
+            "formatter": "json",
+        },
+    }
+    queue_targets = ["console", "broadcast"]
+
+    if file_logging_enabled:
+        handlers["main_file"] = {
+            "()": GzipRotatingFileHandler,
+            "level": "DEBUG",
+            "formatter": "json",
+            "filename": str(log_dir / MAIN_LOG_NAME),
+            "maxBytes": settings.log.main_max_bytes,
+            "backupCount": settings.log.main_backup_count,
+            "encoding": "utf-8",
+        }
+        handlers["login_file"] = {
+            "()": GzipRotatingFileHandler,
+            "level": "INFO",
+            "formatter": "login",
+            "filters": ["login_only"],
+            "filename": str(log_dir / LOGIN_LOG_NAME),
+            "maxBytes": settings.log.login_max_bytes,
+            "backupCount": settings.log.login_backup_count,
+            "encoding": "utf-8",
+        }
+        queue_targets = ["console", "main_file", "login_file", "broadcast"]
+
+    handlers["queue_listener"] = {
+        "class": NonBlockingQueueHandler,
+        "queue": {"()": "queue.Queue", "maxsize": -1},
+        "listener": "litestar.logging.standard.LoggingQueueListener",
+        "handlers": queue_targets,
+        "respect_handler_level": True,
+    }
+
     standard_lib = LoggingConfig(
         formatters={
             "console": formatter(_console_renderer()),
@@ -232,44 +308,7 @@ def create_logging_config(settings: "Settings") -> StructLoggingConfig:
             "login": formatter(render_login_line),
         },
         filters={"login_only": {"()": LoginOnlyFilter}},
-        handlers={
-            "console": {
-                "class": "logging.StreamHandler",
-                "level": "DEBUG",
-                "formatter": "console",
-            },
-            "main_file": {
-                "()": GzipRotatingFileHandler,
-                "level": "DEBUG",
-                "formatter": "json",
-                "filename": str(log_dir / MAIN_LOG_NAME),
-                "maxBytes": settings.log.main_max_bytes,
-                "backupCount": settings.log.main_backup_count,
-                "encoding": "utf-8",
-            },
-            "login_file": {
-                "()": GzipRotatingFileHandler,
-                "level": "INFO",
-                "formatter": "login",
-                "filters": ["login_only"],
-                "filename": str(log_dir / LOGIN_LOG_NAME),
-                "maxBytes": settings.log.login_max_bytes,
-                "backupCount": settings.log.login_backup_count,
-                "encoding": "utf-8",
-            },
-            "broadcast": {
-                "()": BroadcastHandler,
-                "level": "DEBUG",
-                "formatter": "json",
-            },
-            "queue_listener": {
-                "class": NonBlockingQueueHandler,
-                "queue": {"()": "queue.Queue", "maxsize": -1},
-                "listener": "litestar.logging.standard.LoggingQueueListener",
-                "handlers": ["console", "main_file", "login_file", "broadcast"],
-                "respect_handler_level": True,
-            },
-        },
+        handlers=handlers,
         loggers={
             "litestar": {"level": "INFO", "handlers": ["queue_listener"], "propagate": False},
             LOGIN_LOGGER_NAME: {"level": "INFO"},

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -62,6 +62,13 @@ class GzipRotatingFileHandler(RotatingFileHandler):
         self.rotator = _gzip_rotator
 
 
+def _sanitize_login_field(value: str) -> str:
+    """Strip control characters and escape quoting so a hostile username
+    cannot forge extra lines or fields in the login log."""
+    cleaned = "".join(ch for ch in value if ch.isprintable())
+    return cleaned.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def render_login_line(_: Any, __: str, event_dict: dict[str, Any]) -> str:
     """Stable plain-text login line for CrowdSec/fail2ban parsers.
 
@@ -70,8 +77,11 @@ def render_login_line(_: Any, __: str, event_dict: dict[str, Any]) -> str:
     """
     ts = str(event_dict.get("timestamp", ""))[:19] + "Z"
     event = event_dict.get("event", "")
-    user = str(event_dict.get("user", ""))
-    ip = event_dict.get("ip") or "-"
+    user = _sanitize_login_field(str(event_dict.get("user", "")))
+    ip_raw = event_dict.get("ip") or "-"
+    ip = _sanitize_login_field(str(ip_raw)) if ip_raw != "-" else "-"
+    if ip != "-" and (" " in ip or '"' in ip):
+        ip = "-"
     return f'{ts} {event} user="{user}" ip={ip}'
 
 

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -371,7 +371,11 @@ def create_logging_config(settings: "Settings") -> StructLoggingConfig:
         filters={"login_only": {"()": LoginOnlyFilter}},
         handlers=handlers,
         loggers={
-            "litestar": {"level": "INFO", "handlers": ["queue_listener"], "propagate": False},
+            "litestar": {
+                "level": settings.log.level or "INFO",
+                "handlers": ["queue_listener"],
+                "propagate": False,
+            },
             LOGIN_LOGGER_NAME: {"level": "INFO"},
         },
         root={"level": settings.log.level or "INFO", "handlers": ["queue_listener"]},

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -9,6 +9,7 @@ block the event loop.
 from __future__ import annotations
 
 import gzip
+import ipaddress
 import logging
 import os
 import shutil
@@ -63,10 +64,10 @@ class GzipRotatingFileHandler(RotatingFileHandler):
 
 
 def _sanitize_login_field(value: str) -> str:
-    """Strip control characters and escape quoting so a hostile username
-    cannot forge extra lines or fields in the login log."""
+    """Strip control characters, quotes and backslashes so a hostile
+    username cannot forge lines or fields in the login log."""
     cleaned = "".join(ch for ch in value if ch.isprintable())
-    return cleaned.replace("\\", "\\\\").replace('"', '\\"')
+    return cleaned.replace("\\", "").replace('"', "")
 
 
 def render_login_line(_: Any, __: str, event_dict: dict[str, Any]) -> str:
@@ -76,11 +77,13 @@ def render_login_line(_: Any, __: str, event_dict: dict[str, Any]) -> str:
     YYYY-MM-DDTHH:MM:SSZ <event> user="<user>" ip=<ip>
     """
     ts = str(event_dict.get("timestamp", ""))[:19] + "Z"
-    event = event_dict.get("event", "")
+    raw_event = str(event_dict.get("event", ""))
+    event = "".join(ch for ch in raw_event if ch.isalnum() or ch == "_") or "unknown"
     user = _sanitize_login_field(str(event_dict.get("user", "")))
-    ip_raw = event_dict.get("ip") or "-"
-    ip = _sanitize_login_field(str(ip_raw)) if ip_raw != "-" else "-"
-    if ip != "-" and (" " in ip or '"' in ip):
+    raw_ip = str(event_dict.get("ip") or "")
+    try:
+        ip = str(ipaddress.ip_address(raw_ip))
+    except ValueError:
         ip = "-"
     return f'{ts} {event} user="{user}" ip={ip}'
 

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -1,0 +1,39 @@
+"""Structlog logging pipeline building blocks.
+
+Sinks (wired in create_logging_config, Task 6): colored console, JSONL main
+file, plain-text login file (CrowdSec/fail2ban contract), and a WebSocket
+fan-out. All sit behind the stdlib queue listener so file IO and gzip never
+block the event loop.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import structlog
+
+SUCCESS_LEVEL = 25  # between INFO (20) and WARNING (30)
+LOGIN_LOGGER_NAME = "geometrikks.auth.login"
+
+get_logger = structlog.stdlib.get_logger
+
+
+def _stdlib_success(self: logging.Logger, message: str, *args: Any, **kwargs: Any) -> None:
+    if self.isEnabledFor(SUCCESS_LEVEL):
+        self._log(SUCCESS_LEVEL, message, args, **kwargs)
+
+
+def register_success_level() -> None:
+    """Register the SUCCESS level on stdlib logging. Idempotent."""
+    if logging.getLevelName(SUCCESS_LEVEL) != "SUCCESS":
+        logging.addLevelName(SUCCESS_LEVEL, "SUCCESS")
+    if not hasattr(logging.Logger, "success"):
+        logging.Logger.success = _stdlib_success  # type: ignore[attr-defined]
+
+
+class SuccessBoundLogger(structlog.stdlib.BoundLogger):
+    """Stdlib bound logger with a success() method (level 25)."""
+
+    def success(self, event: str | None = None, *args: Any, **kw: Any) -> Any:
+        return self._proxy_to_logger("success", event, *args, **kw)

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -8,7 +8,11 @@ block the event loop.
 
 from __future__ import annotations
 
+import gzip
 import logging
+import os
+import shutil
+from logging.handlers import RotatingFileHandler
 from typing import Any
 
 import structlog
@@ -37,3 +41,22 @@ class SuccessBoundLogger(structlog.stdlib.BoundLogger):
 
     def success(self, event: str | None = None, *args: Any, **kw: Any) -> Any:
         return self._proxy_to_logger("success", event, *args, **kw)
+
+
+def _gzip_rotator(source: str, dest: str) -> None:
+    with open(source, "rb") as sf, gzip.open(dest, "wb") as df:
+        shutil.copyfileobj(sf, df)
+    os.remove(source)
+
+
+def _gz_namer(default_name: str) -> str:
+    return default_name + ".gz"
+
+
+class GzipRotatingFileHandler(RotatingFileHandler):
+    """Size-based rotation that gzips archives: app.log.1.gz ... app.log.N.gz."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.namer = _gz_namer
+        self.rotator = _gzip_rotator

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -60,3 +60,23 @@ class GzipRotatingFileHandler(RotatingFileHandler):
         super().__init__(*args, **kwargs)
         self.namer = _gz_namer
         self.rotator = _gzip_rotator
+
+
+def render_login_line(_: Any, __: str, event_dict: dict[str, Any]) -> str:
+    """Stable plain-text login line for CrowdSec/fail2ban parsers.
+
+    Contract (do not change without a deprecation cycle):
+    YYYY-MM-DDTHH:MM:SSZ <event> user="<user>" ip=<ip>
+    """
+    ts = str(event_dict.get("timestamp", ""))[:19] + "Z"
+    event = event_dict.get("event", "")
+    user = str(event_dict.get("user", ""))
+    ip = event_dict.get("ip") or "-"
+    return f'{ts} {event} user="{user}" ip={ip}'
+
+
+class LoginOnlyFilter(logging.Filter):
+    """Routes only geometrikks.auth.login records into the login file."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.name == LOGIN_LOGGER_NAME

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -15,6 +15,7 @@ import ipaddress
 import json
 import logging
 import os
+import queue
 import shutil
 import sys
 import weakref
@@ -228,6 +229,7 @@ class BroadcastHandler(logging.Handler):
 
 MAIN_LOG_NAME = "geometrikks.log"
 LOGIN_LOG_NAME = "login.log"
+LOG_QUEUE_MAXSIZE = 10_000  # ~10 MB worst case at ~1 KB per record
 
 
 class NonBlockingQueueHandler(QueueHandler):
@@ -242,10 +244,20 @@ class NonBlockingQueueHandler(QueueHandler):
     the way to ``ProcessorFormatter`` in the listener thread. Flattening it
     early turns every record into ``str(event_dict)`` and breaks every
     downstream sink, so this override is a no-op instead.
+
+    ``enqueue`` drops the record when the (bounded) queue is full: if the
+    listener thread stalls (hung disk, gzip rotation on a huge file), losing
+    log lines beats blocking the caller or growing the queue until OOM. The
+    stdlib default would funnel each overflow through ``handleError`` and
+    spam a traceback to stderr per dropped record.
     """
 
     def prepare(self, record: logging.LogRecord) -> logging.LogRecord:
         return record
+
+    def enqueue(self, record: logging.LogRecord) -> None:
+        with contextlib.suppress(queue.Full):
+            self.queue.put_nowait(record)
 
 
 def _capture_exc_info(_: Any, __: str, event_dict: dict[str, Any]) -> dict[str, Any]:
@@ -423,9 +435,12 @@ def create_logging_config(settings: "Settings") -> StructLoggingConfig:
         }
         queue_targets = ["console", "main_file", "login_file", "broadcast"]
 
+    # Bounded so a stalled listener thread caps out at ~LOG_QUEUE_MAXSIZE
+    # records in memory instead of growing until OOM; NonBlockingQueueHandler
+    # drops records once it fills.
     handlers["queue_listener"] = {
         "class": NonBlockingQueueHandler,
-        "queue": {"()": "queue.Queue", "maxsize": -1},
+        "queue": {"()": "queue.Queue", "maxsize": LOG_QUEUE_MAXSIZE},
         "listener": "litestar.logging.standard.LoggingQueueListener",
         "handlers": queue_targets,
         "respect_handler_level": True,

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -54,6 +54,25 @@ class SuccessBoundLogger(structlog.stdlib.BoundLogger):
         return self._proxy_to_logger("success", event, *args, **kw)
 
 
+def ensure_default_configuration() -> None:
+    """Make get_logger() usable before the app installs the full pipeline.
+
+    structlog's out-of-the-box bound logger has no success(), so any module
+    calling logger.success() outside a booted app (scripts, tests hitting
+    services directly) would crash with AttributeError. Point the defaults
+    at SuccessBoundLogger; create_logging_config reconfigures on app init.
+    """
+    register_success_level()
+    if not structlog.is_configured():
+        structlog.configure(
+            wrapper_class=SuccessBoundLogger,
+            logger_factory=structlog.stdlib.LoggerFactory(),
+        )
+
+
+ensure_default_configuration()
+
+
 def _gzip_rotator(source: str, dest: str) -> None:
     with open(source, "rb") as sf, gzip.open(dest, "wb") as df:
         shutil.copyfileobj(sf, df)

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -8,8 +8,11 @@ block the event loop.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import gzip
 import ipaddress
+import json
 import logging
 import os
 import shutil
@@ -93,3 +96,62 @@ class LoginOnlyFilter(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         return record.name == LOGIN_LOGGER_NAME
+
+
+class LogBroadcaster:
+    """Fans rendered log event dicts out to in-process async subscribers.
+
+    publish_threadsafe is called from the queue-listener thread; events hop
+    onto the bound event loop via call_soon_threadsafe. Bounded queues drop
+    the oldest event when a consumer is slow.
+    """
+
+    def __init__(self, max_queue: int = 1000) -> None:
+        self._max_queue = max_queue
+        self._subscribers: set[asyncio.Queue[dict[str, Any]]] = set()
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    def bind_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._loop = loop
+
+    def subscribe(self) -> asyncio.Queue[dict[str, Any]]:
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=self._max_queue)
+        self._subscribers.add(queue)
+        return queue
+
+    def unsubscribe(self, queue: asyncio.Queue[dict[str, Any]]) -> None:
+        self._subscribers.discard(queue)
+
+    def publish_threadsafe(self, event: dict[str, Any]) -> None:
+        loop = self._loop
+        if loop is None or loop.is_closed() or not self._subscribers:
+            return
+        with contextlib.suppress(RuntimeError):  # loop shutting down
+            loop.call_soon_threadsafe(self._publish, event)
+
+    def _publish(self, event: dict[str, Any]) -> None:
+        for queue in list(self._subscribers):
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                with contextlib.suppress(asyncio.QueueEmpty):
+                    queue.get_nowait()
+                with contextlib.suppress(asyncio.QueueFull):
+                    queue.put_nowait(event)
+
+
+log_broadcaster = LogBroadcaster()
+
+
+class BroadcastHandler(logging.Handler):
+    """Publishes each record, rendered by its formatter, to the broadcaster."""
+
+    def __init__(self, broadcaster: LogBroadcaster | None = None) -> None:
+        super().__init__()
+        self._broadcaster = broadcaster or log_broadcaster
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            self._broadcaster.publish_threadsafe(json.loads(self.format(record)))
+        except Exception:
+            self.handleError(record)

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -267,6 +267,7 @@ def create_logging_config(settings: "Settings") -> StructLoggingConfig:
                 "queue": {"()": "queue.Queue", "maxsize": -1},
                 "listener": "litestar.logging.standard.LoggingQueueListener",
                 "handlers": ["console", "main_file", "login_file", "broadcast"],
+                "respect_handler_level": True,
             },
         },
         loggers={

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -272,6 +272,7 @@ def create_logging_config(settings: "Settings") -> StructLoggingConfig:
         },
         loggers={
             "litestar": {"level": "INFO", "handlers": ["queue_listener"], "propagate": False},
+            LOGIN_LOGGER_NAME: {"level": "INFO"},
         },
         root={"level": settings.log.level or "INFO", "handlers": ["queue_listener"]},
         log_exceptions="always",

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -16,10 +16,14 @@ import json
 import logging
 import os
 import shutil
-from logging.handlers import RotatingFileHandler
-from typing import Any
+from logging.handlers import QueueHandler, RotatingFileHandler
+from typing import TYPE_CHECKING, Any
 
 import structlog
+from litestar.logging.config import LoggingConfig, StructLoggingConfig
+
+if TYPE_CHECKING:
+    from geometrikks.config.settings import Settings
 
 SUCCESS_LEVEL = 25  # between INFO (20) and WARNING (30)
 LOGIN_LOGGER_NAME = "geometrikks.auth.login"
@@ -155,3 +159,127 @@ class BroadcastHandler(logging.Handler):
             self._broadcaster.publish_threadsafe(json.loads(self.format(record)))
         except Exception:
             self.handleError(record)
+
+
+MAIN_LOG_NAME = "geometrikks.log"
+LOGIN_LOG_NAME = "login.log"
+
+
+class NonBlockingQueueHandler(QueueHandler):
+    """In-process ``QueueHandler`` that hands records to the queue unmodified.
+
+    The stdlib default ``prepare()`` calls ``self.format()`` to flatten
+    ``record.msg`` into a string so the record survives a pickled trip across
+    a multiprocessing queue. We only ever use an in-process ``queue.Queue``
+    (see queue_listener handler below), and structlog's
+    ``wrap_for_formatter`` relies on ``record.msg`` staying the original
+    event-dict (plus the ``_logger``/``_name`` attributes it attaches) all
+    the way to ``ProcessorFormatter`` in the listener thread. Flattening it
+    early turns every record into ``str(event_dict)`` and breaks every
+    downstream sink, so this override is a no-op instead.
+    """
+
+    def prepare(self, record: logging.LogRecord) -> logging.LogRecord:
+        return record
+
+
+def _shared_processors() -> list[Any]:
+    return [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.ExtraAdder(),
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.TimeStamper(fmt="iso", utc=True),
+        structlog.processors.StackInfoRenderer(),
+    ]
+
+
+def _console_renderer() -> structlog.dev.ConsoleRenderer:
+    styles = structlog.dev.ConsoleRenderer.get_default_level_styles(colors=True)
+    styles["success"] = "\x1b[32m"  # green, matches the UI emerald badge
+    return structlog.dev.ConsoleRenderer(colors=True, level_styles=styles)
+
+
+def create_logging_config(settings: "Settings") -> StructLoggingConfig:
+    """Full pipeline: console + JSONL file + login file + WS broadcast.
+
+    Everything hangs off the stdlib queue listener; structlog and foreign
+    (stdlib) records meet in ProcessorFormatter so all sinks see both.
+    """
+    register_success_level()
+    log_dir = settings.log.dir
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    shared = _shared_processors()
+    fmt = structlog.stdlib.ProcessorFormatter
+
+    def formatter(renderer: Any) -> dict[str, Any]:
+        return {
+            "()": fmt,
+            "processors": [
+                fmt.remove_processors_meta,
+                structlog.processors.format_exc_info,
+                renderer,
+            ],
+            "foreign_pre_chain": shared,
+        }
+
+    standard_lib = LoggingConfig(
+        formatters={
+            "console": formatter(_console_renderer()),
+            "json": formatter(structlog.processors.JSONRenderer()),
+            "login": formatter(render_login_line),
+        },
+        filters={"login_only": {"()": LoginOnlyFilter}},
+        handlers={
+            "console": {
+                "class": "logging.StreamHandler",
+                "level": "DEBUG",
+                "formatter": "console",
+            },
+            "main_file": {
+                "()": GzipRotatingFileHandler,
+                "level": "DEBUG",
+                "formatter": "json",
+                "filename": str(log_dir / MAIN_LOG_NAME),
+                "maxBytes": settings.log.main_max_bytes,
+                "backupCount": settings.log.main_backup_count,
+                "encoding": "utf-8",
+            },
+            "login_file": {
+                "()": GzipRotatingFileHandler,
+                "level": "INFO",
+                "formatter": "login",
+                "filters": ["login_only"],
+                "filename": str(log_dir / LOGIN_LOG_NAME),
+                "maxBytes": settings.log.login_max_bytes,
+                "backupCount": settings.log.login_backup_count,
+                "encoding": "utf-8",
+            },
+            "broadcast": {
+                "()": BroadcastHandler,
+                "level": "DEBUG",
+                "formatter": "json",
+            },
+            "queue_listener": {
+                "class": NonBlockingQueueHandler,
+                "queue": {"()": "queue.Queue", "maxsize": -1},
+                "listener": "litestar.logging.standard.LoggingQueueListener",
+                "handlers": ["console", "main_file", "login_file", "broadcast"],
+            },
+        },
+        loggers={
+            "litestar": {"level": "INFO", "handlers": ["queue_listener"], "propagate": False},
+        },
+        root={"level": settings.log.level or "INFO", "handlers": ["queue_listener"]},
+        log_exceptions="always",
+    )
+
+    return StructLoggingConfig(
+        processors=shared + [fmt.wrap_for_formatter],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=SuccessBoundLogger,
+        standard_lib_logging_config=standard_lib,
+        log_exceptions="always",
+    )

--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -67,7 +67,7 @@ def _gz_namer(default_name: str) -> str:
 class GzipRotatingFileHandler(RotatingFileHandler):
     """Size-based rotation that gzips archives: app.log.1.gz ... app.log.N.gz."""
 
-    _instances: ClassVar["weakref.WeakSet[GzipRotatingFileHandler]"] = weakref.WeakSet()
+    _instances: ClassVar[weakref.WeakSet[GzipRotatingFileHandler]] = weakref.WeakSet()
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -95,14 +95,18 @@ def rotate_log_files() -> list[str]:
         if handler.baseFilename in seen:
             continue
         seen.add(handler.baseFilename)
-        try:
-            size = os.path.getsize(handler.baseFilename)
-        except OSError:
-            continue
-        if size == 0:
-            continue
         handler.acquire()
         try:
+            # Size check under the handler lock, so a concurrent rotation
+            # (double-submitted request, or the handler's own size-triggered
+            # rollover) cannot slip in between the check and the rollover
+            # and leave us rotating a freshly emptied file.
+            try:
+                size = os.path.getsize(handler.baseFilename)
+            except OSError:
+                continue
+            if size == 0:
+                continue
             handler.doRollover()
         finally:
             handler.release()

--- a/geometrikks/server/migrations.py
+++ b/geometrikks/server/migrations.py
@@ -7,7 +7,6 @@ time — everything happens inside the functions.
 from __future__ import annotations
 
 import asyncio
-import logging
 from typing import TYPE_CHECKING
 
 from advanced_alchemy.alembic.commands import AlembicCommands
@@ -16,6 +15,7 @@ from advanced_alchemy.extensions.litestar import base
 from sqlalchemy import text
 
 from geometrikks.config.settings import get_settings
+from geometrikks.server.logging import get_logger
 from geometrikks.server.timescale import teardown_timescaledb
 
 if TYPE_CHECKING:
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
     from geometrikks.config.settings import Settings
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def upgrade_to_head() -> None:

--- a/geometrikks/server/plugins.py
+++ b/geometrikks/server/plugins.py
@@ -12,7 +12,8 @@ import shutil
 from functools import lru_cache
 from pathlib import Path
 
-from litestar.logging import LoggingConfig
+from litestar.middleware.logging import LoggingMiddlewareConfig
+from litestar.plugins.structlog import StructlogConfig, StructlogPlugin
 from litestar.serialization import decode_json, encode_json
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.pool import NullPool
@@ -31,6 +32,7 @@ from litestar_vite import ViteConfig, VitePlugin
 from litestar_vite.config import RuntimeConfig, TypeGenConfig, PathConfig
 
 from geometrikks.config.settings import get_settings, Settings
+from geometrikks.server.logging import create_logging_config
 
 
 @lru_cache(maxsize=1)
@@ -93,20 +95,22 @@ def create_vite_config(settings: Settings) -> ViteConfig:
     )
 
 
-def create_logging_config(settings: Settings) -> LoggingConfig:
-    return LoggingConfig(
-        # settings.log.level is Optional in its type but the Settings resolver
-        # validator always fills it in (falls back to deprecated API_LOG_LEVEL,
-        # then "INFO"); the "or" here only satisfies the type checker.
-        root={"level": settings.log.level or "INFO", "handlers": ["queue_listener"]},
-        formatters={
-            "standard": {"format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"}
-        },
-        log_exceptions="always",
+def create_structlog_plugin(settings: Settings) -> StructlogPlugin:
+    """Structlog pipeline + structured request logging middleware."""
+    return StructlogPlugin(
+        config=StructlogConfig(
+            structlog_logging_config=create_logging_config(settings),
+            middleware_logging_config=LoggingMiddlewareConfig(
+                response_log_fields=("status_code",),
+                request_log_fields=("path", "method", "query", "path_params"),
+            ),
+        )
     )
 
 
-def create_plugins() -> list[SQLAlchemyInitPlugin | GeoAlchemyPlugin | GranianPlugin | VitePlugin | CLIPluginProtocol]:
+def create_plugins() -> list[
+    SQLAlchemyInitPlugin | GeoAlchemyPlugin | GranianPlugin | VitePlugin | CLIPluginProtocol | StructlogPlugin
+]:
     """Instantiate all app plugins; called once from create_app()."""
     from geometrikks.cli import ImportLogsCLIPlugin
 
@@ -117,4 +121,5 @@ def create_plugins() -> list[SQLAlchemyInitPlugin | GeoAlchemyPlugin | GranianPl
         GranianPlugin(),
         VitePlugin(config=create_vite_config(settings)),
         ImportLogsCLIPlugin(),
+        create_structlog_plugin(settings),
     ]

--- a/geometrikks/server/plugins.py
+++ b/geometrikks/server/plugins.py
@@ -95,7 +95,10 @@ def create_vite_config(settings: Settings) -> ViteConfig:
 
 def create_logging_config(settings: Settings) -> LoggingConfig:
     return LoggingConfig(
-        root={"level": settings.api.log_level, "handlers": ["queue_listener"]},
+        # settings.log.level is Optional in its type but the Settings resolver
+        # validator always fills it in (falls back to deprecated API_LOG_LEVEL,
+        # then "INFO"); the "or" here only satisfies the type checker.
+        root={"level": settings.log.level or "INFO", "handlers": ["queue_listener"]},
         formatters={
             "standard": {"format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"}
         },

--- a/geometrikks/server/routes.py
+++ b/geometrikks/server/routes.py
@@ -15,7 +15,7 @@ from geometrikks.api.v1.analytics_controller import AnalyticsController
 from geometrikks.api.v1.auth_controller import AuthController
 from geometrikks.api.v1.crowdsec_controller import CrowdSecController
 from geometrikks.api.v1.system_controller import SystemController
-from geometrikks.api.v1.live_controller import crowdsec_feed, live_feed
+from geometrikks.api.v1.live_controller import crowdsec_feed, live_feed, logs_feed
 from geometrikks.api.v1.settings import read_settings
 from geometrikks.api.v1.stats import stats
 from geometrikks.api.health import health, health_ready
@@ -60,6 +60,7 @@ def get_route_handlers(*, include_auth: bool = True) -> list[ControllerRouterHan
         SystemController,
         live_feed,
         crowdsec_feed,
+        logs_feed,
         read_settings,
         stats,
         health,

--- a/geometrikks/server/routes.py
+++ b/geometrikks/server/routes.py
@@ -14,6 +14,7 @@ from geometrikks.api.v1.access_log_debug_controller import AccessLogDebugControl
 from geometrikks.api.v1.analytics_controller import AnalyticsController
 from geometrikks.api.v1.auth_controller import AuthController
 from geometrikks.api.v1.crowdsec_controller import CrowdSecController
+from geometrikks.api.v1.logs_controller import LogsController
 from geometrikks.api.v1.system_controller import SystemController
 from geometrikks.api.v1.live_controller import crowdsec_feed, live_feed, logs_feed
 from geometrikks.api.v1.settings import read_settings
@@ -57,6 +58,7 @@ def get_route_handlers(*, include_auth: bool = True) -> list[ControllerRouterHan
         AccessLogDebugController,
         AnalyticsController,
         CrowdSecController,
+        LogsController,
         SystemController,
         live_feed,
         crowdsec_feed,

--- a/geometrikks/server/scheduler.py
+++ b/geometrikks/server/scheduler.py
@@ -11,13 +11,13 @@ CAGG Refresh Strategy:
 
 from __future__ import annotations
 
-import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Callable
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
+from geometrikks.server.logging import get_logger
 from geometrikks.server.plugins import get_sqlalchemy_config
 from geometrikks.server.timescale import ALL_CAGGS
 
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from geometrikks.config.settings import Settings
     from geometrikks.services.crowdsec.stream import CrowdSecStreamPoller
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 # =============================================================================

--- a/geometrikks/server/scheduler_tracking.py
+++ b/geometrikks/server/scheduler_tracking.py
@@ -18,9 +18,13 @@ from apscheduler.events import (
     EVENT_JOB_SUBMITTED,
 )
 
+from geometrikks.server.logging import get_logger
+
 if TYPE_CHECKING:
     from apscheduler.events import JobEvent, JobExecutionEvent, JobSubmissionEvent
     from apscheduler.schedulers.base import BaseScheduler
+
+logger = get_logger(__name__)
 
 JobStatus = Literal["success", "error", "missed"]
 
@@ -69,9 +73,21 @@ class JobRunTracker:
         if event.exception is not None:
             info.last_status = "error"
             info.last_error = repr(event.exception)
+            logger.error(
+                "scheduler_job_failed",
+                job_id=event.job_id,
+                error=info.last_error,
+                duration_seconds=info.last_duration_seconds,
+            )
         else:
             info.last_status = "success"
             info.last_error = None
+            logger.success(  # ty: ignore[unresolved-attribute]
+                "scheduler_job_completed",
+                job_id=event.job_id,
+                duration_seconds=info.last_duration_seconds,
+            )
 
     def _on_missed(self, event: "JobEvent") -> None:
         self._info(event.job_id).last_status = "missed"
+        logger.warning("scheduler_job_missed", job_id=event.job_id)

--- a/geometrikks/server/timescale.py
+++ b/geometrikks/server/timescale.py
@@ -16,18 +16,19 @@ CAGG Structure:
 from __future__ import annotations
 
 import asyncio
-import logging
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 from sqlalchemy import text
+
+from geometrikks.server.logging import get_logger
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
 
     from geometrikks.config.settings import AnalyticsSettings
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 # =============================================================================

--- a/geometrikks/services/aggregation/service.py
+++ b/geometrikks/services/aggregation/service.py
@@ -12,18 +12,18 @@ This service handles tasks that require application logic:
 
 from __future__ import annotations
 
-import logging
 from datetime import date
 from typing import TYPE_CHECKING, Any, cast
 
 from sqlalchemy import CursorResult, text
 
+from geometrikks.server.logging import get_logger
 from geometrikks.server.timescale import ALL_CAGGS
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class AggregationService:

--- a/geometrikks/services/crowdsec/service.py
+++ b/geometrikks/services/crowdsec/service.py
@@ -6,7 +6,6 @@ re-logging in once when it expires.
 """
 from __future__ import annotations
 
-import logging
 from datetime import datetime, timezone
 from typing import Any
 
@@ -14,6 +13,7 @@ import httpx
 import msgspec
 
 from geometrikks.config.settings import CrowdSecSettings
+from geometrikks.server.logging import get_logger
 from geometrikks.services.crowdsec.exceptions import (
     CrowdSecAuthError,
     CrowdSecError,
@@ -21,7 +21,7 @@ from geometrikks.services.crowdsec.exceptions import (
 )
 from geometrikks.services.crowdsec.schemas import Alert, Decision, DecisionStreamDelta
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class CrowdSecService:

--- a/geometrikks/services/crowdsec/service.py
+++ b/geometrikks/services/crowdsec/service.py
@@ -50,9 +50,15 @@ class CrowdSecService:
             transport=transport,
         )
         self._machine_token: str | None = None
+        logger.info(
+            "crowdsec_client_configured",
+            url=settings.lapi_url,
+            write_enabled=settings.write_enabled,
+        )
 
     async def aclose(self) -> None:
         await self._client.aclose()
+        logger.info("crowdsec_client_closed")
 
     async def get_decisions(
         self,

--- a/geometrikks/services/crowdsec/stream.py
+++ b/geometrikks/services/crowdsec/stream.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from geometrikks.services.crowdsec.schemas import DecisionStreamDelta
 
 import asyncio
-import logging
 from typing import Any
 
+from geometrikks.server.logging import get_logger
 from geometrikks.services.crowdsec.exceptions import CrowdSecError
 from geometrikks.services.crowdsec.service import CrowdSecService
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 DecisionFrame = dict[str, Any]
 

--- a/geometrikks/services/crowdsec/stream.py
+++ b/geometrikks/services/crowdsec/stream.py
@@ -26,6 +26,7 @@ class CrowdSecStreamPoller:
     def __init__(self, service: CrowdSecService) -> None:
         self._service = service
         self._started = False
+        self._had_failure = False
         self._subscribers: set[asyncio.Queue[DecisionFrame]] = set()
 
     def subscribe(self, maxsize: int = 100) -> asyncio.Queue[DecisionFrame]:
@@ -46,7 +47,11 @@ class CrowdSecStreamPoller:
             delta: DecisionStreamDelta = await self._service.get_decisions_stream(startup=not self._started)
         except CrowdSecError as exc:
             logger.warning("CrowdSec stream poll failed: %s", exc)
+            self._had_failure = True
             return
+        if self._had_failure:
+            logger.success("crowdsec_stream_connected")  # ty: ignore[unresolved-attribute]
+            self._had_failure = False
         first_poll = not self._started
         self._started = True
         if first_poll:

--- a/geometrikks/services/geoip/downloader.py
+++ b/geometrikks/services/geoip/downloader.py
@@ -7,7 +7,6 @@ The license key is used for HTTP Basic auth and never logged.
 
 from __future__ import annotations
 
-import logging
 import tarfile
 import tempfile
 import time
@@ -18,11 +17,12 @@ from typing import TYPE_CHECKING
 import httpx
 
 from geometrikks.lib.utils import GeoIPInfoView, geoip_info
+from geometrikks.server.logging import get_logger
 
 if TYPE_CHECKING:
     from geometrikks.config.settings import GeoIPSettings
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 DOWNLOAD_URL = "https://download.maxmind.com/geoip/databases/GeoLite2-City/download"
 

--- a/geometrikks/services/geoip/downloader.py
+++ b/geometrikks/services/geoip/downloader.py
@@ -112,7 +112,9 @@ async def download_database(settings: "GeoIPSettings") -> Path:
     logger.info("Downloading GeoLite2-City from MaxMind...")
     tarball = await _fetch_tarball(settings)
     _extract_mmdb(tarball, settings.db_path)
-    logger.info("GeoLite2-City updated: %s", settings.db_path)
+    logger.success(  # ty: ignore[unresolved-attribute]
+        "geoip_database_refreshed", path=str(settings.db_path)
+    )
     return settings.db_path
 
 

--- a/geometrikks/services/geoip/home.py
+++ b/geometrikks/services/geoip/home.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import ipaddress
-import logging
 from dataclasses import dataclass
 from typing import Literal
 
@@ -12,8 +11,9 @@ from geoip2.database import Reader
 from geoip2.errors import GeoIP2Error
 
 from geometrikks.config.settings import GeoIPSettings, MapSettings
+from geometrikks.server.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 HomeLocationSource = Literal["configured", "external_ip"]
 

--- a/geometrikks/services/geoip/home.py
+++ b/geometrikks/services/geoip/home.py
@@ -52,6 +52,7 @@ async def resolve_home_location(
     failures leave the animation without a destination instead of failing startup.
     """
     if map_settings.home_latitude is not None and map_settings.home_longitude is not None:
+        logger.info("home_location_resolved", source="configured")
         return HomeLocation(
             latitude=map_settings.home_latitude,
             longitude=map_settings.home_longitude,
@@ -74,6 +75,7 @@ async def resolve_home_location(
         longitude = city.location.longitude
         if latitude is None or longitude is None:
             raise ValueError("GeoIP lookup returned no coordinates")
+        logger.info("home_location_resolved", source="external_ip")
         return HomeLocation(latitude=latitude, longitude=longitude, source="external_ip")
     except (GeoIP2Error, httpx.HTTPError, OSError, ValueError) as exc:
         logger.warning(

--- a/geometrikks/services/importer.py
+++ b/geometrikks/services/importer.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import gzip
 import hashlib
-import logging
 import time
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
@@ -28,6 +27,7 @@ from typing import TYPE_CHECKING
 
 from geometrikks.domain.imports.models import ImportJob
 from geometrikks.domain.imports.repositories import ImportJobRepository
+from geometrikks.server.logging import get_logger
 from geometrikks.services.logparser.logparser import make_cached_city_lookup
 from geometrikks.services.logparser.schemas import ParsedLogRecord
 
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from geometrikks.services.ingestion.service import LogIngestionService
     from geometrikks.services.logparser.logparser import LogParser
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 PROGRESS_EVERY_LINES = 10_000
 FORMAT_CHECK_LINES = 1_000

--- a/geometrikks/services/importer.py
+++ b/geometrikks/services/importer.py
@@ -191,6 +191,12 @@ async def import_file(
                 auto_commit=True,
             )
 
+    logger.success(  # ty: ignore[unresolved-attribute]
+        "import_completed",
+        file=str(path),
+        lines=lines_total,
+        records=records_written,
+    )
     return ImportResult(
         file_path=path, skipped=False, lines_total=lines_total,
         lines_skipped=lines_skipped, records_written=records_written,

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -11,7 +11,6 @@ Analytics aggregation is handled automatically by TimescaleDB continuous aggrega
 
 """
 from __future__ import annotations
-import logging
 import asyncio
 import time
 from collections.abc import Callable
@@ -30,9 +29,10 @@ from geometrikks.services.logparser.schemas import ParsedLogRecord, ParsedGeoDat
 from geometrikks.services.logparser.constants import ALLOWED_GEOIP_LOCALES, GEOIP_LOCALES_DEFAULT
 from geometrikks.services.logparser.logparser import LogParser
 from geometrikks.lib.utils import wait_for_path
+from geometrikks.server.logging import get_logger
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @dataclass

--- a/geometrikks/services/logfiles.py
+++ b/geometrikks/services/logfiles.py
@@ -1,0 +1,111 @@
+"""Enumerate, resolve and tail application/nginx log files.
+
+resolve() is the download allowlist: a (kind, name) pair is only served if
+list_files() enumerates it, so no client-supplied path ever hits the
+filesystem directly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+from geometrikks.server.logging import LOGIN_LOG_NAME, MAIN_LOG_NAME
+
+LogFileKind = Literal["app", "login", "nginx"]
+
+
+@dataclass
+class LogFileEntry:
+    name: str
+    kind: LogFileKind
+    size_bytes: int
+    modified_at: datetime | None
+    available: bool
+
+
+def _entry(path: Path, kind: LogFileKind, name: str | None = None) -> LogFileEntry:
+    try:
+        stat = path.stat()
+        readable = os.access(path, os.R_OK)
+        return LogFileEntry(
+            name=name or path.name,
+            kind=kind,
+            size_bytes=stat.st_size,
+            modified_at=datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc),
+            available=readable,
+        )
+    except OSError:
+        return LogFileEntry(
+            name=name or path.name, kind=kind, size_bytes=0, modified_at=None, available=False
+        )
+
+
+class LogFilesService:
+    def __init__(self, log_dir: Path, nginx_paths: list[Path]) -> None:
+        self._log_dir = log_dir
+        self._nginx_paths = nginx_paths
+
+    def _candidates(self) -> list[tuple[LogFileEntry, Path]]:
+        pairs: list[tuple[LogFileEntry, Path]] = []
+        for stem, kind in ((MAIN_LOG_NAME, "app"), (LOGIN_LOG_NAME, "login")):
+            active = self._log_dir / stem
+            if active.exists():
+                pairs.append((_entry(active, kind), active))
+            for archive in sorted(self._log_dir.glob(f"{stem}.*.gz")):
+                pairs.append((_entry(archive, kind), archive))
+        seen: dict[str, int] = {}
+        for path in self._nginx_paths:
+            name = path.name
+            if name in seen:  # two configured paths with the same basename
+                seen[name] += 1
+                name = f"{path.name}.{seen[path.name]}"
+            else:
+                seen[name] = 1
+            entry = _entry(path, "nginx", name=name)
+            if not path.is_file():
+                entry.available = False
+            pairs.append((entry, path))
+        return pairs
+
+    def list_files(self) -> list[LogFileEntry]:
+        return [entry for entry, _ in self._candidates()]
+
+    def resolve(self, kind: str, name: str) -> Path | None:
+        """Allowlisted download resolution; None for anything not listed."""
+        for entry, path in self._candidates():
+            if entry.kind == kind and entry.name == name and entry.available:
+                return path
+        return None
+
+    def tail_main(self, lines: int) -> list[dict[str, Any]]:
+        """Last N parsed JSONL records of the main log; malformed lines skipped."""
+        main = self._log_dir / MAIN_LOG_NAME
+        if not main.is_file():
+            return []
+        with main.open("r", encoding="utf-8", errors="replace") as fh:
+            raw = deque(fh, maxlen=lines)
+        records: list[dict[str, Any]] = []
+        for line in raw:
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                records.append(parsed)
+        return records
+
+
+def create_log_files_service() -> LogFilesService:
+    from geometrikks.config.settings import get_settings
+
+    settings = get_settings()
+    return LogFilesService(
+        log_dir=settings.log.dir,
+        nginx_paths=list(settings.logparser.log_paths),
+    )

--- a/geometrikks/services/logfiles.py
+++ b/geometrikks/services/logfiles.py
@@ -9,13 +9,18 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
 
-from geometrikks.server.logging import LOGIN_LOG_NAME, MAIN_LOG_NAME
+from geometrikks.server.logging import LOGIN_LOG_NAME, LOGIN_LOGGER_NAME, MAIN_LOG_NAME
+
+_LOGIN_LINE_RE = re.compile(
+    r'^(?P<timestamp>\S+) (?P<event>[A-Za-z0-9_]+) user="(?P<user>[^"]*)" ip=(?P<ip>\S+)$'
+)
 
 LogFileKind = Literal["app", "login", "nginx"]
 
@@ -98,6 +103,32 @@ class LogFilesService:
                 continue
             if isinstance(parsed, dict):
                 records.append(parsed)
+        return records
+
+    def tail_login(self, lines: int) -> list[dict[str, Any]]:
+        """Last N parsed records of the plain-text login log; malformed lines skipped."""
+        login = self._log_dir / LOGIN_LOG_NAME
+        if not login.is_file():
+            return []
+        with login.open("r", encoding="utf-8", errors="replace") as fh:
+            raw = deque(fh, maxlen=lines)
+        records: list[dict[str, Any]] = []
+        for line in raw:
+            match = _LOGIN_LINE_RE.match(line.rstrip("\r\n"))
+            if match is None:
+                continue
+            event = match.group("event")
+            ip = match.group("ip")
+            record: dict[str, Any] = {
+                "timestamp": match.group("timestamp"),
+                "level": "warning" if event == "login_failed" else "info",
+                "event": event,
+                "logger": LOGIN_LOGGER_NAME,
+                "user": match.group("user"),
+            }
+            if ip != "-":
+                record["ip"] = ip
+            records.append(record)
         return records
 
 

--- a/geometrikks/services/logparser/logparser.py
+++ b/geometrikks/services/logparser/logparser.py
@@ -1,7 +1,6 @@
 from collections.abc import AsyncGenerator, Callable
 import re
 import os
-import logging
 import asyncio
 from functools import lru_cache
 from datetime import datetime, timezone
@@ -24,9 +23,10 @@ from .constants import (
 )
 from .schemas import ParsedLogRecord, ParsedGeoData, ParsedAccessLog
 from geometrikks.lib.utils import wait
+from geometrikks.server.logging import get_logger
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def get_ip_type(ip: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Geo metrics ingress service built with Litestar."
 readme = "README.md"
 requires-python = ">=3.13,<3.14"
 dependencies = [
-    "litestar[standard,brotli,jwt,picologging,pydantic]>=2.24.0",
+    "litestar[standard,brotli,jwt,structlog,pydantic]>=2.24.0",
     "geoip2>=5.2.0",
     "geohash2>=1.1",
     "ipy>=1.1",

--- a/resources/components/settings/logs-overview.tsx
+++ b/resources/components/settings/logs-overview.tsx
@@ -133,7 +133,8 @@ export function LogsOverview() {
       seededRef.current = true
       setEntries(toEntries([...(tailRecords as LogRecord[])].reverse()))
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Intentionally seed once: `tailRecords` is a stable staleTime:Infinity
+    // query result and toEntries is a plain closure, not a dependency.
   }, [tailRecords])
 
   useEffect(() => {
@@ -166,7 +167,8 @@ export function LogsOverview() {
       unsubscribeStatus()
       if (flowTimerRef.current) clearTimeout(flowTimerRef.current)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Intentionally mount-once: pausedRef mirrors `paused` so this
+    // subscription does not need to be recreated when it changes.
   }, [])
 
   function togglePause() {

--- a/resources/components/settings/logs-overview.tsx
+++ b/resources/components/settings/logs-overview.tsx
@@ -6,6 +6,7 @@
  */
 import { useEffect, useMemo, useRef, useState } from "react"
 import {
+  ChevronsUpDown,
   Download,
   FolderDown,
   Layers,
@@ -32,14 +33,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { Input } from "@/components/ui/input"
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Input } from "@/components/ui/input"
 import {
   Table,
   TableBody,
@@ -83,6 +83,35 @@ const FILE_KIND_ORDER: LogFileView["kind"][] = ["app", "login", "nginx"]
 /** geometrikks.services.ingestion -> services; falls back to the raw logger name. */
 const component = (r: LogRecord): string => r.logger?.split(".")[1] ?? r.logger ?? "app"
 
+const STANDARD_RECORD_KEYS = new Set(["timestamp", "level", "logger", "event", "exception"])
+
+/**
+ * Every scalar field of a record besides the standard ones, rendered
+ * `key=value` and space-joined, so a row reads e.g. `method=GET path=/api`
+ * without opening the detail dialog. Objects/arrays stay dialog-only.
+ */
+function formatContext(r: LogRecord): string {
+  return Object.entries(r)
+    .filter(
+      ([key, value]) =>
+        !STANDARD_RECORD_KEYS.has(key) &&
+        (typeof value === "string" || typeof value === "number" || typeof value === "boolean"),
+    )
+    .map(([key, value]) => `${key}=${value}`)
+    .join(" ")
+}
+
+function toggleValue(values: string[], value: string): string[] {
+  return values.includes(value) ? values.filter((v) => v !== value) : [...values, value]
+}
+
+/** "All levels" when empty, the value itself for one, "value +N" for more. */
+function multiSelectLabel(selected: string[], allLabel: string): string {
+  if (selected.length === 0) return allLabel
+  if (selected.length === 1) return selected[0]
+  return `${selected[0]} +${selected.length - 1}`
+}
+
 function formatSize(bytes: number): string {
   if (bytes >= 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`
   if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`
@@ -112,8 +141,8 @@ export function LogsOverview() {
   const [pendingCount, setPendingCount] = useState(0)
   const [totalDropped, setTotalDropped] = useState(0)
 
-  const [levelFilter, setLevelFilter] = useState("all")
-  const [componentFilter, setComponentFilter] = useState("all")
+  const [levelFilters, setLevelFilters] = useState<string[]>([])
+  const [componentFilters, setComponentFilters] = useState<string[]>([])
   const [searchInput, setSearchInput] = useState("")
   const search = useDebouncedValue(searchInput, 200)
 
@@ -201,15 +230,15 @@ export function LogsOverview() {
     const needle = search.trim().toLowerCase()
     return entries.filter((e) => {
       const r = e.record
-      if (levelFilter !== "all" && (r.level ?? "") !== levelFilter) return false
-      if (componentFilter !== "all" && component(r) !== componentFilter) return false
+      if (levelFilters.length > 0 && !levelFilters.includes(r.level ?? "")) return false
+      if (componentFilters.length > 0 && !componentFilters.includes(component(r))) return false
       if (needle) {
         const eventMatch = r.event?.toLowerCase().includes(needle) ?? false
         if (!eventMatch && !JSON.stringify(r).toLowerCase().includes(needle)) return false
       }
       return true
     })
-  }, [entries, levelFilter, componentFilter, search])
+  }, [entries, levelFilters, componentFilters, search])
 
   const groupedFiles = useMemo(() => {
     const groups = new Map<LogFileView["kind"], LogFileView[]>()
@@ -272,33 +301,61 @@ export function LogsOverview() {
               )}
             </Button>
 
-            <Select value={levelFilter} onValueChange={setLevelFilter}>
-              <SelectTrigger size="sm" className="h-8 w-36 text-xs pointer-coarse:h-10">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All levels</SelectItem>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 w-36 justify-between text-xs pointer-coarse:h-10"
+                >
+                  <span className="truncate">{multiSelectLabel(levelFilters, "All levels")}</span>
+                  <ChevronsUpDown className="ml-1 h-3.5 w-3.5 shrink-0 opacity-50" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-36">
                 {LEVELS.map((level) => (
-                  <SelectItem key={level} value={level}>
+                  <DropdownMenuCheckboxItem
+                    key={level}
+                    checked={levelFilters.includes(level)}
+                    onCheckedChange={() => setLevelFilters((prev) => toggleValue(prev, level))}
+                    onSelect={(e) => e.preventDefault()}
+                  >
                     {level}
-                  </SelectItem>
+                  </DropdownMenuCheckboxItem>
                 ))}
-              </SelectContent>
-            </Select>
+              </DropdownMenuContent>
+            </DropdownMenu>
 
-            <Select value={componentFilter} onValueChange={setComponentFilter}>
-              <SelectTrigger size="sm" className="h-8 w-40 text-xs pointer-coarse:h-10">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All components</SelectItem>
-                {components.map((c) => (
-                  <SelectItem key={c} value={c}>
-                    {c}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 w-40 justify-between text-xs pointer-coarse:h-10"
+                >
+                  <span className="truncate">
+                    {multiSelectLabel(componentFilters, "All components")}
+                  </span>
+                  <ChevronsUpDown className="ml-1 h-3.5 w-3.5 shrink-0 opacity-50" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="max-h-80 w-40 overflow-y-auto">
+                {components.length === 0 ? (
+                  <div className="px-2 py-1.5 text-sm text-muted-foreground">No components</div>
+                ) : (
+                  components.map((c) => (
+                    <DropdownMenuCheckboxItem
+                      key={c}
+                      checked={componentFilters.includes(c)}
+                      onCheckedChange={() => setComponentFilters((prev) => toggleValue(prev, c))}
+                      onSelect={(e) => e.preventDefault()}
+                    >
+                      {c}
+                    </DropdownMenuCheckboxItem>
+                  ))
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
 
             <div className="relative min-w-48 flex-1">
               <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
@@ -311,91 +368,106 @@ export function LogsOverview() {
             </div>
           </div>
 
-          <Table className="text-sm">
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-24">Time</TableHead>
-                <TableHead className="w-24">Level</TableHead>
-                <TableHead className="w-28">Component</TableHead>
-                <TableHead>Message</TableHead>
-                <TableHead className="w-10" />
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {filtered.map((entry) => {
-                const r = entry.record
-                const hasTraceback = typeof r.exception === "string" && r.exception.length > 0
-                return (
-                  <TableRow
-                    key={entry.id}
-                    tabIndex={0}
-                    role="button"
-                    className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
-                    onClick={() => setSelected(r)}
-                    onKeyDown={(e) => {
-                      // Only react when the row itself is the event target: a
-                      // native keydown on a nested control (the traceback
-                      // button) still bubbles up here even though its click
-                      // handler calls stopPropagation, since that only stops
-                      // the click event, not this separate keydown binding.
-                      if (e.target !== e.currentTarget) return
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault()
-                        setSelected(r)
-                      }
-                    }}
-                  >
-                    <TableCell className="w-24 py-1.5 text-xs tabular-nums text-muted-foreground">
-                      <span title={r.timestamp ? new Date(r.timestamp).toLocaleString() : undefined}>
-                        {r.timestamp ? new Date(r.timestamp).toLocaleTimeString() : "-"}
-                      </span>
-                    </TableCell>
-                    <TableCell className="w-24 py-1.5">
-                      <Badge
-                        variant="outline"
-                        className={cn("gap-1", levelBadgeClasses[r.level ?? ""] ?? levelBadgeClasses.info)}
-                      >
-                        {r.level ?? "info"}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="w-28 py-1.5">
-                      <MonoChip>{component(r)}</MonoChip>
-                    </TableCell>
-                    <TableCell className="w-full max-w-0 py-1.5">
-                      <span className="block truncate font-mono text-xs" title={r.event}>
-                        {r.event ?? "(no message)"}
-                      </span>
-                    </TableCell>
-                    <TableCell className="w-10 py-1.5">
-                      {hasTraceback ? (
-                        <Button
-                          variant="ghost"
-                          size="icon-sm"
-                          className="pointer-coarse:h-10"
-                          aria-label="View traceback"
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            setTracebackRecord(r)
-                          }}
+          <div className="max-h-[65vh] overflow-y-auto rounded-md border">
+            <Table className="text-sm">
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="sticky top-0 z-10 w-24 bg-card">Time</TableHead>
+                  <TableHead className="sticky top-0 z-10 w-24 bg-card">Level</TableHead>
+                  <TableHead className="sticky top-0 z-10 w-28 bg-card">Component</TableHead>
+                  <TableHead className="sticky top-0 z-10 bg-card">Message</TableHead>
+                  <TableHead className="sticky top-0 z-10 w-10 bg-card" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filtered.map((entry) => {
+                  const r = entry.record
+                  const hasTraceback = typeof r.exception === "string" && r.exception.length > 0
+                  return (
+                    <TableRow
+                      key={entry.id}
+                      tabIndex={0}
+                      role="button"
+                      className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                      onClick={() => setSelected(r)}
+                      onKeyDown={(e) => {
+                        // Only react when the row itself is the event target: a
+                        // native keydown on a nested control (the traceback
+                        // button) still bubbles up here even though its click
+                        // handler calls stopPropagation, since that only stops
+                        // the click event, not this separate keydown binding.
+                        if (e.target !== e.currentTarget) return
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault()
+                          setSelected(r)
+                        }
+                      }}
+                    >
+                      <TableCell className="w-24 py-1.5 text-xs tabular-nums text-muted-foreground">
+                        <span title={r.timestamp ? new Date(r.timestamp).toLocaleString() : undefined}>
+                          {r.timestamp ? new Date(r.timestamp).toLocaleTimeString() : "-"}
+                        </span>
+                      </TableCell>
+                      <TableCell className="w-24 py-1.5">
+                        <Badge
+                          variant="outline"
+                          className={cn(
+                            "gap-1 uppercase",
+                            levelBadgeClasses[r.level ?? ""] ?? levelBadgeClasses.info,
+                          )}
                         >
-                          <Layers className="h-3.5 w-3.5" />
-                        </Button>
-                      ) : null}
+                          {r.level ?? "info"}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="w-28 py-1.5">
+                        <MonoChip>{component(r)}</MonoChip>
+                      </TableCell>
+                      <TableCell className="w-full max-w-0 py-1.5">
+                        {(() => {
+                          const context = formatContext(r)
+                          const eventText = r.event ?? "(no message)"
+                          return (
+                            <span
+                              className="block truncate font-mono text-xs"
+                              title={context ? `${eventText} ${context}` : eventText}
+                            >
+                              {eventText}
+                              {context ? <span className="text-muted-foreground"> {context}</span> : null}
+                            </span>
+                          )
+                        })()}
+                      </TableCell>
+                      <TableCell className="w-10 py-1.5">
+                        {hasTraceback ? (
+                          <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            className="pointer-coarse:h-10"
+                            aria-label="View traceback"
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              setTracebackRecord(r)
+                            }}
+                          >
+                            <Layers className="h-3.5 w-3.5" />
+                          </Button>
+                        ) : null}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+                {filtered.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={5} className="h-24 text-center text-sm text-muted-foreground">
+                      {entries.length === 0
+                        ? "Waiting for log lines..."
+                        : "No log lines match the current filters."}
                     </TableCell>
                   </TableRow>
-                )
-              })}
-              {filtered.length === 0 && (
-                <TableRow>
-                  <TableCell colSpan={5} className="h-24 text-center text-sm text-muted-foreground">
-                    {entries.length === 0
-                      ? "Waiting for log lines..."
-                      : "No log lines match the current filters."}
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
+                )}
+              </TableBody>
+            </Table>
+          </div>
         </CardContent>
       </Card>
 
@@ -473,7 +545,10 @@ export function LogsOverview() {
                 <DialogTitle className="flex items-center gap-2">
                   <Badge
                     variant="outline"
-                    className={cn("gap-1", levelBadgeClasses[selected.level ?? ""] ?? levelBadgeClasses.info)}
+                    className={cn(
+                      "gap-1 uppercase",
+                      levelBadgeClasses[selected.level ?? ""] ?? levelBadgeClasses.info,
+                    )}
                   >
                     {selected.level ?? "info"}
                   </Badge>

--- a/resources/components/settings/logs-overview.tsx
+++ b/resources/components/settings/logs-overview.tsx
@@ -2,7 +2,7 @@
  * Live log tail for Settings -> Logs: seeded from the tail endpoint, then
  * appended from the /ws/logs stream. Level/component/search filters, a
  * traceback dialog for exceptions, a full-record detail dialog, and a
- * downloads card for the raw files behind the stream.
+ * downloads tab for the raw files behind the stream.
  */
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
@@ -143,7 +143,7 @@ export function LogsOverview() {
     onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.logs.files }),
   })
 
-  const [activeLog, setActiveLog] = useState<"app" | "login">("app")
+  const [activeTab, setActiveTab] = useState<"app" | "login" | "downloads">("app")
 
   const [entries, setEntries] = useState<Entry[]>([])
   const seededRef = useRef(false)
@@ -257,7 +257,7 @@ export function LogsOverview() {
     }
   }
 
-  const activeEntries = activeLog === "login" ? loginEntries : entries
+  const activeEntries = activeTab === "login" ? loginEntries : entries
 
   const components = useMemo(() => {
     const set = new Set<string>()
@@ -298,34 +298,124 @@ export function LogsOverview() {
     <div className="space-y-4">
       <Card>
         <CardHeader>
-          <Tabs value={activeLog} onValueChange={(v) => setActiveLog(v as "app" | "login")}>
+          <Tabs
+            value={activeTab}
+            onValueChange={(v) => setActiveTab(v as "app" | "login" | "downloads")}
+          >
             <TabsList className="pointer-coarse:h-10">
               <TabsTrigger value="app">System log</TabsTrigger>
               <TabsTrigger value="login">Login log</TabsTrigger>
+              <TabsTrigger value="downloads">Downloads</TabsTrigger>
             </TabsList>
           </Tabs>
-          <div className="flex items-center gap-3">
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-geo-cyan/10">
-              <ScrollText className="h-4 w-4 text-geo-cyan" />
+          {activeTab === "downloads" ? (
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-geo-cyan/10">
+                  <FolderDown className="h-4 w-4 text-geo-cyan" />
+                </div>
+                <div>
+                  <CardTitle className="text-base">Log downloads</CardTitle>
+                  <CardDescription>
+                    Raw files behind the live stream: the application log, login log, and ingested
+                    nginx access logs.
+                  </CardDescription>
+                </div>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                className="pointer-coarse:h-10"
+                disabled={rotateLogs.isPending}
+                onClick={() => rotateLogs.mutate()}
+              >
+                <Archive className="mr-1.5 h-3.5 w-3.5" />
+                {rotateLogs.isPending ? "Rotating..." : "Rotate logs"}
+              </Button>
             </div>
-            <div>
-              <CardTitle className="text-base">
-                <span className="inline-flex items-center gap-2">
-                  <StatusLed tone={ledTone} pulse={ledPulse} />
-                  Live log stream
-                </span>
-              </CardTitle>
-              <CardDescription>
-                Streaming from the {activeLog === "login" ? "login" : "application"} log. Newest
-                first; buffer keeps the last 2,000 lines.{" "}
-                <span className="tabular-nums">{activeEntries.length.toLocaleString()} buffered</span>
-                {totalDropped > 0 ? (
-                  <span className="tabular-nums">, {totalDropped.toLocaleString()} dropped</span>
-                ) : null}
-              </CardDescription>
+          ) : (
+            <div className="flex items-center gap-3">
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-geo-cyan/10">
+                <ScrollText className="h-4 w-4 text-geo-cyan" />
+              </div>
+              <div>
+                <CardTitle className="text-base">
+                  <span className="inline-flex items-center gap-2">
+                    <StatusLed tone={ledTone} pulse={ledPulse} />
+                    Live log stream
+                  </span>
+                </CardTitle>
+                <CardDescription>
+                  Streaming from the {activeTab === "login" ? "login" : "application"} log. Newest
+                  first; buffer keeps the last 2,000 lines.{" "}
+                  <span className="tabular-nums">{activeEntries.length.toLocaleString()} buffered</span>
+                  {totalDropped > 0 ? (
+                    <span className="tabular-nums">, {totalDropped.toLocaleString()} dropped</span>
+                  ) : null}
+                </CardDescription>
+              </div>
             </div>
-          </div>
+          )}
         </CardHeader>
+        {activeTab === "downloads" ? (
+          <CardContent className="space-y-4">
+            {groupedFiles.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                {files ? "No log files found." : "Loading downloads..."}
+              </p>
+            ) : (
+              groupedFiles.map((group) => (
+                <div key={group.kind} className="space-y-1">
+                  <h4 className="text-sm font-medium">{fileKindLabels[group.kind]}</h4>
+                  <div className="divide-y rounded-md border">
+                    {group.files.map((f) => (
+                      <div
+                        key={f.name}
+                        className="flex flex-wrap items-center justify-between gap-2 p-2"
+                      >
+                        <div className="min-w-0">
+                          <div className="truncate font-mono text-xs">{f.name}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {formatSize(f.size_bytes)}
+                            {" · "}
+                            {f.modified_at ? new Date(f.modified_at).toLocaleString() : "unknown"}
+                            {!f.available ? " · not readable" : ""}
+                          </div>
+                        </div>
+                        {f.available ? (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="pointer-coarse:h-10"
+                            asChild
+                          >
+                            <a
+                              href={`/api/v1/logs/files/${f.kind}/${encodeURIComponent(f.name)}`}
+                              download
+                            >
+                              <Download className="mr-1.5 h-3.5 w-3.5" />
+                              Download
+                            </a>
+                          </Button>
+                        ) : (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="pointer-coarse:h-10"
+                            disabled
+                          >
+                            <Download className="mr-1.5 h-3.5 w-3.5" />
+                            Download
+                          </Button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))
+            )}
+          </CardContent>
+        ) : (
         <CardContent className="space-y-3">
           <div className="flex flex-wrap items-center gap-2">
             <Button
@@ -516,84 +606,7 @@ export function LogsOverview() {
             </TableBody>
           </Table>
         </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between gap-3">
-            <div className="flex items-center gap-3">
-              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-geo-cyan/10">
-                <FolderDown className="h-4 w-4 text-geo-cyan" />
-              </div>
-              <div>
-                <CardTitle className="text-base">Log downloads</CardTitle>
-                <CardDescription>
-                  Raw files behind the stream above: the application log, login log, and ingested
-                  nginx access logs.
-                </CardDescription>
-              </div>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              className="pointer-coarse:h-10"
-              disabled={rotateLogs.isPending}
-              onClick={() => rotateLogs.mutate()}
-            >
-              <Archive className="mr-1.5 h-3.5 w-3.5" />
-              {rotateLogs.isPending ? "Rotating..." : "Rotate logs"}
-            </Button>
-          </div>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {groupedFiles.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              {files ? "No log files found." : "Loading downloads..."}
-            </p>
-          ) : (
-            groupedFiles.map((group) => (
-              <div key={group.kind} className="space-y-1">
-                <h4 className="text-sm font-medium">{fileKindLabels[group.kind]}</h4>
-                <div className="divide-y rounded-md border">
-                  {group.files.map((f) => (
-                    <div
-                      key={f.name}
-                      className="flex flex-wrap items-center justify-between gap-2 p-2"
-                    >
-                      <div className="min-w-0">
-                        <div className="truncate font-mono text-xs">{f.name}</div>
-                        <div className="text-xs text-muted-foreground">
-                          {formatSize(f.size_bytes)}
-                          {" · "}
-                          {f.modified_at ? new Date(f.modified_at).toLocaleString() : "unknown"}
-                          {!f.available ? " · not readable" : ""}
-                        </div>
-                      </div>
-                      {f.available ? (
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="pointer-coarse:h-10"
-                          asChild
-                        >
-                          <a href={`/api/v1/logs/files/${f.kind}/${encodeURIComponent(f.name)}`} download>
-                            <Download className="mr-1.5 h-3.5 w-3.5" />
-                            Download
-                          </a>
-                        </Button>
-                      ) : (
-                        <Button variant="outline" size="sm" className="pointer-coarse:h-10" disabled>
-                          <Download className="mr-1.5 h-3.5 w-3.5" />
-                          Download
-                        </Button>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))
-          )}
-        </CardContent>
+        )}
       </Card>
 
       <Dialog open={selected !== null} onOpenChange={(open) => !open && setSelected(null)}>

--- a/resources/components/settings/logs-overview.tsx
+++ b/resources/components/settings/logs-overview.tsx
@@ -1,0 +1,504 @@
+/**
+ * Live log tail for Settings -> Logs: seeded from the tail endpoint, then
+ * appended from the /ws/logs stream. Level/component/search filters, a
+ * traceback dialog for exceptions, a full-record detail dialog, and a
+ * downloads card for the raw files behind the stream.
+ */
+import { useEffect, useMemo, useRef, useState } from "react"
+import {
+  Download,
+  FolderDown,
+  Layers,
+  Pause,
+  Play,
+  ScrollText,
+  Search,
+} from "lucide-react"
+import { cn } from "@/lib/utils"
+import { useDebouncedValue } from "@/hooks/use-debounced-value"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { MonoChip, StatusLed, type LedTone } from "@/components/settings/status-led"
+import { useLogFiles, useLogTail } from "@/lib/queries"
+import { logStream, type LogRecord, type LogStreamStatus } from "@/lib/logstream"
+import type { LogFileView } from "@/generated/api/types.gen"
+
+const MAX_RECORDS = 2000
+const FLOW_IDLE_MS = 2000
+
+const LEVELS = ["debug", "info", "success", "warning", "error", "critical"] as const
+
+const levelBadgeClasses: Record<string, string> = {
+  success: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+  error: "border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400",
+  critical: "border-red-500/50 bg-red-500/20 text-red-700 dark:text-red-300",
+  warning: "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+  info: "border-sky-500/30 bg-sky-500/10 text-sky-600 dark:text-sky-400",
+  debug: "border-border bg-muted text-muted-foreground",
+}
+
+const ledToneByStatus: Record<LogStreamStatus, LedTone> = {
+  connected: "emerald",
+  connecting: "amber",
+  disconnected: "red",
+}
+
+const fileKindLabels: Record<LogFileView["kind"], string> = {
+  app: "Application log",
+  login: "Login log",
+  nginx: "Nginx access logs",
+}
+const FILE_KIND_ORDER: LogFileView["kind"][] = ["app", "login", "nginx"]
+
+/** geometrikks.services.ingestion -> services; falls back to the raw logger name. */
+const component = (r: LogRecord): string => r.logger?.split(".")[1] ?? r.logger ?? "app"
+
+function formatSize(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${bytes} B`
+}
+
+interface Entry {
+  id: number
+  record: LogRecord
+}
+
+export function LogsOverview() {
+  const { data: tailRecords } = useLogTail(500)
+  const { data: files } = useLogFiles()
+
+  const [entries, setEntries] = useState<Entry[]>([])
+  const seededRef = useRef(false)
+  const nextIdRef = useRef(0)
+
+  const [status, setStatus] = useState<LogStreamStatus>("connecting")
+  const [flowing, setFlowing] = useState(false)
+  const flowTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const [paused, setPaused] = useState(false)
+  const pausedRef = useRef(false)
+  const pausedBufferRef = useRef<LogRecord[]>([])
+  const [pendingCount, setPendingCount] = useState(0)
+  const [totalDropped, setTotalDropped] = useState(0)
+
+  const [levelFilter, setLevelFilter] = useState("all")
+  const [componentFilter, setComponentFilter] = useState("all")
+  const [searchInput, setSearchInput] = useState("")
+  const search = useDebouncedValue(searchInput, 200)
+
+  const [selected, setSelected] = useState<LogRecord | null>(null)
+  const [tracebackRecord, setTracebackRecord] = useState<LogRecord | null>(null)
+
+  function toEntries(records: LogRecord[]): Entry[] {
+    return records.map((record) => {
+      nextIdRef.current += 1
+      return { id: nextIdRef.current, record }
+    })
+  }
+
+  // Seed once from the tail backfill; the stream takes over after that.
+  useEffect(() => {
+    if (tailRecords && !seededRef.current) {
+      seededRef.current = true
+      setEntries(toEntries([...(tailRecords as LogRecord[])].reverse()))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tailRecords])
+
+  useEffect(() => {
+    pausedRef.current = paused
+  }, [paused])
+
+  useEffect(() => {
+    const unsubscribeRecords = logStream.onRecords((records, dropped) => {
+      if (dropped) setTotalDropped((d) => d + dropped)
+      if (records.length === 0) return
+
+      setFlowing(true)
+      if (flowTimerRef.current) clearTimeout(flowTimerRef.current)
+      flowTimerRef.current = setTimeout(() => setFlowing(false), FLOW_IDLE_MS)
+
+      if (pausedRef.current) {
+        pausedBufferRef.current = [...pausedBufferRef.current, ...records].slice(-MAX_RECORDS)
+        setPendingCount(pausedBufferRef.current.length)
+        return
+      }
+
+      setEntries((prev) => {
+        const merged = [...toEntries([...records].reverse()), ...prev]
+        return merged.length > MAX_RECORDS ? merged.slice(0, MAX_RECORDS) : merged
+      })
+    })
+    const unsubscribeStatus = logStream.onStatus(setStatus)
+    return () => {
+      unsubscribeRecords()
+      unsubscribeStatus()
+      if (flowTimerRef.current) clearTimeout(flowTimerRef.current)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  function togglePause() {
+    if (paused) {
+      const buffered = pausedBufferRef.current
+      pausedBufferRef.current = []
+      setPendingCount(0)
+      setPaused(false)
+      if (buffered.length > 0) {
+        setEntries((prev) => {
+          const merged = [...toEntries(buffered.slice().reverse()), ...prev]
+          return merged.length > MAX_RECORDS ? merged.slice(0, MAX_RECORDS) : merged
+        })
+      }
+    } else {
+      setPaused(true)
+    }
+  }
+
+  const components = useMemo(() => {
+    const set = new Set<string>()
+    for (const e of entries) set.add(component(e.record))
+    return Array.from(set).sort()
+  }, [entries])
+
+  const filtered = useMemo(() => {
+    const needle = search.trim().toLowerCase()
+    return entries.filter((e) => {
+      const r = e.record
+      if (levelFilter !== "all" && (r.level ?? "") !== levelFilter) return false
+      if (componentFilter !== "all" && component(r) !== componentFilter) return false
+      if (needle) {
+        const eventMatch = r.event?.toLowerCase().includes(needle) ?? false
+        if (!eventMatch && !JSON.stringify(r).toLowerCase().includes(needle)) return false
+      }
+      return true
+    })
+  }, [entries, levelFilter, componentFilter, search])
+
+  const groupedFiles = useMemo(() => {
+    const groups = new Map<LogFileView["kind"], LogFileView[]>()
+    for (const f of files ?? []) {
+      const list = groups.get(f.kind) ?? []
+      list.push(f)
+      groups.set(f.kind, list)
+    }
+    return FILE_KIND_ORDER.map((kind) => ({ kind, files: groups.get(kind) ?? [] })).filter(
+      (g) => g.files.length > 0,
+    )
+  }, [files])
+
+  const ledTone: LedTone = paused ? "amber" : ledToneByStatus[status]
+  const ledPulse = !paused && status === "connected" && flowing
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-geo-cyan/10">
+              <ScrollText className="h-4 w-4 text-geo-cyan" />
+            </div>
+            <div>
+              <CardTitle className="text-base">
+                <span className="inline-flex items-center gap-2">
+                  <StatusLed tone={ledTone} pulse={ledPulse} />
+                  Live log stream
+                </span>
+              </CardTitle>
+              <CardDescription>
+                Streaming from the application log. Newest first; buffer keeps the last 2,000
+                lines. <span className="tabular-nums">{entries.length.toLocaleString()} buffered</span>
+                {totalDropped > 0 ? (
+                  <span className="tabular-nums">, {totalDropped.toLocaleString()} dropped</span>
+                ) : null}
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="pointer-coarse:h-10"
+              onClick={togglePause}
+            >
+              {paused ? (
+                <>
+                  <Play className="mr-1.5 h-3.5 w-3.5" />
+                  {pendingCount > 0 ? `Resume (${pendingCount} new)` : "Resume"}
+                </>
+              ) : (
+                <>
+                  <Pause className="mr-1.5 h-3.5 w-3.5" />
+                  Pause
+                </>
+              )}
+            </Button>
+
+            <Select value={levelFilter} onValueChange={setLevelFilter}>
+              <SelectTrigger size="sm" className="h-8 w-36 text-xs pointer-coarse:h-10">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All levels</SelectItem>
+                {LEVELS.map((level) => (
+                  <SelectItem key={level} value={level}>
+                    {level}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Select value={componentFilter} onValueChange={setComponentFilter}>
+              <SelectTrigger size="sm" className="h-8 w-40 text-xs pointer-coarse:h-10">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All components</SelectItem>
+                {components.map((c) => (
+                  <SelectItem key={c} value={c}>
+                    {c}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <div className="relative min-w-48 flex-1">
+              <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                placeholder="Search message or record..."
+                className="h-8 pl-7 text-xs"
+              />
+            </div>
+          </div>
+
+          <Table className="text-sm">
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-24">Time</TableHead>
+                <TableHead className="w-24">Level</TableHead>
+                <TableHead className="w-28">Component</TableHead>
+                <TableHead>Message</TableHead>
+                <TableHead className="w-10" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filtered.map((entry) => {
+                const r = entry.record
+                const hasTraceback = typeof r.exception === "string" && r.exception.length > 0
+                return (
+                  <TableRow
+                    key={entry.id}
+                    tabIndex={0}
+                    role="button"
+                    className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                    onClick={() => setSelected(r)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault()
+                        setSelected(r)
+                      }
+                    }}
+                  >
+                    <TableCell className="w-24 py-1.5 text-xs tabular-nums text-muted-foreground">
+                      <span title={r.timestamp ? new Date(r.timestamp).toLocaleString() : undefined}>
+                        {r.timestamp ? new Date(r.timestamp).toLocaleTimeString() : "-"}
+                      </span>
+                    </TableCell>
+                    <TableCell className="w-24 py-1.5">
+                      <Badge
+                        variant="outline"
+                        className={cn("gap-1", levelBadgeClasses[r.level ?? ""] ?? levelBadgeClasses.debug)}
+                      >
+                        {r.level ?? "info"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="w-28 py-1.5">
+                      <MonoChip>{component(r)}</MonoChip>
+                    </TableCell>
+                    <TableCell className="w-full max-w-0 py-1.5">
+                      <span className="block truncate font-mono text-xs" title={r.event}>
+                        {r.event ?? "(no message)"}
+                      </span>
+                    </TableCell>
+                    <TableCell className="w-10 py-1.5">
+                      {hasTraceback ? (
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          className="pointer-coarse:h-10"
+                          aria-label="View traceback"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setTracebackRecord(r)
+                          }}
+                        >
+                          <Layers className="h-3.5 w-3.5" />
+                        </Button>
+                      ) : null}
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+              {filtered.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={5} className="h-24 text-center text-sm text-muted-foreground">
+                    {entries.length === 0
+                      ? "Waiting for log lines..."
+                      : "No log lines match the current filters."}
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-geo-cyan/10">
+              <FolderDown className="h-4 w-4 text-geo-cyan" />
+            </div>
+            <div>
+              <CardTitle className="text-base">Log downloads</CardTitle>
+              <CardDescription>
+                Raw files behind the stream above: the application log, login log, and ingested
+                nginx access logs.
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {groupedFiles.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {files ? "No log files found." : "Loading downloads..."}
+            </p>
+          ) : (
+            groupedFiles.map((group) => (
+              <div key={group.kind} className="space-y-1">
+                <h4 className="text-sm font-medium">{fileKindLabels[group.kind]}</h4>
+                <div className="divide-y rounded-md border">
+                  {group.files.map((f) => (
+                    <div
+                      key={f.name}
+                      className="flex flex-wrap items-center justify-between gap-2 p-2"
+                    >
+                      <div className="min-w-0">
+                        <div className="truncate font-mono text-xs">{f.name}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {formatSize(f.size_bytes)}
+                          {" · "}
+                          {f.modified_at ? new Date(f.modified_at).toLocaleString() : "unknown"}
+                          {!f.available ? " · not readable" : ""}
+                        </div>
+                      </div>
+                      {f.available ? (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="pointer-coarse:h-10"
+                          asChild
+                        >
+                          <a href={`/api/v1/logs/files/${f.kind}/${encodeURIComponent(f.name)}`} download>
+                            <Download className="mr-1.5 h-3.5 w-3.5" />
+                            Download
+                          </a>
+                        </Button>
+                      ) : (
+                        <Button variant="outline" size="sm" className="pointer-coarse:h-10" disabled>
+                          <Download className="mr-1.5 h-3.5 w-3.5" />
+                          Download
+                        </Button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={selected !== null} onOpenChange={(open) => !open && setSelected(null)}>
+        <DialogContent className="sm:max-w-2xl">
+          {selected && (
+            <>
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <Badge
+                    variant="outline"
+                    className={cn("gap-1", levelBadgeClasses[selected.level ?? ""] ?? levelBadgeClasses.debug)}
+                  >
+                    {selected.level ?? "info"}
+                  </Badge>
+                  {selected.event ?? "Log record"}
+                </DialogTitle>
+                <DialogDescription>
+                  {selected.timestamp ? new Date(selected.timestamp).toLocaleString() : "unknown time"}
+                  {selected.logger ? ` · ${selected.logger}` : ""}
+                </DialogDescription>
+              </DialogHeader>
+              <pre className="overflow-auto rounded-md bg-muted p-3 text-xs">
+                <code>{JSON.stringify(selected, null, 2)}</code>
+              </pre>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={tracebackRecord !== null}
+        onOpenChange={(open) => !open && setTracebackRecord(null)}
+      >
+        <DialogContent className="sm:max-w-2xl">
+          {tracebackRecord && (
+            <>
+              <DialogHeader>
+                <DialogTitle>Traceback</DialogTitle>
+                <DialogDescription>{tracebackRecord.event ?? "Unhandled exception"}</DialogDescription>
+              </DialogHeader>
+              <pre className="overflow-auto rounded-md bg-muted p-3 text-xs">
+                <code>{tracebackRecord.exception}</code>
+              </pre>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/resources/components/settings/logs-overview.tsx
+++ b/resources/components/settings/logs-overview.tsx
@@ -48,6 +48,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { MonoChip, StatusLed, type LedTone } from "@/components/settings/status-led"
 import { useLogFiles, useLogTail } from "@/lib/queries"
 import { logStream, type LogRecord, type LogStreamStatus } from "@/lib/logstream"
@@ -55,6 +56,9 @@ import type { LogFileView } from "@/generated/api/types.gen"
 
 const MAX_RECORDS = 2000
 const FLOW_IDLE_MS = 2000
+/** geometrikks.server.logging.LOGIN_LOGGER_NAME; login records are broadcast
+ * unfiltered alongside every other record and picked out client-side. */
+const LOGIN_LOGGER_NAME = "geometrikks.auth.login"
 
 const LEVELS = ["debug", "info", "success", "warning", "error", "critical"] as const
 
@@ -125,10 +129,15 @@ interface Entry {
 
 export function LogsOverview() {
   const { data: tailRecords } = useLogTail(500)
+  const { data: loginTailRecords } = useLogTail(500, "login")
   const { data: files } = useLogFiles()
+
+  const [activeLog, setActiveLog] = useState<"app" | "login">("app")
 
   const [entries, setEntries] = useState<Entry[]>([])
   const seededRef = useRef(false)
+  const [loginEntries, setLoginEntries] = useState<Entry[]>([])
+  const seededLoginRef = useRef(false)
   const nextIdRef = useRef(0)
 
   const [status, setStatus] = useState<LogStreamStatus>("connecting")
@@ -156,6 +165,13 @@ export function LogsOverview() {
     })
   }
 
+  // Prepend a chronological (oldest-first) batch to a newest-first buffer,
+  // capped at MAX_RECORDS. Shared by the live stream and the pause flush.
+  function appendCapped(prev: Entry[], records: LogRecord[]): Entry[] {
+    const merged = [...toEntries([...records].reverse()), ...prev]
+    return merged.length > MAX_RECORDS ? merged.slice(0, MAX_RECORDS) : merged
+  }
+
   // Seed once from the tail backfill; the stream takes over after that.
   useEffect(() => {
     if (tailRecords && !seededRef.current) {
@@ -165,6 +181,14 @@ export function LogsOverview() {
     // Intentionally seed once: `tailRecords` is a stable staleTime:Infinity
     // query result and toEntries is a plain closure, not a dependency.
   }, [tailRecords])
+
+  // Same, for the login buffer.
+  useEffect(() => {
+    if (loginTailRecords && !seededLoginRef.current) {
+      seededLoginRef.current = true
+      setLoginEntries(toEntries([...(loginTailRecords as LogRecord[])].reverse()))
+    }
+  }, [loginTailRecords])
 
   useEffect(() => {
     pausedRef.current = paused
@@ -188,10 +212,11 @@ export function LogsOverview() {
         return
       }
 
-      setEntries((prev) => {
-        const merged = [...toEntries([...records].reverse()), ...prev]
-        return merged.length > MAX_RECORDS ? merged.slice(0, MAX_RECORDS) : merged
-      })
+      setEntries((prev) => appendCapped(prev, records))
+      const loginRecords = records.filter((r) => r.logger === LOGIN_LOGGER_NAME)
+      if (loginRecords.length > 0) {
+        setLoginEntries((prev) => appendCapped(prev, loginRecords))
+      }
     })
     const unsubscribeStatus = logStream.onStatus(setStatus)
     return () => {
@@ -210,25 +235,28 @@ export function LogsOverview() {
       setPendingCount(0)
       setPaused(false)
       if (buffered.length > 0) {
-        setEntries((prev) => {
-          const merged = [...toEntries(buffered.slice().reverse()), ...prev]
-          return merged.length > MAX_RECORDS ? merged.slice(0, MAX_RECORDS) : merged
-        })
+        setEntries((prev) => appendCapped(prev, buffered))
+        const loginBuffered = buffered.filter((r) => r.logger === LOGIN_LOGGER_NAME)
+        if (loginBuffered.length > 0) {
+          setLoginEntries((prev) => appendCapped(prev, loginBuffered))
+        }
       }
     } else {
       setPaused(true)
     }
   }
 
+  const activeEntries = activeLog === "login" ? loginEntries : entries
+
   const components = useMemo(() => {
     const set = new Set<string>()
-    for (const e of entries) set.add(component(e.record))
+    for (const e of activeEntries) set.add(component(e.record))
     return Array.from(set).sort()
-  }, [entries])
+  }, [activeEntries])
 
   const filtered = useMemo(() => {
     const needle = search.trim().toLowerCase()
-    return entries.filter((e) => {
+    return activeEntries.filter((e) => {
       const r = e.record
       if (levelFilters.length > 0 && !levelFilters.includes(r.level ?? "")) return false
       if (componentFilters.length > 0 && !componentFilters.includes(component(r))) return false
@@ -238,7 +266,7 @@ export function LogsOverview() {
       }
       return true
     })
-  }, [entries, levelFilters, componentFilters, search])
+  }, [activeEntries, levelFilters, componentFilters, search])
 
   const groupedFiles = useMemo(() => {
     const groups = new Map<LogFileView["kind"], LogFileView[]>()
@@ -259,6 +287,12 @@ export function LogsOverview() {
     <div className="space-y-4">
       <Card>
         <CardHeader>
+          <Tabs value={activeLog} onValueChange={(v) => setActiveLog(v as "app" | "login")}>
+            <TabsList className="pointer-coarse:h-10">
+              <TabsTrigger value="app">System log</TabsTrigger>
+              <TabsTrigger value="login">Login log</TabsTrigger>
+            </TabsList>
+          </Tabs>
           <div className="flex items-center gap-3">
             <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-geo-cyan/10">
               <ScrollText className="h-4 w-4 text-geo-cyan" />
@@ -271,8 +305,9 @@ export function LogsOverview() {
                 </span>
               </CardTitle>
               <CardDescription>
-                Streaming from the application log. Newest first; buffer keeps the last 2,000
-                lines. <span className="tabular-nums">{entries.length.toLocaleString()} buffered</span>
+                Streaming from the {activeLog === "login" ? "login" : "application"} log. Newest
+                first; buffer keeps the last 2,000 lines.{" "}
+                <span className="tabular-nums">{activeEntries.length.toLocaleString()} buffered</span>
                 {totalDropped > 0 ? (
                   <span className="tabular-nums">, {totalDropped.toLocaleString()} dropped</span>
                 ) : null}
@@ -461,7 +496,7 @@ export function LogsOverview() {
               {filtered.length === 0 && (
                 <TableRow>
                   <TableCell colSpan={5} className="h-24 text-center text-sm text-muted-foreground">
-                    {entries.length === 0
+                    {activeEntries.length === 0
                       ? "Waiting for log lines..."
                       : "No log lines match the current filters."}
                   </TableCell>

--- a/resources/components/settings/logs-overview.tsx
+++ b/resources/components/settings/logs-overview.tsx
@@ -330,6 +330,12 @@ export function LogsOverview() {
                     className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
                     onClick={() => setSelected(r)}
                     onKeyDown={(e) => {
+                      // Only react when the row itself is the event target: a
+                      // native keydown on a nested control (the traceback
+                      // button) still bubbles up here even though its click
+                      // handler calls stopPropagation, since that only stops
+                      // the click event, not this separate keydown binding.
+                      if (e.target !== e.currentTarget) return
                       if (e.key === "Enter" || e.key === " ") {
                         e.preventDefault()
                         setSelected(r)

--- a/resources/components/settings/logs-overview.tsx
+++ b/resources/components/settings/logs-overview.tsx
@@ -151,7 +151,10 @@ export function LogsOverview() {
       flowTimerRef.current = setTimeout(() => setFlowing(false), FLOW_IDLE_MS)
 
       if (pausedRef.current) {
-        pausedBufferRef.current = [...pausedBufferRef.current, ...records].slice(-MAX_RECORDS)
+        const combined = [...pausedBufferRef.current, ...records]
+        const overflow = Math.max(0, combined.length - MAX_RECORDS)
+        if (overflow > 0) setTotalDropped((d) => d + overflow)
+        pausedBufferRef.current = combined.slice(-MAX_RECORDS)
         setPendingCount(pausedBufferRef.current.length)
         return
       }
@@ -350,7 +353,7 @@ export function LogsOverview() {
                     <TableCell className="w-24 py-1.5">
                       <Badge
                         variant="outline"
-                        className={cn("gap-1", levelBadgeClasses[r.level ?? ""] ?? levelBadgeClasses.debug)}
+                        className={cn("gap-1", levelBadgeClasses[r.level ?? ""] ?? levelBadgeClasses.info)}
                       >
                         {r.level ?? "info"}
                       </Badge>
@@ -470,7 +473,7 @@ export function LogsOverview() {
                 <DialogTitle className="flex items-center gap-2">
                   <Badge
                     variant="outline"
-                    className={cn("gap-1", levelBadgeClasses[selected.level ?? ""] ?? levelBadgeClasses.debug)}
+                    className={cn("gap-1", levelBadgeClasses[selected.level ?? ""] ?? levelBadgeClasses.info)}
                   >
                     {selected.level ?? "info"}
                   </Badge>

--- a/resources/components/settings/logs-overview.tsx
+++ b/resources/components/settings/logs-overview.tsx
@@ -368,106 +368,107 @@ export function LogsOverview() {
             </div>
           </div>
 
-          <div className="max-h-[65vh] overflow-y-auto rounded-md border">
-            <Table className="text-sm">
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="sticky top-0 z-10 w-24 bg-card">Time</TableHead>
-                  <TableHead className="sticky top-0 z-10 w-24 bg-card">Level</TableHead>
-                  <TableHead className="sticky top-0 z-10 w-28 bg-card">Component</TableHead>
-                  <TableHead className="sticky top-0 z-10 bg-card">Message</TableHead>
-                  <TableHead className="sticky top-0 z-10 w-10 bg-card" />
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {filtered.map((entry) => {
-                  const r = entry.record
-                  const hasTraceback = typeof r.exception === "string" && r.exception.length > 0
-                  return (
-                    <TableRow
-                      key={entry.id}
-                      tabIndex={0}
-                      role="button"
-                      className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
-                      onClick={() => setSelected(r)}
-                      onKeyDown={(e) => {
-                        // Only react when the row itself is the event target: a
-                        // native keydown on a nested control (the traceback
-                        // button) still bubbles up here even though its click
-                        // handler calls stopPropagation, since that only stops
-                        // the click event, not this separate keydown binding.
-                        if (e.target !== e.currentTarget) return
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault()
-                          setSelected(r)
-                        }
-                      }}
-                    >
-                      <TableCell className="w-24 py-1.5 text-xs tabular-nums text-muted-foreground">
-                        <span title={r.timestamp ? new Date(r.timestamp).toLocaleString() : undefined}>
-                          {r.timestamp ? new Date(r.timestamp).toLocaleTimeString() : "-"}
-                        </span>
-                      </TableCell>
-                      <TableCell className="w-24 py-1.5">
-                        <Badge
-                          variant="outline"
-                          className={cn(
-                            "gap-1 uppercase",
-                            levelBadgeClasses[r.level ?? ""] ?? levelBadgeClasses.info,
-                          )}
-                        >
-                          {r.level ?? "info"}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="w-28 py-1.5">
-                        <MonoChip>{component(r)}</MonoChip>
-                      </TableCell>
-                      <TableCell className="w-full max-w-0 py-1.5">
-                        {(() => {
-                          const context = formatContext(r)
-                          const eventText = r.event ?? "(no message)"
-                          return (
-                            <span
-                              className="block truncate font-mono text-xs"
-                              title={context ? `${eventText} ${context}` : eventText}
-                            >
-                              {eventText}
-                              {context ? <span className="text-muted-foreground"> {context}</span> : null}
-                            </span>
-                          )
-                        })()}
-                      </TableCell>
-                      <TableCell className="w-10 py-1.5">
-                        {hasTraceback ? (
-                          <Button
-                            variant="ghost"
-                            size="icon-sm"
-                            className="pointer-coarse:h-10"
-                            aria-label="View traceback"
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              setTracebackRecord(r)
-                            }}
+          <Table
+            className="text-sm"
+            containerClassName="max-h-[65vh] overflow-y-auto rounded-md border"
+          >
+            <TableHeader>
+              <TableRow>
+                <TableHead className="sticky top-0 z-10 w-24 bg-card">Time</TableHead>
+                <TableHead className="sticky top-0 z-10 w-24 bg-card">Level</TableHead>
+                <TableHead className="sticky top-0 z-10 w-28 bg-card">Component</TableHead>
+                <TableHead className="sticky top-0 z-10 bg-card">Message</TableHead>
+                <TableHead className="sticky top-0 z-10 w-10 bg-card" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filtered.map((entry) => {
+                const r = entry.record
+                const hasTraceback = typeof r.exception === "string" && r.exception.length > 0
+                return (
+                  <TableRow
+                    key={entry.id}
+                    tabIndex={0}
+                    role="button"
+                    className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                    onClick={() => setSelected(r)}
+                    onKeyDown={(e) => {
+                      // Only react when the row itself is the event target: a
+                      // native keydown on a nested control (the traceback
+                      // button) still bubbles up here even though its click
+                      // handler calls stopPropagation, since that only stops
+                      // the click event, not this separate keydown binding.
+                      if (e.target !== e.currentTarget) return
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault()
+                        setSelected(r)
+                      }
+                    }}
+                  >
+                    <TableCell className="w-24 py-1.5 text-xs tabular-nums text-muted-foreground">
+                      <span title={r.timestamp ? new Date(r.timestamp).toLocaleString() : undefined}>
+                        {r.timestamp ? new Date(r.timestamp).toLocaleTimeString() : "-"}
+                      </span>
+                    </TableCell>
+                    <TableCell className="w-24 py-1.5">
+                      <Badge
+                        variant="outline"
+                        className={cn(
+                          "gap-1 uppercase",
+                          levelBadgeClasses[r.level ?? ""] ?? levelBadgeClasses.info,
+                        )}
+                      >
+                        {r.level ?? "info"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="w-28 py-1.5">
+                      <MonoChip>{component(r)}</MonoChip>
+                    </TableCell>
+                    <TableCell className="w-full max-w-0 py-1.5">
+                      {(() => {
+                        const context = formatContext(r)
+                        const eventText = r.event ?? "(no message)"
+                        return (
+                          <span
+                            className="block truncate font-mono text-xs"
+                            title={context ? `${eventText} ${context}` : eventText}
                           >
-                            <Layers className="h-3.5 w-3.5" />
-                          </Button>
-                        ) : null}
-                      </TableCell>
-                    </TableRow>
-                  )
-                })}
-                {filtered.length === 0 && (
-                  <TableRow>
-                    <TableCell colSpan={5} className="h-24 text-center text-sm text-muted-foreground">
-                      {entries.length === 0
-                        ? "Waiting for log lines..."
-                        : "No log lines match the current filters."}
+                            {eventText}
+                            {context ? <span className="text-muted-foreground"> {context}</span> : null}
+                          </span>
+                        )
+                      })()}
+                    </TableCell>
+                    <TableCell className="w-10 py-1.5">
+                      {hasTraceback ? (
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          className="pointer-coarse:h-10"
+                          aria-label="View traceback"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setTracebackRecord(r)
+                          }}
+                        >
+                          <Layers className="h-3.5 w-3.5" />
+                        </Button>
+                      ) : null}
                     </TableCell>
                   </TableRow>
-                )}
-              </TableBody>
-            </Table>
-          </div>
+                )
+              })}
+              {filtered.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={5} className="h-24 text-center text-sm text-muted-foreground">
+                    {entries.length === 0
+                      ? "Waiting for log lines..."
+                      : "No log lines match the current filters."}
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
         </CardContent>
       </Card>
 

--- a/resources/components/settings/logs-overview.tsx
+++ b/resources/components/settings/logs-overview.tsx
@@ -5,7 +5,9 @@
  * downloads card for the raw files behind the stream.
  */
 import { useEffect, useMemo, useRef, useState } from "react"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import {
+  Archive,
   ChevronsUpDown,
   Download,
   FolderDown,
@@ -50,8 +52,9 @@ import {
 } from "@/components/ui/table"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { MonoChip, StatusLed, type LedTone } from "@/components/settings/status-led"
-import { useLogFiles, useLogTail } from "@/lib/queries"
+import { useLogFiles, useLogTail, queryKeys } from "@/lib/queries"
 import { logStream, type LogRecord, type LogStreamStatus } from "@/lib/logstream"
+import { apiV1LogsRotateRotate } from "@/generated/api/sdk.gen"
 import type { LogFileView } from "@/generated/api/types.gen"
 
 const MAX_RECORDS = 2000
@@ -131,6 +134,14 @@ export function LogsOverview() {
   const { data: tailRecords } = useLogTail(500)
   const { data: loginTailRecords } = useLogTail(500, "login")
   const { data: files } = useLogFiles()
+  const queryClient = useQueryClient()
+  const rotateLogs = useMutation({
+    mutationFn: async () => {
+      const { data } = await apiV1LogsRotateRotate({ throwOnError: true })
+      return data
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.logs.files }),
+  })
 
   const [activeLog, setActiveLog] = useState<"app" | "login">("app")
 
@@ -509,17 +520,29 @@ export function LogsOverview() {
 
       <Card>
         <CardHeader>
-          <div className="flex items-center gap-3">
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-geo-cyan/10">
-              <FolderDown className="h-4 w-4 text-geo-cyan" />
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-geo-cyan/10">
+                <FolderDown className="h-4 w-4 text-geo-cyan" />
+              </div>
+              <div>
+                <CardTitle className="text-base">Log downloads</CardTitle>
+                <CardDescription>
+                  Raw files behind the stream above: the application log, login log, and ingested
+                  nginx access logs.
+                </CardDescription>
+              </div>
             </div>
-            <div>
-              <CardTitle className="text-base">Log downloads</CardTitle>
-              <CardDescription>
-                Raw files behind the stream above: the application log, login log, and ingested
-                nginx access logs.
-              </CardDescription>
-            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="pointer-coarse:h-10"
+              disabled={rotateLogs.isPending}
+              onClick={() => rotateLogs.mutate()}
+            >
+              <Archive className="mr-1.5 h-3.5 w-3.5" />
+              {rotateLogs.isPending ? "Rotating..." : "Rotate logs"}
+            </Button>
           </div>
         </CardHeader>
         <CardContent className="space-y-4">

--- a/resources/components/ui/table.tsx
+++ b/resources/components/ui/table.tsx
@@ -4,9 +4,16 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Table({ className, ...props }: React.ComponentProps<"table">) {
+function Table({
+  className,
+  containerClassName,
+  ...props
+}: React.ComponentProps<"table"> & { containerClassName?: string }) {
   return (
-    <div data-slot="table-container" className="relative w-full overflow-x-auto">
+    <div
+      data-slot="table-container"
+      className={cn("relative w-full overflow-x-auto", containerClassName)}
+    >
       <table
         data-slot="table"
         className={cn("w-full caption-bottom text-sm", className)}

--- a/resources/generated/api/schemas.gen.ts
+++ b/resources/generated/api/schemas.gen.ts
@@ -1722,6 +1722,20 @@ export const LogFilesResponseSchema = {
   type: "object",
 } as const;
 
+export const LogRotateResponseSchema = {
+  properties: {
+    rotated: {
+      items: {
+        type: "string",
+      },
+      type: "array",
+    },
+  },
+  required: ["rotated"],
+  title: "LogRotateResponse",
+  type: "object",
+} as const;
+
 export const LogTailResponseSchema = {
   properties: {
     records: {

--- a/resources/generated/api/schemas.gen.ts
+++ b/resources/generated/api/schemas.gen.ts
@@ -1676,6 +1676,67 @@ export const LocationTopIPsResponseSchema = {
   type: "object",
 } as const;
 
+export const LogFileViewSchema = {
+  properties: {
+    available: {
+      type: "boolean",
+    },
+    kind: {
+      enum: ["app", "login", "nginx"],
+      type: "string",
+    },
+    modified_at: {
+      oneOf: [
+        {
+          format: "date-time",
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    name: {
+      type: "string",
+    },
+    size_bytes: {
+      type: "integer",
+    },
+  },
+  required: ["available", "kind", "modified_at", "name", "size_bytes"],
+  title: "LogFileView",
+  type: "object",
+} as const;
+
+export const LogFilesResponseSchema = {
+  properties: {
+    files: {
+      items: {
+        $ref: "#/components/schemas/LogFileView",
+      },
+      type: "array",
+    },
+  },
+  required: ["files"],
+  title: "LogFilesResponse",
+  type: "object",
+} as const;
+
+export const LogTailResponseSchema = {
+  properties: {
+    records: {
+      items: {
+        additionalProperties: {},
+        type: "object",
+      },
+      type: "array",
+    },
+  },
+  required: ["records"],
+  title: "LogTailResponse",
+  type: "object",
+} as const;
+
 export const LoginPayloadSchema = {
   properties: {
     password: {

--- a/resources/generated/api/sdk.gen.ts
+++ b/resources/generated/api/sdk.gen.ts
@@ -113,6 +113,14 @@ import type {
   ApiV1GeoLocationsTopIpsGetGlobalTopIpsData,
   ApiV1GeoLocationsTopIpsGetGlobalTopIpsErrors,
   ApiV1GeoLocationsTopIpsGetGlobalTopIpsResponses,
+  ApiV1LogsFilesKindNameDownloadData,
+  ApiV1LogsFilesKindNameDownloadErrors,
+  ApiV1LogsFilesKindNameDownloadResponses,
+  ApiV1LogsFilesListFilesData,
+  ApiV1LogsFilesListFilesResponses,
+  ApiV1LogsTailTailData,
+  ApiV1LogsTailTailErrors,
+  ApiV1LogsTailTailResponses,
   ApiV1SettingsReadSettingsData,
   ApiV1SettingsReadSettingsResponses,
   ApiV1StatsStatsData,
@@ -1158,6 +1166,74 @@ export const apiV1GeoLocationsLocationIdTopIpsGetLocationTopIps = <
       },
     ],
     url: "/api/v1/geo-locations/{location_id}/top-ips",
+    ...options,
+  });
+
+/**
+ * ListFiles
+ */
+export const apiV1LogsFilesListFiles = <ThrowOnError extends boolean = false>(
+  options?: Options<ApiV1LogsFilesListFilesData, ThrowOnError>,
+) =>
+  (options?.client ?? client).get<
+    ApiV1LogsFilesListFilesResponses,
+    unknown,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/logs/files",
+    ...options,
+  });
+
+/**
+ * Download
+ */
+export const apiV1LogsFilesKindNameDownload = <
+  ThrowOnError extends boolean = false,
+>(
+  options: Options<ApiV1LogsFilesKindNameDownloadData, ThrowOnError>,
+) =>
+  (options.client ?? client).get<
+    ApiV1LogsFilesKindNameDownloadResponses,
+    ApiV1LogsFilesKindNameDownloadErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/logs/files/{kind}/{name}",
+    ...options,
+  });
+
+/**
+ * Tail
+ */
+export const apiV1LogsTailTail = <ThrowOnError extends boolean = false>(
+  options?: Options<ApiV1LogsTailTailData, ThrowOnError>,
+) =>
+  (options?.client ?? client).get<
+    ApiV1LogsTailTailResponses,
+    ApiV1LogsTailTailErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/logs/tail",
     ...options,
   });
 

--- a/resources/generated/api/sdk.gen.ts
+++ b/resources/generated/api/sdk.gen.ts
@@ -118,6 +118,8 @@ import type {
   ApiV1LogsFilesKindNameDownloadResponses,
   ApiV1LogsFilesListFilesData,
   ApiV1LogsFilesListFilesResponses,
+  ApiV1LogsRotateRotateData,
+  ApiV1LogsRotateRotateResponses,
   ApiV1LogsTailTailData,
   ApiV1LogsTailTailErrors,
   ApiV1LogsTailTailResponses,
@@ -1212,6 +1214,28 @@ export const apiV1LogsFilesKindNameDownload = <
       },
     ],
     url: "/api/v1/logs/files/{kind}/{name}",
+    ...options,
+  });
+
+/**
+ * Rotate
+ */
+export const apiV1LogsRotateRotate = <ThrowOnError extends boolean = false>(
+  options?: Options<ApiV1LogsRotateRotateData, ThrowOnError>,
+) =>
+  (options?.client ?? client).post<
+    ApiV1LogsRotateRotateResponses,
+    unknown,
+    ThrowOnError
+  >({
+    security: [
+      {
+        in: "cookie",
+        name: "session",
+        type: "apiKey",
+      },
+    ],
+    url: "/api/v1/logs/rotate",
     ...options,
   });
 

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -469,6 +469,33 @@ export type LocationTopIpsResponse = {
 };
 
 /**
+ * LogFileView
+ */
+export type LogFileView = {
+  available: boolean;
+  kind: "app" | "login" | "nginx";
+  modified_at: string | null;
+  name: string;
+  size_bytes: number;
+};
+
+/**
+ * LogFilesResponse
+ */
+export type LogFilesResponse = {
+  files: Array<LogFileView>;
+};
+
+/**
+ * LogTailResponse
+ */
+export type LogTailResponse = {
+  records: Array<{
+    [key: string]: unknown;
+  }>;
+};
+
+/**
  * LoginPayload
  */
 export type LoginPayload = {
@@ -2688,6 +2715,100 @@ export type ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponses = {
 
 export type ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponse =
   ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponses[keyof ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsResponses];
+
+export type ApiV1LogsFilesListFilesData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: "/api/v1/logs/files";
+};
+
+export type ApiV1LogsFilesListFilesResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: LogFilesResponse;
+};
+
+export type ApiV1LogsFilesListFilesResponse =
+  ApiV1LogsFilesListFilesResponses[keyof ApiV1LogsFilesListFilesResponses];
+
+export type ApiV1LogsFilesKindNameDownloadData = {
+  body?: never;
+  path: {
+    kind: string;
+    name: string;
+  };
+  query?: never;
+  url: "/api/v1/logs/files/{kind}/{name}";
+};
+
+export type ApiV1LogsFilesKindNameDownloadErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+    status_code: number;
+  };
+};
+
+export type ApiV1LogsFilesKindNameDownloadError =
+  ApiV1LogsFilesKindNameDownloadErrors[keyof ApiV1LogsFilesKindNameDownloadErrors];
+
+export type ApiV1LogsFilesKindNameDownloadResponses = {
+  /**
+   * File Download
+   */
+  200: string;
+};
+
+export type ApiV1LogsFilesKindNameDownloadResponse =
+  ApiV1LogsFilesKindNameDownloadResponses[keyof ApiV1LogsFilesKindNameDownloadResponses];
+
+export type ApiV1LogsTailTailData = {
+  body?: never;
+  path?: never;
+  query?: {
+    lines?: number;
+  };
+  url: "/api/v1/logs/tail";
+};
+
+export type ApiV1LogsTailTailErrors = {
+  /**
+   * Validation Exception
+   */
+  400: {
+    detail: string;
+    extra?:
+      | null
+      | {
+          [key: string]: unknown;
+        }
+      | Array<unknown>;
+    status_code: number;
+  };
+};
+
+export type ApiV1LogsTailTailError =
+  ApiV1LogsTailTailErrors[keyof ApiV1LogsTailTailErrors];
+
+export type ApiV1LogsTailTailResponses = {
+  /**
+   * Request fulfilled, document follows
+   */
+  200: LogTailResponse;
+};
+
+export type ApiV1LogsTailTailResponse =
+  ApiV1LogsTailTailResponses[keyof ApiV1LogsTailTailResponses];
 
 export type ApiV1SettingsReadSettingsData = {
   body?: never;

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -2777,6 +2777,7 @@ export type ApiV1LogsTailTailData = {
   path?: never;
   query?: {
     lines?: number;
+    source?: "app" | "login";
   };
   url: "/api/v1/logs/tail";
 };

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -487,6 +487,13 @@ export type LogFilesResponse = {
 };
 
 /**
+ * LogRotateResponse
+ */
+export type LogRotateResponse = {
+  rotated: Array<string>;
+};
+
+/**
  * LogTailResponse
  */
 export type LogTailResponse = {
@@ -2771,6 +2778,23 @@ export type ApiV1LogsFilesKindNameDownloadResponses = {
 
 export type ApiV1LogsFilesKindNameDownloadResponse =
   ApiV1LogsFilesKindNameDownloadResponses[keyof ApiV1LogsFilesKindNameDownloadResponses];
+
+export type ApiV1LogsRotateRotateData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: "/api/v1/logs/rotate";
+};
+
+export type ApiV1LogsRotateRotateResponses = {
+  /**
+   * Document created, URL follows
+   */
+  201: LogRotateResponse;
+};
+
+export type ApiV1LogsRotateRotateResponse =
+  ApiV1LogsRotateRotateResponses[keyof ApiV1LogsRotateRotateResponses];
 
 export type ApiV1LogsTailTailData = {
   body?: never;

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -1753,6 +1753,78 @@
         "title": "LocationTopIPsResponse",
         "type": "object"
       },
+      "LogFileView": {
+        "properties": {
+          "available": {
+            "type": "boolean"
+          },
+          "kind": {
+            "enum": [
+              "app",
+              "login",
+              "nginx"
+            ],
+            "type": "string"
+          },
+          "modified_at": {
+            "oneOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "size_bytes": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "available",
+          "kind",
+          "modified_at",
+          "name",
+          "size_bytes"
+        ],
+        "title": "LogFileView",
+        "type": "object"
+      },
+      "LogFilesResponse": {
+        "properties": {
+          "files": {
+            "items": {
+              "$ref": "#/components/schemas/LogFileView"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "files"
+        ],
+        "title": "LogFilesResponse",
+        "type": "object"
+      },
+      "LogTailResponse": {
+        "properties": {
+          "records": {
+            "items": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "records"
+        ],
+        "title": "LogTailResponse",
+        "type": "object"
+      },
       "LoginPayload": {
         "properties": {
           "password": {
@@ -8508,6 +8580,212 @@
         "summary": "GetLocationTopIps",
         "tags": [
           "Geo Locations"
+        ]
+      }
+    },
+    "/api/v1/logs/files": {
+      "get": {
+        "deprecated": false,
+        "operationId": "ApiV1LogsFilesListFiles",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LogFilesResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          }
+        },
+        "summary": "ListFiles",
+        "tags": [
+          "Logs"
+        ]
+      }
+    },
+    "/api/v1/logs/files/{kind}/{name}": {
+      "get": {
+        "deprecated": false,
+        "operationId": "ApiV1LogsFilesKindNameDownload",
+        "parameters": [
+          {
+            "deprecated": false,
+            "in": "path",
+            "name": "kind",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "deprecated": false,
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "": {
+                "schema": {
+                  "contentMediaType": "application/octet-stream",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "File Download",
+            "headers": {
+              "content-length": {
+                "deprecated": false,
+                "description": "File size in bytes",
+                "required": false,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "etag": {
+                "deprecated": false,
+                "description": "Entity tag",
+                "required": false,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "last-modified": {
+                "deprecated": false,
+                "description": "Last modified data-time in RFC 2822 format",
+                "required": false,
+                "schema": {
+                  "format": "date-time",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "Download",
+        "tags": [
+          "Logs"
+        ]
+      }
+    },
+    "/api/v1/logs/tail": {
+      "get": {
+        "deprecated": false,
+        "operationId": "ApiV1LogsTailTail",
+        "parameters": [
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "lines",
+            "required": false,
+            "schema": {
+              "default": 500,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LogTailResponse"
+                }
+              }
+            },
+            "description": "Request fulfilled, document follows",
+            "headers": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Validation Exception",
+                  "examples": [
+                    {
+                      "detail": "Bad Request",
+                      "extra": {},
+                      "status_code": 400
+                    }
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    },
+                    "extra": {
+                      "additionalProperties": {},
+                      "type": [
+                        "null",
+                        "object",
+                        "array"
+                      ]
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "detail",
+                    "status_code"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bad request syntax or unsupported method"
+          }
+        },
+        "summary": "Tail",
+        "tags": [
+          "Logs"
         ]
       }
     },

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -1809,6 +1809,21 @@
         "title": "LogFilesResponse",
         "type": "object"
       },
+      "LogRotateResponse": {
+        "properties": {
+          "rotated": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "rotated"
+        ],
+        "title": "LogRotateResponse",
+        "type": "object"
+      },
       "LogTailResponse": {
         "properties": {
           "records": {
@@ -8709,6 +8724,29 @@
           }
         },
         "summary": "Download",
+        "tags": [
+          "Logs"
+        ]
+      }
+    },
+    "/api/v1/logs/rotate": {
+      "post": {
+        "deprecated": false,
+        "operationId": "ApiV1LogsRotateRotate",
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LogRotateResponse"
+                }
+              }
+            },
+            "description": "Document created, URL follows",
+            "headers": {}
+          }
+        },
+        "summary": "Rotate",
         "tags": [
           "Logs"
         ]

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -8730,6 +8730,22 @@
               "default": 500,
               "type": "integer"
             }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "default": "app",
+              "enum": [
+                "app",
+                "login"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/resources/generated/routes.json
+++ b/resources/generated/routes.json
@@ -8,6 +8,28 @@
       ],
       "uri": "/api/v1/crowdsec/ban"
     },
+    "disabled_vite_hmr_http": {
+      "method": "get",
+      "methods": [
+        "GET"
+      ],
+      "uri": "/static/vite-hmr"
+    },
+    "download": {
+      "method": "get",
+      "methods": [
+        "GET"
+      ],
+      "parameterTypes": {
+        "kind": "string",
+        "name": "string"
+      },
+      "parameters": [
+        "kind",
+        "name"
+      ],
+      "uri": "/api/v1/logs/files/{kind}/{name}"
+    },
     "get_about": {
       "method": "get",
       "methods": [
@@ -468,6 +490,13 @@
       },
       "uri": "/api/v1/crowdsec/decisions"
     },
+    "list_files": {
+      "method": "get",
+      "methods": [
+        "GET"
+      ],
+      "uri": "/api/v1/logs/files"
+    },
     "list_geo_events": {
       "method": "get",
       "methods": [
@@ -575,6 +604,16 @@
         "GET"
       ],
       "uri": "/api/v1/stats"
+    },
+    "tail": {
+      "method": "get",
+      "methods": [
+        "GET"
+      ],
+      "queryParameters": {
+        "lines": "number | undefined"
+      },
+      "uri": "/api/v1/logs/tail"
     },
     "unban": {
       "method": "post",

--- a/resources/generated/routes.json
+++ b/resources/generated/routes.json
@@ -611,7 +611,8 @@
         "GET"
       ],
       "queryParameters": {
-        "lines": "number | undefined"
+        "lines": "number | undefined",
+        "source": "\"app\" | \"login\" | undefined"
       },
       "uri": "/api/v1/logs/tail"
     },

--- a/resources/generated/routes.json
+++ b/resources/generated/routes.json
@@ -578,6 +578,13 @@
       ],
       "uri": "/api/v1/settings"
     },
+    "rotate": {
+      "method": "post",
+      "methods": [
+        "POST"
+      ],
+      "uri": "/api/v1/logs/rotate"
+    },
     "run_scheduler_job": {
       "method": "post",
       "methods": [

--- a/resources/generated/routes.ts
+++ b/resources/generated/routes.ts
@@ -64,6 +64,7 @@ export type RouteName =
   | 'openapi.json'
   | 'openapi.yaml'
   | 'read_settings'
+  | 'rotate'
   | 'run_scheduler_job'
   | 'service_worker'
   | 'stats'
@@ -129,6 +130,7 @@ export interface RoutePathParams {
   'openapi.json': Record<string, never>;
   'openapi.yaml': Record<string, never>;
   'read_settings': Record<string, never>;
+  'rotate': Record<string, never>;
   'run_scheduler_job': {
     job_id: string;
   };
@@ -387,6 +389,7 @@ export interface RouteQueryParams {
   'openapi.json': Record<string, never>;
   'openapi.yaml': Record<string, never>;
   'read_settings': Record<string, never>;
+  'rotate': Record<string, never>;
   'run_scheduler_job': Record<string, never>;
   'service_worker': Record<string, never>;
   'stats': Record<string, never>;
@@ -749,6 +752,13 @@ export const routeDefinitions = {
     path: '/api/v1/settings',
     methods: ['GET'] as const,
     method: 'get',
+    pathParams: [] as const,
+    queryParams: [] as const,
+  },
+  'rotate': {
+    path: '/api/v1/logs/rotate',
+    methods: ['POST'] as const,
+    method: 'post',
     pathParams: [] as const,
     queryParams: [] as const,
   },

--- a/resources/generated/routes.ts
+++ b/resources/generated/routes.ts
@@ -392,6 +392,7 @@ export interface RouteQueryParams {
   'stats': Record<string, never>;
   'tail': {
     lines?: number;
+    source?: "app" | "login";
   };
   'unban': Record<string, never>;
   'vite': Record<string, never>;
@@ -777,7 +778,7 @@ export const routeDefinitions = {
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['lines'] as const,
+    queryParams: ['lines', 'source'] as const,
   },
   'unban': {
     path: '/api/v1/crowdsec/unban',

--- a/resources/generated/routes.ts
+++ b/resources/generated/routes.ts
@@ -16,6 +16,8 @@ export type URI = string;
 /** All available route names */
 export type RouteName =
   | 'ban'
+  | 'disabled_vite_hmr_http'
+  | 'download'
   | 'get_about'
   | 'get_access_log_debug_stats'
   | 'get_access_log_facets'
@@ -52,6 +54,7 @@ export type RouteName =
   | 'list_banned_ips'
   | 'list_banned_locations'
   | 'list_decisions'
+  | 'list_files'
   | 'list_geo_events'
   | 'list_geo_locations'
   | 'login'
@@ -64,6 +67,7 @@ export type RouteName =
   | 'run_scheduler_job'
   | 'service_worker'
   | 'stats'
+  | 'tail'
   | 'unban'
   | 'vite'
   | 'vite_spa'
@@ -72,6 +76,11 @@ export type RouteName =
 /** Path parameter definitions per route */
 export interface RoutePathParams {
   'ban': Record<string, never>;
+  'disabled_vite_hmr_http': Record<string, never>;
+  'download': {
+    kind: string;
+    name: string;
+  };
   'get_about': Record<string, never>;
   'get_access_log_debug_stats': Record<string, never>;
   'get_access_log_facets': Record<string, never>;
@@ -110,6 +119,7 @@ export interface RoutePathParams {
   'list_banned_ips': Record<string, never>;
   'list_banned_locations': Record<string, never>;
   'list_decisions': Record<string, never>;
+  'list_files': Record<string, never>;
   'list_geo_events': Record<string, never>;
   'list_geo_locations': Record<string, never>;
   'login': Record<string, never>;
@@ -124,6 +134,7 @@ export interface RoutePathParams {
   };
   'service_worker': Record<string, never>;
   'stats': Record<string, never>;
+  'tail': Record<string, never>;
   'unban': Record<string, never>;
   'vite': {
     file_path: any;
@@ -137,6 +148,8 @@ export interface RoutePathParams {
 /** Query parameter definitions per route */
 export interface RouteQueryParams {
   'ban': Record<string, never>;
+  'disabled_vite_hmr_http': Record<string, never>;
+  'download': Record<string, never>;
   'get_about': Record<string, never>;
   'get_access_log_debug_stats': {
     from_timestamp?: DateTime;
@@ -349,6 +362,7 @@ export interface RouteQueryParams {
     origins?: string;
     pageSize?: number;
   };
+  'list_files': Record<string, never>;
   'list_geo_events': {
     currentPage?: number;
     from_timestamp?: DateTime;
@@ -376,6 +390,9 @@ export interface RouteQueryParams {
   'run_scheduler_job': Record<string, never>;
   'service_worker': Record<string, never>;
   'stats': Record<string, never>;
+  'tail': {
+    lines?: number;
+  };
   'unban': Record<string, never>;
   'vite': Record<string, never>;
   'vite_spa': Record<string, never>;
@@ -396,6 +413,20 @@ export const routeDefinitions = {
     methods: ['POST'] as const,
     method: 'post',
     pathParams: [] as const,
+    queryParams: [] as const,
+  },
+  'disabled_vite_hmr_http': {
+    path: '/static/vite-hmr',
+    methods: ['GET'] as const,
+    method: 'get',
+    pathParams: [] as const,
+    queryParams: [] as const,
+  },
+  'download': {
+    path: '/api/v1/logs/files/{kind}/{name}',
+    methods: ['GET'] as const,
+    method: 'get',
+    pathParams: ['kind', 'name'] as const,
     queryParams: [] as const,
   },
   'get_about': {
@@ -650,6 +681,13 @@ export const routeDefinitions = {
     pathParams: [] as const,
     queryParams: ['currentPage', 'origins', 'pageSize'] as const,
   },
+  'list_files': {
+    path: '/api/v1/logs/files',
+    methods: ['GET'] as const,
+    method: 'get',
+    pathParams: [] as const,
+    queryParams: [] as const,
+  },
   'list_geo_events': {
     path: '/api/v1/geo-events',
     methods: ['GET'] as const,
@@ -733,6 +771,13 @@ export const routeDefinitions = {
     method: 'get',
     pathParams: [] as const,
     queryParams: [] as const,
+  },
+  'tail': {
+    path: '/api/v1/logs/tail',
+    methods: ['GET'] as const,
+    method: 'get',
+    pathParams: [] as const,
+    queryParams: ['lines'] as const,
   },
   'unban': {
     path: '/api/v1/crowdsec/unban',

--- a/resources/generated/schemas.ts
+++ b/resources/generated/schemas.ts
@@ -31,6 +31,8 @@ import type {
   ApiV1GeoEventsFacetsGetGeoLogFacetsResponses,
   ApiV1LogsFilesListFilesData,
   ApiV1LogsFilesListFilesResponses,
+  ApiV1LogsRotateRotateData,
+  ApiV1LogsRotateRotateResponses,
   ApiV1SettingsReadSettingsData,
   ApiV1SettingsReadSettingsResponses,
   ApiV1StatsStatsData,
@@ -76,6 +78,7 @@ export type OperationName =
   | 'logout'
   | 'me'
   | 'read_settings'
+  | 'rotate'
   | 'stats'
   | 'unban'
 
@@ -100,6 +103,7 @@ export interface OperationDataTypes {
   'logout': ApiV1AuthLogoutLogoutData
   'me': ApiV1AuthMeMeData
   'read_settings': ApiV1SettingsReadSettingsData
+  'rotate': ApiV1LogsRotateRotateData
   'stats': ApiV1StatsStatsData
   'unban': ApiV1CrowdsecUnbanUnbanData
 }
@@ -125,6 +129,7 @@ export interface OperationResponseTypes {
   'logout': ApiV1AuthLogoutLogoutResponses
   'me': ApiV1AuthMeMeResponses
   'read_settings': ApiV1SettingsReadSettingsResponses
+  'rotate': ApiV1LogsRotateRotateResponses
   'stats': ApiV1StatsStatsResponses
   'unban': ApiV1CrowdsecUnbanUnbanResponses
 }
@@ -150,6 +155,7 @@ export interface OperationErrorTypes {
   'logout': never
   'me': never
   'read_settings': never
+  'rotate': never
   'stats': never
   'unban': ApiV1CrowdsecUnbanUnbanErrors
 }

--- a/resources/generated/schemas.ts
+++ b/resources/generated/schemas.ts
@@ -29,6 +29,8 @@ import type {
   ApiV1CrowdsecUnbanUnbanResponses,
   ApiV1GeoEventsFacetsGetGeoLogFacetsData,
   ApiV1GeoEventsFacetsGetGeoLogFacetsResponses,
+  ApiV1LogsFilesListFilesData,
+  ApiV1LogsFilesListFilesResponses,
   ApiV1SettingsReadSettingsData,
   ApiV1SettingsReadSettingsResponses,
   ApiV1StatsStatsData,
@@ -69,6 +71,7 @@ export type OperationName =
   | 'health'
   | 'health_ready'
   | 'list_banned_ips'
+  | 'list_files'
   | 'login'
   | 'logout'
   | 'me'
@@ -92,6 +95,7 @@ export interface OperationDataTypes {
   'health': HealthHealthData
   'health_ready': HealthReadyHealthReadyData
   'list_banned_ips': ApiV1CrowdsecBannedIpsListBannedIpsData
+  'list_files': ApiV1LogsFilesListFilesData
   'login': ApiV1AuthLoginLoginData
   'logout': ApiV1AuthLogoutLogoutData
   'me': ApiV1AuthMeMeData
@@ -116,6 +120,7 @@ export interface OperationResponseTypes {
   'health': HealthHealthResponses
   'health_ready': HealthReadyHealthReadyResponses
   'list_banned_ips': ApiV1CrowdsecBannedIpsListBannedIpsResponses
+  'list_files': ApiV1LogsFilesListFilesResponses
   'login': ApiV1AuthLoginLoginResponses
   'logout': ApiV1AuthLogoutLogoutResponses
   'me': ApiV1AuthMeMeResponses
@@ -140,6 +145,7 @@ export interface OperationErrorTypes {
   'health': never
   'health_ready': never
   'list_banned_ips': never
+  'list_files': never
   'login': ApiV1AuthLoginLoginErrors
   'logout': never
   'me': never

--- a/resources/lib/logstream.ts
+++ b/resources/lib/logstream.ts
@@ -1,0 +1,104 @@
+/**
+ * Reconnecting WebSocket client for /ws/logs.
+ * Same lazy-connect/backoff contract as LiveFeedClient (see websocket.ts).
+ */
+
+export interface LogRecord {
+  timestamp?: string
+  level?: string
+  logger?: string
+  event?: string
+  exception?: string
+  [key: string]: unknown
+}
+
+interface LogBatchFrame {
+  type: "log_batch"
+  records: LogRecord[]
+  dropped: number
+}
+
+export type LogStreamStatus = "connecting" | "connected" | "disconnected"
+
+type RecordsListener = (records: LogRecord[], dropped: number) => void
+type StatusListener = (status: LogStreamStatus) => void
+
+export class LogStreamClient {
+  private ws: WebSocket | null = null
+  private recordsListeners = new Set<RecordsListener>()
+  private statusListeners = new Set<StatusListener>()
+  private status: LogStreamStatus = "disconnected"
+  private backoffMs = 1000
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private shouldRun = false
+
+  private url(): string {
+    const proto = window.location.protocol === "https:" ? "wss:" : "ws:"
+    return `${proto}//${window.location.host}/ws/logs`
+  }
+
+  onRecords(cb: RecordsListener): () => void {
+    this.recordsListeners.add(cb)
+    if (this.recordsListeners.size === 1) this.connect()
+    return () => {
+      this.recordsListeners.delete(cb)
+      if (this.recordsListeners.size === 0) this.disconnect()
+    }
+  }
+
+  onStatus(cb: StatusListener): () => void {
+    this.statusListeners.add(cb)
+    cb(this.status)
+    return () => this.statusListeners.delete(cb)
+  }
+
+  connect(): void {
+    if (this.shouldRun) return
+    this.shouldRun = true
+    this.open()
+  }
+
+  disconnect(): void {
+    this.shouldRun = false
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer)
+    this.ws?.close()
+    this.ws = null
+    this.setStatus("disconnected")
+  }
+
+  private open(): void {
+    this.setStatus("connecting")
+    this.ws = new WebSocket(this.url())
+    this.ws.onopen = () => this.setStatus("connected")
+    this.ws.onmessage = (msg) => {
+      if (typeof msg.data !== "string") return
+      let frame: LogBatchFrame
+      try {
+        frame = JSON.parse(msg.data) as LogBatchFrame
+      } catch {
+        return
+      }
+      if (frame.type === "log_batch") {
+        this.backoffMs = 1000
+        if (frame.records.length || frame.dropped) {
+          this.recordsListeners.forEach((cb) => cb(frame.records, frame.dropped))
+        }
+      }
+    }
+    this.ws.onclose = () => {
+      this.setStatus("disconnected")
+      if (this.shouldRun) {
+        this.reconnectTimer = setTimeout(() => this.open(), this.backoffMs)
+        this.backoffMs = Math.min(this.backoffMs * 2, 30000)
+      }
+    }
+    this.ws.onerror = () => this.ws?.close()
+  }
+
+  private setStatus(status: LogStreamStatus): void {
+    this.status = status
+    this.statusListeners.forEach((cb) => cb(status))
+  }
+}
+
+export const logStream = new LogStreamClient()

--- a/resources/lib/logstream.ts
+++ b/resources/lib/logstream.ts
@@ -68,9 +68,18 @@ export class LogStreamClient {
 
   private open(): void {
     this.setStatus("connecting")
-    this.ws = new WebSocket(this.url())
-    this.ws.onopen = () => this.setStatus("connected")
-    this.ws.onmessage = (msg) => {
+    // Every callback checks `this.ws === ws` so a superseded socket (closed
+    // by disconnect() while its close handshake was still in flight) can
+    // neither deliver frames nor schedule a reconnect. Without the guard, a
+    // quick disconnect/connect cycle (StrictMode remount, page revisit)
+    // leaks a second live socket and every record is delivered twice.
+    const ws = new WebSocket(this.url())
+    this.ws = ws
+    ws.onopen = () => {
+      if (this.ws === ws) this.setStatus("connected")
+    }
+    ws.onmessage = (msg) => {
+      if (this.ws !== ws) return
       if (typeof msg.data !== "string") return
       let frame: LogBatchFrame
       try {
@@ -85,14 +94,15 @@ export class LogStreamClient {
         }
       }
     }
-    this.ws.onclose = () => {
+    ws.onclose = () => {
+      if (this.ws !== ws) return
       this.setStatus("disconnected")
       if (this.shouldRun) {
         this.reconnectTimer = setTimeout(() => this.open(), this.backoffMs)
         this.backoffMs = Math.min(this.backoffMs * 2, 30000)
       }
     }
-    this.ws.onerror = () => this.ws?.close()
+    ws.onerror = () => ws.close()
   }
 
   private setStatus(status: LogStreamStatus): void {

--- a/resources/lib/queries.ts
+++ b/resources/lib/queries.ts
@@ -151,7 +151,7 @@ export const queryKeys = {
     facets: () => [...queryKeys.geoLogs.all, "facets"] as const,
   },
   logs: {
-    tail: (lines: number) => ["logs", "tail", lines] as const,
+    tail: (lines: number, source: "app" | "login") => ["logs", "tail", lines, source] as const,
     files: ["logs", "files"] as const,
   },
 }
@@ -1159,12 +1159,12 @@ export function useGeoEventFacets({ enabled = true }: { enabled?: boolean } = {}
  * Initial page of recent structured log records for the Logs page.
  * The live stream (logStream) takes over after this loads, so it never refetches.
  */
-export function useLogTail(lines = 500) {
+export function useLogTail(lines = 500, source: "app" | "login" = "app") {
   return useQuery({
-    queryKey: queryKeys.logs.tail(lines),
+    queryKey: queryKeys.logs.tail(lines, source),
     queryFn: async () => {
       const { data } = await apiV1LogsTailTail({
-        query: { lines },
+        query: { lines, source },
         throwOnError: true,
       })
       return data.records

--- a/resources/lib/queries.ts
+++ b/resources/lib/queries.ts
@@ -58,6 +58,7 @@ import {
   type AccessLogDebugSortField,
   type AccessLogDebugStats,
 } from "./api"
+import { apiV1LogsFilesListFiles, apiV1LogsTailTail } from "@/generated/api/sdk.gen"
 import { useTimeRange } from "./time-range-context"
 import { useAnalyticsFilters } from "./analytics-filters-context"
 import { useGeoLogFilters } from "./geo-log-filters-context"
@@ -148,6 +149,10 @@ export const queryKeys = {
     geojson: (params: Record<string, unknown>, refreshKey?: number) =>
       [...queryKeys.geoLogs.all, "geojson", params, refreshKey] as const,
     facets: () => [...queryKeys.geoLogs.all, "facets"] as const,
+  },
+  logs: {
+    tail: (lines: number) => ["logs", "tail", lines] as const,
+    files: ["logs", "files"] as const,
   },
 }
 
@@ -1143,5 +1148,41 @@ export function useGeoEventFacets({ enabled = true }: { enabled?: boolean } = {}
     queryFn: fetchGeoEventFacets,
     enabled,
     staleTime: 60 * 1000,
+  })
+}
+
+// ============================================================================
+// Logs
+// ============================================================================
+
+/**
+ * Initial page of recent structured log records for the Logs page.
+ * The live stream (logStream) takes over after this loads, so it never refetches.
+ */
+export function useLogTail(lines = 500) {
+  return useQuery({
+    queryKey: queryKeys.logs.tail(lines),
+    queryFn: async () => {
+      const { data } = await apiV1LogsTailTail({
+        query: { lines },
+        throwOnError: true,
+      })
+      return data.records
+    },
+    staleTime: Number.POSITIVE_INFINITY, // stream takes over after initial load
+  })
+}
+
+/** Available log files (app/login/nginx) for the Logs page file picker. */
+export function useLogFiles() {
+  return useQuery({
+    queryKey: queryKeys.logs.files,
+    queryFn: async () => {
+      const { data } = await apiV1LogsFilesListFiles({
+        throwOnError: true,
+      })
+      return data.files
+    },
+    refetchInterval: 30_000,
   })
 }

--- a/resources/lib/websocket.ts
+++ b/resources/lib/websocket.ts
@@ -84,11 +84,18 @@ export class LiveFeedClient {
 
   private open(): void {
     this.setStatus("connecting")
-    this.ws = new WebSocket(this.url())
-    this.ws.onopen = () => {
-      this.setStatus("connected")
+    // Every callback checks `this.ws === ws` so a superseded socket (closed
+    // by disconnect() while its close handshake was still in flight) can
+    // neither deliver frames nor schedule a reconnect. Without the guard, a
+    // quick disconnect/connect cycle (StrictMode remount, page revisit)
+    // leaks a second live socket and every event is delivered twice.
+    const ws = new WebSocket(this.url())
+    this.ws = ws
+    ws.onopen = () => {
+      if (this.ws === ws) this.setStatus("connected")
     }
-    this.ws.onmessage = (msg) => {
+    ws.onmessage = (msg) => {
+      if (this.ws !== ws) return
       // The server only ever sends JSON text frames; ignore anything else
       // (a Blob/ArrayBuffer or malformed payload) rather than throwing and
       // tearing down live updates.
@@ -107,14 +114,15 @@ export class LiveFeedClient {
         this.eventsListeners.forEach((cb) => cb(frame.events, frame.dropped))
       }
     }
-    this.ws.onclose = () => {
+    ws.onclose = () => {
+      if (this.ws !== ws) return
       this.setStatus("disconnected")
       if (this.shouldRun) {
         this.reconnectTimer = setTimeout(() => this.open(), this.backoffMs)
         this.backoffMs = Math.min(this.backoffMs * 2, 30000)
       }
     }
-    this.ws.onerror = () => this.ws?.close()
+    ws.onerror = () => ws.close()
   }
 
   private setStatus(status: LiveFeedStatus): void {

--- a/resources/routeTree.gen.ts
+++ b/resources/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as AccessLogsRouteImport } from './routes/access-logs'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
 import { Route as SettingsSchedulerRouteImport } from './routes/settings/scheduler'
+import { Route as SettingsLogsRouteImport } from './routes/settings/logs'
 import { Route as SettingsEnvironmentRouteImport } from './routes/settings/environment'
 import { Route as SettingsAboutRouteImport } from './routes/settings/about'
 
@@ -78,6 +79,11 @@ const SettingsSchedulerRoute = SettingsSchedulerRouteImport.update({
   path: '/scheduler',
   getParentRoute: () => SettingsRoute,
 } as any)
+const SettingsLogsRoute = SettingsLogsRouteImport.update({
+  id: '/logs',
+  path: '/logs',
+  getParentRoute: () => SettingsRoute,
+} as any)
 const SettingsEnvironmentRoute = SettingsEnvironmentRouteImport.update({
   id: '/environment',
   path: '/environment',
@@ -101,6 +107,7 @@ export interface FileRoutesByFullPath {
   '/settings': typeof SettingsRouteWithChildren
   '/settings/about': typeof SettingsAboutRoute
   '/settings/environment': typeof SettingsEnvironmentRoute
+  '/settings/logs': typeof SettingsLogsRoute
   '/settings/scheduler': typeof SettingsSchedulerRoute
   '/settings/': typeof SettingsIndexRoute
 }
@@ -115,6 +122,7 @@ export interface FileRoutesByTo {
   '/security': typeof SecurityRoute
   '/settings/about': typeof SettingsAboutRoute
   '/settings/environment': typeof SettingsEnvironmentRoute
+  '/settings/logs': typeof SettingsLogsRoute
   '/settings/scheduler': typeof SettingsSchedulerRoute
   '/settings': typeof SettingsIndexRoute
 }
@@ -131,6 +139,7 @@ export interface FileRoutesById {
   '/settings': typeof SettingsRouteWithChildren
   '/settings/about': typeof SettingsAboutRoute
   '/settings/environment': typeof SettingsEnvironmentRoute
+  '/settings/logs': typeof SettingsLogsRoute
   '/settings/scheduler': typeof SettingsSchedulerRoute
   '/settings/': typeof SettingsIndexRoute
 }
@@ -148,6 +157,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/settings/about'
     | '/settings/environment'
+    | '/settings/logs'
     | '/settings/scheduler'
     | '/settings/'
   fileRoutesByTo: FileRoutesByTo
@@ -162,6 +172,7 @@ export interface FileRouteTypes {
     | '/security'
     | '/settings/about'
     | '/settings/environment'
+    | '/settings/logs'
     | '/settings/scheduler'
     | '/settings'
   id:
@@ -177,6 +188,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/settings/about'
     | '/settings/environment'
+    | '/settings/logs'
     | '/settings/scheduler'
     | '/settings/'
   fileRoutesById: FileRoutesById
@@ -272,6 +284,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsSchedulerRouteImport
       parentRoute: typeof SettingsRoute
     }
+    '/settings/logs': {
+      id: '/settings/logs'
+      path: '/logs'
+      fullPath: '/settings/logs'
+      preLoaderRoute: typeof SettingsLogsRouteImport
+      parentRoute: typeof SettingsRoute
+    }
     '/settings/environment': {
       id: '/settings/environment'
       path: '/environment'
@@ -292,6 +311,7 @@ declare module '@tanstack/react-router' {
 interface SettingsRouteChildren {
   SettingsAboutRoute: typeof SettingsAboutRoute
   SettingsEnvironmentRoute: typeof SettingsEnvironmentRoute
+  SettingsLogsRoute: typeof SettingsLogsRoute
   SettingsSchedulerRoute: typeof SettingsSchedulerRoute
   SettingsIndexRoute: typeof SettingsIndexRoute
 }
@@ -299,6 +319,7 @@ interface SettingsRouteChildren {
 const SettingsRouteChildren: SettingsRouteChildren = {
   SettingsAboutRoute: SettingsAboutRoute,
   SettingsEnvironmentRoute: SettingsEnvironmentRoute,
+  SettingsLogsRoute: SettingsLogsRoute,
   SettingsSchedulerRoute: SettingsSchedulerRoute,
   SettingsIndexRoute: SettingsIndexRoute,
 }

--- a/resources/routes/settings.tsx
+++ b/resources/routes/settings.tsx
@@ -7,6 +7,7 @@ export const Route = createFileRoute("/settings")({
 const tabs = [
   { to: "/settings/environment", label: "Environment" },
   { to: "/settings/scheduler", label: "Scheduler" },
+  { to: "/settings/logs", label: "Logs" },
   { to: "/settings/about", label: "About" },
 ] as const
 

--- a/resources/routes/settings/logs.tsx
+++ b/resources/routes/settings/logs.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { LogsOverview } from "@/components/settings/logs-overview"
+
+export const Route = createFileRoute("/settings/logs")({
+  component: LogsOverview,
+})

--- a/scripts/generate_config_docs.py
+++ b/scripts/generate_config_docs.py
@@ -33,6 +33,7 @@ SECTIONS: list[tuple[str, type[BaseSettings], str]] = [
     ("API server", settings_module.APISettings, "API_"),
     ("Database", settings_module.DatabaseSettings, "DB_"),
     ("GeoIP", settings_module.GeoIPSettings, "GEOIP_"),
+    ("Logging", settings_module.LogSettings, "LOG_"),
     ("Log parser", settings_module.LogParserSettings, "LOGPARSER_"),
     ("Analytics & retention", settings_module.AnalyticsSettings, "ANALYTICS_"),
     ("Scheduler", settings_module.SchedulerSettings, "SCHEDULER_"),
@@ -43,8 +44,8 @@ SECTIONS: list[tuple[str, type[BaseSettings], str]] = [
 
 # Top-level Settings fields that are sub-models, not env vars.
 SKIP_FIELDS = {
-    "api", "database", "geoip", "logparser", "analytics", "scheduler", "map",
-    "crowdsec", "vite",
+    "api", "database", "geoip", "log", "logparser", "analytics", "scheduler",
+    "map", "crowdsec", "vite",
 }
 # Never document secrets' defaults verbatim.
 REDACT = {"password", "license_key", "admin_password", "bouncer_api_key", "machine_password"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def baseline_settings_env():
         # API
         "API_HOST": "0.0.0.0",
         "API_PORT": "8000",
-        "API_LOG_LEVEL": "INFO",
+        "LOG_LEVEL": "INFO",
         # Database
         "DB_ECHO": "false",
         "DB_POOL_SIZE": "5",

--- a/tests/test_auth_endpoints.py
+++ b/tests/test_auth_endpoints.py
@@ -1,7 +1,6 @@
 """Endpoint tests for login/logout/me and the auth middleware boundary."""
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import pytest
@@ -37,6 +36,7 @@ def make_app(**settings_kwargs) -> Litestar:
     app = Litestar(
         route_handlers=[AuthController, protected, fake_health, live_feed],
         on_app_init=[session_auth.on_app_init],
+        logging_config=None,
     )
     app.state.auth_state = build_auth_state(settings)
     # A working ingestion service so the authenticated branch streams rather
@@ -175,18 +175,11 @@ def test_session_cookie_secure_flag_follows_setting():
 
 
 def test_login_attempts_are_logged_with_client_ip():
-    records: list = []
+    import structlog
 
-    class ListHandler(logging.Handler):
-        def emit(self, record: logging.LogRecord) -> None:
-            records.append(record)
-
-    auth_logger = logging.getLogger("geometrikks.api.v1.auth_controller")
-    handler = ListHandler(level=logging.INFO)
     app = make_app()
-    with TestClient(app=app) as client:
-        auth_logger.addHandler(handler)
-        try:
+    with structlog.testing.capture_logs() as captured:
+        with TestClient(app=app) as client:
             client.post(
                 "/api/v1/auth/login",
                 json={"username": "admin", "password": "wrong"},
@@ -195,12 +188,38 @@ def test_login_attempts_are_logged_with_client_ip():
                 "/api/v1/auth/login",
                 json={"username": "admin", "password": "bestpasswordintheworldnojoke"},
             )
-        finally:
-            auth_logger.removeHandler(handler)
-    failed = [r for r in records if "Login failed" in r.getMessage()]
-    succeeded = [r for r in records if "Login succeeded" in r.getMessage()]
-    assert len(failed) == 1 and failed[0].levelno == logging.WARNING
-    assert len(succeeded) == 1 and succeeded[0].levelno == logging.INFO
-    # Both carry the username and a from-<address> clause (TestClient peer).
-    assert "'admin'" in failed[0].getMessage() and "from" in failed[0].getMessage()
-    assert "'admin'" in succeeded[0].getMessage() and "from" in succeeded[0].getMessage()
+    failed = [e for e in captured if e["event"] == "login_failed"]
+    succeeded = [e for e in captured if e["event"] == "login_success"]
+    assert len(failed) == 1 and failed[0]["log_level"] == "warning"
+    assert len(succeeded) == 1 and succeeded[0]["log_level"] == "info"
+    # Both carry the username and the client IP (TestClient peer).
+    assert failed[0]["user"] == "admin" and failed[0]["ip"]
+    assert succeeded[0]["user"] == "admin" and succeeded[0]["ip"]
+
+
+class TestLoginLogFile:
+    def test_login_events_written_in_contract_format(self, tmp_path, monkeypatch):
+        from tests.test_logging_pipeline import LOGIN_LINE_RE, _wait_for
+
+        monkeypatch.setenv("LOG_DIR", str(tmp_path / "logs"))
+        from geometrikks.config.settings import get_settings
+        get_settings.cache_clear()
+        from geometrikks.server.logging import create_logging_config
+        config = create_logging_config(get_settings())
+        config.configure()
+        config.standard_lib_logging_config.configure()
+
+        with TestClient(app=make_app()) as client:
+            client.post("/api/v1/auth/login", json={"username": "admin", "password": "wrong"})
+            client.post(
+                "/api/v1/auth/login",
+                json={"username": "admin", "password": "bestpasswordintheworldnojoke"},
+            )
+            client.post("/api/v1/auth/logout")
+
+        login_file = tmp_path / "logs" / "login.log"
+        assert _wait_for(lambda: login_file.exists() and "logout" in login_file.read_text(encoding="utf-8"))
+        lines = login_file.read_text(encoding="utf-8").splitlines()
+        assert [l.split(" ")[1] for l in lines] == ["login_failed", "login_success", "logout"]
+        for line in lines:
+            assert LOGIN_LINE_RE.match(line), line

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -84,10 +84,11 @@ def test_geoip_missing_file_allowed_by_default():
 def test_api_settings():
     """Test API server configuration."""
     settings = Settings()
-    
+
     assert settings.api.host == "0.0.0.0"
     assert settings.api.port == 8000
-    assert settings.api.log_level in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+    # log_level is now a deprecated fallback; unset unless API_LOG_LEVEL is set.
+    assert settings.api.log_level is None
 
 
 def test_map_home_settings(monkeypatch):
@@ -389,3 +390,39 @@ class TestProxySettings:
 
     def test_session_secure_defaults_false(self):
         assert Settings(_env_file=None).session_secure is False
+
+
+class TestLogSettings:
+    def test_defaults(self, monkeypatch):
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        from geometrikks.config.settings import Settings
+        s = Settings(_env_file=None)
+        assert s.log.dir == Path("logs")
+        assert s.log.level == "INFO"
+        assert s.log.main_max_bytes == 10 * 1024 * 1024
+        assert s.log.main_backup_count == 5
+        assert s.log.login_max_bytes == 10 * 1024 * 1024
+        assert s.log.login_backup_count == 5
+
+    def test_log_level_env(self, monkeypatch):
+        monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+        from geometrikks.config.settings import Settings
+        assert Settings(_env_file=None).log.level == "DEBUG"
+
+    def test_deprecated_api_log_level_used_when_log_level_unset(self, monkeypatch):
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        monkeypatch.setenv("API_LOG_LEVEL", "WARNING")
+        from geometrikks.config.settings import Settings
+        with pytest.warns(DeprecationWarning, match="API_LOG_LEVEL is deprecated"):
+            s = Settings(_env_file=None)
+        assert s.log.level == "WARNING"
+
+    def test_log_level_overrides_deprecated_var(self, monkeypatch):
+        monkeypatch.setenv("LOG_LEVEL", "ERROR")
+        monkeypatch.setenv("API_LOG_LEVEL", "DEBUG")
+        from geometrikks.config.settings import Settings
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # no DeprecationWarning may fire
+            s = Settings(_env_file=None)
+        assert s.log.level == "ERROR"

--- a/tests/test_live_ws.py
+++ b/tests/test_live_ws.py
@@ -114,3 +114,49 @@ def test_ws_closes_when_no_ingestion_service():
         with pytest.raises(WebSocketDisconnect):
             with client.websocket_connect("/ws/live") as ws:
                 ws.receive_json(timeout=2)
+
+
+class TestLogsFeed:
+    def _make_app(self):
+        from geometrikks.api.v1.live_controller import logs_feed
+        return Litestar(route_handlers=[logs_feed])
+
+    def _receive_data_frame(self, ws, publish, timeout: float = 5.0):
+        """Publish repeatedly until a non-heartbeat frame arrives.
+
+        The handler subscribes shortly AFTER the handshake completes, so a
+        single publish can race the subscribe and be missed; heartbeat frames
+        (empty records, dropped=0) are skipped.
+        """
+        import time
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            publish()
+            frame = ws.receive_json(timeout=2)
+            if frame["records"]:
+                return frame
+        raise AssertionError("no data frame received")
+
+    def test_streams_published_events(self):
+        from geometrikks.server.logging import log_broadcaster
+        with TestClient(app=self._make_app()) as client:
+            with client.websocket_connect("/ws/logs") as ws:
+                frame = self._receive_data_frame(
+                    ws,
+                    lambda: log_broadcaster.publish_threadsafe(
+                        {"timestamp": "t", "level": "info", "event": "hello_ws"}
+                    ),
+                )
+                assert frame["type"] == "log_batch"
+                assert any(r.get("event") == "hello_ws" for r in frame["records"])
+
+    def test_level_filter_drops_lower_levels(self):
+        from geometrikks.server.logging import log_broadcaster
+        with TestClient(app=self._make_app()) as client:
+            with client.websocket_connect("/ws/logs?level=warning") as ws:
+                def publish():
+                    log_broadcaster.publish_threadsafe({"level": "debug", "event": "noise"})
+                    log_broadcaster.publish_threadsafe({"level": "error", "event": "boom"})
+                frame = self._receive_data_frame(ws, publish)
+                events = [r["event"] for r in frame["records"]]
+                assert "boom" in events and "noise" not in events

--- a/tests/test_logfiles_service.py
+++ b/tests/test_logfiles_service.py
@@ -1,0 +1,70 @@
+"""LogFilesService: listing, allowlisted resolution, JSONL tail."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def service(tmp_path):
+    from geometrikks.services.logfiles import LogFilesService
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "geometrikks.log").write_text(
+        "\n".join(json.dumps({"event": f"e{i}", "level": "info"}) for i in range(10)) + "\n",
+        encoding="utf-8",
+    )
+    (log_dir / "geometrikks.log.1.gz").write_bytes(b"\x1f\x8b_fake")
+    (log_dir / "login.log").write_text("2026-07-23T00:00:00Z logout user=\"a\" ip=-\n", encoding="utf-8")
+    nginx = tmp_path / "access.log"
+    nginx.write_text("nginx line\n", encoding="utf-8")
+    missing_nginx = tmp_path / "missing" / "other.log"
+    return LogFilesService(log_dir=log_dir, nginx_paths=[nginx, missing_nginx])
+
+
+class TestListFiles:
+    def test_lists_all_kinds(self, service):
+        entries = {(e.kind, e.name): e for e in service.list_files()}
+        assert ("app", "geometrikks.log") in entries
+        assert ("app", "geometrikks.log.1.gz") in entries
+        assert ("login", "login.log") in entries
+        assert ("nginx", "access.log") in entries
+
+    def test_unreadable_nginx_marked_unavailable(self, service):
+        entries = {e.name: e for e in service.list_files() if e.kind == "nginx"}
+        assert entries["access.log"].available is True
+        assert entries["other.log"].available is False
+
+
+class TestResolve:
+    def test_resolves_listed_file(self, service):
+        path = service.resolve("app", "geometrikks.log")
+        assert path is not None and path.name == "geometrikks.log"
+
+    def test_rejects_traversal_and_unknown(self, service):
+        assert service.resolve("app", "../../etc/passwd") is None
+        assert service.resolve("app", "passwd") is None
+        assert service.resolve("nginx", "geometrikks.log") is None
+        assert service.resolve("bogus", "geometrikks.log") is None
+
+    def test_rejects_unavailable_nginx_file(self, service):
+        assert service.resolve("nginx", "other.log") is None
+
+
+class TestTail:
+    def test_returns_last_n_parsed_records(self, service):
+        records = service.tail_main(lines=3)
+        assert [r["event"] for r in records] == ["e7", "e8", "e9"]
+
+    def test_skips_malformed_lines(self, service, tmp_path):
+        main = tmp_path / "logs" / "geometrikks.log"
+        main.write_text('{"event": "good"}\nnot json\n', encoding="utf-8")
+        records = service.tail_main(lines=10)
+        assert [r["event"] for r in records] == ["good"]
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        from geometrikks.services.logfiles import LogFilesService
+        svc = LogFilesService(log_dir=tmp_path / "nope", nginx_paths=[])
+        assert svc.tail_main(lines=5) == []

--- a/tests/test_logfiles_service.py
+++ b/tests/test_logfiles_service.py
@@ -68,3 +68,50 @@ class TestTail:
         from geometrikks.services.logfiles import LogFilesService
         svc = LogFilesService(log_dir=tmp_path / "nope", nginx_paths=[])
         assert svc.tail_main(lines=5) == []
+
+
+class TestTailLogin:
+    def test_parses_valid_lines(self, service):
+        records = service.tail_login(lines=10)
+        assert len(records) == 1
+        record = records[0]
+        assert record["timestamp"] == "2026-07-23T00:00:00Z"
+        assert record["event"] == "logout"
+        assert record["user"] == "a"
+        assert record["level"] == "info"
+        assert record["logger"] == "geometrikks.auth.login"
+
+    def test_login_failed_gets_warning_level(self, service, tmp_path):
+        login = tmp_path / "logs" / "login.log"
+        login.write_text(
+            '2026-07-23T00:01:00Z login_failed user="bob" ip=1.2.3.4\n', encoding="utf-8"
+        )
+        records = service.tail_login(lines=10)
+        assert records[0]["level"] == "warning"
+        assert records[0]["event"] == "login_failed"
+
+    def test_ip_dash_omits_ip_key(self, service):
+        records = service.tail_login(lines=10)
+        assert "ip" not in records[0]
+
+    def test_ip_present_when_valid(self, service, tmp_path):
+        login = tmp_path / "logs" / "login.log"
+        login.write_text(
+            '2026-07-23T00:01:00Z login_success user="bob" ip=1.2.3.4\n', encoding="utf-8"
+        )
+        records = service.tail_login(lines=10)
+        assert records[0]["ip"] == "1.2.3.4"
+
+    def test_skips_malformed_lines(self, service, tmp_path):
+        login = tmp_path / "logs" / "login.log"
+        login.write_text(
+            '2026-07-23T00:01:00Z login_success user="ok" ip=-\nnot a valid line\n',
+            encoding="utf-8",
+        )
+        records = service.tail_login(lines=10)
+        assert [r["event"] for r in records] == ["login_success"]
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        from geometrikks.services.logfiles import LogFilesService
+        svc = LogFilesService(log_dir=tmp_path / "nope", nginx_paths=[])
+        assert svc.tail_login(lines=5) == []

--- a/tests/test_logging_pipeline.py
+++ b/tests/test_logging_pipeline.py
@@ -329,9 +329,9 @@ class TestCreateLoggingConfig:
     def test_handler_levels_are_respected_behind_queue(self, configured_logging):
         import structlog
         from geometrikks.server.logging import LOGIN_LOGGER_NAME
-        # Use a non-login logger for the DEBUG event: the login logger is
-        # pinned at INFO (see TestLoginLoggerLevelPinned), so a DEBUG call on
-        # it would be filtered at the logger itself rather than demonstrate
+        # Use a non-login logger for this probe: the login logger is pinned
+        # at INFO (see TestLoginLoggerLevelPinned), so a DEBUG call on it
+        # would be filtered at the logger itself rather than demonstrate
         # per-handler level filtering behind the shared queue.
         structlog.stdlib.get_logger("geometrikks.test.levels").debug(
             "debug_other_event"
@@ -345,6 +345,17 @@ class TestCreateLoggingConfig:
         # The DEBUG event still reaches the main file (its handler level is DEBUG).
         main = configured_logging / "geometrikks.log"
         assert _wait_for(lambda: "debug_other_event" in main.read_text(encoding="utf-8"))
+
+        # A DEBUG call directly on the login logger, however, is filtered at
+        # the logger itself (pinned to INFO), so it must reach neither file
+        # at all -- this pins both the login-logger level pin and the
+        # per-handler level path in one assertion.
+        structlog.stdlib.get_logger(LOGIN_LOGGER_NAME).debug(
+            "debug_login_event_should_not_appear", user="x", ip="1.2.3.4"
+        )
+        time.sleep(0.2)
+        assert "debug_login_event_should_not_appear" not in login.read_text(encoding="utf-8")
+        assert "debug_login_event_should_not_appear" not in main.read_text(encoding="utf-8")
 
 
 class TestLoginLoggerLevelPinned:
@@ -369,6 +380,78 @@ class TestLoginLoggerLevelPinned:
         assert _wait_for(lambda: "login_success" in login.read_text(encoding="utf-8"))
         line = login.read_text(encoding="utf-8").splitlines()[-1]
         assert LOGIN_LINE_RE.match(line), line
+
+
+@pytest.fixture()
+def _restore_umask():
+    """chmod-based writability tests can leave a directory unreadable for
+    pytest's own cleanup; make sure permissions are restored either way."""
+    dirs: list[Path] = []
+    yield dirs
+    for d in dirs:
+        d.chmod(0o755)
+
+
+class TestLogDirWritabilityFallback:
+    def test_unwritable_log_dir_disables_file_handlers(self, tmp_path, monkeypatch, capsys, _restore_umask):
+        import os
+        if os.geteuid() == 0:
+            pytest.skip("root bypasses directory permission bits")
+
+        log_dir = tmp_path / "unwritable"
+        log_dir.mkdir()
+        log_dir.chmod(0o555)
+        _restore_umask.append(log_dir)
+
+        monkeypatch.setenv("LOG_DIR", str(log_dir))
+        monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+        from geometrikks.config.settings import get_settings
+        get_settings.cache_clear()
+        from geometrikks.server.logging import create_logging_config
+        config = create_logging_config(get_settings())
+        config.configure()
+        config.standard_lib_logging_config.configure()
+
+        # Loud error printed at configure time, mentioning the path and a fix.
+        err = capsys.readouterr().err
+        assert str(log_dir) in err
+        assert "DISABLED" in err
+        assert "chown" in err
+
+        # No file handlers registered; only console/broadcast survive.
+        import logging.handlers as lh
+        root = logging.getLogger()
+        queue_handlers = [h for h in root.handlers if isinstance(h, lh.QueueHandler)]
+        assert queue_handlers, "root must still log through the queue handler"
+        listener_types = {type(h).__name__ for h in queue_handlers[0].listener.handlers}
+        assert "GzipRotatingFileHandler" not in listener_types
+        assert "StreamHandler" in listener_types
+
+        # No log files were created inside the unwritable dir.
+        assert not (log_dir / "geometrikks.log").exists()
+        assert not (log_dir / "login.log").exists()
+
+        # The app still logs (to console) without raising.
+        import structlog
+        structlog.stdlib.get_logger("geometrikks.test").info("still_alive")
+
+    def test_writable_log_dir_keeps_file_handlers(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOG_DIR", str(tmp_path / "logs"))
+        monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+        from geometrikks.config.settings import get_settings
+        get_settings.cache_clear()
+        from geometrikks.server.logging import create_logging_config
+        config = create_logging_config(get_settings())
+        config.configure()
+        config.standard_lib_logging_config.configure()
+
+        import logging.handlers as lh
+        root = logging.getLogger()
+        queue_handlers = [h for h in root.handlers if isinstance(h, lh.QueueHandler)]
+        listener_types = {type(h).__name__ for h in queue_handlers[0].listener.handlers}
+        assert "GzipRotatingFileHandler" in listener_types
+        assert (tmp_path / "logs" / "geometrikks.log").exists()
+        assert (tmp_path / "logs" / "login.log").exists()
 
 
 class TestAppWiring:

--- a/tests/test_logging_pipeline.py
+++ b/tests/test_logging_pipeline.py
@@ -1,0 +1,32 @@
+"""Unit tests for the structlog pipeline building blocks."""
+from __future__ import annotations
+
+import gzip
+import logging
+import re
+from pathlib import Path
+
+import pytest
+
+
+class TestSuccessLevel:
+    def test_registered_between_info_and_warning(self):
+        from geometrikks.server.logging import SUCCESS_LEVEL, register_success_level
+        register_success_level()
+        assert logging.INFO < SUCCESS_LEVEL < logging.WARNING
+        assert logging.getLevelName(SUCCESS_LEVEL) == "SUCCESS"
+
+    def test_stdlib_logger_gains_success_method(self, caplog):
+        from geometrikks.server.logging import SUCCESS_LEVEL, register_success_level
+        register_success_level()
+        logger = logging.getLogger("test.success")
+        with caplog.at_level(SUCCESS_LEVEL, logger="test.success"):
+            logger.success("it worked")
+        assert caplog.records[0].levelno == SUCCESS_LEVEL
+        assert caplog.records[0].getMessage() == "it worked"
+
+    def test_register_is_idempotent(self):
+        from geometrikks.server.logging import register_success_level
+        register_success_level()
+        register_success_level()
+        assert logging.getLevelName(25) == "SUCCESS"

--- a/tests/test_logging_pipeline.py
+++ b/tests/test_logging_pipeline.py
@@ -329,18 +329,46 @@ class TestCreateLoggingConfig:
     def test_handler_levels_are_respected_behind_queue(self, configured_logging):
         import structlog
         from geometrikks.server.logging import LOGIN_LOGGER_NAME
-        structlog.stdlib.get_logger(LOGIN_LOGGER_NAME).debug(
-            "debug_login_event", user="x", ip="1.2.3.4"
+        # Use a non-login logger for the DEBUG event: the login logger is
+        # pinned at INFO (see TestLoginLoggerLevelPinned), so a DEBUG call on
+        # it would be filtered at the logger itself rather than demonstrate
+        # per-handler level filtering behind the shared queue.
+        structlog.stdlib.get_logger("geometrikks.test.levels").debug(
+            "debug_other_event"
         )
         structlog.stdlib.get_logger(LOGIN_LOGGER_NAME).warning(
             "login_failed", user="x", ip="1.2.3.4"
         )
         login = configured_logging / "login.log"
         assert _wait_for(lambda: "login_failed" in login.read_text(encoding="utf-8"))
-        assert "debug_login_event" not in login.read_text(encoding="utf-8")
+        assert "debug_other_event" not in login.read_text(encoding="utf-8")
         # The DEBUG event still reaches the main file (its handler level is DEBUG).
         main = configured_logging / "geometrikks.log"
-        assert _wait_for(lambda: "debug_login_event" in main.read_text(encoding="utf-8"))
+        assert _wait_for(lambda: "debug_other_event" in main.read_text(encoding="utf-8"))
+
+
+class TestLoginLoggerLevelPinned:
+    def test_login_success_reaches_login_file_when_root_level_is_error(self, tmp_path, monkeypatch):
+        """LOG_LEVEL=ERROR must not silence the login feed (CrowdSec/fail2ban)."""
+        monkeypatch.setenv("LOG_DIR", str(tmp_path / "logs"))
+        monkeypatch.setenv("LOG_LEVEL", "ERROR")
+        from geometrikks.config.settings import get_settings
+        get_settings.cache_clear()
+        from geometrikks.server.logging import create_logging_config
+        config = create_logging_config(get_settings())
+        config.configure()
+        config.standard_lib_logging_config.configure()
+        log_dir = tmp_path / "logs"
+
+        import structlog
+        from geometrikks.server.logging import LOGIN_LOGGER_NAME
+        structlog.stdlib.get_logger(LOGIN_LOGGER_NAME).info(
+            "login_success", user="admin", ip="203.0.113.7"
+        )
+        login = log_dir / "login.log"
+        assert _wait_for(lambda: "login_success" in login.read_text(encoding="utf-8"))
+        line = login.read_text(encoding="utf-8").splitlines()[-1]
+        assert LOGIN_LINE_RE.match(line), line
 
 
 class TestAppWiring:

--- a/tests/test_logging_pipeline.py
+++ b/tests/test_logging_pipeline.py
@@ -34,6 +34,37 @@ class TestSuccessLevel:
         register_success_level()
         assert logging.getLevelName(25) == "SUCCESS"
 
+    def test_success_works_without_app_configuration(self, caplog):
+        # Modules like the importer call logger.success() from scripts and
+        # tests that never boot the app; the module-level default must make
+        # that safe instead of leaving structlog's success-less default.
+        import structlog
+
+        from geometrikks.server.logging import ensure_default_configuration, get_logger
+        try:
+            structlog.reset_defaults()
+            ensure_default_configuration()
+            with caplog.at_level(logging.INFO, logger="test.unconfigured"):
+                get_logger("test.unconfigured").success("no app booted")
+            assert any(r.levelname == "SUCCESS" for r in caplog.records)
+        finally:
+            structlog.reset_defaults()
+            ensure_default_configuration()
+
+    def test_default_configuration_does_not_clobber_explicit_config(self):
+        import structlog
+
+        from geometrikks.server.logging import ensure_default_configuration
+        try:
+            structlog.reset_defaults()
+            marker = structlog.testing.LogCapture()
+            structlog.configure(processors=[marker])
+            ensure_default_configuration()
+            assert structlog.get_config()["processors"] == [marker]
+        finally:
+            structlog.reset_defaults()
+            ensure_default_configuration()
+
 
 class TestGzipRotatingFileHandler:
     def _make_handler(self, tmp_path: Path, max_bytes: int = 200):

--- a/tests/test_logging_pipeline.py
+++ b/tests/test_logging_pipeline.py
@@ -6,7 +6,10 @@ import gzip
 import json
 import logging
 import re
+import time
 from pathlib import Path
+
+import pytest
 
 
 class TestSuccessLevel:
@@ -243,3 +246,93 @@ class TestBroadcastHandler:
             assert event == {"event": "hello"}
 
         asyncio.run(scenario())
+
+
+@pytest.fixture()
+def configured_logging(tmp_path, monkeypatch):
+    """Configure the full pipeline against a temp log dir; returns the dir."""
+    monkeypatch.setenv("LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    from geometrikks.config.settings import get_settings
+    get_settings.cache_clear()
+    from geometrikks.server.logging import create_logging_config
+    config = create_logging_config(get_settings())
+    config.configure()
+    config.standard_lib_logging_config.configure()
+    return tmp_path / "logs"
+
+
+def _wait_for(predicate, timeout: float = 3.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+class TestCreateLoggingConfig:
+    def test_handler_tree_and_files(self, configured_logging):
+        import logging.handlers as lh
+        root = logging.getLogger()
+        queue_handlers = [h for h in root.handlers if isinstance(h, lh.QueueHandler)]
+        assert queue_handlers, "root must log through the queue handler"
+        listener_targets = {type(h).__name__ for h in queue_handlers[0].listener.handlers}
+        assert {"StreamHandler", "GzipRotatingFileHandler", "BroadcastHandler"} <= listener_targets
+        assert (configured_logging / "geometrikks.log").exists()
+        assert (configured_logging / "login.log").exists()
+
+    def test_jsonl_main_log_line(self, configured_logging):
+        import json as jsonlib
+        import structlog
+        structlog.stdlib.get_logger("geometrikks.test").info("hello_jsonl", answer=42)
+        main = configured_logging / "geometrikks.log"
+        assert _wait_for(lambda: "hello_jsonl" in main.read_text(encoding="utf-8"))
+        line = [l for l in main.read_text(encoding="utf-8").splitlines() if "hello_jsonl" in l][0]
+        record = jsonlib.loads(line)
+        assert record["event"] == "hello_jsonl"
+        assert record["level"] == "info"
+        assert record["logger"] == "geometrikks.test"
+        assert record["answer"] == 42
+        assert "timestamp" in record
+
+    def test_success_level_renders_in_json(self, configured_logging):
+        import json as jsonlib
+        import structlog
+        structlog.stdlib.get_logger("geometrikks.test").success("it_worked")
+        main = configured_logging / "geometrikks.log"
+        assert _wait_for(lambda: "it_worked" in main.read_text(encoding="utf-8"))
+        line = [l for l in main.read_text(encoding="utf-8").splitlines() if "it_worked" in l][0]
+        assert jsonlib.loads(line)["level"] == "success"
+
+    def test_login_logger_reaches_login_file_with_contract_format(self, configured_logging):
+        import structlog
+        from geometrikks.server.logging import LOGIN_LOGGER_NAME
+        structlog.stdlib.get_logger(LOGIN_LOGGER_NAME).warning(
+            "login_failed", user="admin", ip="203.0.113.7"
+        )
+        login = configured_logging / "login.log"
+        assert _wait_for(lambda: "login_failed" in login.read_text(encoding="utf-8"))
+        line = login.read_text(encoding="utf-8").splitlines()[-1]
+        assert LOGIN_LINE_RE.match(line), line
+        # And the same event also lands in the main log.
+        main = configured_logging / "geometrikks.log"
+        assert _wait_for(lambda: "login_failed" in main.read_text(encoding="utf-8"))
+
+    def test_other_loggers_do_not_reach_login_file(self, configured_logging):
+        import structlog
+        structlog.stdlib.get_logger("geometrikks.other").warning("not_a_login_event")
+        main = configured_logging / "geometrikks.log"
+        assert _wait_for(lambda: "not_a_login_event" in main.read_text(encoding="utf-8"))
+        assert "not_a_login_event" not in (configured_logging / "login.log").read_text(encoding="utf-8")
+
+
+class TestAppWiring:
+    def test_create_app_configures_structlog_pipeline(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOG_DIR", str(tmp_path / "applogs"))
+        monkeypatch.setenv("APP_AUTH_DISABLED", "true")
+        from geometrikks.config.settings import get_settings
+        get_settings.cache_clear()
+        from geometrikks.server.core import create_app
+        create_app()
+        assert (tmp_path / "applogs" / "geometrikks.log").exists()

--- a/tests/test_logging_pipeline.py
+++ b/tests/test_logging_pipeline.py
@@ -380,6 +380,24 @@ class TestExceptionTraceback:
         assert "ValueError" in record["exception"]
         assert "boom for jsonl" in record["exception"]
         assert "Traceback" in record["exception"]
+        assert record["error"] == "ValueError: boom for jsonl"
+
+    def test_explicit_error_kwarg_is_not_clobbered(self, configured_logging):
+        import json as jsonlib
+        import structlog
+        logger = structlog.stdlib.get_logger("geometrikks.test.exc")
+        try:
+            raise ValueError("boom for kwarg")
+        except ValueError:
+            logger.error("caught_error_kwarg", exc_info=True, error="custom message")
+        main = configured_logging / "geometrikks.log"
+        assert _wait_for(lambda: "caught_error_kwarg" in main.read_text(encoding="utf-8"))
+        line = [
+            l for l in main.read_text(encoding="utf-8").splitlines() if "caught_error_kwarg" in l
+        ][0]
+        record = jsonlib.loads(line)
+        assert record["error"] == "custom message"
+        assert "Traceback" in record["exception"]
 
     def test_broadcast_record_carries_exception_traceback(self, configured_logging):
         import structlog
@@ -409,6 +427,7 @@ class TestExceptionTraceback:
                 assert "exception" in event
                 assert "ValueError" in event["exception"]
                 assert "boom for broadcast" in event["exception"]
+                assert event["error"] == "ValueError: boom for broadcast"
             finally:
                 log_broadcaster.unsubscribe(q)
 

--- a/tests/test_logging_pipeline.py
+++ b/tests/test_logging_pipeline.py
@@ -1,12 +1,7 @@
 """Unit tests for the structlog pipeline building blocks."""
 from __future__ import annotations
 
-import gzip
 import logging
-import re
-from pathlib import Path
-
-import pytest
 
 
 class TestSuccessLevel:

--- a/tests/test_logging_pipeline.py
+++ b/tests/test_logging_pipeline.py
@@ -1,7 +1,9 @@
 """Unit tests for the structlog pipeline building blocks."""
 from __future__ import annotations
 
+import gzip
 import logging
+from pathlib import Path
 
 
 class TestSuccessLevel:
@@ -25,3 +27,46 @@ class TestSuccessLevel:
         register_success_level()
         register_success_level()
         assert logging.getLevelName(25) == "SUCCESS"
+
+
+class TestGzipRotatingFileHandler:
+    def _make_handler(self, tmp_path: Path, max_bytes: int = 200):
+        from geometrikks.server.logging import GzipRotatingFileHandler
+        return GzipRotatingFileHandler(
+            filename=str(tmp_path / "app.log"),
+            maxBytes=max_bytes,
+            backupCount=2,
+            encoding="utf-8",
+        )
+
+    def test_rotated_file_is_gzipped(self, tmp_path):
+        handler = self._make_handler(tmp_path)
+        logger = logging.getLogger("test.rotate")
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        try:
+            for i in range(50):
+                logger.info("x" * 40 + str(i))
+        finally:
+            logger.removeHandler(handler)
+            handler.close()
+        archive = tmp_path / "app.log.1.gz"
+        assert archive.exists()
+        content = gzip.decompress(archive.read_bytes()).decode("utf-8")
+        assert "xxxx" in content
+        assert (tmp_path / "app.log").exists()  # active file continues
+
+    def test_backup_count_is_enforced(self, tmp_path):
+        handler = self._make_handler(tmp_path)
+        logger = logging.getLogger("test.rotate2")
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        try:
+            for i in range(300):
+                logger.info("y" * 40 + str(i))
+        finally:
+            logger.removeHandler(handler)
+            handler.close()
+        assert (tmp_path / "app.log.1.gz").exists()
+        assert (tmp_path / "app.log.2.gz").exists()
+        assert not (tmp_path / "app.log.3.gz").exists()

--- a/tests/test_logging_pipeline.py
+++ b/tests/test_logging_pipeline.py
@@ -358,6 +358,36 @@ class TestCreateLoggingConfig:
         assert "debug_login_event_should_not_appear" not in main.read_text(encoding="utf-8")
 
 
+class TestRotateLogFiles:
+    def test_rotates_main_log_and_keeps_logging_working(self, configured_logging):
+        import structlog
+        from geometrikks.server.logging import rotate_log_files
+
+        structlog.stdlib.get_logger("geometrikks.test.rotate").info("before_rotate")
+        main = configured_logging / "geometrikks.log"
+        assert _wait_for(lambda: "before_rotate" in main.read_text(encoding="utf-8"))
+
+        rotated = rotate_log_files()
+        assert "geometrikks.log" in rotated
+        assert (configured_logging / "geometrikks.log.1.gz").exists()
+        assert "before_rotate" not in main.read_text(encoding="utf-8")
+
+        structlog.stdlib.get_logger("geometrikks.test.rotate").info("after_rotate")
+        assert _wait_for(lambda: "after_rotate" in main.read_text(encoding="utf-8"))
+
+    def test_skips_empty_files(self, configured_logging):
+        from geometrikks.server.logging import rotate_log_files
+
+        # login.log exists but is empty until something logs to it.
+        login = configured_logging / "login.log"
+        assert login.exists()
+        assert login.stat().st_size == 0
+
+        rotated = rotate_log_files()
+        assert "login.log" not in rotated
+        assert not (configured_logging / "login.log.1.gz").exists()
+
+
 class TestExceptionTraceback:
     """A caught exception logged with exc_info=True must survive the queue
     handler with its traceback intact (see _capture_exc_info)."""

--- a/tests/test_logging_pipeline.py
+++ b/tests/test_logging_pipeline.py
@@ -313,6 +313,23 @@ class TestCreateLoggingConfig:
         assert (configured_logging / "geometrikks.log").exists()
         assert (configured_logging / "login.log").exists()
 
+    def test_queue_is_bounded(self, configured_logging):
+        import logging.handlers as lh
+        from geometrikks.server.logging import LOG_QUEUE_MAXSIZE
+        root = logging.getLogger()
+        handler = next(h for h in root.handlers if isinstance(h, lh.QueueHandler))
+        assert handler.queue.maxsize == LOG_QUEUE_MAXSIZE
+
+    def test_full_queue_drops_instead_of_blocking_or_raising(self):
+        import queue as queue_mod
+
+        from geometrikks.server.logging import NonBlockingQueueHandler
+        handler = NonBlockingQueueHandler(queue_mod.Queue(maxsize=1))
+        record = logging.LogRecord("t", logging.INFO, __file__, 1, "one", None, None)
+        handler.emit(record)
+        handler.emit(record)  # queue full: must return immediately, no error
+        assert handler.queue.qsize() == 1
+
     def test_jsonl_main_log_line(self, configured_logging):
         import json as jsonlib
         import structlog

--- a/tests/test_logging_pipeline.py
+++ b/tests/test_logging_pipeline.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import gzip
 import logging
+import re
 from pathlib import Path
 
 
@@ -70,3 +71,46 @@ class TestGzipRotatingFileHandler:
         assert (tmp_path / "app.log.1.gz").exists()
         assert (tmp_path / "app.log.2.gz").exists()
         assert not (tmp_path / "app.log.3.gz").exists()
+
+
+LOGIN_LINE_RE = re.compile(
+    r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z '
+    r'(login_success|login_failed|logout) user="[^"]*" ip=\S+$'
+)
+
+
+class TestLoginLineFormat:
+    def test_renders_contract_line(self):
+        from geometrikks.server.logging import render_login_line
+        line = render_login_line(
+            None,
+            "warning",
+            {
+                "timestamp": "2026-07-23T10:15:04.123456Z",
+                "level": "warning",
+                "event": "login_failed",
+                "user": "admin",
+                "ip": "203.0.113.7",
+            },
+        )
+        assert line == '2026-07-23T10:15:04Z login_failed user="admin" ip=203.0.113.7'
+        assert LOGIN_LINE_RE.match(line)
+
+    def test_missing_ip_renders_dash(self):
+        from geometrikks.server.logging import render_login_line
+        line = render_login_line(
+            None, "info",
+            {"timestamp": "2026-07-23T10:15:04Z", "event": "logout", "user": "admin"},
+        )
+        assert line == '2026-07-23T10:15:04Z logout user="admin" ip=-'
+        assert LOGIN_LINE_RE.match(line)
+
+
+class TestLoginOnlyFilter:
+    def test_passes_only_login_logger(self):
+        from geometrikks.server.logging import LOGIN_LOGGER_NAME, LoginOnlyFilter
+        f = LoginOnlyFilter()
+        login = logging.LogRecord(LOGIN_LOGGER_NAME, 20, "", 0, "m", None, None)
+        other = logging.LogRecord("geometrikks.server", 20, "", 0, "m", None, None)
+        assert f.filter(login) is True
+        assert f.filter(other) is False

--- a/tests/test_logging_pipeline.py
+++ b/tests/test_logging_pipeline.py
@@ -1,7 +1,9 @@
 """Unit tests for the structlog pipeline building blocks."""
 from __future__ import annotations
 
+import asyncio
 import gzip
+import json
 import logging
 import re
 from pathlib import Path
@@ -183,3 +185,61 @@ class TestLoginOnlyFilter:
         other = logging.LogRecord("geometrikks.server", 20, "", 0, "m", None, None)
         assert f.filter(login) is True
         assert f.filter(other) is False
+
+
+class TestLogBroadcaster:
+    def test_publish_from_thread_reaches_subscriber(self):
+        from geometrikks.server.logging import LogBroadcaster
+
+        async def scenario():
+            b = LogBroadcaster()
+            b.bind_loop(asyncio.get_running_loop())
+            q = b.subscribe()
+            import threading
+            t = threading.Thread(target=b.publish_threadsafe, args=({"event": "hi"},))
+            t.start()
+            t.join()
+            event = await asyncio.wait_for(q.get(), timeout=2)
+            assert event == {"event": "hi"}
+            b.unsubscribe(q)
+
+        asyncio.run(scenario())
+
+    def test_full_queue_drops_oldest(self):
+        from geometrikks.server.logging import LogBroadcaster
+
+        async def scenario():
+            b = LogBroadcaster(max_queue=2)
+            b.bind_loop(asyncio.get_running_loop())
+            q = b.subscribe()
+            for i in range(3):
+                b._publish({"n": i})
+            assert q.qsize() == 2
+            first = await q.get()
+            assert first == {"n": 1}  # oldest ({"n": 0}) was dropped
+
+        asyncio.run(scenario())
+
+    def test_publish_without_loop_is_noop(self):
+        from geometrikks.server.logging import LogBroadcaster
+        b = LogBroadcaster()
+        b.publish_threadsafe({"event": "ignored"})  # must not raise
+
+
+class TestBroadcastHandler:
+    def test_emit_publishes_formatted_json(self):
+        from geometrikks.server.logging import BroadcastHandler, LogBroadcaster
+
+        async def scenario():
+            broadcaster = LogBroadcaster()
+            broadcaster.bind_loop(asyncio.get_running_loop())
+            q = broadcaster.subscribe()
+            handler = BroadcastHandler(broadcaster=broadcaster)
+            handler.setFormatter(logging.Formatter('{"event": "%(message)s"}'))
+            record = logging.LogRecord("t", logging.INFO, "", 0, "hello", None, None)
+            handler.emit(record)
+            await asyncio.sleep(0)  # let call_soon_threadsafe run
+            event = await asyncio.wait_for(q.get(), timeout=2)
+            assert event == {"event": "hello"}
+
+        asyncio.run(scenario())

--- a/tests/test_logging_pipeline.py
+++ b/tests/test_logging_pipeline.py
@@ -326,6 +326,22 @@ class TestCreateLoggingConfig:
         assert _wait_for(lambda: "not_a_login_event" in main.read_text(encoding="utf-8"))
         assert "not_a_login_event" not in (configured_logging / "login.log").read_text(encoding="utf-8")
 
+    def test_handler_levels_are_respected_behind_queue(self, configured_logging):
+        import structlog
+        from geometrikks.server.logging import LOGIN_LOGGER_NAME
+        structlog.stdlib.get_logger(LOGIN_LOGGER_NAME).debug(
+            "debug_login_event", user="x", ip="1.2.3.4"
+        )
+        structlog.stdlib.get_logger(LOGIN_LOGGER_NAME).warning(
+            "login_failed", user="x", ip="1.2.3.4"
+        )
+        login = configured_logging / "login.log"
+        assert _wait_for(lambda: "login_failed" in login.read_text(encoding="utf-8"))
+        assert "debug_login_event" not in login.read_text(encoding="utf-8")
+        # The DEBUG event still reaches the main file (its handler level is DEBUG).
+        main = configured_logging / "geometrikks.log"
+        assert _wait_for(lambda: "debug_login_event" in main.read_text(encoding="utf-8"))
+
 
 class TestAppWiring:
     def test_create_app_configures_structlog_pipeline(self, tmp_path, monkeypatch):

--- a/tests/test_logging_pipeline.py
+++ b/tests/test_logging_pipeline.py
@@ -439,6 +439,28 @@ class TestLoginLoggerLevelPinned:
         assert LOGIN_LINE_RE.match(line), line
 
 
+class TestLitestarLoggerFollowsLogLevel:
+    def test_warning_level_silences_litestar_info(self, tmp_path, monkeypatch):
+        """LOG_LEVEL=WARNING must silence litestar's INFO HTTP request/response
+        records; the litestar logger follows the configured level instead of a
+        hardcoded INFO pin (unlike the login logger, which is pinned on purpose)."""
+        import logging
+
+        monkeypatch.setenv("LOG_DIR", str(tmp_path / "logs"))
+        monkeypatch.setenv("LOG_LEVEL", "WARNING")
+        from geometrikks.config.settings import get_settings
+        get_settings.cache_clear()
+        from geometrikks.server.logging import create_logging_config
+        config = create_logging_config(get_settings())
+        config.configure()
+        config.standard_lib_logging_config.configure()
+
+        litestar_logger = logging.getLogger("litestar")
+        assert litestar_logger.getEffectiveLevel() == logging.WARNING
+        assert not litestar_logger.isEnabledFor(logging.INFO)
+        assert litestar_logger.isEnabledFor(logging.WARNING)
+
+
 @pytest.fixture()
 def _restore_umask():
     """chmod-based writability tests can leave a directory unreadable for

--- a/tests/test_logging_pipeline.py
+++ b/tests/test_logging_pipeline.py
@@ -358,6 +358,63 @@ class TestCreateLoggingConfig:
         assert "debug_login_event_should_not_appear" not in main.read_text(encoding="utf-8")
 
 
+class TestExceptionTraceback:
+    """A caught exception logged with exc_info=True must survive the queue
+    handler with its traceback intact (see _capture_exc_info)."""
+
+    def test_jsonl_main_log_carries_exception_traceback(self, configured_logging):
+        import json as jsonlib
+        import structlog
+        logger = structlog.stdlib.get_logger("geometrikks.test.exc")
+        try:
+            raise ValueError("boom for jsonl")
+        except ValueError:
+            logger.error("caught_error_jsonl", exc_info=True)
+        main = configured_logging / "geometrikks.log"
+        assert _wait_for(lambda: "caught_error_jsonl" in main.read_text(encoding="utf-8"))
+        line = [
+            l for l in main.read_text(encoding="utf-8").splitlines() if "caught_error_jsonl" in l
+        ][0]
+        record = jsonlib.loads(line)
+        assert "exception" in record
+        assert "ValueError" in record["exception"]
+        assert "boom for jsonl" in record["exception"]
+        assert "Traceback" in record["exception"]
+
+    def test_broadcast_record_carries_exception_traceback(self, configured_logging):
+        import structlog
+        from geometrikks.server.logging import log_broadcaster
+
+        async def scenario():
+            log_broadcaster.bind_loop(asyncio.get_running_loop())
+            q = log_broadcaster.subscribe()
+            try:
+                logger = structlog.stdlib.get_logger("geometrikks.test.exc.broadcast")
+                try:
+                    raise ValueError("boom for broadcast")
+                except ValueError:
+                    logger.error("caught_error_broadcast", exc_info=True)
+
+                event = None
+                deadline = time.time() + 3.0
+                while time.time() < deadline:
+                    try:
+                        candidate = await asyncio.wait_for(q.get(), timeout=0.5)
+                    except asyncio.TimeoutError:
+                        continue
+                    if candidate.get("event") == "caught_error_broadcast":
+                        event = candidate
+                        break
+                assert event is not None, "expected broadcast event was never published"
+                assert "exception" in event
+                assert "ValueError" in event["exception"]
+                assert "boom for broadcast" in event["exception"]
+            finally:
+                log_broadcaster.unsubscribe(q)
+
+        asyncio.run(scenario())
+
+
 class TestLoginLoggerLevelPinned:
     def test_login_success_reaches_login_file_when_root_level_is_error(self, tmp_path, monkeypatch):
         """LOG_LEVEL=ERROR must not silence the login feed (CrowdSec/fail2ban)."""

--- a/tests/test_logging_pipeline.py
+++ b/tests/test_logging_pipeline.py
@@ -75,7 +75,7 @@ class TestGzipRotatingFileHandler:
 
 LOGIN_LINE_RE = re.compile(
     r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z '
-    r'(login_success|login_failed|logout) user="(?:[^"\\]|\\.)*" ip=\S+$'
+    r'(login_success|login_failed|logout) user="[^"]*" ip=\S+$'
 )
 
 
@@ -120,23 +120,59 @@ class TestLoginLineFormat:
         assert LOGIN_LINE_RE.match(line), line
         assert line.endswith("ip=203.0.113.7")
 
-    def test_quote_escape_in_user(self):
+    def test_quotes_are_stripped_from_user(self):
         from geometrikks.server.logging import render_login_line
         line = render_login_line(
             None, "warning",
             {"timestamp": "2026-07-23T10:15:04Z", "event": "login_failed",
              "user": 'a"b', "ip": "203.0.113.7"},
         )
-        assert '\\"' in line and "\n" not in line
+        assert line == '2026-07-23T10:15:04Z login_failed user="ab" ip=203.0.113.7'
+        assert "\\" not in line
+        assert line.count('"') == 2  # only opening and closing quotes around user field
 
     def test_hostile_ip_field_falls_back_to_dash(self):
         from geometrikks.server.logging import render_login_line
+        # Test IP with space and quote
         line = render_login_line(
             None, "warning",
             {"timestamp": "2026-07-23T10:15:04Z", "event": "login_failed",
              "user": "admin", "ip": '1.2.3.4 extra"'},
         )
         assert line.endswith("ip=-")
+        # Test IP with semicolon (invalid)
+        line = render_login_line(
+            None, "warning",
+            {"timestamp": "2026-07-23T10:15:04Z", "event": "login_failed",
+             "user": "admin", "ip": '6.6.6.6;x'},
+        )
+        assert line.endswith("ip=-")
+        # Test valid IPv4
+        line = render_login_line(
+            None, "warning",
+            {"timestamp": "2026-07-23T10:15:04Z", "event": "login_failed",
+             "user": "admin", "ip": "203.0.113.7"},
+        )
+        assert line.endswith("ip=203.0.113.7")
+        # Test valid IPv6
+        line = render_login_line(
+            None, "warning",
+            {"timestamp": "2026-07-23T10:15:04Z", "event": "login_failed",
+             "user": "admin", "ip": "2001:db8::1"},
+        )
+        assert line.endswith("ip=2001:db8::1")
+
+    def test_forged_field_poc_captures_real_ip(self):
+        import re as re_mod
+        from geometrikks.server.logging import render_login_line
+        line = render_login_line(
+            None, "warning",
+            {"timestamp": "2026-07-23T10:15:04Z", "event": "login_failed",
+             "user": 'x" ip=6.6.6.6 extra', "ip": "203.0.113.7"},
+        )
+        m = re_mod.search(r'user="([^"]*)" ip=(\S+)$', line)
+        assert m and m.group(2) == "203.0.113.7"
+        assert LOGIN_LINE_RE.match(line), line
 
 
 class TestLoginOnlyFilter:

--- a/tests/test_logging_pipeline.py
+++ b/tests/test_logging_pipeline.py
@@ -75,7 +75,7 @@ class TestGzipRotatingFileHandler:
 
 LOGIN_LINE_RE = re.compile(
     r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z '
-    r'(login_success|login_failed|logout) user="[^"]*" ip=\S+$'
+    r'(login_success|login_failed|logout) user="(?:[^"\\]|\\.)*" ip=\S+$'
 )
 
 
@@ -104,6 +104,39 @@ class TestLoginLineFormat:
         )
         assert line == '2026-07-23T10:15:04Z logout user="admin" ip=-'
         assert LOGIN_LINE_RE.match(line)
+
+    def test_newline_injection_in_user_is_neutralized(self):
+        from geometrikks.server.logging import render_login_line
+        line = render_login_line(
+            None, "warning",
+            {
+                "timestamp": "2026-07-23T10:15:04Z",
+                "event": "login_failed",
+                "user": 'x" ip=6.6.6.6\n2026-07-23T10:15:05Z login_failed user="admin',
+                "ip": "203.0.113.7",
+            },
+        )
+        assert "\n" not in line
+        assert LOGIN_LINE_RE.match(line), line
+        assert line.endswith("ip=203.0.113.7")
+
+    def test_quote_escape_in_user(self):
+        from geometrikks.server.logging import render_login_line
+        line = render_login_line(
+            None, "warning",
+            {"timestamp": "2026-07-23T10:15:04Z", "event": "login_failed",
+             "user": 'a"b', "ip": "203.0.113.7"},
+        )
+        assert '\\"' in line and "\n" not in line
+
+    def test_hostile_ip_field_falls_back_to_dash(self):
+        from geometrikks.server.logging import render_login_line
+        line = render_login_line(
+            None, "warning",
+            {"timestamp": "2026-07-23T10:15:04Z", "event": "login_failed",
+             "user": "admin", "ip": '1.2.3.4 extra"'},
+        )
+        assert line.endswith("ip=-")
 
 
 class TestLoginOnlyFilter:

--- a/tests/test_logs_controller.py
+++ b/tests/test_logs_controller.py
@@ -40,6 +40,18 @@ class TestTailEndpoint:
         assert client.get("/api/v1/logs/tail", params={"lines": 999999}).status_code == 200
         assert client.get("/api/v1/logs/tail", params={"lines": 0}).status_code == 200
 
+    def test_source_login_returns_login_records(self, client):
+        resp = client.get("/api/v1/logs/tail", params={"source": "login"})
+        assert resp.status_code == 200
+        records = resp.json()["records"]
+        assert len(records) == 1
+        assert records[0]["event"] == "logout"
+        assert records[0]["logger"] == "geometrikks.auth.login"
+
+    def test_source_bogus_returns_400(self, client):
+        resp = client.get("/api/v1/logs/tail", params={"source": "bogus"})
+        assert resp.status_code == 400
+
 
 class TestFilesEndpoint:
     def test_lists_files(self, client):

--- a/tests/test_logs_controller.py
+++ b/tests/test_logs_controller.py
@@ -1,0 +1,68 @@
+"""Endpoint tests for /api/v1/logs (tail, files, download)."""
+from __future__ import annotations
+
+import json
+
+import pytest
+from litestar import Litestar
+from litestar.testing import TestClient
+
+from geometrikks.api.v1.logs_controller import LogsController
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "geometrikks.log").write_text(
+        "\n".join(json.dumps({"event": f"e{i}", "level": "info"}) for i in range(20)) + "\n",
+        encoding="utf-8",
+    )
+    (log_dir / "login.log").write_text("2026-07-23T00:00:00Z logout user=\"a\" ip=-\n", encoding="utf-8")
+    nginx = tmp_path / "access.log"
+    nginx.write_text("nginx line\n", encoding="utf-8")
+    monkeypatch.setenv("LOG_DIR", str(log_dir))
+    monkeypatch.setenv("LOGPARSER_LOG_PATHS", str(nginx))
+    from geometrikks.config.settings import get_settings
+    get_settings.cache_clear()
+    with TestClient(app=Litestar(route_handlers=[LogsController])) as c:
+        yield c
+
+
+class TestTailEndpoint:
+    def test_returns_last_lines(self, client):
+        resp = client.get("/api/v1/logs/tail", params={"lines": 5})
+        assert resp.status_code == 200
+        records = resp.json()["records"]
+        assert [r["event"] for r in records] == ["e15", "e16", "e17", "e18", "e19"]
+
+    def test_lines_clamped_to_2000(self, client):
+        assert client.get("/api/v1/logs/tail", params={"lines": 999999}).status_code == 200
+        assert client.get("/api/v1/logs/tail", params={"lines": 0}).status_code == 200
+
+
+class TestFilesEndpoint:
+    def test_lists_files(self, client):
+        resp = client.get("/api/v1/logs/files")
+        assert resp.status_code == 200
+        files = {(f["kind"], f["name"]) for f in resp.json()["files"]}
+        assert ("app", "geometrikks.log") in files
+        assert ("login", "login.log") in files
+        assert ("nginx", "access.log") in files
+
+
+class TestDownloadEndpoint:
+    def test_downloads_listed_file(self, client):
+        resp = client.get("/api/v1/logs/files/app/geometrikks.log")
+        assert resp.status_code == 200
+        assert "attachment" in resp.headers.get("content-disposition", "")
+        assert b"e19" in resp.content
+
+    def test_unknown_name_404(self, client):
+        assert client.get("/api/v1/logs/files/app/nope.log").status_code == 404
+
+    def test_traversal_404(self, client):
+        assert client.get("/api/v1/logs/files/app/..%2F..%2Fetc%2Fpasswd").status_code == 404
+
+    def test_kind_mismatch_404(self, client):
+        assert client.get("/api/v1/logs/files/nginx/geometrikks.log").status_code == 404

--- a/tests/test_logs_controller.py
+++ b/tests/test_logs_controller.py
@@ -63,6 +63,13 @@ class TestFilesEndpoint:
         assert ("nginx", "access.log") in files
 
 
+class TestRotateEndpoint:
+    def test_returns_201_with_rotated_list(self, client):
+        resp = client.post("/api/v1/logs/rotate")
+        assert resp.status_code == 201
+        assert isinstance(resp.json()["rotated"], list)
+
+
 class TestDownloadEndpoint:
     def test_downloads_listed_file(self, client):
         resp = client.get("/api/v1/logs/files/app/geometrikks.log")

--- a/tests/test_scheduler_tracking.py
+++ b/tests/test_scheduler_tracking.py
@@ -3,7 +3,26 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from geometrikks.server.scheduler_tracking import JobRunInfo, JobRunTracker
+
+
+@pytest.fixture(autouse=True)
+def _configure_logging(tmp_path, monkeypatch):
+    """Configure structlog so logger.success()/.error() work in _on_executed.
+
+    Module-wide autouse: _on_executed now logs on every call, so every test
+    in this file (not just the outcome-logging ones) needs the configured
+    wrapper class, not just the .success() calls.
+    """
+    monkeypatch.setenv("LOG_DIR", str(tmp_path / "logs"))
+    from geometrikks.config.settings import get_settings
+    get_settings.cache_clear()
+    from geometrikks.server.logging import create_logging_config
+    config = create_logging_config(get_settings())
+    config.configure()
+    config.standard_lib_logging_config.configure()
 
 
 def test_unknown_job_returns_defaults():
@@ -45,3 +64,37 @@ def test_missed_event():
     info = tracker.get("a")
     assert info.last_status == "missed"
     assert info.running is False
+
+
+class TestJobOutcomeLogging:
+    def test_success_logged_at_success_level(self, caplog):
+        from geometrikks.server.logging import SUCCESS_LEVEL
+        from geometrikks.server.scheduler_tracking import JobRunTracker
+
+        tracker = JobRunTracker()
+
+        class FakeSubmit:
+            job_id = "job-a"
+
+        class FakeExec:
+            job_id = "job-a"
+            exception = None
+
+        with caplog.at_level(SUCCESS_LEVEL, logger="geometrikks.server.scheduler_tracking"):
+            tracker._on_submitted(FakeSubmit())
+            tracker._on_executed(FakeExec())
+        assert any(r.levelno == SUCCESS_LEVEL for r in caplog.records)
+
+    def test_error_logged(self, caplog):
+        import logging as stdlib_logging
+        from geometrikks.server.scheduler_tracking import JobRunTracker
+
+        tracker = JobRunTracker()
+
+        class FakeExec:
+            job_id = "job-b"
+            exception = RuntimeError("boom")
+
+        with caplog.at_level(stdlib_logging.ERROR, logger="geometrikks.server.scheduler_tracking"):
+            tracker._on_executed(FakeExec())
+        assert any(r.levelno == stdlib_logging.ERROR for r in caplog.records)

--- a/tests/test_scheduler_tracking.py
+++ b/tests/test_scheduler_tracking.py
@@ -8,13 +8,16 @@ import pytest
 from geometrikks.server.scheduler_tracking import JobRunInfo, JobRunTracker
 
 
-@pytest.fixture(autouse=True)
-def _configure_logging(tmp_path, monkeypatch):
-    """Configure structlog so logger.success()/.error() work in _on_executed.
+@pytest.fixture()
+def configured_logging(tmp_path, monkeypatch):
+    """Configure structlog with the SuccessBoundLogger wrapper class.
 
-    Module-wide autouse: _on_executed now logs on every call, so every test
-    in this file (not just the outcome-logging ones) needs the configured
-    wrapper class, not just the .success() calls.
+    Opt-in (not autouse): only tests that exercise the `.success()` branch
+    of `_on_executed` need this. An unconfigured stdlib logger already
+    supports `.error()`/`.warning()`, and `config.configure()` mutates
+    process-global structlog state with no teardown, so it should only run
+    where it is actually needed (see tests/test_logging_pipeline.py for the
+    same convention).
     """
     monkeypatch.setenv("LOG_DIR", str(tmp_path / "logs"))
     from geometrikks.config.settings import get_settings
@@ -33,7 +36,7 @@ def test_unknown_job_returns_defaults():
     assert info.last_status is None
 
 
-def test_submit_then_success():
+def test_submit_then_success(configured_logging):
     tracker = JobRunTracker()
     tracker._on_submitted(SimpleNamespace(job_id="a"))
     assert tracker.get("a").running is True
@@ -67,6 +70,11 @@ def test_missed_event():
 
 
 class TestJobOutcomeLogging:
+    @pytest.fixture(autouse=True)
+    def _configure(self, configured_logging):
+        # .success() needs the configured wrapper class.
+        pass
+
     def test_success_logged_at_success_level(self, caplog):
         from geometrikks.server.logging import SUCCESS_LEVEL
         from geometrikks.server.scheduler_tracking import JobRunTracker

--- a/uv.lock
+++ b/uv.lock
@@ -508,7 +508,7 @@ dependencies = [
     { name = "httpx" },
     { name = "httpx-oauth" },
     { name = "ipy" },
-    { name = "litestar", extra = ["brotli", "jwt", "pydantic", "standard"] },
+    { name = "litestar", extra = ["brotli", "jwt", "pydantic", "standard", "structlog"] },
     { name = "litestar-geoalchemy" },
     { name = "litestar-granian" },
     { name = "litestar-vite" },
@@ -540,7 +540,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28" },
     { name = "httpx-oauth", specifier = ">=0.17.0" },
     { name = "ipy", specifier = ">=1.1" },
-    { name = "litestar", extras = ["standard", "brotli", "jwt", "picologging", "pydantic"], specifier = ">=2.24.0" },
+    { name = "litestar", extras = ["standard", "brotli", "jwt", "structlog", "pydantic"], specifier = ">=2.24.0" },
     { name = "litestar-geoalchemy", specifier = ">=0.3.0" },
     { name = "litestar-granian", specifier = ">=0.15.0" },
     { name = "litestar-vite", specifier = ">=0.25.0" },
@@ -769,6 +769,9 @@ standard = [
     { name = "jinja2" },
     { name = "jsbeautifier" },
     { name = "uvicorn", extra = ["standard"] },
+]
+structlog = [
+    { name = "structlog" },
 ]
 
 [[package]]
@@ -1403,6 +1406,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/df/de669c7054cd47c4439ac34b1b2ee8b804a794791fbb10720e997a2c87c7/sqlalchemy-2.0.51-cp313-cp313-win32.whl", hash = "sha256:b93ab07b5292dbe7e6b8da89475275e7042744283921344b56105f3eeb0f828b", size = 2117721, upload-time = "2026-06-15T16:23:12.36Z" },
     { url = "https://files.pythonhosted.org/packages/d0/8a/403c51d064196bae20a0bc2476577f83a3f8dd299719a97417086b7f2ec5/sqlalchemy-2.0.51-cp313-cp313-win_amd64.whl", hash = "sha256:0f053118c30e53161857a953e4de667d90e274980dccbe5dd3829bbbeece72a5", size = 2143615, upload-time = "2026-06-15T16:23:13.906Z" },
     { url = "https://files.pythonhosted.org/packages/e2/22/dbf013a12ec759e54a34a119e9e217435b3f71b2dd5c61a7ade0a25dae87/sqlalchemy-2.0.51-py3-none-any.whl", hash = "sha256:bb024d8b621d0be75f4f44ecc7c950450026e76d66dc8f791bb5331d7fed59d5", size = 1944334, upload-time = "2026-06-15T16:09:22.418Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/89/b4a0bcfdf4f71a3dea31379f095929613d7e4528a0996bca6aa964cd0dca/structlog-26.1.0.tar.gz", hash = "sha256:f63a716cbd1b1291cf7661de7794b455acfa4c43c5bcf1630e6ad5ddc1adb3b7", size = 1459881, upload-time = "2026-06-06T07:33:39.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/18/489c97b834dfff9cf2fc2507cede4bcd4b11e67f84bc462acd1992496f86/structlog-26.1.0-py3-none-any.whl", hash = "sha256:e081a26d6c373e6d201eca24eede26d8ffab07f88f477822e679183428d3d91e", size = 73764, upload-time = "2026-06-06T07:33:38.046Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #43

## Summary

Replaces ad-hoc stdlib logging with a structured structlog pipeline and builds a full log-management surface on top of it.

### Backend

- structlog pipeline behind a non-blocking stdlib queue listener: colored console output, JSONL main log (`logs/geometrikks.log`), and a plain-text login log (`logs/login.log`) in a CrowdSec/fail2ban-friendly format. Both rotate by size and gzip their archives.
- New `LOG_*` settings (`LOG_LEVEL`, `LOG_DIR`, size/backup limits); `API_LOG_LEVEL` deprecated but still honored as a fallback.
- New SUCCESS level (25) for completed jobs; scheduler outcomes, WS connects, CrowdSec stream state, GeoIP refreshes and imports all emit structured lifecycle events.
- `login_success` / `login_failed` / `logout` events feed `login.log` for host-side tools; the login logger stays pinned at INFO so raising `LOG_LEVEL` never silences the CrowdSec feed.
- Logs API: `GET /api/v1/logs/tail` (app or login source), `GET /api/v1/logs/files`, per-file download, and `POST /api/v1/logs/rotate` for on-demand rotation. `/ws/logs` streams records live with an optional minimum-level filter.
- Exceptions carry full tracebacks plus a stringified `error` summary key; `docker-compose.yml` mounts `./logs` and the app degrades to console-only logging (with a loud startup error) if the directory is unwritable.

### Frontend

- Logs page at Settings -> Logs: live log stream seeded from the tail endpoint and appended over `/ws/logs`, with level/component multi-select filters, search, pause (buffer-and-flush resume), traceback and record-detail dialogs.
- Tabs switch between the system log, the login log, and a Downloads tab listing the raw files with a "Rotate logs" button.
- Fixed a pre-existing WebSocket reconnect race (shared with the live map feed) that could double-deliver records after a remount.
<img width="1912" height="1034" alt="image" src="https://github.com/user-attachments/assets/442c7f68-2233-4fea-b857-3c5d49a9fc5d" />
<img width="1912" height="1034" alt="image" src="https://github.com/user-attachments/assets/ccc8c37b-0184-4476-b63d-190884bfa473" />
<img width="1912" height="1034" alt="image" src="https://github.com/user-attachments/assets/e74780d3-ea76-4a50-9ee3-dfb462c0f469" />


## Testing

- 465 tests pass (unit + TimescaleDB integration), ty clean, frontend build clean.
- Manually verified end-to-end in the browser: streaming, filters, both log tabs, rotation producing real gzip archives, downloads.