### PR TITLE
Add PUID/PGID support to the docker image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ LOGPARSER_HOST_NAME=my-server
 # Database password (used by both containers; change from the default)
 DB_PASSWORD=geopass
 
+# Uid/gid the app runs as; ./logs is chowned to this at startup. Match your
+# host user (id -u / id -g) if host tools need to manage the log files.
+PUID=1000
+PGID=1000
+
 # Optional: CrowdSec integration (read-only decision views + ban stats)
 # docker exec crowdsec cscli bouncers add geometrikks  -> prints the API key
 #CROWDSEC_LAPI_URL=http://crowdsec:8080

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The docker image now supports `PUID`/`PGID`: the
+  entrypoint re-maps the container user, fixes ownership of `/app/logs` and
+  the GeoIP volume at startup, then drops privileges with gosu - no more
+  `mkdir`/`chown` pre-step before `docker compose up -d`. Containers started
+  with a `user:` override keep today's fully non-root behavior.
 - New `LOG_*` settings: `LOG_LEVEL`, `LOG_DIR`, and size/backup-count
   limits for the main and login log files.
 - Logs API: `GET /api/v1/logs/tail`, `GET /api/v1/logs/files`, per-file

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,12 @@ ARG APP_IMAGE_TAG=local
 RUN groupadd --gid 1000 geometrikks \
     && useradd --uid 1000 --gid geometrikks --shell /bin/bash --create-home geometrikks
 
+# gosu: the entrypoint starts as root to remap the geometrikks user to
+# PUID/PGID and fix volume ownership, then drops privileges with it.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gosu \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY --chown=geometrikks:geometrikks --from=python-builder /app/.venv /app/.venv
@@ -79,13 +85,18 @@ ENV PATH="/app/.venv/bin:$PATH" \
 
 VOLUME ["/app/data/geoip"]
 
-USER geometrikks
+COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 STOPSIGNAL SIGTERM
 EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=5).read()" || exit 1
+
+# The entrypoint remaps the geometrikks user to PUID/PGID (default
+# 1000:1000), chowns /app/logs and /app/data/geoip, and drops privileges
+# before exec-ing the CMD. With a non-root `user:` override it just execs.
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # Run with Granian via Litestar CLI
 CMD ["litestar", "--app", "geometrikks.server.core:create_app", "run", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -459,6 +459,35 @@ hardened setups)? Set a `user:` on the `app` service in the compose file;
 the entrypoint detects it, skips the re-mapping, and just runs the app as
 that user. You are then back to managing `./logs` ownership yourself.
 
+Want to harden further? The entrypoint only needs the capabilities the
+remap itself uses, and `gosu` is not a setuid binary, so both of these are
+verified working combinations. With PUID/PGID re-mapping:
+
+```yaml
+  app:
+    # ...
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+```
+
+Or with a `user:` override, where the image needs no capabilities at all:
+
+```yaml
+  app:
+    # ...
+    user: "1000:1000"
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+```
+
 ## FAQ
 
 **I'm using Nginx Proxy Manager (or another proxy-manager container) - what

--- a/README.md
+++ b/README.md
@@ -406,15 +406,16 @@ history - rotated or archived nginx logs, plain or gzip-compressed - use the
 `litestar import-logs` CLI command:
 
 ```bash
-docker compose exec app litestar import-logs /var/log/nginx/access.log.1.gz
+docker compose exec -u geometrikks app litestar import-logs /var/log/nginx/access.log.1.gz
 ```
 
 It reuses the live ingestion pipeline (same parsing, GeoIP lookup, and DB
 writes), uses the timestamps in each log line rather than wall-clock time,
 and refreshes the continuous aggregates for the imported range when done.
 Multiple files can be passed in one invocation; paths are **container**
-paths, and the container runs as the non-root `geometrikks` user (uid 1000),
-so host files must be readable by it.
+paths, and the import runs as the non-root `geometrikks` user
+(`PUID`:`PGID`, default 1000:1000), so host files must be readable by it
+(`-u geometrikks` keeps `exec` from running the import as root).
 
 `exec` requires the `app` service to already be running. If the stack is
 stopped, use `run --rm` instead:
@@ -445,6 +446,19 @@ credentials, MaxMind key, log paths, DB password). For the full set of
 environment variables - every default, every setting - see
 [`docs/configuration.md`](docs/configuration.md).
 
+### PUID and PGID
+
+The container starts as root just long enough to re-map its internal user to
+`PUID`:`PGID` (default `1000:1000`), fix ownership of `/app/logs` and the
+GeoIP volume, and then drops privileges - the app process itself never runs
+as root. Set `PUID`/`PGID` in `.env` to the user that should own `./logs` on
+the host (usually your own: `id -u` / `id -g`).
+
+Running in an environment that forbids root entirely (rootless Docker,
+hardened setups)? Set a `user:` on the `app` service in the compose file;
+the entrypoint detects it, skips the re-mapping, and just runs the app as
+that user. You are then back to managing `./logs` ownership yourself.
+
 ## FAQ
 
 **I'm using Nginx Proxy Manager (or another proxy-manager container) - what
@@ -456,10 +470,10 @@ inside it, using the *container* path (`/var/log/nginx/...`), not the host
 path.
 
 **Permission denied reading my log files?**
-The app container runs as uid 1000, and log mounts are read-only. Make sure
-the log files (and their parent directory) are readable by uid 1000/its
-group on the host - `chmod`/`chown` or an ACL entry, whichever fits your
-setup. Read-only mounts are intentional: GeoMetrikks never needs to write to
+The app container runs as `PUID`:`PGID` (default 1000:1000), and log mounts
+are read-only. Make sure the log files (and their parent directory) are
+readable by that uid/gid on the host - `chmod`/`chown` or an ACL entry,
+whichever fits your setup. Read-only mounts are intentional: GeoMetrikks never needs to write to
 your nginx logs.
 
 **Does this run on arm64?**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@
 #   docker compose up -d
 #
 # ./logs on the host holds the application log and login.log, readable by
-# host-side tools like CrowdSec/fail2ban. Create it with the right owner
-# before first start: mkdir -p logs && chown 1000:1000 logs (the container
-# runs as uid 1000; without this the app falls back to console-only logging).
+# host-side tools like CrowdSec/fail2ban. The container chowns it to
+# PUID:PGID (default 1000:1000) at startup; set PUID/PGID in .env to match
+# your host user if you want different ownership.
 #
 # Developing GeoMetrikks itself? Use docker-compose.dev.yml instead.
 services:
@@ -34,6 +34,8 @@ services:
     environment:
       DB_HOST: timescale_db
       DB_PASSWORD: ${DB_PASSWORD:-geopass}
+      PUID: ${PUID:-1000}
+      PGID: ${PGID:-1000}
     ports:
       - "8000:8000"
     env_file:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# Started with a non-root `user:` override (rootless docker, hardened
+# setups): no privilege to remap anything, so behave exactly like the old
+# static-USER image and run the command as-is.
+if [ "$(id -u)" -ne 0 ]; then
+    exec "$@"
+fi
+
+PUID="${PUID:-1000}"
+PGID="${PGID:-1000}"
+
+if [ "$(id -g geometrikks)" -ne "$PGID" ]; then
+    groupmod --non-unique --gid "$PGID" geometrikks
+fi
+if [ "$(id -u geometrikks)" -ne "$PUID" ]; then
+    usermod --non-unique --uid "$PUID" geometrikks
+fi
+
+# Docker auto-creates a missing ./logs bind mount owned root:root, and the
+# geoip named volume is initialized owned by the build-time uid 1000; both
+# must be writable by the runtime uid.
+chown -R "$PUID:$PGID" /app/logs /app/data/geoip
+
+echo "geometrikks: starting as uid=$PUID gid=$PGID"
+exec gosu geometrikks "$@"


### PR DESCRIPTION
## Summary

Adopts `PUID`/`PGID` pattern so `docker compose up -d` works with no manual `mkdir`/`chown` pre-step, and users control who owns `./logs` on the host.

- The image no longer bakes `USER geometrikks`; a new bash entrypoint starts as root, re-maps the `geometrikks` user/group to `PUID`:`PGID` (default `1000:1000`) only when they differ, chowns `/app/logs` and `/app/data/geoip`, then drops privileges with `gosu` and execs the unchanged CMD. The app process itself never runs as root.
- Started with a non-root `user:` override (rootless docker, hardened setups), the entrypoint skips the remap/chown and just execs, matching the old static-USER behavior. This is documented in the README as the escape hatch for root-forbidden environments.
- `docker-compose.yml` passes `PUID`/`PGID` through from `.env` and the header comment no longer tells users to pre-chown `./logs`; `.env.example` gains the two variables.
- README: new "PUID and PGID" section under Configuration, updated import-logs and permissions FAQ wording, and the import-logs `exec` example now uses `-u geometrikks` (plain `exec` would otherwise enter as root now that the image has no `USER` directive).

## Verification

All on a locally built image:

- Auto-created (root-owned) `./logs` bind mount: files end up owned `1000:1000` on the host, app runs as uid 1000.
- `PUID=1234 PGID=4321`: process and files owned `1234:4321`.
- `--user 1000:1000` override: entrypoint skips remap and execs directly, same behavior as before.
- Full compose stack: app reaches healthy (healthcheck works without a `USER` directive), `geometrikks.log`/`login.log` appear on the host owned `1000:1000`, GeoLite2 download succeeds into the geoip volume, PID 1 and granian workers confirmed uid 1000 while only `exec` shells default to root.
- `docker compose exec -u geometrikks app litestar import-logs ...` runs as uid 1000 and completes.
- `pytest`: 467 passed.