### PR TITLE
Fix PUID crash: make /app writable by the remapped uid

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -20,7 +20,10 @@ fi
 
 # Docker auto-creates a missing ./logs bind mount owned root:root, and the
 # geoip named volume is initialized owned by the build-time uid 1000; both
-# must be writable by the runtime uid.
+# must be writable by the runtime uid. /app itself (non-recursive) must be
+# writable too: litestar-vite rewrites /app/.litestar.json at startup via
+# mkstemp + rename, which needs write on the directory.
+chown "$PUID:$PGID" /app
 chown -R "$PUID:$PGID" /app/logs /app/data/geoip
 
 echo "geometrikks: starting as uid=$PUID gid=$PGID"


### PR DESCRIPTION
## Summary

Follow-up to #54. Any `PUID` other than 1000 crash-looped the container: litestar-vite rewrites `/app/.litestar.json` at startup via `mkstemp` + rename, which needs write permission on the `/app` directory itself, and the build leaves `/app` owned by uid 1000. Found on unraid (`PUID=99`/`PGID=100`):

```
PermissionError: [Errno 13] Permission denied: '/app/tmprfgrx4m4.tmp'
```

The entrypoint now chowns the `/app` directory inode (non-recursive, so the venv and app files are untouched) along with the existing `/app/logs` and `/app/data/geoip` chowns before dropping privileges.

## Verification

- Reproduced the crash locally with `PUID=99 PGID=100` on the pre-fix image (identical traceback).
- With the fix, a full compose stack under `PUID=99 PGID=100` reaches healthy: log files on the host owned `99:100`, GeoLite2 download into a fresh geoip volume succeeds, health endpoint returns 200.
- Default `PUID=1000` path re-verified unchanged.

No changelog entry: fixes an unreleased feature (the #54 entry still describes the shipped behavior).