### PR TITLE
feat(settings): show runtime-resolved values in the Environment overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the system log, the login log, and a Downloads tab listing the raw files
   (app log, login log, gzip archives, ingested nginx access logs) with a
   "Rotate logs" button.
-- `GET /api/v1/system/settings` now overlays runtime-resolved values the raw
-  config can't show: the auto-detected map home coordinates, whether a
-  usable GeoIP database is loaded, and CrowdSec's effective `enabled` /
-  `write_enabled` status.
+- `GET /api/v1/system/settings` and the Settings -> Environment overview now
+  surface runtime-resolved values raw config can't show: the auto-detected
+  map home coordinates (badged "auto-detected"), and GeoIP database
+  availability plus CrowdSec's effective `enabled`/`write_enabled` status
+  (both badged "runtime").
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the system log, the login log, and a Downloads tab listing the raw files
   (app log, login log, gzip archives, ingested nginx access logs) with a
   "Rotate logs" button.
+- `GET /api/v1/system/settings` now overlays runtime-resolved values the raw
+  config can't show: the auto-detected map home coordinates, whether a
+  usable GeoIP database is loaded, and CrowdSec's effective `enabled` /
+  `write_enabled` status.
 
 ### Changed
 

--- a/geometrikks/api/v1/system_controller.py
+++ b/geometrikks/api/v1/system_controller.py
@@ -15,12 +15,17 @@ from typing import TYPE_CHECKING
 
 import maxminddb
 from litestar import Controller, Request, get, post
+from litestar.datastructures import State
 from litestar.exceptions import NotFoundException
 from litestar.status_codes import HTTP_202_ACCEPTED
 from sqlalchemy import text
 
-from geometrikks.config.introspection import SystemSettingsResponse, build_settings_overview
-from geometrikks.config.settings import get_settings
+from geometrikks.config.introspection import (
+    ComputedField,
+    SystemSettingsResponse,
+    build_settings_overview,
+)
+from geometrikks.config.settings import Settings, get_settings
 from geometrikks.server.logging import get_logger
 from geometrikks.server.scheduler_tracking import JobRunTracker, JobStatus
 from geometrikks.lib.utils import GeoIPInfoView, geoip_info
@@ -145,6 +150,30 @@ def _job_view(job: "Job", tracker: JobRunTracker) -> SchedulerJobView:
     )
 
 
+def _computed_settings_overlay(
+    settings: Settings, state: State
+) -> dict[tuple[str, str], ComputedField]:
+    """Runtime-resolved values the raw config does not expose."""
+    overlay: dict[tuple[str, str], ComputedField] = {}
+
+    home = getattr(state, "map_home_location", None)
+    if home is not None and home.source == "external_ip":
+        overlay[("map", "home_latitude")] = ComputedField(home.latitude, "external_ip")
+        overlay[("map", "home_longitude")] = ComputedField(home.longitude, "external_ip")
+
+    overlay[("geoip", "available")] = ComputedField(
+        bool(getattr(state, "geoip_available", False)),
+        "runtime",
+        "Whether a usable GeoLite2 database is loaded",
+    )
+
+    overlay[("crowdsec", "enabled")] = ComputedField(settings.crowdsec.enabled, "runtime")
+    overlay[("crowdsec", "write_enabled")] = ComputedField(
+        settings.crowdsec.write_enabled, "runtime"
+    )
+    return overlay
+
+
 class SystemController(Controller):
     """Settings overview and scheduler administration."""
 
@@ -152,9 +181,15 @@ class SystemController(Controller):
     tags = ["System"]
 
     @get("/settings")
-    async def get_system_settings(self) -> SystemSettingsResponse:
-        """Full settings tree with descriptions; secrets structurally redacted."""
-        return build_settings_overview(get_settings())
+    async def get_system_settings(self, request: Request) -> SystemSettingsResponse:
+        """Full settings tree with descriptions; secrets structurally redacted.
+
+        Overlays runtime-resolved values (auto-detected map home, GeoIP
+        availability, CrowdSec effective status) that the raw config omits.
+        """
+        settings = get_settings()
+        overlay = _computed_settings_overlay(settings, request.app.state)
+        return build_settings_overview(settings, computed=overlay)
 
     @get("/about")
     async def get_about(self, request: Request) -> AboutResponse:

--- a/geometrikks/config/introspection.py
+++ b/geometrikks/config/introspection.py
@@ -7,6 +7,7 @@ secrets must be typed SecretStr, which also protects reprs and logs.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, get_args
 
@@ -18,6 +19,20 @@ from pydantic_settings import BaseSettings
 from geometrikks.config.settings import Settings
 
 SECRET_PLACEHOLDER = "******"
+
+
+@dataclass
+class ComputedField:
+    """A runtime-resolved value overlaid onto the static settings view.
+
+    Attaches to an existing field by key, or becomes a synthetic derived row
+    when the key has no backing model field.
+    """
+
+    value: Any
+    source: str
+    description: str | None = None
+
 
 # Display titles that plain str.title() gets wrong.
 _SECTION_TITLES = {
@@ -34,8 +49,10 @@ class SettingFieldView:
     value: Any
     default: Any
     description: str | None
-    env_var: str
+    env_var: str | None
     is_secret: bool
+    computed_value: Any = None
+    computed_source: str | None = None
 
 
 @dataclass
@@ -70,12 +87,19 @@ def _default_value(info: FieldInfo, secret: bool) -> Any:
     return to_jsonable_python(info.default, fallback=str)
 
 
-def _section(name: str, model: BaseSettings) -> SettingsSectionView:
+def _section(
+    name: str,
+    model: BaseSettings,
+    computed: Mapping[str, ComputedField] | None = None,
+) -> SettingsSectionView:
+    overlay = computed or {}
     dumped = model.model_dump(mode="json")
     fields: list[SettingFieldView] = []
+    real_keys: set[str] = set()
     for field_name, info in type(model).model_fields.items():
         if isinstance(getattr(model, field_name), BaseSettings):
             continue  # sub-configurations become their own sections
+        real_keys.add(field_name)
         secret = _is_secret(info.annotation)
         value = dumped.get(field_name)
         if secret:
@@ -83,6 +107,7 @@ def _section(name: str, model: BaseSettings) -> SettingsSectionView:
             # check treat SecretStr("") as absent, so the overview must too.
             raw = getattr(model, field_name)
             value = SECRET_PLACEHOLDER if raw is not None and raw.get_secret_value() else None
+        override = overlay.get(field_name)
         fields.append(
             SettingFieldView(
                 key=field_name,
@@ -91,6 +116,23 @@ def _section(name: str, model: BaseSettings) -> SettingsSectionView:
                 description=info.description,
                 env_var=_env_var(model, field_name, info),
                 is_secret=secret,
+                computed_value=override.value if override else None,
+                computed_source=override.source if override else None,
+            )
+        )
+    for key, cf in overlay.items():
+        if key in real_keys:
+            continue  # derived value with no backing field: synthesize a row
+        fields.append(
+            SettingFieldView(
+                key=key,
+                value=None,
+                default=None,
+                description=cf.description,
+                env_var=None,
+                is_secret=False,
+                computed_value=cf.value,
+                computed_source=cf.source,
             )
         )
     doc = (type(model).__doc__ or "").strip().splitlines()
@@ -102,11 +144,24 @@ def _section(name: str, model: BaseSettings) -> SettingsSectionView:
     )
 
 
-def build_settings_overview(settings: Settings) -> SystemSettingsResponse:
-    """Flatten the Settings tree into redacted, described sections."""
-    sections = [_section("app", settings)]
+def build_settings_overview(
+    settings: Settings,
+    *,
+    computed: Mapping[tuple[str, str], ComputedField] | None = None,
+) -> SystemSettingsResponse:
+    """Flatten the Settings tree into redacted, described sections.
+
+    ``computed`` overlays runtime-resolved values keyed by ``(section, field)``:
+    matching keys attach to their field, unmatched keys become derived rows.
+    """
+    overlay = computed or {}
+
+    def _for(section_name: str) -> dict[str, ComputedField]:
+        return {key: cf for (sec, key), cf in overlay.items() if sec == section_name}
+
+    sections = [_section("app", settings, _for("app"))]
     for field_name in Settings.model_fields:
         value = getattr(settings, field_name)
         if isinstance(value, BaseSettings):
-            sections.append(_section(field_name, value))
+            sections.append(_section(field_name, value, _for(field_name)))
     return SystemSettingsResponse(sections=sections)

--- a/resources/components/settings/environment-overview.tsx
+++ b/resources/components/settings/environment-overview.tsx
@@ -42,6 +42,11 @@ const sectionIcons: Record<string, React.ComponentType<{ className?: string }>> 
   vite: Zap,
 }
 
+const computedLabel: Record<string, string> = {
+  external_ip: "auto-detected",
+  runtime: "runtime",
+}
+
 function formatValue(value: unknown): string {
   if (value === null || value === undefined) return "not set"
   if (typeof value === "boolean") return value ? "true" : "false"
@@ -73,6 +78,24 @@ function ValueBlock({ field }: { field: SettingFieldView }) {
             not set
           </Badge>
         )}
+      </span>
+    )
+  }
+  const hasValue = field.value !== null && field.value !== undefined
+  const hasComputed = field.computed_value !== null && field.computed_value !== undefined
+  if (!hasValue && hasComputed) {
+    const label = computedLabel[field.computed_source ?? ""] ?? "computed"
+    return (
+      <span className="inline-flex items-baseline gap-1.5">
+        <code className="font-mono text-xs break-all font-medium text-foreground">
+          {formatValue(field.computed_value)}
+        </code>
+        <Badge
+          variant="outline"
+          className="border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400"
+        >
+          {label}
+        </Badge>
       </span>
     )
   }
@@ -110,7 +133,7 @@ function FieldRow({ field }: { field: SettingFieldView }) {
               default: <code className="font-mono">{formatValue(field.default)}</code>
             </span>
           )}
-          <MonoChip>{field.env_var}</MonoChip>
+          {field.env_var && <MonoChip>{field.env_var}</MonoChip>}
         </div>
       </div>
     </div>
@@ -188,7 +211,7 @@ export function EnvironmentOverview() {
           (!overriddenOnly || isOverridden(f)) &&
           (!q ||
             f.key.toLowerCase().includes(q) ||
-            f.env_var.toLowerCase().includes(q) ||
+            (f.env_var ?? "").toLowerCase().includes(q) ||
             section.title.toLowerCase().includes(q) ||
             (f.description ?? "").toLowerCase().includes(q)),
       ),
@@ -225,7 +248,12 @@ export function EnvironmentOverview() {
         </Button>
         <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
           <StatusLed tone="cyan" />
-          {totalOverridden} of {data.sections.reduce((n, s) => n + s.fields.length, 0)} settings
+          {totalOverridden} of{" "}
+          {data.sections.reduce(
+            (n, s) => n + s.fields.filter((f) => f.env_var).length,
+            0,
+          )}{" "}
+          settings
           overridden by env
         </span>
       </div>

--- a/resources/generated/api/schemas.gen.ts
+++ b/resources/generated/api/schemas.gen.ts
@@ -2200,6 +2200,17 @@ export const SchedulerJobsResponseSchema = {
 
 export const SettingFieldViewSchema = {
   properties: {
+    computed_source: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    computed_value: {},
     default: {},
     description: {
       oneOf: [
@@ -2212,7 +2223,14 @@ export const SettingFieldViewSchema = {
       ],
     },
     env_var: {
-      type: "string",
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     is_secret: {
       type: "boolean",

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -650,9 +650,11 @@ export type SchedulerJobsResponse = {
  * SettingFieldView
  */
 export type SettingFieldView = {
+  computed_source?: string | null;
+  computed_value?: unknown;
   default: unknown;
   description: string | null;
-  env_var: string;
+  env_var: string | null;
   is_secret: boolean;
   key: string;
   value: unknown;

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -2323,6 +2323,17 @@
       },
       "SettingFieldView": {
         "properties": {
+          "computed_source": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "computed_value": {},
           "default": {},
           "description": {
             "oneOf": [
@@ -2335,7 +2346,14 @@
             ]
           },
           "env_var": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "is_secret": {
             "type": "boolean"

--- a/tests/test_settings_introspection.py
+++ b/tests/test_settings_introspection.py
@@ -1,7 +1,11 @@
 """Settings introspection: full overview, descriptions, type-enforced redaction."""
 from __future__ import annotations
 
-from geometrikks.config.introspection import SECRET_PLACEHOLDER, build_settings_overview
+from geometrikks.config.introspection import (
+    SECRET_PLACEHOLDER,
+    ComputedField,
+    build_settings_overview,
+)
 from geometrikks.config.settings import Settings
 
 
@@ -75,3 +79,38 @@ def test_app_section_excludes_sub_models():
     app_keys = {f.key for f in _section(overview, "app").fields}
     assert "database" not in app_keys
     assert "name" in app_keys
+
+
+def test_computed_overlay_attaches_to_existing_field():
+    overview = build_settings_overview(
+        Settings(),
+        computed={("map", "home_latitude"): ComputedField(59.9, "external_ip")},
+    )
+    lat = _field(_section(overview, "map"), "home_latitude")
+    assert lat.value is None  # literal config value is left untouched
+    assert lat.computed_value == 59.9
+    assert lat.computed_source == "external_ip"
+
+
+def test_computed_overlay_synthesizes_derived_row():
+    overview = build_settings_overview(
+        Settings(),
+        computed={
+            ("crowdsec", "enabled"): ComputedField(True, "runtime", "read access"),
+        },
+    )
+    row = _field(_section(overview, "crowdsec"), "enabled")
+    assert row.value is None
+    assert row.env_var is None
+    assert row.is_secret is False
+    assert row.default is None
+    assert row.computed_value is True
+    assert row.computed_source == "runtime"
+    assert row.description == "read access"
+
+
+def test_no_overlay_leaves_fields_uncomputed():
+    overview = build_settings_overview(Settings())
+    lat = _field(_section(overview, "map"), "home_latitude")
+    assert lat.computed_value is None
+    assert lat.computed_source is None

--- a/tests/test_system_controller.py
+++ b/tests/test_system_controller.py
@@ -152,3 +152,52 @@ async def test_about_database_degrades_when_db_unreachable(monkeypatch):
         "timescaledb_version": None,
         "postgis_version": None,
     }
+
+
+async def test_system_settings_surface_computed_values(monkeypatch):
+    monkeypatch.setenv("CROWDSEC_LAPI_URL", "http://localhost:8080")
+    monkeypatch.setenv("CROWDSEC_BOUNCER_API_KEY", "bouncer-key")
+
+    from geometrikks.services.geoip.home import HomeLocation
+
+    async def startup(app: Litestar) -> None:
+        app.state.map_home_location = HomeLocation(
+            latitude=59.91, longitude=10.75, source="external_ip"
+        )
+        app.state.geoip_available = True
+
+    app = Litestar(route_handlers=[SystemController], on_startup=[startup])
+    async with AsyncTestClient(app=app) as client:
+        resp = await client.get("/api/v1/system/settings")
+    assert resp.status_code == 200
+    sections = {s["name"]: s for s in resp.json()["sections"]}
+
+    def field(section: str, key: str) -> dict:
+        return next(f for f in sections[section]["fields"] if f["key"] == key)
+
+    lat = field("map", "home_latitude")
+    assert lat["value"] is None
+    assert lat["computed_value"] == 59.91
+    assert lat["computed_source"] == "external_ip"
+
+    avail = field("geoip", "available")
+    assert avail["computed_value"] is True
+    assert avail["computed_source"] == "runtime"
+    assert avail["env_var"] is None
+
+    enabled = field("crowdsec", "enabled")
+    assert enabled["computed_value"] is True
+    assert enabled["computed_source"] == "runtime"
+
+
+async def test_system_settings_no_computed_home_when_absent():
+    # make_app() seeds no map_home_location and no geoip_available.
+    async with AsyncTestClient(app=make_app()) as client:
+        resp = await client.get("/api/v1/system/settings")
+    sections = {s["name"]: s for s in resp.json()["sections"]}
+    lat = next(f for f in sections["map"]["fields"] if f["key"] == "home_latitude")
+    assert lat["computed_value"] is None
+
+    avail = next(f for f in sections["geoip"]["fields"] if f["key"] == "available")
+    assert avail["computed_value"] is False
+    assert avail["computed_source"] == "runtime"


### PR DESCRIPTION
## Summary

The settings Environment overview only showed literal configured values, hiding what the system actually resolved at runtime. This adds a computed-value overlay:

- `introspection.py` gains a generic, domain-agnostic `ComputedField` overlay keyed by `(section, field)`: matching keys attach a computed value to the existing row (the literal `value` stays untouched), unmatched keys synthesize derived rows.
- `GET /api/v1/system/settings` builds the domain overlay from settings and `app.state`:
  - Map `home_latitude`/`home_longitude` when auto-detected from the external IP
  - GeoIP `available` (whether a usable GeoLite2 database actually loaded)
  - CrowdSec effective `enabled`/`write_enabled` (derived properties, previously invisible)
- The Environment overview renders computed values with an amber provenance badge ("auto-detected" / "runtime"), derived rows omit the env-var chip, and the "N of M overridden" denominator counts only env-backed fields.

The cached `Settings` singleton is never mutated; the API change is backward compatible (new optional fields, `env_var` widened to nullable).

## Testing

- 472 backend tests pass (`uv run pytest`), including 5 new tests covering overlay attach, derived-row synthesis, no-overlay identity, and both endpoint states (seeded and empty `app.state`).
- `bun run tsc --noEmit` and `bun run build` clean; API types regenerated via `litestar assets generate-types`.
- Manually verified in the browser: auto-detected badge on map home, runtime rows for GeoIP/CrowdSec, honest overridden count, working search filter.