### PR TITLE
feat(parser): add ignore IP/CIDR list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `LOGPARSER_IGNORE_IPS` setting: IPs/CIDRs the parser drops entirely so
   your own traffic through the reverse proxy is never ingested (applies to
   live tailing and file imports).
-  ([#45](https://github.com/GilbN/geometrikks/issues/45))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   map home coordinates (badged "auto-detected"), and GeoIP database
   availability plus CrowdSec's effective `enabled`/`write_enabled` status
   (both badged "runtime").
+- `LOGPARSER_IGNORE_IPS` setting: IPs/CIDRs the parser drops entirely so
+  your own traffic through the reverse proxy is never ingested (applies to
+  live tailing and file imports).
+  ([#45](https://github.com/GilbN/geometrikks/issues/45))
 
 ### Changed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,7 @@ list most users need is in `.env.example`; everything below is available.
 | `LOGPARSER_COMMIT_INTERVAL` | `5.0` | Maximum time interval in seconds between database commits. This will commit even if batch_size is not reached. |
 | `LOGPARSER_SKIP_VALIDATION` | `false` | Skip validation of log lines. |
 | `LOGPARSER_STORE_DEBUG_LINES` | `false` | Store all raw log lines in AccessLogDebug table. When False, only malformed requests are stored. |
+| `LOGPARSER_IGNORE_IPS` | *(computed)* | IPs/CIDRs the parser drops entirely (no geo event, access log, or debug row). Use for your own traffic hitting the reverse proxy. Env accepts one value, comma-separated values, or a JSON list. Empty (default): nothing is ignored. |
 
 ## Analytics & retention
 

--- a/geometrikks/api/v1/stats.py
+++ b/geometrikks/api/v1/stats.py
@@ -27,6 +27,7 @@ async def stats(ingestion_service: NamedDependency[LogIngestionService | None]) 
             "total_parsed_lines": 0,
             "total_skipped_lines": 0,
             "total_pending_records": 0,
+            "total_ignored_lines": 0,
             "total_processed": 0,
             "is_running": False,
         }
@@ -35,6 +36,7 @@ async def stats(ingestion_service: NamedDependency[LogIngestionService | None]) 
         "total_parsed_lines": ingestion_service.parsed_lines,
         "total_skipped_lines": ingestion_service.skipped_lines,
         "total_pending_records": ingestion_service.pending_records,
+        "total_ignored_lines": ingestion_service.ignored_lines,
         "total_processed": ingestion_service.total_processed,
         "is_running": ingestion_service.is_running,
     }

--- a/geometrikks/cli.py
+++ b/geometrikks/cli.py
@@ -73,7 +73,11 @@ async def _run_import(paths: list[Path], *, force: bool, batch_size: int) -> Non
     try:
         for path in paths:
             click.echo(f"Importing {path} ...")
-            parser = LogParser(log_path=path, send_logs=settings.logparser.send_logs)
+            parser = LogParser(
+                log_path=path,
+                send_logs=settings.logparser.send_logs,
+                ignore_ips=settings.logparser.ignore_ips,
+            )
 
             def show_progress(lines: int, lps: float) -> None:
                 click.echo(f"  {lines:>12,} lines  ({lps:,.0f} lines/s)")

--- a/geometrikks/config/settings.py
+++ b/geometrikks/config/settings.py
@@ -225,6 +225,15 @@ class LogParserSettings(BaseSettings):
         default=False,
         description="Store all raw log lines in AccessLogDebug table. When False, only malformed requests are stored.",
     )
+    ignore_ips: Annotated[list[str], NoDecode] = Field(
+        default_factory=list,
+        description=(
+            "IPs/CIDRs the parser drops entirely (no geo event, access log, "
+            "or debug row). Use for your own traffic hitting the reverse "
+            "proxy. Env accepts one value, comma-separated values, or a "
+            "JSON list. Empty (default): nothing is ignored."
+        ),
+    )
 
     @field_validator("log_paths", mode="before")
     @classmethod
@@ -237,6 +246,32 @@ class LogParserSettings(BaseSettings):
             if stripped.startswith("["):
                 return json.loads(stripped)
             return [stripped]
+        return value
+
+    @field_validator("ignore_ips", mode="before")
+    @classmethod
+    def parse_ignore_ips(cls, value: object) -> object:
+        """Accept one value, comma-separated values, or a JSON list."""
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return []
+            if stripped.startswith("["):
+                return json.loads(stripped)
+            return [part.strip() for part in stripped.split(",") if part.strip()]
+        return value
+
+    @field_validator("ignore_ips")
+    @classmethod
+    def validate_ignore_ips(cls, value: list[str]) -> list[str]:
+        """Fail at startup on entries that are not an IP or CIDR."""
+        for entry in value:
+            try:
+                ip_network(entry, strict=False)
+            except ValueError as exc:
+                raise ValueError(
+                    f"LOGPARSER_IGNORE_IPS entry {entry!r} is not an IP address or CIDR"
+                ) from exc
         return value
 
 

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -132,6 +132,7 @@ async def on_startup(app: "Litestar") -> None:
             send_logs=settings.logparser.send_logs,
             poll_interval=settings.logparser.poll_interval,
             hostname=settings.logparser.host_name,
+            ignore_ips=settings.logparser.ignore_ips,
         )
         for path in settings.logparser.log_paths
     ]

--- a/geometrikks/services/importer.py
+++ b/geometrikks/services/importer.py
@@ -142,6 +142,9 @@ async def import_file(
     for line in iter_lines(path):
         lines_total += 1
         record = parser.parse_line(line, lookup)
+        if record is None:  # IP on the ignore list; drop the line entirely
+            lines_skipped += 1
+            continue
         batch.append(record)
 
         if record.ip_address is None:  # line didn't match the format

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -547,3 +547,8 @@ class LogIngestionService:
     def skipped_lines(self) -> int:
         """Total skipped lines across all tailed files."""
         return sum(parser.skipped_lines for parser in self.parsers)
+
+    @property
+    def ignored_lines(self) -> int:
+        """Total ignore-list dropped lines across all tailed files."""
+        return sum(parser.ignored_lines for parser in self.parsers)

--- a/geometrikks/services/logparser/logparser.py
+++ b/geometrikks/services/logparser/logparser.py
@@ -4,6 +4,7 @@ import os
 import asyncio
 from functools import lru_cache
 from datetime import datetime, timezone
+from ipaddress import ip_address as parse_ip_address, ip_network
 from pathlib import Path
 from typing import Any
 
@@ -69,6 +70,27 @@ def make_cached_city_lookup(reader: Reader, maxsize: int = 1024) -> Callable[[st
     return lookup
 
 
+def make_cached_ignore_check(ignore_ips: list[str]) -> Callable[[str], bool]:
+    """Build a cached membership check for the ignore list, keyed on IP only.
+
+    Networks are parsed once and captured in a closure; invalid client IPs
+    return False (they fail later checks anyway).
+    """
+    networks = [ip_network(entry, strict=False) for entry in ignore_ips]
+
+    @lru_cache(maxsize=1024)
+    def is_ignored(ip: str) -> bool:
+        if not networks:
+            return False
+        try:
+            addr = parse_ip_address(ip)
+        except ValueError:
+            return False
+        return any(addr in network for network in networks)
+
+    return is_ignored
+
+
 def _convert_to_none(value: str | None) -> str | None:
     """Convert '-' or missing values to None for optional fields."""
     if value is None:
@@ -94,6 +116,7 @@ class LogParser:
         send_logs: bool = False,
         poll_interval: float = 1.0,
         hostname: str = "localhost",
+        ignore_ips: list[str] | None = None,
     ) -> None:
         """I'm here to parse ass and kick logs, and I'm all out of logs...
 
@@ -102,15 +125,19 @@ class LogParser:
             send_logs (bool, optional): If True, parse full access log data. Defaults to False.
             poll_interval (float, optional): How often to check for new log lines. Defaults to 1.0.
             hostname (str, optional): Hostname to tag geo events with. Defaults to "localhost".
+            ignore_ips (list[str] | None, optional): IPs/CIDRs whose lines are dropped entirely. Defaults to None.
         """
         self.log_path: Path = log_path
         self.send_logs: bool = send_logs
         self.poll_interval: int | float = poll_interval
         self.hostname: str = hostname
-        
+        self.ignore_ips: list[str] = ignore_ips or []
+        self._is_ignored: Callable[[str], bool] = make_cached_ignore_check(self.ignore_ips)
+
         # Statistics
         self.parsed_lines: int = 0
         self.skipped_lines: int = 0
+        self.ignored_lines: int = 0
 
         # Stop event for graceful shutdown (set by ingestion service)
         self._stop_event: asyncio.Event | None = None
@@ -118,6 +145,8 @@ class LogParser:
         logger.debug("Log file path: %s", self.log_path)
         logger.debug("Send NGINX logs: %s", self.send_logs)
         logger.debug("Hostname: %s", self.hostname)
+        if self.ignore_ips:
+            logger.info("Ignoring traffic from: %s", ", ".join(self.ignore_ips))
 
     def set_stop_event(self, event: asyncio.Event) -> None:
         """Set the stop event for graceful shutdown."""
@@ -130,6 +159,10 @@ class LogParser:
     def skipped_lines_count(self) -> int:
         """Return the number of skipped lines."""
         return self.skipped_lines
+
+    def ignored_lines_count(self) -> int:
+        """Return the number of ignored (ignore-list) lines."""
+        return self.ignored_lines
 
     def validate_log_line(self, log_line: str) -> re.Match[str] | None:
         """Validate the log line against the IPv4 and IPv6 patterns."""
@@ -165,7 +198,7 @@ class LogParser:
 
     def parse_line(
         self, line: str, lookup: Callable[[str], City | None]
-    ) -> ParsedLogRecord:
+    ) -> ParsedLogRecord | None:
         """Parse one raw log line into a ParsedLogRecord (shared by tail + import).
 
         Pure, synchronous method that validates the line, performs GeoIP lookup,
@@ -178,6 +211,8 @@ class LogParser:
         Returns:
             ParsedLogRecord with parsed data. A record with ip_address=None indicates
             the line didn't match the expected format (counted in skipped_lines).
+            None when the client IP is on the ignore list; the line is dropped
+            and counted in ignored_lines.
         """
         matched = self.validate_log_line(line)
         raw_line = line.strip()
@@ -196,6 +231,12 @@ class LogParser:
             )
 
         ip = matched.group(1)
+
+        if self._is_ignored(ip):
+            logger.debug("Ignoring line from ignored IP %s", ip)
+            self.ignored_lines += 1
+            return None
+
         self.parsed_lines += 1
 
         geo_data: ParsedGeoData | None = self._parse_geo_data(ip, matched, lookup)
@@ -485,7 +526,8 @@ class LogParser:
 
         Yields:
             ParsedLogRecord for each log line (matched or unmatched).
-            None when no new line is available (timeout/idle).
+            None when no new line is available (timeout/idle) or the line's
+            IP is on the ignore list.
         """
         if not skip_validation:
             logger.debug("Validating log file format.")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -209,6 +209,40 @@ def test_logparser_empty_list_rejected(monkeypatch):
         Settings()
 
 
+def test_logparser_ignore_ips_default_empty():
+    """Nothing is ignored unless configured."""
+    settings = Settings()
+    assert settings.logparser.ignore_ips == []
+
+
+def test_logparser_ignore_ips_single_value(monkeypatch):
+    """A bare IP string becomes a one-element list."""
+    monkeypatch.setenv("LOGPARSER_IGNORE_IPS", "203.0.113.7")
+    settings = Settings()
+    assert settings.logparser.ignore_ips == ["203.0.113.7"]
+
+
+def test_logparser_ignore_ips_comma_separated(monkeypatch):
+    """Comma-separated IPs/CIDRs are split and trimmed."""
+    monkeypatch.setenv("LOGPARSER_IGNORE_IPS", "203.0.113.7, 198.51.100.0/24")
+    settings = Settings()
+    assert settings.logparser.ignore_ips == ["203.0.113.7", "198.51.100.0/24"]
+
+
+def test_logparser_ignore_ips_json_list(monkeypatch):
+    """A JSON list of IPs/CIDRs is parsed as-is, IPv6 included."""
+    monkeypatch.setenv("LOGPARSER_IGNORE_IPS", '["203.0.113.7", "2001:db8::/32"]')
+    settings = Settings()
+    assert settings.logparser.ignore_ips == ["203.0.113.7", "2001:db8::/32"]
+
+
+def test_logparser_ignore_ips_invalid_entry_rejected(monkeypatch):
+    """Entries that are not an IP or CIDR fail settings validation."""
+    monkeypatch.setenv("LOGPARSER_IGNORE_IPS", "not-an-ip")
+    with pytest.raises(ValidationError, match="not an IP address or CIDR"):
+        Settings()
+
+
 class TestAuthSettings:
     """APP_ADMIN_USER / APP_ADMIN_PASSWORD / APP_AUTH_DISABLED."""
 

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -183,6 +183,35 @@ async def test_import_file_counts_matched_records_only(tmp_path, geoip_reader, m
     assert result.records_written == 4
 
 
+async def test_import_file_ignored_ips_counted_as_skipped(tmp_path, geoip_reader, monkeypatch):
+    """Lines from ignore-listed IPs are dropped entirely and counted as skipped."""
+    from geometrikks.services import importer
+
+    log = tmp_path / "own.log"
+    lines = [
+        make_log_line(TEST_IP, day=1),
+        make_log_line("81.2.69.142", day=2),  # other IP in the test mmdb
+    ]
+    log.write_text("".join(l + "\n" for l in lines))
+
+    service, FakeRepo, session_maker = _import_deps(tmp_path)
+    monkeypatch.setattr(importer, "ImportJobRepository", FakeRepo)
+    parser = LogParser(log_path=log, send_logs=True, ignore_ips=[TEST_IP])
+
+    result = await importer.import_file(
+        log, service=service, parser=parser, reader=geoip_reader,
+        session_maker=session_maker,
+    )
+
+    assert result.skipped is False
+    assert result.lines_total == 2
+    assert result.lines_skipped == 1
+    assert result.records_written == 1
+    # the ignored record must never reach the flush batch
+    flushed = [r for call in service.flush_records.await_args_list for r in call.args[0]]
+    assert all(r.ip_address != TEST_IP for r in flushed)
+
+
 async def test_import_file_aborts_on_unrecognized_format(tmp_path, geoip_reader, monkeypatch):
     """A wrong-format file must abort before anything is written (debug-table flood guard)."""
     from geometrikks.services import importer

--- a/tests/test_logparser.py
+++ b/tests/test_logparser.py
@@ -519,3 +519,55 @@ class TestParseLine:
         assert record.is_malformed is True
         assert record.ip_address is None
         assert parser.skipped_lines == 1
+
+    def test_parse_line_ignored_exact_ip(self, geoip_reader):
+        from geometrikks.services.logparser.logparser import LogParser, make_cached_city_lookup
+        parser = LogParser(
+            log_path=Path("/dev/null"), send_logs=True, ignore_ips=["2.125.160.216"]
+        )
+        lookup = make_cached_city_lookup(geoip_reader)
+        record = parser.parse_line(make_log_line("2.125.160.216"), lookup)
+        assert record is None
+        assert parser.ignored_lines == 1
+        assert parser.skipped_lines == 0
+        assert parser.parsed_lines == 0
+
+    def test_parse_line_ignored_cidr(self, geoip_reader):
+        from geometrikks.services.logparser.logparser import LogParser, make_cached_city_lookup
+        parser = LogParser(
+            log_path=Path("/dev/null"), send_logs=True, ignore_ips=["2.125.160.0/24"]
+        )
+        lookup = make_cached_city_lookup(geoip_reader)
+        record = parser.parse_line(make_log_line("2.125.160.216"), lookup)
+        assert record is None
+        assert parser.ignored_lines == 1
+
+    def test_parse_line_ignored_ipv6_cidr(self, geoip_reader):
+        from geometrikks.services.logparser.logparser import LogParser, make_cached_city_lookup
+        parser = LogParser(
+            log_path=Path("/dev/null"), send_logs=True, ignore_ips=["2001:db8::/32"]
+        )
+        lookup = make_cached_city_lookup(geoip_reader)
+        record = parser.parse_line(make_log_line("2001:db8::1"), lookup)
+        assert record is None
+        assert parser.ignored_lines == 1
+
+    def test_parse_line_non_matching_ip_passes(self, geoip_reader):
+        from geometrikks.services.logparser.logparser import LogParser, make_cached_city_lookup
+        parser = LogParser(
+            log_path=Path("/dev/null"), send_logs=True, ignore_ips=["203.0.113.0/24"]
+        )
+        lookup = make_cached_city_lookup(geoip_reader)
+        record = parser.parse_line(make_log_line("2.125.160.216"), lookup)
+        assert record is not None
+        assert record.ip_address == "2.125.160.216"
+        assert parser.ignored_lines == 0
+        assert parser.parsed_lines == 1
+
+    def test_parse_line_empty_ignore_list_noop(self, geoip_reader):
+        from geometrikks.services.logparser.logparser import LogParser, make_cached_city_lookup
+        parser = LogParser(log_path=Path("/dev/null"), send_logs=True)
+        lookup = make_cached_city_lookup(geoip_reader)
+        record = parser.parse_line(make_log_line("2.125.160.216"), lookup)
+        assert record is not None
+        assert parser.ignored_lines == 0


### PR DESCRIPTION
Closes #45

## What

New `LOGPARSER_IGNORE_IPS` setting listing IPs/CIDRs whose log lines the parser drops entirely, so your own traffic hitting the reverse-proxied GeoMetrikks endpoint is never ingested. Local/private IPs were already filtered; this covers your public WAN IP.

- Accepts a single value, comma-separated values, or a JSON list (same UX as `APP_TRUSTED_PROXIES`), IPv4 and IPv6, bare IPs or CIDR ranges. Invalid entries fail settings validation at startup.
- Matching happens in `LogParser.parse_line`, the shared choke point, so live tailing and historical file imports behave identically. Matched lines produce no geo event, access log, or debug row.
- Cached per-IP membership check (`lru_cache`, networks parsed once); new `ignored_lines` counter on the parser and an aggregate property on the ingestion service; startup log line lists the active ignore networks.
- Importer counts ignored lines toward `lines_skipped` (no schema change).

## Testing

- Settings parsing: single/comma/JSON forms, IPv6, invalid entry rejection.
- Parser: exact IP, IPv4 CIDR, IPv6 CIDR, non-matching pass-through, empty-list no-op, counter isolation from `skipped_lines`/`parsed_lines`.
- Importer: ignored lines counted as skipped and never flushed.
- Full suite green: 483 passed (unit + integration).

`docs/configuration.md` regenerated; changelog entry added.