### PR TITLE
feat(map): go-to-home control and clickable home location pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `LOGPARSER_IGNORE_IPS` setting: IPs/CIDRs the parser drops entirely so
   your own traffic through the reverse proxy is never ingested (applies to
   live tailing and file imports).
+- Map controls: a "Go to home location" button next to "Fit to data bounds"
+  that flies the map to the configured/auto-detected home coordinates. Shown
+  only when a home location is resolved.
+- Home location marker: a home-icon pin on the map at the
+  configured/auto-detected home coordinates; clicking it zooms to the home
+  location. Toggled via "Home marker" in the map controls (on by default,
+  preference stored in the browser).
 
 ### Changed
 

--- a/resources/components/map/GeoMap.tsx
+++ b/resources/components/map/GeoMap.tsx
@@ -30,6 +30,7 @@ import {
 } from "./layers"
 import { MapControls } from "./MapControls"
 import { LivePulses } from "./LivePulses"
+import { HomeMarker } from "./HomeMarker"
 import { MapLegend } from "./MapLegend"
 import { MapPopup, type PopupInfo } from "./MapPopup"
 import { Card, CardContent } from "@/components/ui/card"
@@ -50,10 +51,19 @@ const INITIAL_VIEW_STATE = {
 
 const ROUTE_EFFECTS_STORAGE_KEY = "geometrikks-route-effects-enabled"
 const MAP_PROJECTION_STORAGE_KEY = "geometrikks-map-projection"
+const HOME_MARKER_STORAGE_KEY = "geometrikks-home-marker-enabled"
 
 function loadRouteEffectsPreference(): boolean {
   try {
     return localStorage.getItem(ROUTE_EFFECTS_STORAGE_KEY) !== "false"
+  } catch {
+    return true
+  }
+}
+
+function loadHomeMarkerPreference(): boolean {
+  try {
+    return localStorage.getItem(HOME_MARKER_STORAGE_KEY) !== "false"
   } catch {
     return true
   }
@@ -96,6 +106,7 @@ export default function GeoMap() {
   const [projection, setProjection] = useState<MapProjection>(loadMapProjectionPreference)
   const [liveMode, setLiveMode] = useState(demoTrafficMode !== "off")
   const [routeEffectsEnabled, setRouteEffectsEnabled] = useState(loadRouteEffectsPreference)
+  const [homeMarkerEnabled, setHomeMarkerEnabled] = useState(loadHomeMarkerPreference)
   const [showBanned, setShowBanned] = useState(false)
   const [popup, setPopup] = useState<PopupInfo | null>(null)
 
@@ -128,6 +139,14 @@ export default function GeoMap() {
       // Storage may be blocked; keep the in-memory preference for this session.
     }
   }, [routeEffectsEnabled])
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(HOME_MARKER_STORAGE_KEY, String(homeMarkerEnabled))
+    } catch {
+      // Storage may be blocked; keep the in-memory preference for this session.
+    }
+  }, [homeMarkerEnabled])
 
   useEffect(() => {
     try {
@@ -216,6 +235,16 @@ export default function GeoMap() {
       duration: 1500,
     })
   }, [])
+
+  // Fly to the configured server home location
+  const goToHome = useCallback(() => {
+    if (!homeDestination) return
+    mapRef.current?.flyTo({
+      center: homeDestination,
+      zoom: 7,
+      duration: 1500,
+    })
+  }, [homeDestination])
 
   const changeProjection = useCallback((nextProjection: MapProjection) => {
     if (nextProjection === projection) return
@@ -379,6 +408,11 @@ export default function GeoMap() {
           demoMode={demoTrafficMode}
         />
 
+        {/* Server home location beacon */}
+        {homeMarkerEnabled && (
+          <HomeMarker coordinates={homeDestination} onClick={goToHome} />
+        )}
+
         {/* Popup */}
         {popup && activeLayer === "markers" && (
           <MapPopup
@@ -402,12 +436,15 @@ export default function GeoMap() {
         routeEffectsEnabled={routeEffectsEnabled}
         onRouteEffectsChange={setRouteEffectsEnabled}
         routeHomeAvailable={homeDestination !== null}
+        homeMarkerEnabled={homeMarkerEnabled}
+        onHomeMarkerChange={setHomeMarkerEnabled}
         bannedOverlayAvailable={crowdsecStatus?.enabled === true}
         bannedOverlayEnabled={showBanned}
         onBannedOverlayChange={setShowBanned}
         bannedCount={bannedLocations?.length ?? 0}
         bannedOverlayLoading={showBanned && isFetchingBanned}
         onFitBounds={fitToBounds}
+        onGoHome={goToHome}
         isLoading={isLoading}
         featureStats={geojson?.stats ?? { events: 0, countries: 0, cities: 0, locations: 0 }}
         topIPs={globalTopIPs?.top_ips ?? []}

--- a/resources/components/map/HomeMarker.tsx
+++ b/resources/components/map/HomeMarker.tsx
@@ -1,0 +1,71 @@
+/**
+ * Map pin for the configured server home location.
+ *
+ * A teardrop pin with the home glyph in its head, anchored so the tip sits
+ * on the exact coordinate. Because the body floats above the point, data
+ * markers at (or near) home stay visible. A DOM marker rather than a map
+ * layer so it stays crisp at every zoom level. The ground ripple pauses when
+ * the user prefers reduced motion. Clicking the pin head flies the map to
+ * the home location, mirroring the "Go to home location" control; only the
+ * head is interactive so data markers under the tip stay clickable.
+ */
+import { Marker } from "react-map-gl/maplibre"
+import { Home } from "lucide-react"
+
+type Coordinate = [longitude: number, latitude: number]
+
+export function HomeMarker({
+  coordinates,
+  onClick,
+}: {
+  coordinates: Coordinate | null
+  onClick?: () => void
+}) {
+  if (!coordinates) return null
+  const [longitude, latitude] = coordinates
+
+  return (
+    <Marker
+      longitude={longitude}
+      latitude={latitude}
+      anchor="bottom"
+      className="pointer-events-none"
+    >
+      <div className="relative" aria-label="Server home location">
+        {/* Ground ripple where the tip meets the coordinate */}
+        <span className="absolute bottom-0 left-1/2 h-3 w-3 -translate-x-1/2 translate-y-1/2 rounded-full border border-geo-cyan/70 animate-ping [animation-duration:2.4s] motion-reduce:animate-none motion-reduce:opacity-0" />
+        {/* Teardrop pin */}
+        <svg
+          width="30"
+          height="40"
+          viewBox="0 0 30 40"
+          className="drop-shadow-[0_0_6px_var(--geo-cyan-dim)]"
+        >
+          <path
+            d="M15 38.5 C 11 31.5 3 21.5 3 13 A 12 12 0 1 1 27 13 C 27 21.5 19 31.5 15 38.5 Z"
+            fill="var(--background)"
+            fillOpacity="0.92"
+            stroke="var(--geo-cyan)"
+            strokeWidth="2"
+            strokeLinejoin="round"
+          />
+        </svg>
+        {/* Home glyph centered in the pin head (head center is at y=13 of 40) */}
+        <Home className="absolute top-[6px] left-1/2 h-3.5 w-3.5 -translate-x-1/2 text-geo-cyan" />
+        {/* Only the head is clickable; the stem and tip pass clicks through so
+            data markers sharing the home coordinate remain reachable. */}
+        <button
+          type="button"
+          onClick={(event) => {
+            // Keep the click from reaching the map's own click handlers.
+            event.stopPropagation()
+            onClick?.()
+          }}
+          title="Go to home location"
+          aria-label="Zoom to home location"
+          className="pointer-events-auto absolute top-px left-1/2 h-6 w-6 -translate-x-1/2 cursor-pointer rounded-full"
+        />
+      </div>
+    </Marker>
+  )
+}

--- a/resources/components/map/MapControls.tsx
+++ b/resources/components/map/MapControls.tsx
@@ -25,6 +25,7 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import {
   Flame,
   Globe2,
+  Home,
   Loader2,
   MapPin,
   Maximize2,
@@ -51,6 +52,8 @@ interface MapControlsProps {
   routeEffectsEnabled: boolean
   onRouteEffectsChange: (enabled: boolean) => void
   routeHomeAvailable: boolean
+  homeMarkerEnabled: boolean
+  onHomeMarkerChange: (enabled: boolean) => void
   /** CrowdSec integration configured; hides the overlay toggle when false. */
   bannedOverlayAvailable: boolean
   bannedOverlayEnabled: boolean
@@ -59,6 +62,8 @@ interface MapControlsProps {
   /** Banned-locations fetch in flight; shows a spinner on the toggle. */
   bannedOverlayLoading?: boolean
   onFitBounds: () => void
+  /** Fly to the resolved map home location; button hidden when routeHomeAvailable is false. */
+  onGoHome?: () => void
   isLoading?: boolean
   featureStats: GeoJSONFeatureStats
   topIPs: TopIPDTO[]
@@ -83,12 +88,15 @@ export function MapControls({
   routeEffectsEnabled,
   onRouteEffectsChange,
   routeHomeAvailable,
+  homeMarkerEnabled,
+  onHomeMarkerChange,
   bannedOverlayAvailable,
   bannedOverlayEnabled,
   onBannedOverlayChange,
   bannedCount,
   bannedOverlayLoading = false,
   onFitBounds,
+  onGoHome,
   isLoading = false,
   featureStats,
   topIPs,
@@ -218,6 +226,24 @@ export function MapControls({
               </Badge>
             )}
           </Button>
+          {routeHomeAvailable && (
+            <Button
+              variant="outline"
+              onClick={() => onHomeMarkerChange(!homeMarkerEnabled)}
+              aria-pressed={homeMarkerEnabled}
+              title="Show a beacon at the server home location"
+              className={cn(
+                "cursor-pointer w-full justify-start gap-2 px-3 pointer-coarse:h-10",
+                homeMarkerEnabled && "bg-geo-cyan/15 text-geo-cyan border-geo-cyan/30",
+              )}
+            >
+              <Home className="h-4 w-4" />
+              <span className="text-sm font-medium">Home marker</span>
+              <Badge variant="secondary" className="ml-auto text-[9px] uppercase">
+                {homeMarkerEnabled ? "on" : "off"}
+              </Badge>
+            </Button>
+          )}
           {bannedOverlayAvailable && (
             <Button
               variant="outline"
@@ -267,18 +293,31 @@ export function MapControls({
         />
       </Card>
 
-      {/* Fit Bounds Button */}
+      {/* Fit Bounds / Go Home Buttons */}
       <Card className="p-1 shrink-0">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onFitBounds}
-          disabled={isLoading || events === 0}
-          title="Fit to data bounds"
-          className="cursor-pointer pointer-coarse:size-10"
-        >
-          <Maximize2 className="h-4 w-4" />
-        </Button>
+        <div className="flex gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onFitBounds}
+            disabled={isLoading || events === 0}
+            title="Fit to data bounds"
+            className="cursor-pointer pointer-coarse:size-10"
+          >
+            <Maximize2 className="h-4 w-4" />
+          </Button>
+          {routeHomeAvailable && onGoHome && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onGoHome}
+              title="Go to home location"
+              className="cursor-pointer pointer-coarse:size-10"
+            >
+              <Home className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
       </Card>
 
       {/* Status Indicator */}


### PR DESCRIPTION
## Summary

- Adds a **Go to home location** button next to "Fit to data bounds" in the map controls. It flies the map to the configured/auto-detected home coordinates and only appears when a home location is resolved.
- Adds a **home location pin** on the map: a teardrop pin in the geo-cyan theme with the home glyph in its head, tip anchored on the exact home coordinate, with a subtle ground ripple (paused under reduced motion).
- Clicking the **pin head** zooms to the home location (same behavior as the menu button). Only the head is interactive; the stem and tip pass clicks through so data markers sharing the home coordinate stay clickable.
- New **Home marker** toggle in the map controls (shown only when a home location is available), on by default, preference persisted in localStorage like the route-effects and projection toggles.

<img width="1912" height="1034" alt="image" src="https://github.com/user-attachments/assets/98463ed6-e606-48ff-8197-7802c6093a24" />

## Notes

- The pin is a DOM marker so it stays crisp at every zoom level and adapts to the theme background variable.
- Changelog updated under Unreleased.

## Testing

- `tsc -b --noEmit` passes.
- Manually verified: fly-to from both the menu button and the pin head, marker popups still clickable when a cluster shares the home coordinate, toggle persistence across reloads, zoomed-out and zoomed-in rendering, reduced-motion handling.