### PR TITLE
fix(map): zoom buttons unclickable next to the map-controls panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `API_LOG_LEVEL` in favor of `LOG_LEVEL`; still honored as a fallback,
   with a `DeprecationWarning`.
 
+### Fixed
+
+- Map zoom/compass buttons were unclickable when the map-controls panel was
+  tall enough to reach down beside them.
+
 ## [0.4.3] - 2026-07-22
 
 ### Fixed

--- a/resources/components/map/MapControls.tsx
+++ b/resources/components/map/MapControls.tsx
@@ -425,9 +425,12 @@ export function MapControls({
     )
   }
 
-  // Desktop expanded state - full controls docked top-right
+  // Desktop expanded state - full controls docked top-right.
+  // The wrapper is click-through: its bounding box spans the full panel height,
+  // and the transparent strip below the collapse button would otherwise swallow
+  // clicks meant for the map zoom controls docked bottom-right (issue #53).
   return (
-    <div className="absolute top-4 right-4 z-10 flex gap-2 max-h-[calc(100vh-2rem)] pointer-events-auto">
+    <div className="absolute top-4 right-4 z-10 flex gap-2 max-h-[calc(100vh-2rem)] pointer-events-none">
       {/* Scrollable controls area */}
       <div
         className="flex flex-col gap-2 p-1 overflow-y-auto overscroll-contain pointer-events-auto max-h-full max-w-[min(200px,calc(100vw-4rem))]"
@@ -439,7 +442,7 @@ export function MapControls({
       <Button
         size="icon"
         variant="outline"
-        className="mt-1 bg-background shrink-0 p-1 self-start cursor-pointer"
+        className="mt-1 bg-background shrink-0 p-1 self-start cursor-pointer pointer-events-auto"
         onClick={() => setIsExpanded(false)}
         title="Hide map controls"
       >


### PR DESCRIPTION
## Summary

Fixes #53.

The desktop map-controls panel wrapper (`absolute top-4 right-4 z-10 ... pointer-events-auto`) is a flex row whose bounding box spans the full height of the card column. The transparent strip below the collapse button sat on top of MapLibre's bottom-right `NavigationControl`, so whenever the panel was tall enough to reach down beside the zoom/compass buttons, clicks landed on the invisible wrapper instead of the buttons.

## Change

- The wrapper is now `pointer-events-none` (click-through).
- Pointer events are re-enabled only on the interactive children: the scrollable card column (already had it) and the collapse button (added).
- Changelog entry under Unreleased/Fixed.

## Testing

- `tsc -b --noEmit` passes.
- Manually verified in the browser: with the panel bottom edge right next to the navigation control, zoom in/out and compass all respond; panel scrolling, toggles, and collapse/expand still work.