### PR TITLE
fix(map): narrow the live threat lane to refused requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   picture while live mode is on. Requests per minute with a sparkline and a
   trend against the first half of the window, a response-mix bar, the busiest
   origin countries in that window, and the request feed itself split into an
-  "All" and a "Threats" lane. A footer counts distinct banned IPs seen. The
+  "All" and a "Threats" lane. The threat lane holds requests the server
+  refused (401, 403, 429, 444) and everything from a banned IP; a 404 is
+  ordinary traffic and stays out of it. A footer counts distinct banned IPs
+  seen. The
   rail can be switched off from the "Live overlays" card in the map controls,
   and the choice is remembered in the browser.
 - Live mode on a phone shows a vitals pill with the current rate, a sparkline,

--- a/resources/components/map/LiveFeedSheet.tsx
+++ b/resources/components/map/LiveFeedSheet.tsx
@@ -40,7 +40,7 @@ export function LiveFeedSheet({
         <DrawerHeader className="pb-2">
           <DrawerTitle>Live traffic</DrawerTitle>
           <DrawerDescription className="sr-only">
-            Requests arriving now, with a separate lane for 4xx responses and banned IPs.
+            Requests arriving now, with a separate lane for refused requests and banned IPs.
           </DrawerDescription>
         </DrawerHeader>
 

--- a/resources/lib/demo-traffic.ts
+++ b/resources/lib/demo-traffic.ts
@@ -32,10 +32,17 @@ export function getDemoTrafficMode(): DemoTrafficMode {
   return "off"
 }
 
-/** A 100-entry status cycle: 79 percent 2xx, 8 percent 3xx, 10 percent 4xx, 3 percent 5xx. */
+/**
+ * A 100-entry status cycle: roughly 74 percent 2xx, 8 percent 3xx, 15 percent
+ * 4xx, 3 percent 5xx. The 4xx share is mostly 404, the way real traffic is,
+ * with a few refusals so the threat lane has something in it that is not just
+ * a banned IP.
+ */
 const DEMO_STATUS_CYCLE: readonly number[] = Array.from({ length: 100 }, (_, index) => {
   if (index % 33 === 32) return 502
   if (index % 10 === 7) return 404
+  if (index % 19 === 4) return 403
+  if (index % 23 === 9) return 401
   if (index % 11 === 5) return 301
   return 200
 })
@@ -74,7 +81,7 @@ export function makeDemoRequests(cursor: number, count: number, now: number): Li
     const origin = DEMO_TRAFFIC_ORIGINS[step % DEMO_TRAFFIC_ORIGINS.length]
     const code = DEMO_STATUS_CYCLE[step % DEMO_STATUS_CYCLE.length]
     const banned = step % 17 === 3
-    const probing = banned || code === 404
+    const probing = banned || (code >= 400 && code < 500)
     const url = probing
       ? DEMO_PROBE_PATHS[step % DEMO_PROBE_PATHS.length]
       : DEMO_PATHS[step % DEMO_PATHS.length]
@@ -92,7 +99,7 @@ export function makeDemoRequests(cursor: number, count: number, now: number): Li
       countryCode: origin.countryCode,
       statusClass: status,
       banned,
-      threat: isThreat(status, banned),
+      threat: isThreat(code, banned),
       log: {
         timestamp,
         ip_address: ip,

--- a/resources/lib/live-traffic/classify.test.ts
+++ b/resources/lib/live-traffic/classify.test.ts
@@ -29,22 +29,42 @@ describe("statusClass", () => {
 })
 
 describe("isThreat", () => {
-  it("counts 4xx", () => {
-    expect(isThreat("4xx", false)).toBe(true)
+  it("counts the refusals", () => {
+    expect(isThreat(401, false)).toBe(true)
+    expect(isThreat(403, false)).toBe(true)
+    expect(isThreat(429, false)).toBe(true)
+    expect(isThreat(444, false)).toBe(true)
+  })
+
+  it("does not count a 404, which ordinary traffic produces constantly", () => {
+    expect(isThreat(404, false)).toBe(false)
+  })
+
+  it("does not count the other client errors", () => {
+    expect(isThreat(400, false)).toBe(false)
+    expect(isThreat(410, false)).toBe(false)
+    expect(isThreat(422, false)).toBe(false)
   })
 
   it("counts any banned IP whatever it asked for", () => {
-    expect(isThreat("2xx", true)).toBe(true)
-    expect(isThreat("unknown", true)).toBe(true)
+    expect(isThreat(200, true)).toBe(true)
+    expect(isThreat(404, true)).toBe(true)
+    expect(isThreat(null, true)).toBe(true)
   })
 
   it("does not count 5xx, which is the server's own fault", () => {
-    expect(isThreat("5xx", false)).toBe(false)
+    expect(isThreat(500, false)).toBe(false)
+    expect(isThreat(502, false)).toBe(false)
   })
 
   it("does not count ordinary traffic", () => {
-    expect(isThreat("2xx", false)).toBe(false)
-    expect(isThreat("3xx", false)).toBe(false)
+    expect(isThreat(200, false)).toBe(false)
+    expect(isThreat(304, false)).toBe(false)
+  })
+
+  it("does not count a geo event with no log line to judge", () => {
+    expect(isThreat(null, false)).toBe(false)
+    expect(isThreat(undefined, false)).toBe(false)
   })
 })
 

--- a/resources/lib/live-traffic/classify.ts
+++ b/resources/lib/live-traffic/classify.ts
@@ -31,12 +31,29 @@ export function statusClass(code: number | null | undefined): StatusClass {
 }
 
 /**
- * A threat is someone poking at the server: a 4xx, or anything at all from an
- * IP CrowdSec has banned. A 5xx is the server's own failure and belongs in the
- * error rate, not the threat lane.
+ * The responses that mean the server refused the caller, rather than merely
+ * failing to find what they asked for.
+ *
+ * 404 is deliberately absent. It is the most common 4xx in ordinary traffic,
+ * from stale links, missing favicons and well-known probes every browser
+ * makes, so counting it turns the threat lane into a second copy of the feed.
+ * Scanning does show up as 404s, but as a burst from one address rather than
+ * as any single request, which is a rate signal this per-request lane cannot
+ * see. The ban list is what carries that verdict here.
+ *
+ * 444 is nginx closing the connection with no response, which in a proxy log
+ * is almost always a deliberate block rule.
  */
-export function isThreat(status: StatusClass, banned: boolean): boolean {
-  return banned || status === "4xx"
+const REFUSED_STATUS_CODES = new Set([401, 403, 429, 444])
+
+/**
+ * A threat is someone the server turned away: an unauthorized, forbidden,
+ * rate-limited or dropped request, or anything at all from an IP CrowdSec has
+ * banned. A 5xx is the server's own failure and belongs in the error rate,
+ * not the threat lane.
+ */
+export function isThreat(code: number | null | undefined, banned: boolean): boolean {
+  return banned || (typeof code === "number" && REFUSED_STATUS_CODES.has(code))
 }
 
 export function packetColor(status: StatusClass): string {

--- a/resources/lib/live-traffic/pairing.test.ts
+++ b/resources/lib/live-traffic/pairing.test.ts
@@ -128,6 +128,19 @@ describe("pairLiveEvents", () => {
     expect(requests[0].threat).toBe(false)
   })
 
+  it("marks a refused request as a threat but leaves a 404 alone", () => {
+    const requests = pairLiveEvents(
+      [geo("1.1.1.1"), log("1.1.1.1", 403), geo("2.2.2.2"), log("2.2.2.2", 404)],
+      new Set(),
+      1000,
+    )
+
+    expect(requests[0].threat).toBe(true)
+    // Both are 4xx on the map and in the response mix; only one is a threat.
+    expect(requests[1].statusClass).toBe("4xx")
+    expect(requests[1].threat).toBe(false)
+  })
+
   it("returns nothing for an empty heartbeat frame", () => {
     expect(pairLiveEvents([], new Set(), 1000)).toEqual([])
   })

--- a/resources/lib/live-traffic/pairing.ts
+++ b/resources/lib/live-traffic/pairing.ts
@@ -33,7 +33,7 @@ function build(
     log,
     statusClass: status,
     banned,
-    threat: isThreat(status, banned),
+    threat: isThreat(log?.status_code, banned),
   }
 }
 

--- a/resources/lib/live-traffic/types.ts
+++ b/resources/lib/live-traffic/types.ts
@@ -46,7 +46,7 @@ export interface Vitals {
   rpm: number
   /** 5xx share of the window, 0 to 1. */
   errorRate: number
-  /** 4xx-or-banned requests in the window. */
+  /** Refused-or-banned requests in the window. See isThreat. */
   threatCount: number
   uniqueIps: number
   countries: number


### PR DESCRIPTION
The live rail shipped with `threat` meaning "any 4xx, or a banned IP". In practice that puts 404 in the threat lane, and 404 is the most common client error ordinary traffic produces: stale links, missing favicons, and the well-known probes every browser fires unprompted. The lane ends up a near-copy of the full feed, and the pill's red shield count is on more or less permanently, which is the fastest way to teach someone to ignore it.

## What counts now

A threat is a request the server **turned away**:

| Code | Why |
|------|-----|
| 401 | Failed authentication |
| 403 | Blocked by a rule, a WAF, or an ACL |
| 429 | Rate limited |
| 444 | nginx closing the connection with no response, which in a proxy log is almost always a deliberate block |

Plus anything at all from a banned IP, unchanged. A 5xx is still the server's own failure and stays in the error rate rather than the threat lane.

Everything else in the 4xx class, 404 included, is ordinary traffic here.

## On 404 specifically

Scanning is real and it does show up as 404s, but as a *burst from one address*, not as any single request. That is a rate signal, and this lane classifies one request at a time with no view of an address's history. Pretending a per-request check can see it just marks every broken link as an attack. The ban list is what carries that verdict in this UI, and a banned IP is a threat whatever it asks for.

If per-IP 404 rate is worth surfacing later, it wants to be its own signal with its own threshold, not a widening of this predicate.

## Changes

- `isThreat` now takes the numeric status code rather than the status class, since the class is exactly the resolution that loses this distinction.
- 404 keeps its amber packet colour and its place in the response mix. Nothing about the map or the mix changes; only the lane, the pill's shield count, and `Vitals.threatCount` do.
- The demo traffic generator gained a few 403s and 401s, so the threat lane in demo mode holds something other than banned IPs.

## Tests

75 passing. `isThreat` gained cases for each refusal code, for 404 and the other client errors staying out, for a banned IP overriding any code, and for a geo event with no log line to judge. Pairing gained a case asserting a 403 and a 404 are both 4xx but only one is a threat.

Typecheck clean.
