### PR TITLE
fix: copy button in debug log detail dialog on insecure origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The gap check now respects hourly aggregate retention, so buckets that
   retention already dropped on purpose are no longer treated as missing and
   rebuilt, only to be dropped again by the next retention run.
+- Debug Logs: the "Copy" button in the line-detail dialog did nothing when
+  GeoMetrikks was reached over plain HTTP on a LAN address. Browsers only
+  expose the clipboard API to HTTPS and loopback origins, so copying now
+  falls back to a hidden-textarea copy, and reports "Copy failed" instead of
+  silently doing nothing when even that is refused.
 
 ## [0.5.0] - 2026-07-25
 

--- a/resources/components/debug-logs/debug-log-detail-dialog.tsx
+++ b/resources/components/debug-logs/debug-log-detail-dialog.tsx
@@ -2,8 +2,8 @@
  * Detail view for one debug line: the full raw line (copyable), the parse
  * error, and the access-log context when the line parsed into one.
  */
-import { useState, type ReactNode } from "react"
-import { Check, Copy } from "lucide-react"
+import { useRef, useState, type ReactNode } from "react"
+import { AlertTriangle, Check, Copy } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -13,6 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { copyText } from "@/lib/clipboard"
 import type { AccessLogDebugEntry } from "@/lib/api"
 
 function DetailRow({ label, value }: { label: string; value: ReactNode }) {
@@ -33,22 +34,21 @@ export function DebugLogDetailDialog({
   entry: AccessLogDebugEntry | null
   onOpenChange: (open: boolean) => void
 }) {
-  const [copied, setCopied] = useState(false)
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle")
+  const contentRef = useRef<HTMLDivElement>(null)
 
   async function copyRawLine() {
     if (!entry) return
-    try {
-      await navigator.clipboard.writeText(entry.rawLine)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
-    } catch {
-      // Clipboard access unavailable or denied; leave the button state unchanged.
-    }
+    // The fallback textarea has to live inside the dialog, or its focus trap
+    // steals the selection before the copy runs.
+    const copied = await copyText(entry.rawLine, { container: contentRef.current })
+    setCopyState(copied ? "copied" : "failed")
+    setTimeout(() => setCopyState("idle"), copied ? 1500 : 4000)
   }
 
   return (
     <Dialog open={entry !== null} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-2xl">
+      <DialogContent ref={contentRef} className="sm:max-w-2xl">
         {entry && (
           <>
             <DialogHeader>
@@ -73,9 +73,31 @@ export function DebugLogDetailDialog({
             <div className="space-y-1">
               <div className="flex items-center justify-between">
                 <span className="text-xs font-medium text-muted-foreground">Raw line</span>
-                <Button variant="ghost" size="sm" className="h-7 px-2 pointer-coarse:h-10" onClick={copyRawLine}>
-                  {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-                  <span className="ml-1 text-xs">{copied ? "Copied" : "Copy"}</span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 pointer-coarse:h-10"
+                  onClick={copyRawLine}
+                  title={
+                    copyState === "failed"
+                      ? "This browser blocks clipboard access over plain HTTP. Select the line below and copy it manually."
+                      : undefined
+                  }
+                >
+                  {copyState === "copied" ? (
+                    <Check className="h-3.5 w-3.5" />
+                  ) : copyState === "failed" ? (
+                    <AlertTriangle className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
+                  ) : (
+                    <Copy className="h-3.5 w-3.5" />
+                  )}
+                  <span className="ml-1 text-xs">
+                    {copyState === "copied"
+                      ? "Copied"
+                      : copyState === "failed"
+                        ? "Copy failed"
+                        : "Copy"}
+                  </span>
                 </Button>
               </div>
               <pre className="max-h-48 overflow-y-auto whitespace-pre-wrap break-all rounded-md border bg-muted/50 p-3 font-mono text-xs">

--- a/resources/components/debug-logs/debug-log-detail-dialog.tsx
+++ b/resources/components/debug-logs/debug-log-detail-dialog.tsx
@@ -2,7 +2,7 @@
  * Detail view for one debug line: the full raw line (copyable), the parse
  * error, and the access-log context when the line parsed into one.
  */
-import { useRef, useState, type ReactNode } from "react"
+import { useEffect, useRef, useState, type ReactNode } from "react"
 import { AlertTriangle, Check, Copy } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -36,6 +36,13 @@ export function DebugLogDetailDialog({
 }) {
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle")
   const contentRef = useRef<HTMLDivElement>(null)
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current)
+    }
+  }, [])
 
   async function copyRawLine() {
     if (!entry) return
@@ -43,7 +50,9 @@ export function DebugLogDetailDialog({
     // steals the selection before the copy runs.
     const copied = await copyText(entry.rawLine, { container: contentRef.current })
     setCopyState(copied ? "copied" : "failed")
-    setTimeout(() => setCopyState("idle"), copied ? 1500 : 4000)
+    // Drop any pending reset, or an earlier click's timer clears this state early.
+    if (resetTimerRef.current) clearTimeout(resetTimerRef.current)
+    resetTimerRef.current = setTimeout(() => setCopyState("idle"), copied ? 1500 : 4000)
   }
 
   return (
@@ -78,11 +87,6 @@ export function DebugLogDetailDialog({
                   size="sm"
                   className="h-7 px-2 pointer-coarse:h-10"
                   onClick={copyRawLine}
-                  title={
-                    copyState === "failed"
-                      ? "This browser blocks clipboard access over plain HTTP. Select the line below and copy it manually."
-                      : undefined
-                  }
                 >
                   {copyState === "copied" ? (
                     <Check className="h-3.5 w-3.5" />
@@ -100,6 +104,12 @@ export function DebugLogDetailDialog({
                   </span>
                 </Button>
               </div>
+              {copyState === "failed" && (
+                <p role="status" className="text-xs text-amber-600 dark:text-amber-400">
+                  Clipboard access was blocked, usually because this page is served over plain
+                  HTTP. Select the line below to copy it manually.
+                </p>
+              )}
               <pre className="max-h-48 overflow-y-auto whitespace-pre-wrap break-all rounded-md border bg-muted/50 p-3 font-mono text-xs">
                 {entry.rawLine}
               </pre>

--- a/resources/lib/clipboard.test.ts
+++ b/resources/lib/clipboard.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest"
+import { copyText } from "./clipboard"
+
+function fakeTextarea() {
+  return {
+    value: "",
+    readOnly: false,
+    setAttribute: vi.fn(),
+    focus: vi.fn(),
+    select: vi.fn(),
+    setSelectionRange: vi.fn(),
+    remove: vi.fn(),
+  }
+}
+
+function fakeDocument(execCommandResult: boolean) {
+  const textarea = fakeTextarea()
+  const body = { append: vi.fn() }
+  const document = {
+    createElement: vi.fn(() => textarea),
+    execCommand: vi.fn(() => execCommandResult),
+    activeElement: null,
+    body,
+  }
+  return { document: document as unknown as Document, textarea, body }
+}
+
+describe("copyText", () => {
+  it("uses the async Clipboard API when it is available", async () => {
+    const writeText = vi.fn(async () => {})
+    const { document, body } = fakeDocument(true)
+
+    await expect(copyText("hello", { clipboard: { writeText }, document })).resolves.toBe(true)
+    expect(writeText).toHaveBeenCalledWith("hello")
+    expect(body.append).not.toHaveBeenCalled()
+  })
+
+  it("falls back to execCommand on an insecure origin, where clipboard is undefined", async () => {
+    const { document, textarea, body } = fakeDocument(true)
+
+    await expect(copyText("raw log line", { clipboard: undefined, document })).resolves.toBe(true)
+    expect(textarea.value).toBe("raw log line")
+    expect(body.append).toHaveBeenCalledWith(textarea)
+    expect(textarea.setSelectionRange).toHaveBeenCalledWith(0, "raw log line".length)
+    expect(document.execCommand).toHaveBeenCalledWith("copy")
+  })
+
+  it("falls back to execCommand when writeText rejects", async () => {
+    const writeText = vi.fn(async () => {
+      throw new Error("Document is not focused")
+    })
+    const { document } = fakeDocument(true)
+
+    await expect(copyText("hello", { clipboard: { writeText }, document })).resolves.toBe(true)
+    expect(document.execCommand).toHaveBeenCalledWith("copy")
+  })
+
+  it("appends into the given container so a focus trap cannot steal the selection", async () => {
+    const { document, textarea, body } = fakeDocument(true)
+    const container = { append: vi.fn() } as unknown as HTMLElement
+
+    await copyText("hello", { clipboard: undefined, document, container })
+    expect(container.append).toHaveBeenCalledWith(textarea)
+    expect(body.append).not.toHaveBeenCalled()
+  })
+
+  it("always removes the textarea it appended", async () => {
+    const { document, textarea } = fakeDocument(false)
+
+    await copyText("hello", { clipboard: undefined, document })
+    expect(textarea.remove).toHaveBeenCalled()
+  })
+
+  it("reports failure when execCommand refuses to copy", async () => {
+    const { document } = fakeDocument(false)
+
+    await expect(copyText("hello", { clipboard: undefined, document })).resolves.toBe(false)
+  })
+
+  it("reports failure when neither clipboard nor document is available", async () => {
+    await expect(copyText("hello", { clipboard: undefined, document: undefined })).resolves.toBe(
+      false,
+    )
+  })
+})

--- a/resources/lib/clipboard.ts
+++ b/resources/lib/clipboard.ts
@@ -1,0 +1,77 @@
+/**
+ * Clipboard writes that also work on insecure origins.
+ *
+ * `navigator.clipboard` only exists in a secure context: HTTPS, or a loopback
+ * host like `http://localhost`. GeoMetrikks is commonly reached over plain HTTP
+ * on a LAN address, where the whole Clipboard API is missing and nothing the
+ * server sends can change that, so fall back to a hidden-textarea
+ * `document.execCommand("copy")`. That call is deprecated but is not gated on
+ * secure context, and it remains the only way to copy from an insecure origin.
+ */
+
+/** The async Clipboard API surface used here, narrowed so tests can fake it. */
+type ClipboardWriter = Pick<Clipboard, "writeText">
+
+export interface CopyTextOptions {
+  /**
+   * Element the fallback textarea is appended to. Pass the dialog or popover
+   * that owns the copy button: a focus trap bounces focus out of anything
+   * mounted outside it, which drops the selection before the copy runs.
+   * Defaults to `document.body`.
+   */
+  container?: HTMLElement | null
+  /** Overrides `navigator.clipboard`. Injected by tests. */
+  clipboard?: ClipboardWriter
+  /** Overrides `globalThis.document`. Injected by tests. */
+  document?: Document
+}
+
+const FALLBACK_STYLE = "position:fixed;top:0;left:0;width:1px;height:1px;opacity:0;"
+
+/**
+ * Copies `text`, returning whether it landed on the clipboard.
+ *
+ * Callers must handle `false`: on an insecure origin with a browser that has
+ * dropped `execCommand` there is no way to copy, and silently doing nothing
+ * reads as a broken button.
+ */
+export async function copyText(text: string, options: CopyTextOptions = {}): Promise<boolean> {
+  const clipboard = "clipboard" in options ? options.clipboard : globalThis.navigator?.clipboard
+  const doc = "document" in options ? options.document : globalThis.document
+
+  if (clipboard) {
+    try {
+      await clipboard.writeText(text)
+      return true
+    } catch {
+      // Permission denied, or the document is not focused. Try the fallback.
+    }
+  }
+
+  if (!doc) return false
+  return copyViaExecCommand(text, doc, options.container ?? doc.body)
+}
+
+function copyViaExecCommand(text: string, doc: Document, host: HTMLElement): boolean {
+  const textarea = doc.createElement("textarea")
+  textarea.value = text
+  textarea.readOnly = true
+  textarea.setAttribute("aria-hidden", "true")
+  textarea.setAttribute("tabindex", "-1")
+  textarea.setAttribute("style", FALLBACK_STYLE)
+  host.append(textarea)
+
+  const previouslyFocused = doc.activeElement as HTMLElement | null
+  try {
+    textarea.focus({ preventScroll: true })
+    textarea.select()
+    // Safari ignores select() on a readOnly textarea.
+    textarea.setSelectionRange(0, text.length)
+    return doc.execCommand("copy")
+  } catch {
+    return false
+  } finally {
+    textarea.remove()
+    previouslyFocused?.focus?.({ preventScroll: true })
+  }
+}


### PR DESCRIPTION
### Fixed

- Debug Logs: the "Copy" button in the line-detail dialog did nothing when
  GeoMetrikks was reached over plain HTTP on a LAN address. Browsers only
  expose the clipboard API to HTTPS and loopback origins, so copying now
  falls back to a hidden-textarea copy, and reports "Copy failed" instead of
  silently doing nothing when even that is refused.