### PR TITLE
ci: run Vitest in frontend job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,5 +50,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - name: Install
         run: bun install --frozen-lockfile
+      - name: Run frontend tests
+        run: bun run test
       - name: Build (vite + tsc)
         run: bun run build


### PR DESCRIPTION
## Summary

- run Vitest as a separate step in the frontend CI job
- keep the existing frontend build step after the tests

## Why

Vitest and the frontend test suite were added after the workflow was created,
so CI installed dependencies and built the frontend without running its tests.

## Validation

- `bun run test` — 7 files, 86 tests passed
- `bun run build`
- `git diff --check`
