### PR TITLE
feat(analytics): CAGG-backed top lists, geo routing fixes and fast facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Geo Logs chart on ranges up to 24 hours no longer includes events from just
   before the selected window in its first data point, and its unique-IP counts
   on those short ranges are exact instead of estimated.
+- Aggregate-backed queries that stitch partial-bucket edges from raw data
+  (Geo Logs grouped rows and top lists, and the new analytics top lists) no
+  longer scan the entire raw table to do so: the window bounds are now bound
+  as plain query parameters so TimescaleDB can skip irrelevant time chunks.
+  On a database with 18M rows these queries dropped from seconds to tens of
+  milliseconds.
 
 ## [0.5.0] - 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Map top-IP lists (global and per-location) no longer include events from
   outside the selected range on ranges over 24 hours: the window was
   previously floored to whole days, over-counting the partial first day.
+- Geo Logs chart on ranges up to 24 hours no longer includes events from just
+  before the selected window in its first data point, and its unique-IP counts
+  on those short ranges are exact instead of estimated.
 
 ## [0.5.0] - 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Geo Logs summary and chart stay on the fast aggregate path when filtered
   by country, city or IP on ranges over 24 hours. Hostname filters still
   scan raw events.
-- Access Logs country and city filter dropdowns load from aggregates
-  instead of scanning the full log history, and now list values from all
-  recorded history rather than only the raw retention window.
+- Access Logs country, city and host filter dropdowns, and the Geo Logs
+  hostname dropdown, load from aggregates instead of scanning the full log
+  history, and now list values from all recorded history rather than only
+  the raw retention window.
 
 ### Fixed
 
@@ -35,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as plain query parameters so TimescaleDB can skip irrelevant time chunks.
   On a database with 18M rows these queries dropped from seconds to tens of
   milliseconds.
+- Top lists across Analytics, Geo Logs and the map order rows with equal
+  counts deterministically (alphabetical within a tie), so tied entries no
+  longer shuffle between refreshes or differ between query paths.
 
 ## [0.5.0] - 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,15 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Geo Logs chart on ranges up to 24 hours no longer includes events from just
   before the selected window in its first data point, and its unique-IP counts
   on those short ranges are exact instead of estimated.
-- Aggregate-backed queries that stitch partial-bucket edges from raw data
-  (Geo Logs grouped rows and top lists, and the new analytics top lists) no
-  longer scan the entire raw table to do so: the window bounds are now bound
-  as plain query parameters so TimescaleDB can skip irrelevant time chunks.
-  On a database with 18M rows these queries dropped from seconds to tens of
-  milliseconds.
+- Geo Logs grouped rows and top lists on ranges over 24 hours no longer
+  scan the entire raw event history while stitching partial-bucket window
+  edges: TimescaleDB can now skip time chunks outside the selected range.
+  On a database with 18M rows these queries dropped from seconds to tens
+  of milliseconds.
 - Top lists across Analytics, Geo Logs and the map order rows with equal
   counts deterministically (alphabetical within a tie), so tied entries no
-  longer shuffle between refreshes or differ between query paths.
+  longer shuffle between refreshes.
 - Startup no longer re-backfills hourly aggregate history on every restart.
   The gap check now respects hourly aggregate retention, so buckets that
   retention already dropped on purpose are no longer treated as missing and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Top lists across Analytics, Geo Logs and the map order rows with equal
   counts deterministically (alphabetical within a tie), so tied entries no
   longer shuffle between refreshes or differ between query paths.
+- Startup no longer re-backfills hourly aggregate history on every restart.
+  The gap check now respects hourly aggregate retention, so buckets that
+  retention already dropped on purpose are no longer treated as missing and
+  rebuilt, only to be dropped again by the next retention run.
 
 ## [0.5.0] - 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Analytics top lists (URLs, user agents, IPs, countries, cities) are now
+  served from continuous aggregates on ranges over 24 hours instead of
+  scanning raw access logs, making long-range views much faster. The IP,
+  country and city lists stay on the fast path even with country/city/IP
+  filters; filtered URL and user-agent lists still scan raw logs.
+- Geo Logs summary and chart stay on the fast aggregate path when filtered
+  by country, city or IP on ranges over 24 hours. Hostname filters still
+  scan raw events.
+- Access Logs country and city filter dropdowns load from aggregates
+  instead of scanning the full log history, and now list values from all
+  recorded history rather than only the raw retention window.
+
+### Fixed
+
+- Map top-IP lists (global and per-location) no longer include events from
+  outside the selected range on ranges over 24 hours: the window was
+  previously floored to whole days, over-counting the partial first day.
+
 ## [0.5.0] - 2026-07-25
 
 ### Added

--- a/geometrikks/api/v1/analytics_controller.py
+++ b/geometrikks/api/v1/analytics_controller.py
@@ -560,10 +560,10 @@ class AnalyticsController(Controller):
             ],
         )
 
-    @get("/top-urls", description="Top URLs by hits from raw access logs (time-bounded).")
+    @get("/top-urls", description="Top URLs by hits (CAGG-served above 24h; filters force a raw scan).")
     async def get_top_urls(
         self,
-        live_stats_repo: NamedDependency[LiveStatsRepository],
+        summary_stats_repo: NamedDependency[SummaryStatsRepository],
         start_date: Annotated[
             datetime,
             Parameter(
@@ -599,19 +599,23 @@ class AnalyticsController(Controller):
             Parameter(description="Exclude these client IPs (repeatable)", required=False),
         ] = None,
     ) -> TopUrlsResponse:
-        """Get the top URLs by hit count for a date range."""
+        """Get the top URLs by hit count for a date range.
+
+        Perf note: filtered queries scan raw access_logs and are bounded by
+        raw_retention_days (same trade-off as filtered /time-series).
+        """
         filters = _build_filters(country_code, city, ip_address, ip_address_not_in)
-        rows = await live_stats_repo.get_top_urls(start_date, end_date, limit=limit, filters=filters)
+        rows = await summary_stats_repo.get_top_urls(start_date, end_date, limit=limit, filters=filters)
         return TopUrlsResponse(
             start_date=start_date.isoformat(),
             end_date=end_date.isoformat(),
             items=[TopUrlDTO(**vars(r)) for r in rows],
         )
 
-    @get("/top-user-agents", description="Top user agents by hits from raw access logs.")
+    @get("/top-user-agents", description="Top user agents by hits (CAGG-served above 24h; filters force a raw scan).")
     async def get_top_user_agents(
         self,
-        live_stats_repo: NamedDependency[LiveStatsRepository],
+        summary_stats_repo: NamedDependency[SummaryStatsRepository],
         start_date: Annotated[
             datetime,
             Parameter(
@@ -647,19 +651,23 @@ class AnalyticsController(Controller):
             Parameter(description="Exclude these client IPs (repeatable)", required=False),
         ] = None,
     ) -> TopUserAgentsResponse:
-        """Get the top user agents by hit count for a date range."""
+        """Get the top user agents by hit count for a date range.
+
+        Perf note: filtered queries scan raw access_logs and are bounded by
+        raw_retention_days (same trade-off as filtered /time-series).
+        """
         filters = _build_filters(country_code, city, ip_address, ip_address_not_in)
-        rows = await live_stats_repo.get_top_user_agents(start_date, end_date, limit=limit, filters=filters)
+        rows = await summary_stats_repo.get_top_user_agents(start_date, end_date, limit=limit, filters=filters)
         return TopUserAgentsResponse(
             start_date=start_date.isoformat(),
             end_date=end_date.isoformat(),
             items=[TopUserAgentDTO(**vars(r)) for r in rows],
         )
 
-    @get("/top-ips", description="Top client IPs by hits from raw access logs (time-bounded).")
+    @get("/top-ips", description="Top client IPs by hits (CAGG-served above 24h, filters included).")
     async def get_top_ips(
         self,
-        live_stats_repo: NamedDependency[LiveStatsRepository],
+        summary_stats_repo: NamedDependency[SummaryStatsRepository],
         start_date: Annotated[
             datetime,
             Parameter(description="Start date (ISO 8601)"),
@@ -691,17 +699,17 @@ class AnalyticsController(Controller):
     ) -> TopIpsResponse:
         """Get the top client IPs by hit count for a date range."""
         filters = _build_filters(country_code, city, ip_address, ip_address_not_in)
-        rows = await live_stats_repo.get_top_ips(start_date, end_date, limit=limit, filters=filters)
+        rows = await summary_stats_repo.get_top_ips(start_date, end_date, limit=limit, filters=filters)
         return TopIpsResponse(
             start_date=start_date.isoformat(),
             end_date=end_date.isoformat(),
             items=[TopIpDTO(**vars(r)) for r in rows],
         )
 
-    @get("/top-countries", description="Top countries by hits from raw access logs (time-bounded).")
+    @get("/top-countries", description="Top countries by hits (CAGG-served above 24h, filters included).")
     async def get_top_countries(
         self,
-        live_stats_repo: NamedDependency[LiveStatsRepository],
+        summary_stats_repo: NamedDependency[SummaryStatsRepository],
         start_date: Annotated[
             datetime,
             Parameter(description="Start date (ISO 8601)"),
@@ -733,17 +741,17 @@ class AnalyticsController(Controller):
     ) -> TopCountriesStatsResponse:
         """Get the top countries by hit count for a date range."""
         filters = _build_filters(country_code, city, ip_address, ip_address_not_in)
-        rows = await live_stats_repo.get_top_countries(start_date, end_date, limit=limit, filters=filters)
+        rows = await summary_stats_repo.get_top_countries(start_date, end_date, limit=limit, filters=filters)
         return TopCountriesStatsResponse(
             start_date=start_date.isoformat(),
             end_date=end_date.isoformat(),
             items=[TopCountryStatsDTO(**vars(r)) for r in rows],
         )
 
-    @get("/top-cities", description="Top cities by hits from raw access logs (time-bounded).")
+    @get("/top-cities", description="Top cities by hits (CAGG-served above 24h, filters included).")
     async def get_top_cities(
         self,
-        live_stats_repo: NamedDependency[LiveStatsRepository],
+        summary_stats_repo: NamedDependency[SummaryStatsRepository],
         start_date: Annotated[
             datetime,
             Parameter(description="Start date (ISO 8601)"),
@@ -775,7 +783,7 @@ class AnalyticsController(Controller):
     ) -> TopCitiesResponse:
         """Get the top cities by hit count for a date range."""
         filters = _build_filters(country_code, city, ip_address, ip_address_not_in)
-        rows = await live_stats_repo.get_top_cities(start_date, end_date, limit=limit, filters=filters)
+        rows = await summary_stats_repo.get_top_cities(start_date, end_date, limit=limit, filters=filters)
         return TopCitiesResponse(
             start_date=start_date.isoformat(),
             end_date=end_date.isoformat(),

--- a/geometrikks/api/v1/geo_events_controller.py
+++ b/geometrikks/api/v1/geo_events_controller.py
@@ -156,10 +156,10 @@ def _resolve_chart_granularity(
 class GeoEventController(Controller):
     """Geo-event endpoints: raw event listing and geo-logs page aggregates.
 
-    Perf note: hostname filters (and any filter on summary/time-series) force
-    raw geo_events scans instead of the CAGGs, so those queries are bounded by
-    raw_retention_days (default 180d) — same trade-off as the filtered
-    analytics queries.
+    Perf note: only hostname filters force raw geo_events scans for
+    summary/time-series now (no CAGG carries a hostname dimension); those
+    queries are bounded by raw_retention_days (default 180d). Country/city/IP
+    filters ride the stitched per-IP CAGGs instead.
     """
 
     path = "/api/v1/geo-events"
@@ -240,8 +240,9 @@ class GeoEventController(Controller):
     ) -> GeoLogSummaryResponse:
         """Totals and unique counts for the period, optionally vs the previous one.
 
-        Unfiltered ranges > 24h use HLL-backed CAGGs (approximate uniques);
-        filtered ranges scan raw geo_events for exact counts.
+        Hostname-filtered ranges scan raw geo_events; country/city/IP filters
+        use per-IP CAGGs (exact uniques); unfiltered ranges > 24h use HLL
+        CAGGs (approximate uniques).
         """
         from_timestamp = _ensure_utc(from_timestamp)
         to_timestamp = _ensure_utc(to_timestamp)
@@ -291,7 +292,12 @@ class GeoEventController(Controller):
             ),
         ] = None,
     ) -> GeoLogTimeSeriesResponse:
-        """Bucketed totals + unique IPs; filtered ranges scan raw geo_events."""
+        """Bucketed totals + unique IPs.
+
+        Hostname-filtered ranges scan raw geo_events; country/city/IP filters
+        use per-IP CAGGs (exact uniques); unfiltered ranges > 24h use HLL
+        CAGGs (approximate uniques).
+        """
         from_timestamp = _ensure_utc(from_timestamp)
         to_timestamp = _ensure_utc(to_timestamp)
         resolved = _resolve_chart_granularity(from_timestamp, to_timestamp, granularity)

--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -14,6 +14,8 @@ CAGG Structure:
 - geo_summary_hourly_stats / geo_summary_daily_stats: Geo metrics with HyperLogLog (events, unique IPs/countries/cities)
 - location_hourly_stats / location_daily_stats: Location event counts for map (GeoJSON features)
 - ip_location_daily_stats: Per-IP counts by location for top IPs
+- url_hourly_stats / url_daily_stats: Top URLs by hits, error_hits, total_bytes, total_request_time
+- user_agent_hourly_stats / user_agent_daily_stats: Top user agents by hits
 
 HyperLogLog sketches enable accurate unique counts across any time range.
 For short ranges (≤1 hour), raw table queries provide exact time range results.
@@ -591,6 +593,103 @@ class SummaryStatsRepository:
         result = await self.session.execute(stmt, {"start": start, "end": end})
         return [dict(row._mapping) for row in result.fetchall()]
 
+    async def get_top_urls(
+        self, start: datetime, end: datetime, limit: int = 25, *, filters: AnalyticsFilters | None = None
+    ) -> list[TopUrlRow]:
+        """Top URLs by hits: stitched url CAGG read above 24h, raw otherwise.
+
+        Any active filter forces the raw path: the url CAGGs carry no
+        country/city/IP dimensions (adding them would multiply cardinality).
+        """
+        filters = filters or AnalyticsFilters()
+        granularity = get_stats_granularity(start, end)
+        if granularity == StatsGranularity.RAW or filters.is_active():
+            return await LiveStatsRepository(self.session).get_top_urls(
+                start, end, limit, filters=filters
+            )
+        table = f"url_{granularity.value}_stats"
+        interval = "1 hour" if granularity == StatsGranularity.HOURLY else "1 day"
+        stmt = text(f"""
+            {_stitched_bounds_cte(interval)},
+            combined AS (
+                SELECT s.url, s.hits, s.error_hits, s.total_bytes, s.total_request_time
+                FROM {table} s, bounds
+                WHERE s.bucket >= bounds.a_start AND s.bucket < bounds.a_end
+                UNION ALL
+                SELECT al.url, CAST(1 AS BIGINT), CAST((al.status_code >= 400)::int AS BIGINT),
+                       al.bytes_sent, al.request_time
+                FROM access_logs al, bounds
+                WHERE ((al.timestamp >= bounds.rs AND al.timestamp < bounds.a_start)
+                    OR (al.timestamp >= bounds.a_end AND al.timestamp < bounds.re))
+                  AND al.url IS NOT NULL
+            )
+            SELECT
+                url,
+                CAST(SUM(hits) AS BIGINT) AS hits,
+                CAST(SUM(error_hits) AS BIGINT) AS error_hits,
+                CAST(COALESCE(SUM(total_bytes), 0) AS BIGINT) AS total_bytes,
+                COALESCE(SUM(total_request_time) / NULLIF(SUM(hits), 0), 0) AS avg_request_time
+            FROM combined
+            GROUP BY url
+            ORDER BY hits DESC
+            LIMIT :limit
+        """)
+        result = await self.session.execute(
+            stmt, {"start": start, "end": end, "limit": limit}
+        )
+        return [
+            TopUrlRow(
+                url=row.url,
+                hits=row.hits,
+                error_hits=row.error_hits,
+                total_bytes=row.total_bytes,
+                avg_request_time=float(row.avg_request_time),
+            )
+            for row in result.fetchall()
+        ]
+
+    async def get_top_user_agents(
+        self, start: datetime, end: datetime, limit: int = 25, *, filters: AnalyticsFilters | None = None
+    ) -> list[TopUserAgentRow]:
+        """Top user agents by hits: stitched CAGG read above 24h, raw otherwise.
+
+        Any active filter forces the raw path (no dims on the UA CAGGs).
+        """
+        filters = filters or AnalyticsFilters()
+        granularity = get_stats_granularity(start, end)
+        if granularity == StatsGranularity.RAW or filters.is_active():
+            return await LiveStatsRepository(self.session).get_top_user_agents(
+                start, end, limit, filters=filters
+            )
+        table = f"user_agent_{granularity.value}_stats"
+        interval = "1 hour" if granularity == StatsGranularity.HOURLY else "1 day"
+        stmt = text(f"""
+            {_stitched_bounds_cte(interval)},
+            combined AS (
+                SELECT s.user_agent, s.hits
+                FROM {table} s, bounds
+                WHERE s.bucket >= bounds.a_start AND s.bucket < bounds.a_end
+                UNION ALL
+                SELECT al.user_agent, CAST(1 AS BIGINT)
+                FROM access_logs al, bounds
+                WHERE ((al.timestamp >= bounds.rs AND al.timestamp < bounds.a_start)
+                    OR (al.timestamp >= bounds.a_end AND al.timestamp < bounds.re))
+                  AND al.user_agent IS NOT NULL
+            )
+            SELECT user_agent, CAST(SUM(hits) AS BIGINT) AS hits
+            FROM combined
+            GROUP BY user_agent
+            ORDER BY hits DESC
+            LIMIT :limit
+        """)
+        result = await self.session.execute(
+            stmt, {"start": start, "end": end, "limit": limit}
+        )
+        return [
+            TopUserAgentRow(user_agent=row.user_agent, hits=row.hits)
+            for row in result.fetchall()
+        ]
+
 
 @dataclass
 class TopUrlRow:
@@ -677,6 +776,39 @@ class AnalyticsFilters:
             clauses.append("AND NOT (ip_address = ANY(CAST(:filter_ips_exclude AS inet[])))")
             params["filter_ips_exclude"] = list(self.ip_exclude)
         return " ".join(clauses), params
+
+
+def _stitched_bounds_cte(interval: str) -> str:
+    """WITH-clause opener exposing ``bounds`` for a stitched CAGG read.
+
+    ``bounds`` snaps the [:start, :end) window inward to whole buckets
+    (a_start/a_end); the leftover head/tail slices are read from the raw
+    hypertable by the caller's second UNION leg, so the union is exactly
+    equal to a raw scan of the window. a_start/a_end are clamped so a window
+    spanning no complete bucket degenerates to a pure raw scan.
+    """
+    return f"""
+        WITH bounds AS (
+            SELECT
+                rs, re, a_start,
+                GREATEST(time_bucket(INTERVAL '{interval}', re), a_start) AS a_end
+            FROM (
+                SELECT
+                    CAST(:start AS timestamptz) AS rs,
+                    CAST(:end AS timestamptz) AS re,
+                    LEAST(
+                        CASE
+                            WHEN time_bucket(INTERVAL '{interval}', CAST(:start AS timestamptz))
+                                 = CAST(:start AS timestamptz)
+                            THEN CAST(:start AS timestamptz)
+                            ELSE time_bucket(INTERVAL '{interval}', CAST(:start AS timestamptz))
+                                 + INTERVAL '{interval}'
+                        END,
+                        CAST(:end AS timestamptz)
+                    ) AS a_start
+            ) b
+        )
+    """
 
 
 class LiveStatsRepository:

--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -16,6 +16,7 @@ CAGG Structure:
 - ip_location_daily_stats: Per-IP counts by location for top IPs
 - url_hourly_stats / url_daily_stats: Top URLs by hits, error_hits, total_bytes, total_request_time
 - user_agent_hourly_stats / user_agent_daily_stats: Top user agents by hits
+- log_ip_{hourly,daily}_stats: Per-IP access-log counts (top IPs/countries/cities, facets)
 
 HyperLogLog sketches enable accurate unique counts across any time range.
 For short ranges (≤1 hour), raw table queries provide exact time range results.

--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -690,6 +690,126 @@ class SummaryStatsRepository:
             for row in result.fetchall()
         ]
 
+    def _log_ip_combined_cte(self, granularity: StatsGranularity) -> str:
+        """WITH clause exposing ``combined`` for a stitched log_ip CAGG read.
+
+        ``combined`` yields (ip_address, country_code, city, country_name,
+        hits, error_hits, total_bytes); rows are keyed by IP on both legs, so
+        COUNT(DISTINCT ip_address) over it stays exact and the unaliased
+        AnalyticsFilters conditions apply to either leg's rows.
+        """
+        table = f"log_ip_{granularity.value}_stats"
+        interval = "1 hour" if granularity == StatsGranularity.HOURLY else "1 day"
+        return f"""
+            {_stitched_bounds_cte(interval)},
+            combined AS (
+                SELECT s.ip_address, s.country_code, s.city, s.country_name,
+                       s.hits, s.error_hits, s.total_bytes
+                FROM {table} s, bounds
+                WHERE s.bucket >= bounds.a_start AND s.bucket < bounds.a_end
+                UNION ALL
+                SELECT al.ip_address, al.country_code, al.city, al.country_name,
+                       CAST(1 AS BIGINT), CAST((al.status_code >= 400)::int AS BIGINT),
+                       al.bytes_sent
+                FROM access_logs al, bounds
+                WHERE (al.timestamp >= bounds.rs AND al.timestamp < bounds.a_start)
+                   OR (al.timestamp >= bounds.a_end AND al.timestamp < bounds.re)
+            )
+        """
+
+    async def get_top_ips(
+        self, start: datetime, end: datetime, limit: int = 25, *, filters: AnalyticsFilters | None = None
+    ) -> list[TopIpRow]:
+        """Top client IPs: stitched log_ip CAGG read above 24h, raw otherwise.
+
+        Country/city/IP filters apply on the CAGG path (its columns carry the
+        dimensions), so filtered long ranges stay fast.
+        """
+        filters = filters or AnalyticsFilters()
+        granularity = get_stats_granularity(start, end)
+        if granularity == StatsGranularity.RAW:
+            return await LiveStatsRepository(self.session).get_top_ips(
+                start, end, limit, filters=filters
+            )
+        filter_sql, filter_params = filters.sql_conditions()
+        stmt = text(f"""
+            {self._log_ip_combined_cte(granularity)}
+            SELECT
+                host(ip_address) AS ip_address,
+                CAST(SUM(hits) AS BIGINT) AS hits,
+                CAST(SUM(error_hits) AS BIGINT) AS error_hits,
+                CAST(COALESCE(SUM(total_bytes), 0) AS BIGINT) AS total_bytes,
+                MAX(country_code) AS country_code,
+                MAX(city) AS city
+            FROM combined
+            WHERE TRUE {filter_sql}
+            GROUP BY ip_address
+            ORDER BY hits DESC
+            LIMIT :limit
+        """)
+        result = await self.session.execute(
+            stmt, {"start": start, "end": end, "limit": limit, **filter_params}
+        )
+        return [TopIpRow(**row._mapping) for row in result.fetchall()]
+
+    async def get_top_countries(
+        self, start: datetime, end: datetime, limit: int = 25, *, filters: AnalyticsFilters | None = None
+    ) -> list[TopCountryRow]:
+        """Top countries with exact unique-IP counts (combined is IP-keyed)."""
+        filters = filters or AnalyticsFilters()
+        granularity = get_stats_granularity(start, end)
+        if granularity == StatsGranularity.RAW:
+            return await LiveStatsRepository(self.session).get_top_countries(
+                start, end, limit, filters=filters
+            )
+        filter_sql, filter_params = filters.sql_conditions()
+        stmt = text(f"""
+            {self._log_ip_combined_cte(granularity)}
+            SELECT
+                country_code,
+                MAX(country_name) AS country_name,
+                CAST(SUM(hits) AS BIGINT) AS hits,
+                CAST(COUNT(DISTINCT ip_address) AS BIGINT) AS unique_ips
+            FROM combined
+            WHERE country_code IS NOT NULL {filter_sql}
+            GROUP BY country_code
+            ORDER BY hits DESC
+            LIMIT :limit
+        """)
+        result = await self.session.execute(
+            stmt, {"start": start, "end": end, "limit": limit, **filter_params}
+        )
+        return [TopCountryRow(**row._mapping) for row in result.fetchall()]
+
+    async def get_top_cities(
+        self, start: datetime, end: datetime, limit: int = 25, *, filters: AnalyticsFilters | None = None
+    ) -> list[TopCityRow]:
+        """Top cities with exact unique-IP counts (NULL cities excluded)."""
+        filters = filters or AnalyticsFilters()
+        granularity = get_stats_granularity(start, end)
+        if granularity == StatsGranularity.RAW:
+            return await LiveStatsRepository(self.session).get_top_cities(
+                start, end, limit, filters=filters
+            )
+        filter_sql, filter_params = filters.sql_conditions()
+        stmt = text(f"""
+            {self._log_ip_combined_cte(granularity)}
+            SELECT
+                city,
+                MAX(country_code) AS country_code,
+                CAST(SUM(hits) AS BIGINT) AS hits,
+                CAST(COUNT(DISTINCT ip_address) AS BIGINT) AS unique_ips
+            FROM combined
+            WHERE city IS NOT NULL {filter_sql}
+            GROUP BY city
+            ORDER BY hits DESC
+            LIMIT :limit
+        """)
+        result = await self.session.execute(
+            stmt, {"start": start, "end": end, "limit": limit, **filter_params}
+        )
+        return [TopCityRow(**row._mapping) for row in result.fetchall()]
+
 
 @dataclass
 class TopUrlRow:

--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -635,7 +635,7 @@ class SummaryStatsRepository:
                 COALESCE(SUM(total_request_time) / NULLIF(SUM(hits), 0), 0) AS avg_request_time
             FROM combined
             GROUP BY url
-            ORDER BY hits DESC
+            ORDER BY hits DESC, url
             LIMIT :limit
         """)
         result = await self.session.execute(
@@ -685,7 +685,7 @@ class SummaryStatsRepository:
             SELECT user_agent, CAST(SUM(hits) AS BIGINT) AS hits
             FROM combined
             GROUP BY user_agent
-            ORDER BY hits DESC
+            ORDER BY hits DESC, user_agent
             LIMIT :limit
         """)
         result = await self.session.execute(
@@ -754,7 +754,7 @@ class SummaryStatsRepository:
             FROM combined
             WHERE TRUE {filter_sql}
             GROUP BY ip_address
-            ORDER BY hits DESC
+            ORDER BY hits DESC, ip_address
             LIMIT :limit
         """)
         result = await self.session.execute(
@@ -783,7 +783,7 @@ class SummaryStatsRepository:
             FROM combined
             WHERE country_code IS NOT NULL {filter_sql}
             GROUP BY country_code
-            ORDER BY hits DESC
+            ORDER BY hits DESC, country_code
             LIMIT :limit
         """)
         result = await self.session.execute(
@@ -812,7 +812,7 @@ class SummaryStatsRepository:
             FROM combined
             WHERE city IS NOT NULL {filter_sql}
             GROUP BY city
-            ORDER BY hits DESC
+            ORDER BY hits DESC, city
             LIMIT :limit
         """)
         result = await self.session.execute(
@@ -1127,7 +1127,7 @@ class LiveStatsRepository:
             WHERE timestamp >= :start AND timestamp < :end AND url IS NOT NULL
             {filter_sql}
             GROUP BY url
-            ORDER BY hits DESC
+            ORDER BY hits DESC, url
             LIMIT :limit
         """)
         result = await self.session.execute(
@@ -1155,7 +1155,7 @@ class LiveStatsRepository:
             WHERE timestamp >= :start AND timestamp < :end AND user_agent IS NOT NULL
             {filter_sql}
             GROUP BY user_agent
-            ORDER BY hits DESC
+            ORDER BY hits DESC, user_agent
             LIMIT :limit
         """)
         result = await self.session.execute(
@@ -1180,7 +1180,7 @@ class LiveStatsRepository:
             WHERE timestamp >= :start AND timestamp < :end
             {filter_sql}
             GROUP BY ip_address
-            ORDER BY hits DESC
+            ORDER BY hits DESC, ip_address
             LIMIT :limit
         """)
         result = await self.session.execute(
@@ -1203,7 +1203,7 @@ class LiveStatsRepository:
             WHERE timestamp >= :start AND timestamp < :end AND country_code IS NOT NULL
             {filter_sql}
             GROUP BY country_code
-            ORDER BY hits DESC
+            ORDER BY hits DESC, country_code
             LIMIT :limit
         """)
         result = await self.session.execute(
@@ -1226,7 +1226,7 @@ class LiveStatsRepository:
             WHERE timestamp >= :start AND timestamp < :end AND city IS NOT NULL
             {filter_sql}
             GROUP BY city
-            ORDER BY hits DESC
+            ORDER BY hits DESC, city
             LIMIT :limit
         """)
         result = await self.session.execute(

--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -609,19 +609,22 @@ class SummaryStatsRepository:
                 start, end, limit, filters=filters
             )
         table = f"url_{granularity.value}_stats"
-        interval = "1 hour" if granularity == StatsGranularity.HOURLY else "1 day"
         stmt = text(f"""
-            {_stitched_bounds_cte(interval)},
-            combined AS (
+            WITH combined AS (
                 SELECT s.url, s.hits, s.error_hits, s.total_bytes, s.total_request_time
-                FROM {table} s, bounds
-                WHERE s.bucket >= bounds.a_start AND s.bucket < bounds.a_end
+                FROM {table} s
+                WHERE s.bucket >= :a_start AND s.bucket < :a_end
                 UNION ALL
                 SELECT al.url, CAST(1 AS BIGINT), CAST((al.status_code >= 400)::int AS BIGINT),
                        al.bytes_sent, al.request_time
-                FROM access_logs al, bounds
-                WHERE ((al.timestamp >= bounds.rs AND al.timestamp < bounds.a_start)
-                    OR (al.timestamp >= bounds.a_end AND al.timestamp < bounds.re))
+                FROM access_logs al
+                WHERE al.timestamp >= :start AND al.timestamp < :a_start
+                  AND al.url IS NOT NULL
+                UNION ALL
+                SELECT al.url, CAST(1 AS BIGINT), CAST((al.status_code >= 400)::int AS BIGINT),
+                       al.bytes_sent, al.request_time
+                FROM access_logs al
+                WHERE al.timestamp >= :a_end AND al.timestamp < :end
                   AND al.url IS NOT NULL
             )
             SELECT
@@ -636,7 +639,7 @@ class SummaryStatsRepository:
             LIMIT :limit
         """)
         result = await self.session.execute(
-            stmt, {"start": start, "end": end, "limit": limit}
+            stmt, {**_stitch_params(start, end, granularity), "limit": limit}
         )
         return [
             TopUrlRow(
@@ -663,18 +666,20 @@ class SummaryStatsRepository:
                 start, end, limit, filters=filters
             )
         table = f"user_agent_{granularity.value}_stats"
-        interval = "1 hour" if granularity == StatsGranularity.HOURLY else "1 day"
         stmt = text(f"""
-            {_stitched_bounds_cte(interval)},
-            combined AS (
+            WITH combined AS (
                 SELECT s.user_agent, s.hits
-                FROM {table} s, bounds
-                WHERE s.bucket >= bounds.a_start AND s.bucket < bounds.a_end
+                FROM {table} s
+                WHERE s.bucket >= :a_start AND s.bucket < :a_end
                 UNION ALL
                 SELECT al.user_agent, CAST(1 AS BIGINT)
-                FROM access_logs al, bounds
-                WHERE ((al.timestamp >= bounds.rs AND al.timestamp < bounds.a_start)
-                    OR (al.timestamp >= bounds.a_end AND al.timestamp < bounds.re))
+                FROM access_logs al
+                WHERE al.timestamp >= :start AND al.timestamp < :a_start
+                  AND al.user_agent IS NOT NULL
+                UNION ALL
+                SELECT al.user_agent, CAST(1 AS BIGINT)
+                FROM access_logs al
+                WHERE al.timestamp >= :a_end AND al.timestamp < :end
                   AND al.user_agent IS NOT NULL
             )
             SELECT user_agent, CAST(SUM(hits) AS BIGINT) AS hits
@@ -684,7 +689,7 @@ class SummaryStatsRepository:
             LIMIT :limit
         """)
         result = await self.session.execute(
-            stmt, {"start": start, "end": end, "limit": limit}
+            stmt, {**_stitch_params(start, end, granularity), "limit": limit}
         )
         return [
             TopUserAgentRow(user_agent=row.user_agent, hits=row.hits)
@@ -695,26 +700,30 @@ class SummaryStatsRepository:
         """WITH clause exposing ``combined`` for a stitched log_ip CAGG read.
 
         ``combined`` yields (ip_address, country_code, city, country_name,
-        hits, error_hits, total_bytes); rows are keyed by IP on both legs, so
+        hits, error_hits, total_bytes); rows are keyed by IP on all legs, so
         COUNT(DISTINCT ip_address) over it stays exact and the unaliased
-        AnalyticsFilters conditions apply to either leg's rows.
+        AnalyticsFilters conditions apply to any leg's rows. Callers bind the
+        params from ``_stitch_params``.
         """
         table = f"log_ip_{granularity.value}_stats"
-        interval = "1 hour" if granularity == StatsGranularity.HOURLY else "1 day"
         return f"""
-            {_stitched_bounds_cte(interval)},
-            combined AS (
+            WITH combined AS (
                 SELECT s.ip_address, s.country_code, s.city, s.country_name,
                        s.hits, s.error_hits, s.total_bytes
-                FROM {table} s, bounds
-                WHERE s.bucket >= bounds.a_start AND s.bucket < bounds.a_end
+                FROM {table} s
+                WHERE s.bucket >= :a_start AND s.bucket < :a_end
                 UNION ALL
                 SELECT al.ip_address, al.country_code, al.city, al.country_name,
                        CAST(1 AS BIGINT), CAST((al.status_code >= 400)::int AS BIGINT),
                        al.bytes_sent
-                FROM access_logs al, bounds
-                WHERE (al.timestamp >= bounds.rs AND al.timestamp < bounds.a_start)
-                   OR (al.timestamp >= bounds.a_end AND al.timestamp < bounds.re)
+                FROM access_logs al
+                WHERE al.timestamp >= :start AND al.timestamp < :a_start
+                UNION ALL
+                SELECT al.ip_address, al.country_code, al.city, al.country_name,
+                       CAST(1 AS BIGINT), CAST((al.status_code >= 400)::int AS BIGINT),
+                       al.bytes_sent
+                FROM access_logs al
+                WHERE al.timestamp >= :a_end AND al.timestamp < :end
             )
         """
 
@@ -749,7 +758,7 @@ class SummaryStatsRepository:
             LIMIT :limit
         """)
         result = await self.session.execute(
-            stmt, {"start": start, "end": end, "limit": limit, **filter_params}
+            stmt, {**_stitch_params(start, end, granularity), "limit": limit, **filter_params}
         )
         return [TopIpRow(**row._mapping) for row in result.fetchall()]
 
@@ -778,7 +787,7 @@ class SummaryStatsRepository:
             LIMIT :limit
         """)
         result = await self.session.execute(
-            stmt, {"start": start, "end": end, "limit": limit, **filter_params}
+            stmt, {**_stitch_params(start, end, granularity), "limit": limit, **filter_params}
         )
         return [TopCountryRow(**row._mapping) for row in result.fetchall()]
 
@@ -807,7 +816,7 @@ class SummaryStatsRepository:
             LIMIT :limit
         """)
         result = await self.session.execute(
-            stmt, {"start": start, "end": end, "limit": limit, **filter_params}
+            stmt, {**_stitch_params(start, end, granularity), "limit": limit, **filter_params}
         )
         return [TopCityRow(**row._mapping) for row in result.fetchall()]
 
@@ -899,37 +908,34 @@ class AnalyticsFilters:
         return " ".join(clauses), params
 
 
-def _stitched_bounds_cte(interval: str) -> str:
-    """WITH-clause opener exposing ``bounds`` for a stitched CAGG read.
+def _stitch_params(
+    start: datetime, end: datetime, granularity: StatsGranularity
+) -> dict:
+    """Bind params for a stitched CAGG read: window edges + inward bucket snap.
 
-    ``bounds`` snaps the [:start, :end) window inward to whole buckets
-    (a_start/a_end); the leftover head/tail slices are read from the raw
-    hypertable by the caller's second UNION leg, so the union is exactly
-    equal to a raw scan of the window. a_start/a_end are clamped so a window
+    a_start/a_end snap the [start, end) window inward to whole buckets (UTC
+    aligned, matching time_bucket); the CAGG leg reads [a_start, a_end) and
+    the raw head/tail legs read [start, a_start) and [a_end, end), so the
+    union is exactly equal to a raw scan of the window. Clamped so a window
     spanning no complete bucket degenerates to a pure raw scan.
+
+    Computed in Python and bound as plain parameters deliberately: routing
+    the bounds through a SQL CTE joined into each leg turns the timestamp
+    constraints into join predicates, which TimescaleDB cannot use for chunk
+    exclusion - the raw legs then decompress and scan the entire hypertable.
     """
-    return f"""
-        WITH bounds AS (
-            SELECT
-                rs, re, a_start,
-                GREATEST(time_bucket(INTERVAL '{interval}', re), a_start) AS a_end
-            FROM (
-                SELECT
-                    CAST(:start AS timestamptz) AS rs,
-                    CAST(:end AS timestamptz) AS re,
-                    LEAST(
-                        CASE
-                            WHEN time_bucket(INTERVAL '{interval}', CAST(:start AS timestamptz))
-                                 = CAST(:start AS timestamptz)
-                            THEN CAST(:start AS timestamptz)
-                            ELSE time_bucket(INTERVAL '{interval}', CAST(:start AS timestamptz))
-                                 + INTERVAL '{interval}'
-                        END,
-                        CAST(:end AS timestamptz)
-                    ) AS a_start
-            ) b
-        )
-    """
+    if granularity == StatsGranularity.DAILY:
+        floor_start = start.replace(hour=0, minute=0, second=0, microsecond=0)
+        floor_end = end.replace(hour=0, minute=0, second=0, microsecond=0)
+        step = timedelta(days=1)
+    else:
+        floor_start = start.replace(minute=0, second=0, microsecond=0)
+        floor_end = end.replace(minute=0, second=0, microsecond=0)
+        step = timedelta(hours=1)
+    a_start = start if floor_start == start else floor_start + step
+    a_start = min(a_start, end)
+    a_end = max(floor_end, a_start)
+    return {"start": start, "end": end, "a_start": a_start, "a_end": a_end}
 
 
 class LiveStatsRepository:

--- a/geometrikks/domain/geo/repositories.py
+++ b/geometrikks/domain/geo/repositories.py
@@ -4,7 +4,8 @@ CAGG Routing:
 - RAW (geo_events): For time ranges <= 24 hours (exact granularity needed)
 - location_hourly_stats: For time ranges > 24 hours and <= 30 days
 - location_daily_stats: For time ranges > 30 days
-- ip_location_daily_stats: For top IPs queries (time ranges > 24 hours)
+- ip_location_{hourly,daily}_stats: For top IPs queries, stitched with raw edges
+  for exact partial-bucket coverage.
 
 Note: We use hourly CAGGs for up to 30 days because they properly support
 real-time aggregation. Daily CAGGs have watermark limitations that can cause
@@ -60,6 +61,65 @@ def get_stats_granularity(from_timestamp: datetime, to_timestamp: datetime) -> S
         return StatsGranularity.HOURLY
     else:
         return StatsGranularity.DAILY
+
+
+IP_LOCATION_CAGGS = {
+    StatsGranularity.HOURLY: ("ip_location_hourly_stats", "1 hour"),
+    StatsGranularity.DAILY: ("ip_location_daily_stats", "1 day"),
+}
+
+
+def stitched_ip_location_cte(granularity: StatsGranularity) -> str:
+    """WITH clause exposing ``combined`` for a per-IP CAGG read.
+
+    Reading a CAGG requires whole buckets, so a window that starts mid-bucket
+    used to be floored outward - silently pulling in a partial extra bucket and
+    over-counting against the equivalent raw scan. Here ``bounds`` snaps the
+    window *inward* to whole buckets and the leftover head/tail slices are read
+    straight from ``geo_events``, so the union is exact.
+
+    ``combined`` yields (location_id, ip_address, event_count, last_seen); it is
+    keyed by IP on both legs, so ``COUNT(DISTINCT ip_address)`` over it stays
+    exact rather than summing per-bucket counts. ``last_seen`` is bucket-granular
+    for CAGG rows and exact for the raw edge rows.
+
+    ``a_start``/``a_end`` are clamped so a window spanning no complete bucket
+    degenerates to a pure raw scan (empty CAGG leg, one head slice covering the
+    whole window) instead of emitting overlapping head and tail ranges.
+    """
+    table, interval = IP_LOCATION_CAGGS[granularity]
+    return f"""
+        WITH bounds AS (
+            SELECT
+                rs, re, a_start,
+                GREATEST(time_bucket(INTERVAL '{interval}', re), a_start) AS a_end
+            FROM (
+                SELECT
+                    CAST(:start AS timestamptz) AS rs,
+                    CAST(:end AS timestamptz) AS re,
+                    LEAST(
+                        CASE
+                            WHEN time_bucket(INTERVAL '{interval}', CAST(:start AS timestamptz))
+                                 = CAST(:start AS timestamptz)
+                            THEN CAST(:start AS timestamptz)
+                            ELSE time_bucket(INTERVAL '{interval}', CAST(:start AS timestamptz))
+                                 + INTERVAL '{interval}'
+                        END,
+                        CAST(:end AS timestamptz)
+                    ) AS a_start
+            ) b
+        ),
+        combined AS (
+            SELECT s.location_id, s.ip_address, s.event_count, s.bucket AS last_seen
+            FROM {table} s, bounds
+            WHERE s.bucket >= bounds.a_start AND s.bucket < bounds.a_end
+            UNION ALL
+            SELECT ge.location_id, ge.ip_address, CAST(1 AS BIGINT), ge.timestamp
+            FROM geo_events ge, bounds
+            WHERE (ge.timestamp >= bounds.rs AND ge.timestamp < bounds.a_start)
+               OR (ge.timestamp >= bounds.a_end AND ge.timestamp < bounds.re)
+        )
+    """
 
 
 @dataclass
@@ -244,8 +304,9 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
         """Get top N IPs for a specific location by event count.
 
         Routes to optimal source based on time range:
-        - ≤ 1 hour: RAW geo_events table
-        - > 1 hour: ip_location_daily_stats CAGG
+        - <= 24 hours: RAW geo_events table
+        - > 24 hours, <= 30 days: ip_location_hourly_stats (stitched-exact)
+        - > 30 days: ip_location_daily_stats (stitched-exact)
 
         Args:
             location_id: The location ID to get top IPs for.
@@ -272,29 +333,27 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
         )
 
         if granularity == StatsGranularity.RAW:
-            # Query raw geo_events table for exact time range granularity
             stmt = text("""
                 SELECT
                     ip_address,
                     CAST(COUNT(*) AS INTEGER) AS event_count
                 FROM geo_events
                 WHERE location_id = :location_id
-                  AND timestamp >= :from_ts AND timestamp < :to_ts
+                  AND timestamp >= :start AND timestamp < :end
                 GROUP BY ip_address
                 ORDER BY event_count DESC
                 LIMIT :limit
             """)
         else:
-            # Query daily CAGG - TimescaleDB real-time aggregation handles recent data
-            # Floor to day boundary for CAGG query
-            stmt = text("""
+            # Stitched read: whole buckets from the hourly/daily per-IP CAGG,
+            # partial head/tail from raw geo_events, so the window is exact.
+            stmt = text(f"""
+                {stitched_ip_location_cte(granularity)}
                 SELECT
                     ip_address,
                     CAST(SUM(event_count) AS INTEGER) AS event_count
-                FROM ip_location_daily_stats
+                FROM combined
                 WHERE location_id = :location_id
-                  AND bucket >= time_bucket('1 day', CAST(:from_ts AS timestamptz))
-                  AND bucket < :to_ts
                 GROUP BY ip_address
                 ORDER BY event_count DESC
                 LIMIT :limit
@@ -304,8 +363,8 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
             stmt,
             {
                 "location_id": location_id,
-                "from_ts": from_timestamp,
-                "to_ts": to_timestamp,
+                "start": from_timestamp,
+                "end": to_timestamp,
                 "limit": limit,
             },
         )
@@ -319,8 +378,9 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
         """Get global top N IPs by event count with their primary location.
 
         Routes to optimal source based on time range:
-        - ≤ 1 hour: RAW geo_events table
-        - > 1 hour: ip_location_daily_stats CAGG
+        - <= 24 hours: RAW geo_events table
+        - > 24 hours, <= 30 days: ip_location_hourly_stats (stitched-exact)
+        - > 30 days: ip_location_daily_stats (stitched-exact)
 
         For IPs that appear in multiple locations, returns the location
         where they have the highest event count.
@@ -343,37 +403,33 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
         )
 
         if granularity == StatsGranularity.RAW:
-            # Query raw geo_events table for exact time range granularity
             stmt = text("""
                 SELECT
                     CAST(COUNT(*) AS INTEGER) AS total_count,
                     location_id,
                     ip_address
                 FROM geo_events
-                WHERE timestamp >= :from_ts AND timestamp < :to_ts
+                WHERE timestamp >= :start AND timestamp < :end
                 GROUP BY location_id, ip_address
                 ORDER BY total_count DESC
                 LIMIT :fetch_limit
             """)
         else:
-            # Query daily CAGG - TimescaleDB real-time aggregation handles recent data
-            # Floor to day boundary for CAGG query
-            stmt = text("""
+            stmt = text(f"""
+                {stitched_ip_location_cte(granularity)}
                 SELECT
                     CAST(SUM(event_count) AS INTEGER) AS total_count,
                     location_id,
                     ip_address
-                FROM ip_location_daily_stats
-                WHERE bucket >= time_bucket('1 day', CAST(:from_ts AS timestamptz))
-                  AND bucket < :to_ts
+                FROM combined
                 GROUP BY location_id, ip_address
                 ORDER BY total_count DESC
                 LIMIT :fetch_limit
             """)
 
         result = await self.session.execute(stmt, {
-            "from_ts": from_timestamp,
-            "to_ts": to_timestamp,
+            "start": from_timestamp,
+            "end": to_timestamp,
             "fetch_limit": limit * 10,  # Fetch more to account for deduplication
         })
 

--- a/geometrikks/domain/geo/repositories.py
+++ b/geometrikks/domain/geo/repositories.py
@@ -256,7 +256,7 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
                 JOIN geo_events ge ON ge.location_id = gl.id
                 WHERE ge.timestamp >= :from_ts AND ge.timestamp < :to_ts{filters_sql}
                 GROUP BY gl.id
-                ORDER BY event_count DESC
+                ORDER BY event_count DESC, gl.id
             """)
         else:
             # Query appropriate CAGG
@@ -274,7 +274,7 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
                 WHERE ls.bucket >= time_bucket('{bucket_interval}', CAST(:from_ts AS timestamptz))
                   AND ls.bucket < :to_ts{filters_sql}
                 GROUP BY gl.id
-                ORDER BY event_count DESC
+                ORDER BY event_count DESC, gl.id
             """)
 
         result = await self.session.execute(stmt, params)
@@ -350,7 +350,7 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
                 WHERE location_id = :location_id
                   AND timestamp >= :start AND timestamp < :end
                 GROUP BY ip_address
-                ORDER BY event_count DESC
+                ORDER BY event_count DESC, ip_address
                 LIMIT :limit
             """)
         else:
@@ -364,7 +364,7 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
                 FROM combined
                 WHERE location_id = :location_id
                 GROUP BY ip_address
-                ORDER BY event_count DESC
+                ORDER BY event_count DESC, ip_address
                 LIMIT :limit
             """)
 
@@ -418,7 +418,7 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
                 FROM geo_events
                 WHERE timestamp >= :start AND timestamp < :end
                 GROUP BY location_id, ip_address
-                ORDER BY total_count DESC
+                ORDER BY total_count DESC, location_id, ip_address
                 LIMIT :fetch_limit
             """)
         else:
@@ -430,7 +430,7 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
                     ip_address
                 FROM combined
                 GROUP BY location_id, ip_address
-                ORDER BY total_count DESC
+                ORDER BY total_count DESC, location_id, ip_address
                 LIMIT :fetch_limit
             """)
 
@@ -499,7 +499,7 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
                 WHERE ge.timestamp >= :from_ts AND ge.timestamp < :to_ts
                   AND gl.country_code IS NOT NULL
                 GROUP BY gl.country_code, gl.country_name
-                ORDER BY event_count DESC
+                ORDER BY event_count DESC, gl.country_code
                 LIMIT :limit
             """)
         else:
@@ -518,7 +518,7 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
                   AND ls.bucket < :to_ts
                   AND gl.country_code IS NOT NULL
                 GROUP BY gl.country_code, gl.country_name
-                ORDER BY event_count DESC
+                ORDER BY event_count DESC, gl.country_code
                 LIMIT :limit
             """)
 

--- a/geometrikks/domain/geo/repositories.py
+++ b/geometrikks/domain/geo/repositories.py
@@ -69,55 +69,64 @@ IP_LOCATION_CAGGS = {
 }
 
 
+def stitch_params(
+    start: datetime, end: datetime, granularity: StatsGranularity
+) -> dict:
+    """Bind params for a stitched CAGG read: window edges + inward bucket snap.
+
+    a_start/a_end snap the [start, end) window inward to whole buckets (UTC
+    aligned, matching time_bucket). Clamped so a window spanning no complete
+    bucket degenerates to a pure raw scan (empty CAGG leg, one head slice
+    covering the whole window).
+
+    Computed in Python and bound as plain parameters deliberately: routing
+    the bounds through a SQL CTE joined into each leg turns the timestamp
+    constraints into join predicates, which TimescaleDB cannot use for chunk
+    exclusion - the raw legs then decompress and scan the entire hypertable.
+    """
+    if granularity == StatsGranularity.DAILY:
+        floor_start = start.replace(hour=0, minute=0, second=0, microsecond=0)
+        floor_end = end.replace(hour=0, minute=0, second=0, microsecond=0)
+        step = timedelta(days=1)
+    else:
+        floor_start = start.replace(minute=0, second=0, microsecond=0)
+        floor_end = end.replace(minute=0, second=0, microsecond=0)
+        step = timedelta(hours=1)
+    a_start = start if floor_start == start else floor_start + step
+    a_start = min(a_start, end)
+    a_end = max(floor_end, a_start)
+    return {"start": start, "end": end, "a_start": a_start, "a_end": a_end}
+
+
 def stitched_ip_location_cte(granularity: StatsGranularity) -> str:
     """WITH clause exposing ``combined`` for a per-IP CAGG read.
 
     Reading a CAGG requires whole buckets, so a window that starts mid-bucket
     used to be floored outward - silently pulling in a partial extra bucket and
-    over-counting against the equivalent raw scan. Here ``bounds`` snaps the
-    window *inward* to whole buckets and the leftover head/tail slices are read
-    straight from ``geo_events``, so the union is exact.
+    over-counting against the equivalent raw scan. The window is snapped
+    *inward* to whole buckets (``stitch_params``; callers bind its params) and
+    the leftover head/tail slices are read straight from ``geo_events``, so
+    the union is exact.
 
     ``combined`` yields (location_id, ip_address, event_count, last_seen); it is
-    keyed by IP on both legs, so ``COUNT(DISTINCT ip_address)`` over it stays
+    keyed by IP on all legs, so ``COUNT(DISTINCT ip_address)`` over it stays
     exact rather than summing per-bucket counts. ``last_seen`` is bucket-granular
     for CAGG rows and exact for the raw edge rows.
-
-    ``a_start``/``a_end`` are clamped so a window spanning no complete bucket
-    degenerates to a pure raw scan (empty CAGG leg, one head slice covering the
-    whole window) instead of emitting overlapping head and tail ranges.
     """
-    table, interval = IP_LOCATION_CAGGS[granularity]
+    table, _ = IP_LOCATION_CAGGS[granularity]
     return f"""
-        WITH bounds AS (
-            SELECT
-                rs, re, a_start,
-                GREATEST(time_bucket(INTERVAL '{interval}', re), a_start) AS a_end
-            FROM (
-                SELECT
-                    CAST(:start AS timestamptz) AS rs,
-                    CAST(:end AS timestamptz) AS re,
-                    LEAST(
-                        CASE
-                            WHEN time_bucket(INTERVAL '{interval}', CAST(:start AS timestamptz))
-                                 = CAST(:start AS timestamptz)
-                            THEN CAST(:start AS timestamptz)
-                            ELSE time_bucket(INTERVAL '{interval}', CAST(:start AS timestamptz))
-                                 + INTERVAL '{interval}'
-                        END,
-                        CAST(:end AS timestamptz)
-                    ) AS a_start
-            ) b
-        ),
-        combined AS (
+        WITH combined AS (
             SELECT s.location_id, s.ip_address, s.event_count, s.bucket AS last_seen
-            FROM {table} s, bounds
-            WHERE s.bucket >= bounds.a_start AND s.bucket < bounds.a_end
+            FROM {table} s
+            WHERE s.bucket >= :a_start AND s.bucket < :a_end
             UNION ALL
             SELECT ge.location_id, ge.ip_address, CAST(1 AS BIGINT), ge.timestamp
-            FROM geo_events ge, bounds
-            WHERE (ge.timestamp >= bounds.rs AND ge.timestamp < bounds.a_start)
-               OR (ge.timestamp >= bounds.a_end AND ge.timestamp < bounds.re)
+            FROM geo_events ge
+            WHERE ge.timestamp >= :start AND ge.timestamp < :a_start
+            UNION ALL
+            SELECT ge.location_id, ge.ip_address, CAST(1 AS BIGINT), ge.timestamp
+            FROM geo_events ge
+            WHERE ge.timestamp >= :a_end AND ge.timestamp < :end
         )
     """
 
@@ -359,14 +368,12 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
                 LIMIT :limit
             """)
 
+        if granularity == StatsGranularity.RAW:
+            params: dict = {"start": from_timestamp, "end": to_timestamp}
+        else:
+            params = stitch_params(from_timestamp, to_timestamp, granularity)
         result = await self.session.execute(
-            stmt,
-            {
-                "location_id": location_id,
-                "start": from_timestamp,
-                "end": to_timestamp,
-                "limit": limit,
-            },
+            stmt, {"location_id": location_id, "limit": limit, **params}
         )
         rows = result.fetchall()
 
@@ -427,9 +434,12 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
                 LIMIT :fetch_limit
             """)
 
+        if granularity == StatsGranularity.RAW:
+            params: dict = {"start": from_timestamp, "end": to_timestamp}
+        else:
+            params = stitch_params(from_timestamp, to_timestamp, granularity)
         result = await self.session.execute(stmt, {
-            "start": from_timestamp,
-            "end": to_timestamp,
+            **params,
             "fetch_limit": limit * 10,  # Fetch more to account for deduplication
         })
 

--- a/geometrikks/domain/geo/services.py
+++ b/geometrikks/domain/geo/services.py
@@ -323,7 +323,7 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                 WHERE ge.timestamp >= :start AND ge.timestamp < :end
                 {filter_sql}
                 GROUP BY ge.ip_address
-                ORDER BY event_count DESC
+                ORDER BY event_count DESC, ip_address
                 LIMIT :limit
             """)
         else:
@@ -340,7 +340,7 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                 WHERE TRUE
                 {filter_sql}
                 GROUP BY c.ip_address
-                ORDER BY event_count DESC
+                ORDER BY event_count DESC, ip_address
                 LIMIT :limit
             """)
         if granularity == StatsGranularity.RAW or filters.forces_raw:
@@ -378,7 +378,7 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                 WHERE ge.timestamp >= :start AND ge.timestamp < :end
                 {filter_sql}
                 GROUP BY gl.country_code
-                ORDER BY event_count DESC
+                ORDER BY event_count DESC, country_code
                 LIMIT :limit
             """)
         else:
@@ -396,7 +396,7 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                 WHERE TRUE
                 {filter_sql}
                 GROUP BY gl.country_code
-                ORDER BY event_count DESC
+                ORDER BY event_count DESC, country_code
                 LIMIT :limit
             """)
         if granularity == StatsGranularity.RAW or filters.forces_raw:
@@ -435,7 +435,7 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                   AND gl.city IS NOT NULL
                 {filter_sql}
                 GROUP BY gl.city
-                ORDER BY event_count DESC
+                ORDER BY event_count DESC, city
                 LIMIT :limit
             """)
         else:
@@ -452,7 +452,7 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                 WHERE gl.city IS NOT NULL
                 {filter_sql}
                 GROUP BY gl.city
-                ORDER BY event_count DESC
+                ORDER BY event_count DESC, city
                 LIMIT :limit
             """)
         if granularity == StatsGranularity.RAW or filters.forces_raw:
@@ -476,7 +476,10 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
         """Distinct country/city/hostname values, for filter dropdowns.
 
         Countries are deduped by code (a non-null name wins) and sorted by
-        the displayed name, mirroring AccessLogService.get_facets.
+        the displayed name, mirroring AccessLogService.get_facets. Hostnames
+        come from hostname_daily_stats (real-time aggregated) rather than a
+        DISTINCT over raw geo_events, whose cost scales with total volume;
+        values persist beyond raw retention like the access-log facets.
         """
         session = self._session
         country_name = func.max(GeoLocation.country_name)
@@ -496,9 +499,9 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
             )
         ).scalars().all()
         hostnames = (
-            await session.execute(
-                select(GeoEvent.hostname).distinct().order_by(GeoEvent.hostname)
-            )
+            await session.execute(text(
+                "SELECT DISTINCT hostname FROM hostname_daily_stats ORDER BY hostname"
+            ))
         ).scalars().all()
         return GeoEventFacets(
             countries=[GeoCountryFacet(code=code, name=name or code) for code, name in country_rows],

--- a/geometrikks/domain/geo/services.py
+++ b/geometrikks/domain/geo/services.py
@@ -215,9 +215,13 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
         ``granularity`` must be HOURLY or DAILY (the controller clamps RAW to
         HOURLY, matching the analytics charts) and only picks the bucket size;
         routing is decided separately from the actual ``start``/``end`` span.
-        Hostname filters (or <= 24h ranges) scan raw geo_events; country/city/
-        IP filters on longer ranges use the stitched per-IP CAGGs with exact
-        uniques; unfiltered ranges use the HLL geo_summary CAGGs.
+        Hostname filters and <= 24h windows scan raw geo_events. An hourly-
+        bucket override on a > 30d window (``granularity`` HOURLY while the
+        window itself is DAILY-routed) also scans raw when any filter is
+        active, since hourly CAGG retention doesn't cover ranges that long
+        and the stitched per-IP CAGGs only carry the daily rollup there.
+        Other country/city/IP-filtered ranges use the stitched per-IP CAGGs;
+        unfiltered ranges > 24h use the HLL geo_summary CAGGs.
         """
         if granularity not in (StatsGranularity.HOURLY, StatsGranularity.DAILY):
             raise ValueError("granularity must be HOURLY or DAILY")
@@ -227,7 +231,15 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
         # when the caller asks for hourly buckets on it.
         data_granularity = get_stats_granularity(start, end)
 
-        if filters.forces_raw or data_granularity == StatsGranularity.RAW:
+        if (
+            filters.forces_raw
+            or data_granularity == StatsGranularity.RAW
+            or (
+                filters.is_active()
+                and granularity == StatsGranularity.HOURLY
+                and data_granularity == StatsGranularity.DAILY
+            )
+        ):
             filter_sql, filter_params = filters.sql_conditions("ge", "gl")
             stmt = text(f"""
                 SELECT

--- a/geometrikks/domain/geo/services.py
+++ b/geometrikks/domain/geo/services.py
@@ -19,7 +19,7 @@ from advanced_alchemy.service import SQLAlchemyAsyncRepositoryService
 from sqlalchemy import func, select, text
 
 from geometrikks.domain.geo.models import GeoEvent, GeoLocation
-from geometrikks.domain.geo.repositories import StatsGranularity, get_stats_granularity
+from geometrikks.domain.geo.repositories import StatsGranularity, get_stats_granularity, stitched_ip_location_cte
 from geometrikks.domain.geo.schemas import (
     GeoCountryFacet,
     GeoEventFacets,
@@ -34,65 +34,6 @@ from geometrikks.domain.geo.schemas import (
 from geometrikks.server.logging import get_logger
 
 logger = get_logger(__name__)
-
-
-_IP_LOCATION_CAGGS = {
-    StatsGranularity.HOURLY: ("ip_location_hourly_stats", "1 hour"),
-    StatsGranularity.DAILY: ("ip_location_daily_stats", "1 day"),
-}
-
-
-def _stitched_ip_location_cte(granularity: StatsGranularity) -> str:
-    """WITH clause exposing ``combined`` for a per-IP CAGG read.
-
-    Reading a CAGG requires whole buckets, so a window that starts mid-bucket
-    used to be floored outward — silently pulling in a partial extra bucket and
-    over-counting against the equivalent raw scan. Here ``bounds`` snaps the
-    window *inward* to whole buckets and the leftover head/tail slices are read
-    straight from ``geo_events``, so the union is exact.
-
-    ``combined`` yields (location_id, ip_address, event_count, last_seen); it is
-    keyed by IP on both legs, so ``COUNT(DISTINCT ip_address)`` over it stays
-    exact rather than summing per-bucket counts. ``last_seen`` is bucket-granular
-    for CAGG rows and exact for the raw edge rows.
-
-    ``a_start``/``a_end`` are clamped so a window spanning no complete bucket
-    degenerates to a pure raw scan (empty CAGG leg, one head slice covering the
-    whole window) instead of emitting overlapping head and tail ranges.
-    """
-    table, interval = _IP_LOCATION_CAGGS[granularity]
-    return f"""
-        WITH bounds AS (
-            SELECT
-                rs, re, a_start,
-                GREATEST(time_bucket(INTERVAL '{interval}', re), a_start) AS a_end
-            FROM (
-                SELECT
-                    CAST(:start AS timestamptz) AS rs,
-                    CAST(:end AS timestamptz) AS re,
-                    LEAST(
-                        CASE
-                            WHEN time_bucket(INTERVAL '{interval}', CAST(:start AS timestamptz))
-                                 = CAST(:start AS timestamptz)
-                            THEN CAST(:start AS timestamptz)
-                            ELSE time_bucket(INTERVAL '{interval}', CAST(:start AS timestamptz))
-                                 + INTERVAL '{interval}'
-                        END,
-                        CAST(:end AS timestamptz)
-                    ) AS a_start
-            ) b
-        ),
-        combined AS (
-            SELECT s.location_id, s.ip_address, s.event_count, s.bucket AS last_seen
-            FROM {table} s, bounds
-            WHERE s.bucket >= bounds.a_start AND s.bucket < bounds.a_end
-            UNION ALL
-            SELECT ge.location_id, ge.ip_address, CAST(1 AS BIGINT), ge.timestamp
-            FROM geo_events ge, bounds
-            WHERE (ge.timestamp >= bounds.rs AND ge.timestamp < bounds.a_start)
-               OR (ge.timestamp >= bounds.a_end AND ge.timestamp < bounds.re)
-        )
-    """
 
 
 class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
@@ -151,7 +92,7 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
         else:
             filter_sql, filter_params = filters.sql_conditions("c", "gl")
             source = f"""
-                {_stitched_ip_location_cte(granularity)}
+                {stitched_ip_location_cte(granularity)}
                 SELECT
                     {location_cols},
                     host(c.ip_address) AS ip_address,
@@ -324,7 +265,7 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
         else:
             filter_sql, filter_params = filters.sql_conditions("c", "gl")
             stmt = text(f"""
-                {_stitched_ip_location_cte(granularity)}
+                {stitched_ip_location_cte(granularity)}
                 SELECT
                     host(c.ip_address) AS ip_address,
                     CAST(SUM(c.event_count) AS BIGINT) AS event_count,
@@ -376,7 +317,7 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
             # The CAGG is keyed by IP, so COUNT(DISTINCT) stays exact here.
             filter_sql, filter_params = filters.sql_conditions("c", "gl")
             stmt = text(f"""
-                {_stitched_ip_location_cte(granularity)}
+                {stitched_ip_location_cte(granularity)}
                 SELECT
                     gl.country_code,
                     MAX(gl.country_name) AS country_name,
@@ -428,7 +369,7 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
         else:
             filter_sql, filter_params = filters.sql_conditions("c", "gl")
             stmt = text(f"""
-                {_stitched_ip_location_cte(granularity)}
+                {stitched_ip_location_cte(granularity)}
                 SELECT
                     gl.city,
                     MAX(gl.country_code) AS country_code,

--- a/geometrikks/domain/geo/services.py
+++ b/geometrikks/domain/geo/services.py
@@ -3,8 +3,9 @@
 Query routing follows the repository convention:
 - RAW geo_events for ranges ≤ 24h, and whenever a hostname filter is set
   (no CAGG carries a hostname dimension).
-- ip_location_{hourly,daily}_stats for grouped/top-IP queries on longer ranges
-  (keyed by location + IP, so country/city/IP filters still apply there).
+- ip_location_{hourly,daily}_stats for grouped/top-IP queries and for
+  country/city/IP-filtered summary/time-series queries on longer ranges
+  (keyed by location + IP, so those filters still apply there).
   Whole buckets come from the CAGG and the partial head/tail from raw
   geo_events, so these stay exact against a raw scan of the same window.
 - geo_summary_{hourly,daily}_stats (HLL uniques) for unfiltered summary and
@@ -143,12 +144,12 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
     ) -> GeoLogPeriod:
         """Aggregate totals/uniques for the period.
 
-        Filtered or ≤ 24h: exact COUNT/COUNT DISTINCT from raw geo_events
-        (CAGGs carry no dimensions to filter on). Unfiltered longer ranges:
-        geo_summary CAGGs with HLL rollups.
+        Hostname filters (or <= 24h ranges) scan raw geo_events; country/city/IP
+        filters use the stitched per-IP CAGGs with exact uniques; unfiltered
+        longer ranges use the HLL geo_summary CAGGs.
         """
         granularity = get_stats_granularity(start, end)
-        if granularity == StatsGranularity.RAW or filters.is_active():
+        if granularity == StatsGranularity.RAW or filters.forces_raw:
             filter_sql, filter_params = filters.sql_conditions("ge", "gl")
             stmt = text(f"""
                 SELECT
@@ -159,6 +160,23 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                 FROM geo_events ge
                 JOIN geo_locations gl ON ge.location_id = gl.id
                 WHERE ge.timestamp >= :start AND ge.timestamp < :end
+                {filter_sql}
+            """)
+            params = {"start": start, "end": end, **filter_params}
+        elif filters.is_active():
+            # Country/city/IP filters: stitched per-IP CAGG read joined to
+            # geo_locations. Keyed by IP, so every unique count is exact.
+            filter_sql, filter_params = filters.sql_conditions("c", "gl")
+            stmt = text(f"""
+                {stitched_ip_location_cte(granularity)}
+                SELECT
+                    CAST(COALESCE(SUM(c.event_count), 0) AS BIGINT) AS total_events,
+                    CAST(COUNT(DISTINCT c.ip_address) AS BIGINT) AS unique_ips,
+                    CAST(COUNT(DISTINCT gl.country_code) AS BIGINT) AS unique_countries,
+                    CAST(COUNT(DISTINCT gl.city) AS BIGINT) AS unique_cities
+                FROM combined c
+                JOIN geo_locations gl ON c.location_id = gl.id
+                WHERE TRUE
                 {filter_sql}
             """)
             params = {"start": start, "end": end, **filter_params}
@@ -195,14 +213,21 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
         """Bucketed event totals + unique IPs for the chart.
 
         ``granularity`` must be HOURLY or DAILY (the controller clamps RAW to
-        HOURLY, matching the analytics charts). Unfiltered: geo_summary CAGGs;
-        filtered: raw time_bucket scan.
+        HOURLY, matching the analytics charts) and only picks the bucket size;
+        routing is decided separately from the actual ``start``/``end`` span.
+        Hostname filters (or <= 24h ranges) scan raw geo_events; country/city/
+        IP filters on longer ranges use the stitched per-IP CAGGs with exact
+        uniques; unfiltered ranges use the HLL geo_summary CAGGs.
         """
         if granularity not in (StatsGranularity.HOURLY, StatsGranularity.DAILY):
             raise ValueError("granularity must be HOURLY or DAILY")
         interval = "1 hour" if granularity == StatsGranularity.HOURLY else "1 day"
+        # Routing (raw vs CAGG) tracks the actual span, independent of the
+        # requested bucket size above: a <= 24h span must stay on raw even
+        # when the caller asks for hourly buckets on it.
+        data_granularity = get_stats_granularity(start, end)
 
-        if filters.is_active():
+        if filters.forces_raw or data_granularity == StatsGranularity.RAW:
             filter_sql, filter_params = filters.sql_conditions("ge", "gl")
             stmt = text(f"""
                 SELECT
@@ -212,6 +237,25 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                 FROM geo_events ge
                 JOIN geo_locations gl ON ge.location_id = gl.id
                 WHERE ge.timestamp >= :start AND ge.timestamp < :end
+                {filter_sql}
+                GROUP BY bucket
+                ORDER BY bucket ASC
+            """)
+            params = {"start": start, "end": end, **filter_params}
+        elif filters.is_active():
+            # Country/city/IP filters: stitched per-IP CAGG rows re-bucketed.
+            # CAGG-leg rows carry last_seen = bucket; raw edge rows carry the
+            # exact timestamp, so partial head/tail buckets fold correctly.
+            filter_sql, filter_params = filters.sql_conditions("c", "gl")
+            stmt = text(f"""
+                {stitched_ip_location_cte(granularity)}
+                SELECT
+                    time_bucket('{interval}', c.last_seen) AS bucket,
+                    CAST(SUM(c.event_count) AS BIGINT) AS total_events,
+                    CAST(COUNT(DISTINCT c.ip_address) AS BIGINT) AS unique_ips
+                FROM combined c
+                JOIN geo_locations gl ON c.location_id = gl.id
+                WHERE TRUE
                 {filter_sql}
                 GROUP BY bucket
                 ORDER BY bucket ASC

--- a/geometrikks/domain/geo/services.py
+++ b/geometrikks/domain/geo/services.py
@@ -20,7 +20,12 @@ from advanced_alchemy.service import SQLAlchemyAsyncRepositoryService
 from sqlalchemy import func, select, text
 
 from geometrikks.domain.geo.models import GeoEvent, GeoLocation
-from geometrikks.domain.geo.repositories import StatsGranularity, get_stats_granularity, stitched_ip_location_cte
+from geometrikks.domain.geo.repositories import (
+    StatsGranularity,
+    get_stats_granularity,
+    stitch_params,
+    stitched_ip_location_cte,
+)
 from geometrikks.domain.geo.schemas import (
     GeoCountryFacet,
     GeoEventFacets,
@@ -108,7 +113,10 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
             """
             order_col = "ip_address"
 
-        params = {"start": start, "end": end, **filter_params}
+        if use_raw:
+            params = {"start": start, "end": end, **filter_params}
+        else:
+            params = {**stitch_params(start, end, granularity), **filter_params}
         stmt = text(
             f"SELECT * FROM ({source}) grouped "
             f"ORDER BY event_count {sort_order.upper()}, location_id, {order_col} "
@@ -179,7 +187,7 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                 WHERE TRUE
                 {filter_sql}
             """)
-            params = {"start": start, "end": end, **filter_params}
+            params = {**stitch_params(start, end, granularity), **filter_params}
         else:
             table = f"geo_summary_{granularity.value}_stats"
             interval = "1 hour" if granularity == StatsGranularity.HOURLY else "1 day"
@@ -272,7 +280,7 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                 GROUP BY bucket
                 ORDER BY bucket ASC
             """)
-            params = {"start": start, "end": end, **filter_params}
+            params = {**stitch_params(start, end, granularity), **filter_params}
         else:
             table = f"geo_summary_{granularity.value}_stats"
             stmt = text(f"""
@@ -335,8 +343,12 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                 ORDER BY event_count DESC
                 LIMIT :limit
             """)
+        if granularity == StatsGranularity.RAW or filters.forces_raw:
+            window_params: dict = {"start": start, "end": end}
+        else:
+            window_params = stitch_params(start, end, granularity)
         result = await self._session.execute(
-            stmt, {"start": start, "end": end, "limit": limit, **filter_params}
+            stmt, {**window_params, "limit": limit, **filter_params}
         )
         return [
             TopGeoIp(
@@ -387,8 +399,12 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                 ORDER BY event_count DESC
                 LIMIT :limit
             """)
+        if granularity == StatsGranularity.RAW or filters.forces_raw:
+            window_params: dict = {"start": start, "end": end}
+        else:
+            window_params = stitch_params(start, end, granularity)
         result = await self._session.execute(
-            stmt, {"start": start, "end": end, "limit": limit, **filter_params}
+            stmt, {**window_params, "limit": limit, **filter_params}
         )
         return [
             TopGeoCountry(
@@ -439,8 +455,12 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                 ORDER BY event_count DESC
                 LIMIT :limit
             """)
+        if granularity == StatsGranularity.RAW or filters.forces_raw:
+            window_params: dict = {"start": start, "end": end}
+        else:
+            window_params = stitch_params(start, end, granularity)
         result = await self._session.execute(
-            stmt, {"start": start, "end": end, "limit": limit, **filter_params}
+            stmt, {**window_params, "limit": limit, **filter_params}
         )
         return [
             TopGeoCity(

--- a/geometrikks/domain/logs/services.py
+++ b/geometrikks/domain/logs/services.py
@@ -42,12 +42,11 @@ class AccessLogService(SQLAlchemyAsyncRepositoryService[AccessLog]):
     async def get_facets(self) -> AccessLogFacets:
         """Distinct country/city/host values present in the data, for filter dropdowns.
 
-        Countries and cities come from log_ip_daily_stats (real-time
-        aggregated), not the raw hypertable: the facet query cost then scales
-        with distinct values per day instead of total log volume. Values
-        persist beyond raw retention (the daily CAGG keeps history), which is
-        the desired behavior for filter dropdowns. Hosts stay on the raw
-        table: host is indexed and carried by no CAGG.
+        Countries and cities come from log_ip_daily_stats and hosts from
+        host_daily_stats (both real-time aggregated), not the raw hypertable:
+        the facet query cost then scales with distinct values per day instead
+        of total log volume. Values persist beyond raw retention (daily CAGGs
+        keep history), which is the desired behavior for filter dropdowns.
 
         Rows without geo data (NULL columns) are excluded; ``name`` falls back
         to the code when ``country_name`` is missing. Countries are deduped by
@@ -70,12 +69,9 @@ class AccessLogService(SQLAlchemyAsyncRepositoryService[AccessLog]):
             ))
         ).scalars().all()
         hosts = (
-            await session.execute(
-                select(AccessLog.host)
-                .where(AccessLog.host.is_not(None))
-                .distinct()
-                .order_by(AccessLog.host)
-            )
+            await session.execute(text(
+                "SELECT DISTINCT host FROM host_daily_stats ORDER BY host"
+            ))
         ).scalars().all()
         return AccessLogFacets(
             countries=[CountryFacet(code=code, name=name or code) for code, name in country_rows],

--- a/geometrikks/domain/logs/services.py
+++ b/geometrikks/domain/logs/services.py
@@ -7,7 +7,7 @@ from advanced_alchemy.filters import FilterTypes, LimitOffset
 from advanced_alchemy.repository import SQLAlchemyAsyncRepository
 from advanced_alchemy.service import SQLAlchemyAsyncRepositoryService
 from litestar.exceptions import ValidationException
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 
 from geometrikks.domain.logs.models import AccessLog, AccessLogDebug
 from geometrikks.domain.logs.schemas import (
@@ -42,27 +42,32 @@ class AccessLogService(SQLAlchemyAsyncRepositoryService[AccessLog]):
     async def get_facets(self) -> AccessLogFacets:
         """Distinct country/city/host values present in the data, for filter dropdowns.
 
+        Countries and cities come from log_ip_daily_stats (real-time
+        aggregated), not the raw hypertable: the facet query cost then scales
+        with distinct values per day instead of total log volume. Values
+        persist beyond raw retention (the daily CAGG keeps history), which is
+        the desired behavior for filter dropdowns. Hosts stay on the raw
+        table: host is indexed and carried by no CAGG.
+
         Rows without geo data (NULL columns) are excluded; ``name`` falls back
         to the code when ``country_name`` is missing. Countries are deduped by
         code (a non-null name wins over NULL) and sorted by the displayed name.
         """
         session = self.repository.session
-        country_name = func.max(AccessLog.country_name)
         country_rows = (
-            await session.execute(
-                select(AccessLog.country_code, country_name)
-                .where(AccessLog.country_code.is_not(None))
-                .group_by(AccessLog.country_code)
-                .order_by(func.coalesce(country_name, AccessLog.country_code))
-            )
+            await session.execute(text(
+                "SELECT country_code, MAX(country_name) AS name "
+                "FROM log_ip_daily_stats "
+                "WHERE country_code IS NOT NULL "
+                "GROUP BY country_code "
+                "ORDER BY COALESCE(MAX(country_name), country_code)"
+            ))
         ).all()
         cities = (
-            await session.execute(
-                select(AccessLog.city)
-                .where(AccessLog.city.is_not(None))
-                .distinct()
-                .order_by(AccessLog.city)
-            )
+            await session.execute(text(
+                "SELECT DISTINCT city FROM log_ip_daily_stats "
+                "WHERE city IS NOT NULL ORDER BY city"
+            ))
         ).scalars().all()
         hosts = (
             await session.execute(

--- a/geometrikks/server/timescale.py
+++ b/geometrikks/server/timescale.py
@@ -14,6 +14,7 @@ CAGG Structure:
 - log_ip_{hourly,daily}_stats: Per-IP access-log counts (top IPs/countries/cities, facets)
 - url_{hourly,daily}_stats: Per-URL access-log counts (top URLs)
 - user_agent_{hourly,daily}_stats: Per-user-agent counts (top user agents)
+- host_daily_stats / hostname_daily_stats: Daily host rollups for facet dropdowns
 """
 
 from __future__ import annotations
@@ -363,6 +364,50 @@ async def _create_user_agent_caggs(conn: "AsyncConnection") -> None:
         """))
 
 
+async def _create_host_facet_caggs(conn: "AsyncConnection") -> None:
+    """Create tiny daily host/hostname CAGGs for the facet dropdowns.
+
+    A DISTINCT over the raw hypertables scans every chunk (compressed chunks
+    carry no usable btree for a loose index scan), which costs ~600ms at 18M
+    rows for a handful of values. These daily rollups keep the facet reads at
+    a few ms. Daily only: no query needs hourly host data.
+    """
+    await conn.execute(text("""
+        CREATE MATERIALIZED VIEW IF NOT EXISTS host_daily_stats
+        WITH (timescaledb.continuous) AS
+        SELECT
+            time_bucket('1 day', timestamp) AS bucket,
+            host,
+            COUNT(*) AS hits
+        FROM access_logs
+        WHERE host IS NOT NULL
+        GROUP BY bucket, host
+        WITH NO DATA
+    """))
+    logger.info("CAGG created/verified: host_daily_stats")
+    await conn.execute(text("""
+        CREATE INDEX IF NOT EXISTS ix_host_daily_stats_bucket
+        ON host_daily_stats (bucket DESC)
+    """))
+
+    await conn.execute(text("""
+        CREATE MATERIALIZED VIEW IF NOT EXISTS hostname_daily_stats
+        WITH (timescaledb.continuous) AS
+        SELECT
+            time_bucket('1 day', timestamp) AS bucket,
+            hostname,
+            COUNT(*) AS event_count
+        FROM geo_events
+        GROUP BY bucket, hostname
+        WITH NO DATA
+    """))
+    logger.info("CAGG created/verified: hostname_daily_stats")
+    await conn.execute(text("""
+        CREATE INDEX IF NOT EXISTS ix_hostname_daily_stats_bucket
+        ON hostname_daily_stats (bucket DESC)
+    """))
+
+
 # =============================================================================
 # Policy Configuration
 # =============================================================================
@@ -389,6 +434,8 @@ CAGG_REFRESH_CONFIG = [
     ("log_ip_daily_stats", "3 days", "1 hour"),
     ("url_daily_stats", "3 days", "1 hour"),
     ("user_agent_daily_stats", "3 days", "1 hour"),
+    ("host_daily_stats", "3 days", "1 hour"),
+    ("hostname_daily_stats", "3 days", "1 hour"),
 ]
 
 HOURLY_CAGGS = [
@@ -546,6 +593,8 @@ ALL_CAGGS = [
     "url_daily_stats",
     "user_agent_hourly_stats",
     "user_agent_daily_stats",
+    "host_daily_stats",
+    "hostname_daily_stats",
 ]
 
 
@@ -659,6 +708,7 @@ async def setup_timescaledb(
         await _create_log_ip_caggs(conn)
         await _create_url_caggs(conn)
         await _create_user_agent_caggs(conn)
+        await _create_host_facet_caggs(conn)
 
         # Enable real-time aggregation (merges materialized + live data)
         await _enable_realtime_aggregation(conn)
@@ -761,6 +811,8 @@ CAGG_SOURCE_TABLES: dict[str, str] = {
     "url_daily_stats": "access_logs",
     "user_agent_hourly_stats": "access_logs",
     "user_agent_daily_stats": "access_logs",
+    "host_daily_stats": "access_logs",
+    "hostname_daily_stats": "geo_events",
 }
 
 

--- a/geometrikks/server/timescale.py
+++ b/geometrikks/server/timescale.py
@@ -736,7 +736,11 @@ async def setup_timescaledb(
 
     # Repair deployments whose data predates CAGG refresh coverage
     # (issue #14: long-range charts truncated while top lists are not).
-    await backfill_cagg_gaps(engine, raw_retention_days=analytics.raw_retention_days)
+    await backfill_cagg_gaps(
+        engine,
+        raw_retention_days=analytics.raw_retention_days,
+        hourly_retention_days=analytics.hourly_retention_days,
+    )
 
     logger.info("TimescaleDB setup complete")
 
@@ -816,7 +820,9 @@ CAGG_SOURCE_TABLES: dict[str, str] = {
 }
 
 
-async def backfill_cagg_gaps(engine: "AsyncEngine", *, raw_retention_days: int) -> None:
+async def backfill_cagg_gaps(
+    engine: "AsyncEngine", *, raw_retention_days: int, hourly_retention_days: int
+) -> None:
     """Materialize CAGG history that predates refresh-policy coverage.
 
     CAGGs are created WITH NO DATA and refresh policies only cover a
@@ -826,11 +832,20 @@ async def backfill_cagg_gaps(engine: "AsyncEngine", *, raw_retention_days: int) 
     while raw-table queries still see it (issue #14 symptom). Detect the
     gap (earliest raw row older than earliest materialized bucket) and
     refresh the missing range. Idempotent and cheap when there is no gap.
+
+    Hourly CAGGs keep only ``hourly_retention_days`` of buckets, so their
+    probe horizon is clamped to that window: when raw retention is longer,
+    buckets beyond hourly retention are deliberately dropped, and treating
+    them as a gap would re-backfill (and re-drop) the same ~120 days of
+    hourly buckets on every startup.
     """
-    horizon = datetime.now(timezone.utc) - timedelta(days=raw_retention_days)
+    now = datetime.now(timezone.utc)
+    raw_horizon = now - timedelta(days=raw_retention_days)
+    hourly_horizon = now - timedelta(days=hourly_retention_days)
     to_backfill: list[tuple[str, datetime]] = []
 
     for cagg, source in CAGG_SOURCE_TABLES.items():
+        horizon = max(raw_horizon, hourly_horizon) if cagg in HOURLY_CAGGS else raw_horizon
         # Isolate each CAGG on its own connection: a probe failure (e.g. a
         # future CAGG whose time column is not "bucket") must not abort app
         # startup, and a failed statement poisons its whole connection's

--- a/geometrikks/server/timescale.py
+++ b/geometrikks/server/timescale.py
@@ -11,6 +11,9 @@ CAGG Structure:
 - geo_summary_hourly_stats / geo_summary_daily_stats: Geo metrics with HyperLogLog
 - location_hourly_stats / location_daily_stats: Location event counts for map
 - ip_location_{hourly,daily}_stats: Per-IP counts by location for top IPs
+- log_ip_{hourly,daily}_stats: Per-IP access-log counts (top IPs/countries/cities, facets)
+- url_{hourly,daily}_stats: Per-URL access-log counts (top URLs)
+- user_agent_{hourly,daily}_stats: Per-user-agent counts (top user agents)
 """
 
 from __future__ import annotations
@@ -267,6 +270,99 @@ async def _create_ip_location_cagg(conn: "AsyncConnection") -> None:
         """))
 
 
+async def _create_log_ip_caggs(conn: "AsyncConnection") -> None:
+    """Create per-IP access-log CAGGs (hourly + daily).
+
+    Used for: analytics /top-ips, /top-countries, /top-cities and the
+    access-log country/city facets. Keyed by IP (with its country/city), so
+    COUNT(DISTINCT ip_address) per country/city stays exact and
+    country/city/IP filters apply directly to CAGG columns.
+    """
+    for suffix, interval in (("hourly", "1 hour"), ("daily", "1 day")):
+        await conn.execute(text(f"""
+            CREATE MATERIALIZED VIEW IF NOT EXISTS log_ip_{suffix}_stats
+            WITH (timescaledb.continuous) AS
+            SELECT
+                time_bucket('{interval}', timestamp) AS bucket,
+                ip_address,
+                country_code,
+                city,
+                MAX(country_name) AS country_name,
+                COUNT(*) AS hits,
+                COUNT(*) FILTER (WHERE status_code >= 400) AS error_hits,
+                COALESCE(SUM(bytes_sent), 0) AS total_bytes
+            FROM access_logs
+            GROUP BY bucket, ip_address, country_code, city
+            WITH NO DATA
+        """))
+        logger.info("CAGG created/verified: log_ip_%s_stats", suffix)
+
+        await conn.execute(text(f"""
+            CREATE INDEX IF NOT EXISTS ix_log_ip_{suffix}_stats_bucket
+            ON log_ip_{suffix}_stats (bucket DESC)
+        """))
+        await conn.execute(text(f"""
+            CREATE INDEX IF NOT EXISTS ix_log_ip_{suffix}_stats_ip_bucket
+            ON log_ip_{suffix}_stats (ip_address, bucket DESC)
+        """))
+
+
+async def _create_url_caggs(conn: "AsyncConnection") -> None:
+    """Create per-URL access-log CAGGs (hourly + daily).
+
+    Used for: analytics /top-urls (unfiltered path). total_request_time is a
+    SUM so the rolled-up average is exact (SUM/SUM), never an AVG of AVGs.
+    """
+    for suffix, interval in (("hourly", "1 hour"), ("daily", "1 day")):
+        await conn.execute(text(f"""
+            CREATE MATERIALIZED VIEW IF NOT EXISTS url_{suffix}_stats
+            WITH (timescaledb.continuous) AS
+            SELECT
+                time_bucket('{interval}', timestamp) AS bucket,
+                url,
+                COUNT(*) AS hits,
+                COUNT(*) FILTER (WHERE status_code >= 400) AS error_hits,
+                COALESCE(SUM(bytes_sent), 0) AS total_bytes,
+                SUM(request_time) AS total_request_time
+            FROM access_logs
+            WHERE url IS NOT NULL
+            GROUP BY bucket, url
+            WITH NO DATA
+        """))
+        logger.info("CAGG created/verified: url_%s_stats", suffix)
+
+        await conn.execute(text(f"""
+            CREATE INDEX IF NOT EXISTS ix_url_{suffix}_stats_bucket
+            ON url_{suffix}_stats (bucket DESC)
+        """))
+
+
+async def _create_user_agent_caggs(conn: "AsyncConnection") -> None:
+    """Create per-user-agent access-log CAGGs (hourly + daily).
+
+    Used for: analytics /top-user-agents (unfiltered path).
+    """
+    for suffix, interval in (("hourly", "1 hour"), ("daily", "1 day")):
+        await conn.execute(text(f"""
+            CREATE MATERIALIZED VIEW IF NOT EXISTS user_agent_{suffix}_stats
+            WITH (timescaledb.continuous) AS
+            SELECT
+                time_bucket('{interval}', timestamp) AS bucket,
+                user_agent,
+                COUNT(*) AS hits
+            FROM access_logs
+            WHERE user_agent IS NOT NULL
+            GROUP BY bucket, user_agent
+            WITH NO DATA
+        """))
+        logger.info("CAGG created/verified: user_agent_%s_stats", suffix)
+
+        await conn.execute(text(f"""
+            CREATE INDEX IF NOT EXISTS ix_user_agent_{suffix}_stats_bucket
+            ON user_agent_{suffix}_stats (bucket DESC)
+        """))
+
+
 # =============================================================================
 # Policy Configuration
 # =============================================================================
@@ -281,12 +377,18 @@ CAGG_REFRESH_CONFIG = [
     ("geo_summary_hourly_stats", "3 hours", "1 hour"),
     ("location_hourly_stats", "3 hours", "1 hour"),
     ("ip_location_hourly_stats", "3 hours", "1 hour"),
+    ("log_ip_hourly_stats", "3 hours", "1 hour"),
+    ("url_hourly_stats", "3 hours", "1 hour"),
+    ("user_agent_hourly_stats", "3 hours", "1 hour"),
     # Daily CAGGs: refresh up to 1 hour ago to keep data fresh
     # (using "1 day" would leave too large a gap for real-time aggregation)
     ("summary_daily_stats", "3 days", "1 hour"),
     ("geo_summary_daily_stats", "3 days", "1 hour"),
     ("location_daily_stats", "3 days", "1 hour"),
     ("ip_location_daily_stats", "3 days", "1 hour"),
+    ("log_ip_daily_stats", "3 days", "1 hour"),
+    ("url_daily_stats", "3 days", "1 hour"),
+    ("user_agent_daily_stats", "3 days", "1 hour"),
 ]
 
 HOURLY_CAGGS = [
@@ -294,6 +396,9 @@ HOURLY_CAGGS = [
     "geo_summary_hourly_stats",
     "location_hourly_stats",
     "ip_location_hourly_stats",
+    "log_ip_hourly_stats",
+    "url_hourly_stats",
+    "user_agent_hourly_stats",
 ]
 
 
@@ -435,6 +540,12 @@ ALL_CAGGS = [
     "location_daily_stats",
     "ip_location_hourly_stats",
     "ip_location_daily_stats",
+    "log_ip_hourly_stats",
+    "log_ip_daily_stats",
+    "url_hourly_stats",
+    "url_daily_stats",
+    "user_agent_hourly_stats",
+    "user_agent_daily_stats",
 ]
 
 
@@ -545,6 +656,9 @@ async def setup_timescaledb(
         await _create_geo_summary_caggs(conn)
         await _create_location_caggs(conn)
         await _create_ip_location_cagg(conn)
+        await _create_log_ip_caggs(conn)
+        await _create_url_caggs(conn)
+        await _create_user_agent_caggs(conn)
 
         # Enable real-time aggregation (merges materialized + live data)
         await _enable_realtime_aggregation(conn)
@@ -641,6 +755,12 @@ CAGG_SOURCE_TABLES: dict[str, str] = {
     "location_daily_stats": "geo_events",
     "ip_location_hourly_stats": "geo_events",
     "ip_location_daily_stats": "geo_events",
+    "log_ip_hourly_stats": "access_logs",
+    "log_ip_daily_stats": "access_logs",
+    "url_hourly_stats": "access_logs",
+    "url_daily_stats": "access_logs",
+    "user_agent_hourly_stats": "access_logs",
+    "user_agent_daily_stats": "access_logs",
 }
 
 

--- a/resources/generated/api/sdk.gen.ts
+++ b/resources/generated/api/sdk.gen.ts
@@ -399,7 +399,7 @@ export const apiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeries = <
 /**
  * GetTopCities
  *
- * Top cities by hits from raw access logs (time-bounded).
+ * Top cities by hits (CAGG-served above 24h, filters included).
  */
 export const apiV1AnalyticsTopCitiesGetTopCities = <
   ThrowOnError extends boolean = false,
@@ -425,7 +425,7 @@ export const apiV1AnalyticsTopCitiesGetTopCities = <
 /**
  * GetTopCountries
  *
- * Top countries by hits from raw access logs (time-bounded).
+ * Top countries by hits (CAGG-served above 24h, filters included).
  */
 export const apiV1AnalyticsTopCountriesGetTopCountries = <
   ThrowOnError extends boolean = false,
@@ -451,7 +451,7 @@ export const apiV1AnalyticsTopCountriesGetTopCountries = <
 /**
  * GetTopIps
  *
- * Top client IPs by hits from raw access logs (time-bounded).
+ * Top client IPs by hits (CAGG-served above 24h, filters included).
  */
 export const apiV1AnalyticsTopIpsGetTopIps = <
   ThrowOnError extends boolean = false,
@@ -477,7 +477,7 @@ export const apiV1AnalyticsTopIpsGetTopIps = <
 /**
  * GetTopUrls
  *
- * Top URLs by hits from raw access logs (time-bounded).
+ * Top URLs by hits (CAGG-served above 24h; filters force a raw scan).
  */
 export const apiV1AnalyticsTopUrlsGetTopUrls = <
   ThrowOnError extends boolean = false,
@@ -503,7 +503,7 @@ export const apiV1AnalyticsTopUrlsGetTopUrls = <
 /**
  * GetTopUserAgents
  *
- * Top user agents by hits from raw access logs.
+ * Top user agents by hits (CAGG-served above 24h; filters force a raw scan).
  */
 export const apiV1AnalyticsTopUserAgentsGetTopUserAgents = <
   ThrowOnError extends boolean = false,

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -3072,7 +3072,7 @@
   "info": {
     "description": "Real-time GeoIP lookups and traffic analytics API",
     "title": "GeoMetrikks API",
-    "version": "0.4.3"
+    "version": "0.5.0"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -4599,7 +4599,7 @@
     "/api/v1/analytics/top-cities": {
       "get": {
         "deprecated": false,
-        "description": "Top cities by hits from raw access logs (time-bounded).",
+        "description": "Top cities by hits (CAGG-served above 24h, filters included).",
         "operationId": "ApiV1AnalyticsTopCitiesGetTopCities",
         "parameters": [
           {
@@ -4799,7 +4799,7 @@
     "/api/v1/analytics/top-countries": {
       "get": {
         "deprecated": false,
-        "description": "Top countries by hits from raw access logs (time-bounded).",
+        "description": "Top countries by hits (CAGG-served above 24h, filters included).",
         "operationId": "ApiV1AnalyticsTopCountriesGetTopCountries",
         "parameters": [
           {
@@ -4999,7 +4999,7 @@
     "/api/v1/analytics/top-ips": {
       "get": {
         "deprecated": false,
-        "description": "Top client IPs by hits from raw access logs (time-bounded).",
+        "description": "Top client IPs by hits (CAGG-served above 24h, filters included).",
         "operationId": "ApiV1AnalyticsTopIpsGetTopIps",
         "parameters": [
           {
@@ -5199,7 +5199,7 @@
     "/api/v1/analytics/top-urls": {
       "get": {
         "deprecated": false,
-        "description": "Top URLs by hits from raw access logs (time-bounded).",
+        "description": "Top URLs by hits (CAGG-served above 24h; filters force a raw scan).",
         "operationId": "ApiV1AnalyticsTopUrlsGetTopUrls",
         "parameters": [
           {
@@ -5415,7 +5415,7 @@
     "/api/v1/analytics/top-user-agents": {
       "get": {
         "deprecated": false,
-        "description": "Top user agents by hits from raw access logs.",
+        "description": "Top user agents by hits (CAGG-served above 24h; filters force a raw scan).",
         "operationId": "ApiV1AnalyticsTopUserAgentsGetTopUserAgents",
         "parameters": [
           {

--- a/tests/integration/test_access_logs_list_pg.py
+++ b/tests/integration/test_access_logs_list_pg.py
@@ -272,10 +272,18 @@ async def test_country_and_city_collection_filters_narrow_results(pg_session_mak
     assert total_city == 1 and str(by_city[0].ip_address) == "10.0.0.2"
 
 
-async def test_facets_lists_distinct_hosts(pg_session_maker, clean_tables) -> None:
+async def test_facets_lists_distinct_hosts(pg_engine, pg_session_maker, clean_tables) -> None:
     await _insert(pg_session_maker, NOW - timedelta(hours=1), "10.0.0.1", host="b.example.com")
     await _insert(pg_session_maker, NOW - timedelta(hours=1), "10.0.0.2", host="a.example.com")
     await _insert(pg_session_maker, NOW - timedelta(hours=1), "10.0.0.3", host="b.example.com")
+    # Hosts now read host_daily_stats: refresh the window so stale materialized
+    # buckets from earlier tests are wiped (clean_tables only DELETEs raw rows).
+    await refresh_caggs_range(
+        pg_engine,
+        start=NOW - timedelta(days=1),
+        end=NOW + timedelta(hours=1),
+        caggs=["host_daily_stats"],
+    )
     async with pg_session_maker() as session:
         facets = await AccessLogService(session=session).get_facets()
     # Deduped and alphabetical.

--- a/tests/integration/test_access_logs_list_pg.py
+++ b/tests/integration/test_access_logs_list_pg.py
@@ -15,6 +15,7 @@ from advanced_alchemy.filters import (
 from sqlalchemy import or_, text
 
 from geometrikks.domain.logs.services import AccessLogService
+from geometrikks.server.timescale import refresh_caggs_range
 
 # Wall-clock-relative so seeds stay inside the raw-retention window (see conftest).
 NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
@@ -181,7 +182,7 @@ async def test_sort_by_status_ascending(pg_session_maker, clean_tables) -> None:
     assert [r.status_code for r in results] == [200, 404, 500]
 
 
-async def test_get_facets_distinct_sorted_and_null_free(pg_session_maker, clean_tables) -> None:
+async def test_get_facets_distinct_sorted_and_null_free(pg_session_maker, pg_engine, clean_tables) -> None:
     ts = NOW - timedelta(hours=1)
     # Two Oslo/NO rows -> must dedupe; one SE row; one row without geo data.
     await _insert(pg_session_maker, ts, "10.0.0.1",
@@ -192,6 +193,16 @@ async def test_get_facets_distinct_sorted_and_null_free(pg_session_maker, clean_
                   country_code="SE", country_name="Sweden", city="Stockholm")
     await _insert(pg_session_maker, ts, "10.0.0.4")
 
+    # Facets now read log_ip_daily_stats: refresh the window so stale
+    # materialized buckets from earlier tests are wiped (clean_tables only
+    # DELETEs raw rows) and the fresh seeds are materialized.
+    await refresh_caggs_range(
+        pg_engine,
+        start=NOW - timedelta(days=1),
+        end=NOW + timedelta(hours=1),
+        caggs=["log_ip_daily_stats"],
+    )
+
     async with pg_session_maker() as session:
         facets = await AccessLogService(session=session).get_facets()
 
@@ -199,11 +210,21 @@ async def test_get_facets_distinct_sorted_and_null_free(pg_session_maker, clean_
     assert facets.cities == ["Oslo", "Stockholm"]
 
 
-async def test_get_facets_dedupes_by_code_preferring_non_null_name(pg_session_maker, clean_tables) -> None:
+async def test_get_facets_dedupes_by_code_preferring_non_null_name(pg_session_maker, pg_engine, clean_tables) -> None:
     ts = NOW - timedelta(hours=1)
     # Same code with and without a name -> one entry, named variant wins.
     await _insert(pg_session_maker, ts, "10.0.0.1", country_code="NO")
     await _insert(pg_session_maker, ts, "10.0.0.2", country_code="NO", country_name="Norway")
+
+    # Facets now read log_ip_daily_stats: refresh the window so stale
+    # materialized buckets from earlier tests are wiped (clean_tables only
+    # DELETEs raw rows) and the fresh seeds are materialized.
+    await refresh_caggs_range(
+        pg_engine,
+        start=NOW - timedelta(days=1),
+        end=NOW + timedelta(hours=1),
+        caggs=["log_ip_daily_stats"],
+    )
 
     async with pg_session_maker() as session:
         facets = await AccessLogService(session=session).get_facets()
@@ -211,8 +232,18 @@ async def test_get_facets_dedupes_by_code_preferring_non_null_name(pg_session_ma
     assert [(c.code, c.name) for c in facets.countries] == [("NO", "Norway")]
 
 
-async def test_get_facets_falls_back_to_code_when_name_missing(pg_session_maker, clean_tables) -> None:
+async def test_get_facets_falls_back_to_code_when_name_missing(pg_session_maker, pg_engine, clean_tables) -> None:
     await _insert(pg_session_maker, NOW - timedelta(hours=1), "10.0.0.5", country_code="DE")
+
+    # Facets now read log_ip_daily_stats: refresh the window so stale
+    # materialized buckets from earlier tests are wiped (clean_tables only
+    # DELETEs raw rows) and the fresh seeds are materialized.
+    await refresh_caggs_range(
+        pg_engine,
+        start=NOW - timedelta(days=1),
+        end=NOW + timedelta(hours=1),
+        caggs=["log_ip_daily_stats"],
+    )
 
     async with pg_session_maker() as session:
         facets = await AccessLogService(session=session).get_facets()

--- a/tests/integration/test_cagg_backfill.py
+++ b/tests/integration/test_cagg_backfill.py
@@ -56,7 +56,7 @@ async def test_backfill_recovers_history(pg_engine, pg_session_maker, clean_tabl
         )
     assert all(r.bucket.date() != OLD.date() for r in rows), "precondition: bug reproduced"
 
-    await backfill_cagg_gaps(pg_engine, raw_retention_days=180)
+    await backfill_cagg_gaps(pg_engine, raw_retention_days=180, hourly_retention_days=60)
 
     async with pg_session_maker() as session:
         rows = await SummaryStatsRepository(session=session).get_time_series(
@@ -91,7 +91,7 @@ async def test_one_bad_probe_does_not_cascade(pg_engine, pg_session_maker, clean
     bad = {"broken_cagg": "table_that_does_not_exist", **ts.CAGG_SOURCE_TABLES}
     monkeypatch.setattr(ts, "CAGG_SOURCE_TABLES", bad)
 
-    await ts.backfill_cagg_gaps(pg_engine, raw_retention_days=180)
+    await ts.backfill_cagg_gaps(pg_engine, raw_retention_days=180, hourly_retention_days=60)
 
     async with pg_session_maker() as session:
         rows = await SummaryStatsRepository(session=session).get_time_series(
@@ -100,3 +100,49 @@ async def test_one_bad_probe_does_not_cascade(pg_engine, pg_session_maker, clean
     assert any(r.bucket.date() == OLD.date() for r in rows), (
         "later CAGG was skipped: one bad probe cascaded across the shared connection"
     )
+
+
+async def test_hourly_probe_clamped_to_hourly_retention(pg_engine, pg_session_maker, clean_tables):
+    """Hourly CAGGs keep only hourly_retention_days of buckets: raw rows older
+    than that are not a gap, and re-detecting them re-backfills (and re-drops)
+    the same buckets on every startup."""
+    import geometrikks.server.timescale as ts
+
+    # Wipe stale materialized OLD-day buckets left by earlier tests in this
+    # file (clean_tables deletes raw rows, which only invalidates; a refresh
+    # over the empty range is what actually drops the stale buckets).
+    await _refresh(pg_engine, "summary_hourly_stats",
+                   OLD - timedelta(days=1), OLD + timedelta(days=1))
+
+    async with pg_session_maker() as session:
+        for ts_val, ip in ((OLD, "10.0.0.1"), (RECENT, "10.0.0.2")):
+            await session.execute(text(
+                "INSERT INTO access_logs (timestamp, ip_address, status_code, bytes_sent, request_time) "
+                "VALUES (:ts, :ip, 200, 100, 0.01)"
+            ), {"ts": ts_val, "ip": ip})
+        await session.commit()
+
+    # Advance the hourly watermark past OLD without materializing it.
+    await _refresh(pg_engine, "summary_hourly_stats",
+                   NOW - timedelta(days=3), NOW - timedelta(hours=1))
+
+    async def hourly_mat_dates() -> set:
+        async with pg_engine.connect() as conn:
+            mat = (await conn.execute(text(
+                "SELECT format('%I.%I', materialization_hypertable_schema, "
+                "materialization_hypertable_name) "
+                "FROM timescaledb_information.continuous_aggregates "
+                "WHERE view_name = 'summary_hourly_stats'"
+            ))).scalar()
+            rows = (await conn.execute(
+                text(f"SELECT DISTINCT bucket::date FROM {mat}")  # noqa: S608
+            )).scalars().all()
+        return set(rows)
+
+    # OLD (10d ago) is beyond a 5-day hourly retention horizon: not a gap.
+    await ts.backfill_cagg_gaps(pg_engine, raw_retention_days=180, hourly_retention_days=5)
+    assert OLD.date() not in await hourly_mat_dates()
+
+    # Within a 15-day horizon the same missing range is real and gets repaired.
+    await ts.backfill_cagg_gaps(pg_engine, raw_retention_days=180, hourly_retention_days=15)
+    assert OLD.date() in await hourly_mat_dates()

--- a/tests/integration/test_geo_logs_pg.py
+++ b/tests/integration/test_geo_logs_pg.py
@@ -548,6 +548,44 @@ class TestMisalignedWindowParity:
         ]
 
 
+class TestLocationTopIpsMisaligned:
+    """get_location_top_ips / get_global_top_ips must route hourly and stitch:
+    the old code read ip_location_daily_stats day-floored for every >24h
+    range, over-counting the partial first day."""
+
+    async def _refresh(self, pg_engine):
+        await refresh_caggs_range(
+            pg_engine, start=NOW - timedelta(days=4), end=NOW + timedelta(hours=1)
+        )
+
+    async def test_location_top_ips_excludes_edge_events(self, pg_engine, pg_session_maker, clean_tables):
+        from geometrikks.domain.geo.repositories import GeoLocationRepository
+
+        locs = await seed_boundary(pg_session_maker)
+        await self._refresh(pg_engine)
+        async with pg_session_maker() as session:
+            rows = await GeoLocationRepository(session=session).get_location_top_ips(
+                locs["no"], B_START, B_END, limit=10
+            )
+        assert [(r.ip_address, r.event_count) for r in rows] == [
+            ("1.1.1.1", 4),
+        ], "9.9.9.9 (head edge, same day bucket) must not appear"
+
+    async def test_global_top_ips_excludes_edge_events(self, pg_engine, pg_session_maker, clean_tables):
+        from geometrikks.domain.geo.repositories import GeoLocationRepository
+
+        locs = await seed_boundary(pg_session_maker)
+        await self._refresh(pg_engine)
+        async with pg_session_maker() as session:
+            rows = await GeoLocationRepository(session=session).get_global_top_ips(
+                B_START, B_END, limit=10
+            )
+        assert [(str(ip), count, loc.id) for ip, count, loc in rows] == [
+            ("1.1.1.1", 4, locs["no"]),
+            ("2.2.2.2", 3, locs["se"]),
+        ], "9.9.9.9 / 8.8.8.8 edge events are outside the window"
+
+
 class TestFacets:
     async def test_distinct_sorted_values(self, pg_session_maker, clean_tables):
         await seed_raw(pg_session_maker)

--- a/tests/integration/test_geo_logs_pg.py
+++ b/tests/integration/test_geo_logs_pg.py
@@ -591,8 +591,16 @@ class TestLocationTopIpsMisaligned:
 
 
 class TestFacets:
-    async def test_distinct_sorted_values(self, pg_session_maker, clean_tables):
+    async def test_distinct_sorted_values(self, pg_engine, pg_session_maker, clean_tables):
         await seed_raw(pg_session_maker)
+        # Hostnames now read hostname_daily_stats: refresh the window so stale
+        # materialized buckets from earlier tests are wiped.
+        await refresh_caggs_range(
+            pg_engine,
+            start=NOW - timedelta(days=1),
+            end=NOW + timedelta(hours=1),
+            caggs=["hostname_daily_stats"],
+        )
         async with pg_session_maker() as session:
             facets = await GeoEventService(session=session).get_facets()
         assert [(c.code, c.name) for c in facets.countries] == [
@@ -641,3 +649,27 @@ class TestFilteredSummaryAndSeriesCaggPath:
                 B_START, B_END, GeoEventFilters(hostnames=["web1"])
             )
         assert period.total_events == 4  # raw path needs no CAGG refresh
+
+
+class TestTieOrdering:
+    """Equal-count geo top-IP rows must order deterministically on the
+    stitched CAGG path (ip ASC tie-break)."""
+
+    async def test_tied_geo_top_ips_deterministic(self, pg_engine, pg_session_maker, clean_tables):
+        async with pg_session_maker() as session:
+            locs = await _seed_locations(session)
+            ts = NOW - timedelta(days=2)
+            await _insert_events(session, ts=ts, ip="6.6.6.6", hostname="web1", location_id=locs["no"], n=2)
+            await _insert_events(session, ts=ts, ip="5.5.5.5", hostname="web1", location_id=locs["no"], n=2)
+            await session.commit()
+        await refresh_caggs_range(
+            pg_engine, start=NOW - timedelta(days=4), end=NOW + timedelta(hours=1)
+        )
+        start = NOW - timedelta(days=3, hours=2)
+        async with pg_session_maker() as session:
+            rows = await GeoEventService(session=session).get_top_ips(
+                start, NOW, GeoEventFilters(), limit=10
+            )
+        assert [(r.ip_address, r.event_count) for r in rows] == [
+            ("5.5.5.5", 2), ("6.6.6.6", 2)
+        ]

--- a/tests/integration/test_geo_logs_pg.py
+++ b/tests/integration/test_geo_logs_pg.py
@@ -255,9 +255,13 @@ class TestSummary:
         assert period.total_events == 9
         assert period.unique_ips == 2
 
-    async def test_filtered_long_range_uses_raw(self, pg_engine, pg_session_maker, clean_tables):
-        """Any filter forces the raw path on long ranges (CAGGs have no dims)."""
+    async def test_filtered_long_range_uses_cagg_path(self, pg_engine, pg_session_maker, clean_tables):
+        """Country/city/IP filters now ride the stitched ip_location CAGGs;
+        results stay identical to the raw scan they replaced."""
         await seed_multiday(pg_session_maker)
+        await refresh_caggs_range(
+            pg_engine, start=NOW - timedelta(days=4), end=NOW + timedelta(hours=1)
+        )
         async with pg_session_maker() as session:
             period = await GeoEventService(session=session).get_summary(
                 NOW - timedelta(days=3, hours=2), NOW, GeoEventFilters(ip_exclude=["1.1.1.1"])
@@ -596,3 +600,44 @@ class TestFacets:
         ]
         assert facets.cities == ["Oslo", "Umea"]
         assert facets.hostnames == ["web1", "web2"]
+
+
+class TestFilteredSummaryAndSeriesCaggPath:
+    """Country/city/IP filters on >24h ranges must use the stitched
+    ip_location CAGG path and match the raw scan exactly; hostname still raw."""
+
+    async def _refresh(self, pg_engine):
+        await refresh_caggs_range(
+            pg_engine, start=NOW - timedelta(days=4), end=NOW + timedelta(hours=1)
+        )
+
+    async def test_country_filtered_summary_matches_raw(self, pg_engine, pg_session_maker, clean_tables):
+        await seed_boundary(pg_session_maker)
+        await self._refresh(pg_engine)
+        async with pg_session_maker() as session:
+            period = await GeoEventService(session=session).get_summary(
+                B_START, B_END, GeoEventFilters(country_codes=["NO"])
+            )
+        assert (
+            period.total_events, period.unique_ips,
+            period.unique_countries, period.unique_cities,
+        ) == (4, 1, 1, 1), "9.9.9.9 head-edge NO event must not be counted"
+
+    async def test_ip_filtered_time_series_matches_raw(self, pg_engine, pg_session_maker, clean_tables):
+        await seed_boundary(pg_session_maker)
+        await self._refresh(pg_engine)
+        async with pg_session_maker() as session:
+            points = await GeoEventService(session=session).get_time_series(
+                B_START, B_END, StatsGranularity.HOURLY,
+                GeoEventFilters(ip_include=["1.1.1.1"]),
+            )
+        assert [(p.total_events, p.unique_ips) for p in points] == [(1, 1), (3, 1)]
+        assert points[0].timestamp < points[1].timestamp
+
+    async def test_hostname_filter_still_raw_and_exact(self, pg_engine, pg_session_maker, clean_tables):
+        await seed_boundary(pg_session_maker)
+        async with pg_session_maker() as session:
+            period = await GeoEventService(session=session).get_summary(
+                B_START, B_END, GeoEventFilters(hostnames=["web1"])
+            )
+        assert period.total_events == 4  # raw path needs no CAGG refresh

--- a/tests/integration/test_top_caggs_pg.py
+++ b/tests/integration/test_top_caggs_pg.py
@@ -1,0 +1,52 @@
+"""Access-log top-N CAGGs on real TimescaleDB (issue #58).
+
+Covers CAGG existence/wiring, stitched-exact parity of the routed
+SummaryStatsRepository top-N reads against LiveStatsRepository raw scans,
+filter routing, and the CAGG-backed access-log facets.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import text
+
+from geometrikks.server.timescale import refresh_caggs_range
+
+# Wall-clock derived, hour-aligned (see test_repositories_pg.py for why).
+NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+
+# Misaligned >24h window: neither edge on an hour boundary, so CAGG reads
+# must stitch partial head/tail buckets from raw access_logs.
+B_START = NOW - timedelta(days=3) + timedelta(minutes=30)
+B_END = NOW - timedelta(minutes=30)
+
+NEW_CAGGS = (
+    "log_ip_hourly_stats",
+    "log_ip_daily_stats",
+    "url_hourly_stats",
+    "url_daily_stats",
+    "user_agent_hourly_stats",
+    "user_agent_daily_stats",
+)
+
+
+class TestCaggWiring:
+    async def test_new_caggs_exist(self, pg_engine):
+        async with pg_engine.connect() as conn:
+            names = [
+                r[0]
+                for r in await conn.execute(text(
+                    "SELECT view_name FROM timescaledb_information.continuous_aggregates"
+                ))
+            ]
+        for cagg in NEW_CAGGS:
+            assert cagg in names
+
+    async def test_new_caggs_are_refreshable(self, pg_engine, clean_tables):
+        """Names must be on the refresh allowlist and the CALL must succeed."""
+        await refresh_caggs_range(
+            pg_engine,
+            start=NOW - timedelta(days=4),
+            end=NOW + timedelta(hours=1),
+            caggs=list(NEW_CAGGS),
+        )

--- a/tests/integration/test_top_caggs_pg.py
+++ b/tests/integration/test_top_caggs_pg.py
@@ -65,9 +65,10 @@ async def _insert_log(
     country=None, country_name=None, city=None, host=None,
 ):
     # access_logs is an id-only base: no created_at/updated_at columns.
-    # rt defaults to 0.25: exact in binary floating point, so the CAGG's
-    # SUM/SUM average matches raw AVG() bit-for-bit and parity asserts can
-    # compare the float fields with ==.
+    # rt values (0.25, 0.5) are chosen to be exact in binary floating point
+    # so sums and divisions stay exact, and are varied across buckets so
+    # weighted-average (correct SUM/SUM) vs unweighted-average regressions
+    # are caught (e.g., AVG(request_time) per bucket then AVG those).
     await session.execute(text(
         "INSERT INTO access_logs (timestamp, ip_address, method, url, status_code, "
         "bytes_sent, request_time, user_agent, country_code, country_name, city, host) "
@@ -98,7 +99,7 @@ async def seed_boundary_logs(session_maker) -> None:
         # In window, day 3.
         await _insert_log(
             session, ts=B_START + timedelta(minutes=10), ip="1.1.1.1", url="/a",
-            user_agent="bot/1.0", bytes_sent=200,
+            user_agent="bot/1.0", bytes_sent=200, rt=0.5,
             country="NO", country_name="Norway", city="Oslo",
         )
         # In window, day 2: three /a hits, one is a 500.
@@ -146,6 +147,7 @@ class TestTopUrlsParity:
             ("/a", 4, 1, 800),
             ("/b", 3, 0, 150),
         ], "/edge rows are outside the window"
+        assert routed[0].avg_request_time == 0.3125
         assert routed[0].avg_request_time == raw[0].avg_request_time
 
 

--- a/tests/integration/test_top_caggs_pg.py
+++ b/tests/integration/test_top_caggs_pg.py
@@ -163,3 +163,63 @@ class TestTopUserAgentsParity:
             ("bot/1.0", 4),
             ("curl/8.0", 3),
         ]
+
+
+class TestTopIpsCountriesCitiesParity:
+    async def test_top_ips_matches_raw_scan(self, pg_engine, pg_session_maker, clean_tables):
+        await seed_boundary_logs(pg_session_maker)
+        await _refresh_all(pg_engine)
+        async with pg_session_maker() as session:
+            routed = await SummaryStatsRepository(session=session).get_top_ips(B_START, B_END)
+            raw = await LiveStatsRepository(session=session).get_top_ips(B_START, B_END)
+        assert routed == raw
+        assert [(r.ip_address, r.hits, r.error_hits, r.total_bytes, r.country_code, r.city) for r in routed] == [
+            ("1.1.1.1", 4, 1, 800, "NO", "Oslo"),
+            ("2.2.2.2", 3, 0, 150, "SE", "Umea"),
+            ("7.7.7.7", 1, 0, 100, None, None),
+        ], "edge IPs 9.9.9.9 / 8.8.8.8 are outside the window; NULL-geo IP counts"
+
+    async def test_top_countries_matches_raw_scan(self, pg_engine, pg_session_maker, clean_tables):
+        await seed_boundary_logs(pg_session_maker)
+        await _refresh_all(pg_engine)
+        async with pg_session_maker() as session:
+            routed = await SummaryStatsRepository(session=session).get_top_countries(B_START, B_END)
+            raw = await LiveStatsRepository(session=session).get_top_countries(B_START, B_END)
+        assert routed == raw
+        assert [(r.country_code, r.country_name, r.hits, r.unique_ips) for r in routed] == [
+            ("NO", "Norway", 4, 1),
+            ("SE", "Sweden", 3, 1),
+        ]
+
+    async def test_top_cities_matches_raw_scan(self, pg_engine, pg_session_maker, clean_tables):
+        await seed_boundary_logs(pg_session_maker)
+        await _refresh_all(pg_engine)
+        async with pg_session_maker() as session:
+            routed = await SummaryStatsRepository(session=session).get_top_cities(B_START, B_END)
+            raw = await LiveStatsRepository(session=session).get_top_cities(B_START, B_END)
+        assert routed == raw
+        assert [(r.city, r.country_code, r.hits, r.unique_ips) for r in routed] == [
+            ("Oslo", "NO", 4, 1),
+            ("Umea", "SE", 3, 1),
+        ]
+
+    async def test_filtered_top_ips_stays_on_cagg_and_matches_raw(self, pg_engine, pg_session_maker, clean_tables):
+        """Country filter on a >24h range: CAGG path, identical to raw."""
+        await seed_boundary_logs(pg_session_maker)
+        await _refresh_all(pg_engine)
+        flt = AnalyticsFilters(country_codes=["NO"])
+        async with pg_session_maker() as session:
+            routed = await SummaryStatsRepository(session=session).get_top_ips(B_START, B_END, filters=flt)
+            raw = await LiveStatsRepository(session=session).get_top_ips(B_START, B_END, filters=flt)
+        assert routed == raw
+        assert [(r.ip_address, r.hits) for r in routed] == [("1.1.1.1", 4)]
+
+    async def test_ip_exclude_filter_matches_raw(self, pg_engine, pg_session_maker, clean_tables):
+        await seed_boundary_logs(pg_session_maker)
+        await _refresh_all(pg_engine)
+        flt = AnalyticsFilters(ip_exclude=["1.1.1.1"])
+        async with pg_session_maker() as session:
+            routed = await SummaryStatsRepository(session=session).get_top_countries(B_START, B_END, filters=flt)
+            raw = await LiveStatsRepository(session=session).get_top_countries(B_START, B_END, filters=flt)
+        assert routed == raw
+        assert [(r.country_code, r.hits) for r in routed] == [("SE", 3)]

--- a/tests/integration/test_top_caggs_pg.py
+++ b/tests/integration/test_top_caggs_pg.py
@@ -27,6 +27,8 @@ NEW_CAGGS = (
     "url_daily_stats",
     "user_agent_hourly_stats",
     "user_agent_daily_stats",
+    "host_daily_stats",
+    "hostname_daily_stats",
 )
 
 
@@ -223,3 +225,30 @@ class TestTopIpsCountriesCitiesParity:
             raw = await LiveStatsRepository(session=session).get_top_countries(B_START, B_END, filters=flt)
         assert routed == raw
         assert [(r.country_code, r.hits) for r in routed] == [("SE", 3)]
+
+
+class TestTieOrdering:
+    """Rows with equal hit counts must order deterministically and identically
+    on both paths. Observed on real data: without a tie-break key, tied rows
+    shuffled between the CAGG-stitched and raw plans."""
+
+    async def test_tied_urls_and_ips_order_identically(self, pg_engine, pg_session_maker, clean_tables):
+        ts = NOW - timedelta(days=2)
+        async with pg_session_maker() as session:
+            for url, ip in (("/tie-b", "5.5.5.5"), ("/tie-a", "6.6.6.6")):
+                for _ in range(2):
+                    await _insert_log(
+                        session, ts=ts, url=url, user_agent="tie/1.0", ip=ip,
+                        country="NO", country_name="Norway", city="Oslo",
+                    )
+            await session.commit()
+        await _refresh_all(pg_engine)
+        async with pg_session_maker() as session:
+            routed_u = await SummaryStatsRepository(session=session).get_top_urls(B_START, B_END)
+            raw_u = await LiveStatsRepository(session=session).get_top_urls(B_START, B_END)
+            routed_i = await SummaryStatsRepository(session=session).get_top_ips(B_START, B_END)
+            raw_i = await LiveStatsRepository(session=session).get_top_ips(B_START, B_END)
+        assert [r.url for r in routed_u] == ["/tie-a", "/tie-b"], "equal hits break ties by url ASC"
+        assert routed_u == raw_u
+        assert [r.ip_address for r in routed_i] == ["5.5.5.5", "6.6.6.6"], "equal hits break ties by ip ASC"
+        assert routed_i == raw_i

--- a/tests/integration/test_top_caggs_pg.py
+++ b/tests/integration/test_top_caggs_pg.py
@@ -50,3 +50,114 @@ class TestCaggWiring:
             end=NOW + timedelta(hours=1),
             caggs=list(NEW_CAGGS),
         )
+
+
+from geometrikks.domain.analytics.repositories import (
+    AnalyticsFilters,
+    LiveStatsRepository,
+    SummaryStatsRepository,
+)
+
+
+async def _insert_log(
+    session, *, ts, url="/page", user_agent="ua/1.0", status=200,
+    bytes_sent=100, rt=0.25, ip="10.0.0.1",
+    country=None, country_name=None, city=None, host=None,
+):
+    # access_logs is an id-only base: no created_at/updated_at columns.
+    # rt defaults to 0.25: exact in binary floating point, so the CAGG's
+    # SUM/SUM average matches raw AVG() bit-for-bit and parity asserts can
+    # compare the float fields with ==.
+    await session.execute(text(
+        "INSERT INTO access_logs (timestamp, ip_address, method, url, status_code, "
+        "bytes_sent, request_time, user_agent, country_code, country_name, city, host) "
+        "VALUES (:ts, :ip, 'GET', :url, :status, :bytes, :rt, :ua, "
+        ":country, :country_name, :city, :host)"
+    ), {
+        "ts": ts, "url": url, "status": status, "bytes": bytes_sent, "rt": rt,
+        "ua": user_agent, "ip": ip, "country": country,
+        "country_name": country_name, "city": city, "host": host,
+    })
+
+
+async def seed_boundary_logs(session_maker) -> None:
+    """Logs straddling the misaligned [B_START, B_END) window.
+
+    9.9.9.9 / 8.8.8.8 rows sit OUTSIDE the window but inside the same hour
+    buckets as its edges: exactly what bucket-flooring would wrongly include.
+    In-window totals: /a 4 hits (1 error, 800 bytes) from 1.1.1.1 (NO/Oslo),
+    /b 3 hits (150 bytes) from 2.2.2.2 (SE/Umea), plus one malformed line
+    (NULL url/user_agent/geo) from 7.7.7.7 that only top-IPs may count.
+    """
+    async with session_maker() as session:
+        # Head edge: before the window, same hour bucket as B_START.
+        await _insert_log(
+            session, ts=B_START - timedelta(minutes=20), ip="9.9.9.9", url="/edge",
+            user_agent="edge/1.0", country="DE", country_name="Germany", city="Berlin",
+        )
+        # In window, day 3.
+        await _insert_log(
+            session, ts=B_START + timedelta(minutes=10), ip="1.1.1.1", url="/a",
+            user_agent="bot/1.0", bytes_sent=200,
+            country="NO", country_name="Norway", city="Oslo",
+        )
+        # In window, day 2: three /a hits, one is a 500.
+        for status in (200, 200, 500):
+            await _insert_log(
+                session, ts=NOW - timedelta(days=2), ip="1.1.1.1", url="/a",
+                user_agent="bot/1.0", status=status, bytes_sent=200,
+                country="NO", country_name="Norway", city="Oslo",
+            )
+        # In window, day 1 + near the tail.
+        for ts in (NOW - timedelta(days=1), NOW - timedelta(days=1), B_END - timedelta(minutes=10)):
+            await _insert_log(
+                session, ts=ts, ip="2.2.2.2", url="/b",
+                user_agent="curl/8.0", bytes_sent=50,
+                country="SE", country_name="Sweden", city="Umea",
+            )
+        # In window: a malformed line (no URL, no UA, no geo) - counted by
+        # top-IPs, excluded from top-URLs/user-agents/countries/cities.
+        await _insert_log(
+            session, ts=NOW - timedelta(days=1), ip="7.7.7.7", url=None, user_agent=None,
+        )
+        # Tail edge: after the window, same hour bucket as B_END.
+        await _insert_log(
+            session, ts=B_END + timedelta(minutes=10), ip="8.8.8.8", url="/edge",
+            user_agent="edge/1.0", country="US", country_name="United States", city="NYC",
+        )
+        await session.commit()
+
+
+async def _refresh_all(pg_engine) -> None:
+    await refresh_caggs_range(
+        pg_engine, start=NOW - timedelta(days=4), end=NOW + timedelta(hours=1)
+    )
+
+
+class TestTopUrlsParity:
+    async def test_matches_raw_scan_and_excludes_edges(self, pg_engine, pg_session_maker, clean_tables):
+        await seed_boundary_logs(pg_session_maker)
+        await _refresh_all(pg_engine)
+        async with pg_session_maker() as session:
+            routed = await SummaryStatsRepository(session=session).get_top_urls(B_START, B_END)
+            raw = await LiveStatsRepository(session=session).get_top_urls(B_START, B_END)
+        assert routed == raw
+        assert [(r.url, r.hits, r.error_hits, r.total_bytes) for r in routed] == [
+            ("/a", 4, 1, 800),
+            ("/b", 3, 0, 150),
+        ], "/edge rows are outside the window"
+        assert routed[0].avg_request_time == raw[0].avg_request_time
+
+
+class TestTopUserAgentsParity:
+    async def test_matches_raw_scan_and_excludes_edges(self, pg_engine, pg_session_maker, clean_tables):
+        await seed_boundary_logs(pg_session_maker)
+        await _refresh_all(pg_engine)
+        async with pg_session_maker() as session:
+            routed = await SummaryStatsRepository(session=session).get_top_user_agents(B_START, B_END)
+            raw = await LiveStatsRepository(session=session).get_top_user_agents(B_START, B_END)
+        assert routed == raw
+        assert [(r.user_agent, r.hits) for r in routed] == [
+            ("bot/1.0", 4),
+            ("curl/8.0", 3),
+        ]

--- a/tests/test_geo_routing.py
+++ b/tests/test_geo_routing.py
@@ -1,0 +1,69 @@
+"""GeoEventService summary/time-series routing: hostname forces raw,
+country/city/IP filters ride the stitched ip_location CAGGs."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from geometrikks.domain.geo.repositories import StatsGranularity
+from geometrikks.domain.geo.schemas import GeoEventFilters
+from geometrikks.domain.geo.services import GeoEventService
+
+NOW = datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc)
+WEEK_START = NOW - timedelta(days=7)
+
+
+class _Result:
+    def fetchall(self):
+        return []
+
+    def one(self):
+        return SimpleNamespace(
+            total_events=0, unique_ips=0, unique_countries=0, unique_cities=0
+        )
+
+
+class _RecordingSession:
+    # Minimal surface for advanced-alchemy repository construction.
+    bind = SimpleNamespace(
+        dialect=SimpleNamespace(name="postgresql", server_version_info=(18, 0))
+    )
+    info: dict = {}
+
+    def __init__(self):
+        self.statements: list[str] = []
+
+    async def execute(self, stmt, params=None):
+        self.statements.append(str(stmt))
+        return _Result()
+
+
+async def test_country_filtered_summary_uses_ip_location_cagg():
+    session = _RecordingSession()
+    await GeoEventService(session=session).get_summary(
+        WEEK_START, NOW, GeoEventFilters(country_codes=["NO"])
+    )
+    assert "ip_location_hourly_stats" in session.statements[0]
+
+
+async def test_hostname_filtered_summary_stays_raw():
+    session = _RecordingSession()
+    await GeoEventService(session=session).get_summary(
+        WEEK_START, NOW, GeoEventFilters(hostnames=["web1"])
+    )
+    assert "ip_location_hourly_stats" not in session.statements[0]
+    assert "FROM geo_events" in session.statements[0]
+
+
+async def test_ip_filtered_time_series_uses_ip_location_cagg():
+    session = _RecordingSession()
+    await GeoEventService(session=session).get_time_series(
+        WEEK_START, NOW, StatsGranularity.HOURLY, GeoEventFilters(ip_include=["1.1.1.1"])
+    )
+    assert "ip_location_hourly_stats" in session.statements[0]
+
+
+async def test_unfiltered_summary_keeps_hll_cagg():
+    session = _RecordingSession()
+    await GeoEventService(session=session).get_summary(WEEK_START, NOW, GeoEventFilters())
+    assert "geo_summary_hourly_stats" in session.statements[0]

--- a/tests/test_geo_routing.py
+++ b/tests/test_geo_routing.py
@@ -86,3 +86,15 @@ async def test_hourly_override_on_long_filtered_range_goes_raw():
     )
     assert "ip_location_hourly_stats" not in session.statements[0]
     assert "FROM geo_events" in session.statements[0]
+
+
+async def test_stitched_sql_binds_bounds_as_params():
+    """Regression: stitch bounds must be plain bind params, never a joined CTE
+    (a CTE join defeats TimescaleDB chunk exclusion on the raw legs)."""
+    session = _RecordingSession()
+    await GeoEventService(session=session).get_summary(
+        WEEK_START, NOW, GeoEventFilters(country_codes=["NO"])
+    )
+    sql = session.statements[0]
+    assert "bounds" not in sql
+    assert ":a_start" in sql and ":a_end" in sql

--- a/tests/test_geo_routing.py
+++ b/tests/test_geo_routing.py
@@ -67,3 +67,22 @@ async def test_unfiltered_summary_keeps_hll_cagg():
     session = _RecordingSession()
     await GeoEventService(session=session).get_summary(WEEK_START, NOW, GeoEventFilters())
     assert "geo_summary_hourly_stats" in session.statements[0]
+
+
+async def test_unfiltered_short_range_time_series_goes_raw():
+    session = _RecordingSession()
+    await GeoEventService(session=session).get_time_series(
+        NOW - timedelta(hours=6), NOW, StatsGranularity.HOURLY, GeoEventFilters()
+    )
+    assert "geo_summary_hourly_stats" not in session.statements[0]
+    assert "FROM geo_events" in session.statements[0]
+
+
+async def test_hourly_override_on_long_filtered_range_goes_raw():
+    session = _RecordingSession()
+    await GeoEventService(session=session).get_time_series(
+        NOW - timedelta(days=90), NOW, StatsGranularity.HOURLY,
+        GeoEventFilters(country_codes=["NO"]),
+    )
+    assert "ip_location_hourly_stats" not in session.statements[0]
+    assert "FROM geo_events" in session.statements[0]

--- a/tests/test_top_stats_routing.py
+++ b/tests/test_top_stats_routing.py
@@ -101,3 +101,18 @@ async def test_top_cities_week_range_uses_hourly_cagg():
     session = _RecordingSession()
     await SummaryStatsRepository(session=session).get_top_cities(WEEK_START, NOW)
     assert "log_ip_hourly_stats" in session.statements[0]
+
+
+async def test_stitched_sql_binds_bounds_as_params():
+    """Regression: stitch bounds must be plain bind params, never a joined CTE.
+
+    A bounds CTE joined into each leg turns the timestamp constraints into
+    join predicates, which TimescaleDB cannot use for chunk exclusion - the
+    raw legs then decompress and scan the entire hypertable (seconds instead
+    of milliseconds on large databases).
+    """
+    session = _RecordingSession()
+    await SummaryStatsRepository(session=session).get_top_ips(WEEK_START, NOW)
+    sql = session.statements[0]
+    assert "bounds" not in sql
+    assert ":a_start" in sql and ":a_end" in sql

--- a/tests/test_top_stats_routing.py
+++ b/tests/test_top_stats_routing.py
@@ -74,3 +74,30 @@ async def test_top_user_agents_filter_forces_raw():
     )
     assert "user_agent_hourly_stats" not in session.statements[0]
     assert "FROM access_logs" in session.statements[0]
+
+
+async def test_top_ips_short_range_goes_raw():
+    session = _RecordingSession()
+    await SummaryStatsRepository(session=session).get_top_ips(SHORT_START, NOW)
+    assert "log_ip_hourly_stats" not in session.statements[0]
+    assert "FROM access_logs" in session.statements[0]
+
+
+async def test_top_ips_week_range_uses_hourly_cagg_even_filtered():
+    session = _RecordingSession()
+    await SummaryStatsRepository(session=session).get_top_ips(
+        WEEK_START, NOW, filters=AnalyticsFilters(country_codes=["NO"])
+    )
+    assert "log_ip_hourly_stats" in session.statements[0]
+
+
+async def test_top_countries_long_range_uses_daily_cagg():
+    session = _RecordingSession()
+    await SummaryStatsRepository(session=session).get_top_countries(LONG_START, NOW)
+    assert "log_ip_daily_stats" in session.statements[0]
+
+
+async def test_top_cities_week_range_uses_hourly_cagg():
+    session = _RecordingSession()
+    await SummaryStatsRepository(session=session).get_top_cities(WEEK_START, NOW)
+    assert "log_ip_hourly_stats" in session.statements[0]

--- a/tests/test_top_stats_routing.py
+++ b/tests/test_top_stats_routing.py
@@ -1,0 +1,76 @@
+"""SummaryStatsRepository top-N routing: raw <= 24h, CAGG above, filter rules.
+
+Uses a recording fake session: the first executed statement's SQL reveals
+which path was taken (raw scans mention "FROM access_logs" outside a CTE;
+CAGG reads mention the *_stats view name).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from geometrikks.domain.analytics.repositories import (
+    AnalyticsFilters,
+    SummaryStatsRepository,
+)
+
+NOW = datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc)
+SHORT_START = NOW - timedelta(hours=6)     # RAW routing
+WEEK_START = NOW - timedelta(days=7)       # HOURLY routing
+LONG_START = NOW - timedelta(days=60)      # DAILY routing
+
+
+class _Result:
+    def fetchall(self):
+        return []
+
+
+class _RecordingSession:
+    def __init__(self):
+        self.statements: list[str] = []
+
+    async def execute(self, stmt, params=None):
+        self.statements.append(str(stmt))
+        return _Result()
+
+
+async def test_top_urls_short_range_goes_raw():
+    session = _RecordingSession()
+    await SummaryStatsRepository(session=session).get_top_urls(SHORT_START, NOW)
+    assert "url_hourly_stats" not in session.statements[0]
+    assert "FROM access_logs" in session.statements[0]
+
+
+async def test_top_urls_week_range_uses_hourly_cagg():
+    session = _RecordingSession()
+    await SummaryStatsRepository(session=session).get_top_urls(WEEK_START, NOW)
+    assert "url_hourly_stats" in session.statements[0]
+
+
+async def test_top_urls_long_range_uses_daily_cagg():
+    session = _RecordingSession()
+    await SummaryStatsRepository(session=session).get_top_urls(LONG_START, NOW)
+    assert "url_daily_stats" in session.statements[0]
+
+
+async def test_top_urls_any_filter_forces_raw():
+    session = _RecordingSession()
+    await SummaryStatsRepository(session=session).get_top_urls(
+        WEEK_START, NOW, filters=AnalyticsFilters(country_codes=["NO"])
+    )
+    assert "url_hourly_stats" not in session.statements[0]
+    assert "FROM access_logs" in session.statements[0]
+
+
+async def test_top_user_agents_week_range_uses_hourly_cagg():
+    session = _RecordingSession()
+    await SummaryStatsRepository(session=session).get_top_user_agents(WEEK_START, NOW)
+    assert "user_agent_hourly_stats" in session.statements[0]
+
+
+async def test_top_user_agents_filter_forces_raw():
+    session = _RecordingSession()
+    await SummaryStatsRepository(session=session).get_top_user_agents(
+        WEEK_START, NOW, filters=AnalyticsFilters(ip_exclude=["1.1.1.1"])
+    )
+    assert "user_agent_hourly_stats" not in session.statements[0]
+    assert "FROM access_logs" in session.statements[0]


### PR DESCRIPTION
Closes #58

## What

Serves the five analytics top-list endpoints (`/top-urls`, `/top-user-agents`, `/top-ips`, `/top-countries`, `/top-cities`) from TimescaleDB continuous aggregates on ranges over 24 hours instead of scanning raw `access_logs`, and applies the same treatment to the adjacent slow paths found along the way.

### New continuous aggregates (all list-driven, auto-backfilled on first startup)

- `log_ip_{hourly,daily}_stats`: keyed by IP with country/city, serving top IPs/countries/cities with exact unique-IP counts; country/city/IP filters stay on the fast path.
- `url_{hourly,daily}_stats` and `user_agent_{hourly,daily}_stats`: top URLs / user agents (filters fall back to raw).
- `host_daily_stats` and `hostname_daily_stats`: tiny daily rollups backing the host/hostname facet dropdowns.

### Query layer

- Stitched-exact reads: whole buckets from the CAGG, partial head/tail from raw, bounds bound as plain parameters so chunk exclusion works. Results are exactly equal to a raw scan of the same window (parity-asserted in integration tests against seeded boundary data, and spot-verified against an 18M-row database).
- Geo Logs summary/chart route country/city/IP filters through the per-IP CAGGs (hostname still raw); an hourly-bucket override on a >30d filtered window falls back to raw so hourly-CAGG retention cannot truncate results.
- Deterministic tie-break ordering on every top list, both paths.

### Fixes (pre-existing, user-visible)

- Map top-IP lists day-floored their window on >24h ranges, over-counting the partial first day.
- Geo Logs grouped rows / top lists scanned the entire raw history while stitching window edges (seconds at 18M rows, now tens of ms).
- Geo Logs chart on <=24h ranges included pre-window events in its first data point and used estimated uniques; both exact now.
- Startup re-backfilled ~120 days of hourly aggregate buckets on every restart because the gap probe ignored hourly retention.

## Measured (18M-row database, 7-day range)

| endpoint | before | after |
|---|---|---|
| analytics top-countries | 3.9 s | 28 ms |
| analytics top-cities | 3.5 s | 29 ms |
| analytics top-ips | 3.2 s | 27 ms |
| access-log facets | 687 ms | 66 ms |
| geo facets | ~460 ms | 25 ms |

90-day range: top-countries/cities went from ~10.5 s (raw) to ~150 ms.

## Testing

- 536 tests passing, including new integration suites: CAGG wiring, stitched-window parity vs raw scans on misaligned windows, filter routing, tie ordering, facet parity, and the hourly gap-probe clamp (red/green).
- Endpoint sweep against a live 18M-row database with independent raw-SQL parity checks on summary counts, grouped totals and host lists.

## Notes

- No API surface changes: same routes and response shapes; only description strings updated (client regenerated).
- Existing deployments backfill the new aggregates automatically on first startup (one-time, ~15 s at 18M rows).
- Facet dropdowns now list values from all recorded history rather than only the raw retention window.