### PR TITLE
ci: smoke test production Docker image

### DIFF
--- a/.github/scripts/pr-smoke-summary.cjs
+++ b/.github/scripts/pr-smoke-summary.cjs
@@ -1,0 +1,100 @@
+const COMMENT_MARKER = "<!-- geometrikks-container-smoke -->";
+
+const STATUS_LABELS = {
+  success: "✅ success",
+  failure: "❌ failure",
+  cancelled: "⚪ cancelled",
+  skipped: "⏭️ skipped",
+  timed_out: "⏱️ timed out",
+  neutral: "➖ neutral",
+  action_required: "⚠️ action required",
+};
+
+function statusLabel(conclusion) {
+  return STATUS_LABELS[conclusion] ?? "⏭️ not run";
+}
+
+function buildComment({ workflowRun, jobs }) {
+  const frontend = jobs.find((job) => job.name === "frontend");
+  const steps = new Map(
+    (frontend?.steps ?? []).map((step) => [step.name, step.conclusion]),
+  );
+  const artifactName = `container-smoke-${workflowRun.run_attempt}`;
+
+  return `${COMMENT_MARKER}
+## Production image smoke test
+
+| Check | Result |
+| --- | --- |
+| Overall CI | ${statusLabel(workflowRun.conclusion)} |
+| Frontend job | ${statusLabel(frontend?.conclusion)} |
+| Build production image | ${statusLabel(steps.get("Build production image"))} |
+| HTTP smoke checks | ${statusLabel(steps.get("Run HTTP smoke checks"))} |
+| Browser smoke test | ${statusLabel(steps.get("Run browser smoke test"))} |
+| Artifact upload | ${statusLabel(steps.get("Upload smoke artifacts"))} |
+
+[View workflow run and download \`${artifactName}\`](${workflowRun.html_url})`;
+}
+
+async function main({ github, context, core }) {
+  const workflowRun = context.payload.workflow_run;
+  const pullRequest = workflowRun.pull_requests?.[0];
+
+  if (workflowRun.event !== "pull_request" || !pullRequest) {
+    core.notice("No pull request is associated with this workflow run.");
+    return;
+  }
+
+  const testedHeadSha = pullRequest.head?.sha;
+  if (testedHeadSha) {
+    const { data: currentPullRequest } = await github.rest.pulls.get({
+      ...context.repo,
+      pull_number: pullRequest.number,
+    });
+    if (currentPullRequest.head.sha !== testedHeadSha) {
+      core.notice("Skipping stale workflow run for an older PR head.");
+      return;
+    }
+  }
+
+  const jobs = await github.paginate(
+    github.rest.actions.listJobsForWorkflowRun,
+    {
+      ...context.repo,
+      run_id: workflowRun.id,
+      per_page: 100,
+    },
+  );
+  const body = buildComment({ workflowRun, jobs });
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    ...context.repo,
+    issue_number: pullRequest.number,
+    per_page: 100,
+  });
+  const existing = comments.find(
+    (comment) =>
+      comment.user?.login === "github-actions[bot]" &&
+      comment.body?.includes(COMMENT_MARKER),
+  );
+
+  if (existing) {
+    await github.rest.issues.updateComment({
+      ...context.repo,
+      comment_id: existing.id,
+      body,
+    });
+    return;
+  }
+
+  await github.rest.issues.createComment({
+    ...context.repo,
+    issue_number: pullRequest.number,
+    body,
+  });
+}
+
+module.exports = {
+  COMMENT_MARKER,
+  buildComment,
+  main,
+};

--- a/.github/scripts/pr-smoke-summary.cjs
+++ b/.github/scripts/pr-smoke-summary.cjs
@@ -14,6 +14,9 @@ function statusLabel(conclusion) {
   return STATUS_LABELS[conclusion] ?? "⏭️ not run";
 }
 
+// The step names below must match the display names of the frontend job's
+// steps in .github/workflows/ci.yml. Renaming a step there silently turns
+// its row into "not run" here.
 function buildComment({ workflowRun, jobs }) {
   const frontend = jobs.find((job) => job.name === "frontend");
   const steps = new Map(
@@ -38,6 +41,10 @@ function buildComment({ workflowRun, jobs }) {
 
 async function main({ github, context, core }) {
   const workflowRun = context.payload.workflow_run;
+  // Known limitation: workflow_run.pull_requests is empty for PRs opened
+  // from forks, so those get no sticky comment (the run link in the Checks
+  // tab still works). If forks ever matter, resolve the PR via
+  // repos.listPullRequestsAssociatedWithCommit on workflowRun.head_sha.
   const pullRequest = workflowRun.pull_requests?.[0];
 
   if (workflowRun.event !== "pull_request" || !pullRequest) {

--- a/.github/scripts/pr-smoke-summary.test.cjs
+++ b/.github/scripts/pr-smoke-summary.test.cjs
@@ -1,0 +1,292 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+let summary = {};
+try {
+  summary = require("./pr-smoke-summary.cjs");
+} catch {
+  // The first TDD run intentionally exercises the missing implementation.
+}
+
+test("buildComment reports failures and steps that did not run", () => {
+  assert.equal(
+    typeof summary.buildComment,
+    "function",
+    "buildComment must be implemented",
+  );
+
+  const body = summary.buildComment({
+    workflowRun: {
+      conclusion: "failure",
+      html_url: "https://github.com/GilbN/geometrikks/actions/runs/123",
+      run_attempt: 2,
+    },
+    jobs: [
+      {
+        name: "frontend",
+        conclusion: "failure",
+        steps: [
+          { name: "Build production image", conclusion: "success" },
+          { name: "Run HTTP smoke checks", conclusion: "failure" },
+          { name: "Run browser smoke test", conclusion: "skipped" },
+          { name: "Upload smoke artifacts", conclusion: "success" },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(
+    body,
+    `<!-- geometrikks-container-smoke -->
+## Production image smoke test
+
+| Check | Result |
+| --- | --- |
+| Overall CI | ❌ failure |
+| Frontend job | ❌ failure |
+| Build production image | ✅ success |
+| HTTP smoke checks | ❌ failure |
+| Browser smoke test | ⏭️ skipped |
+| Artifact upload | ✅ success |
+
+[View workflow run and download \`container-smoke-2\`](https://github.com/GilbN/geometrikks/actions/runs/123)`,
+  );
+});
+
+test("main updates the existing smoke comment instead of adding a duplicate", async () => {
+  assert.equal(typeof summary.main, "function", "main must be implemented");
+
+  const comments = [
+    {
+      id: 7,
+      user: { login: "github-actions[bot]" },
+      body: "<!-- geometrikks-container-smoke -->\nold result",
+    },
+    {
+      id: 8,
+      user: { login: "maintainer" },
+      body: "Keep this comment",
+    },
+  ];
+  const jobs = [
+    {
+      name: "frontend",
+      conclusion: "success",
+      steps: [
+        { name: "Build production image", conclusion: "success" },
+        { name: "Run HTTP smoke checks", conclusion: "success" },
+        { name: "Run browser smoke test", conclusion: "success" },
+        { name: "Upload smoke artifacts", conclusion: "success" },
+      ],
+    },
+  ];
+  const github = {
+    paginate: async (method, parameters) => (await method(parameters)).data,
+    rest: {
+      actions: {
+        listJobsForWorkflowRun: async () => ({ data: jobs }),
+      },
+      pulls: {
+        get: async () => ({ data: { head: { sha: "source-head-sha" } } }),
+      },
+      issues: {
+        listComments: async () => ({ data: comments }),
+        updateComment: async ({ comment_id, body }) => {
+          comments.find((comment) => comment.id === comment_id).body = body;
+        },
+        createComment: async ({ body }) => {
+          comments.push({
+            id: 9,
+            user: { login: "github-actions[bot]" },
+            body,
+          });
+        },
+      },
+    },
+  };
+  const context = {
+    repo: { owner: "GilbN", repo: "geometrikks" },
+    payload: {
+      workflow_run: {
+        id: 123,
+        event: "pull_request",
+        head_sha: "synthetic-merge-sha",
+        conclusion: "success",
+        html_url: "https://github.com/GilbN/geometrikks/actions/runs/123",
+        run_attempt: 1,
+        pull_requests: [{ number: 42, head: { sha: "source-head-sha" } }],
+      },
+    },
+  };
+
+  await summary.main({ github, context, core: { notice() {} } });
+
+  assert.equal(comments.length, 2);
+  assert.match(comments[0].body, /\| Browser smoke test \| ✅ success \|/);
+  assert.equal(comments[1].body, "Keep this comment");
+});
+
+test("main creates the first smoke comment when no marker comment exists", async () => {
+  const comments = [];
+  const github = {
+    paginate: async (method, parameters) => (await method(parameters)).data,
+    rest: {
+      actions: {
+        listJobsForWorkflowRun: async () => ({
+          data: [{ name: "frontend", conclusion: "cancelled", steps: [] }],
+        }),
+      },
+      issues: {
+        listComments: async () => ({ data: comments }),
+        updateComment: async () => {
+          assert.fail("There is no existing comment to update");
+        },
+        createComment: async ({ issue_number, body }) => {
+          comments.push({
+            id: 1,
+            issue_number,
+            user: { login: "github-actions[bot]" },
+            body,
+          });
+        },
+      },
+    },
+  };
+  const context = {
+    repo: { owner: "GilbN", repo: "geometrikks" },
+    payload: {
+      workflow_run: {
+        id: 456,
+        event: "pull_request",
+        conclusion: "cancelled",
+        html_url: "https://github.com/GilbN/geometrikks/actions/runs/456",
+        run_attempt: 1,
+        pull_requests: [{ number: 43 }],
+      },
+    },
+  };
+
+  await summary.main({ github, context, core: { notice() {} } });
+
+  assert.equal(comments.length, 1);
+  assert.equal(comments[0].issue_number, 43);
+  assert.match(comments[0].body, /\| Overall CI \| ⚪ cancelled \|/);
+});
+
+test("main does not replace the comment with a stale workflow run", async () => {
+  const comments = [
+    {
+      id: 7,
+      user: { login: "github-actions[bot]" },
+      body: "<!-- geometrikks-container-smoke -->\nnewer result",
+    },
+  ];
+  const github = {
+    paginate: async (method, parameters) => (await method(parameters)).data,
+    rest: {
+      actions: {
+        listJobsForWorkflowRun: async () => ({
+          data: [{ name: "frontend", conclusion: "cancelled", steps: [] }],
+        }),
+      },
+      pulls: {
+        get: async () => ({ data: { head: { sha: "new-head-sha" } } }),
+      },
+      issues: {
+        listComments: async () => ({ data: comments }),
+        updateComment: async ({ comment_id, body }) => {
+          comments.find((comment) => comment.id === comment_id).body = body;
+        },
+        createComment: async () => {
+          assert.fail("A stale run must not create a comment");
+        },
+      },
+    },
+  };
+  const notices = [];
+  const context = {
+    repo: { owner: "GilbN", repo: "geometrikks" },
+    payload: {
+      workflow_run: {
+        id: 789,
+        event: "pull_request",
+        head_sha: "synthetic-old-merge-sha",
+        conclusion: "cancelled",
+        html_url: "https://github.com/GilbN/geometrikks/actions/runs/789",
+        run_attempt: 1,
+        pull_requests: [{ number: 44, head: { sha: "old-source-head-sha" } }],
+      },
+    },
+  };
+
+  await summary.main({
+    github,
+    context,
+    core: {
+      notice(message) {
+        notices.push(message);
+      },
+    },
+  });
+
+  assert.equal(
+    comments[0].body,
+    "<!-- geometrikks-container-smoke -->\nnewer result",
+  );
+  assert.deepEqual(notices, ["Skipping stale workflow run for an older PR head."]);
+});
+
+test("main skips runs whose payload has no PR association", async () => {
+  const comments = [];
+  const github = {
+    paginate: async (method, parameters) => (await method(parameters)).data,
+    rest: {
+      repos: {
+        listPullRequestsAssociatedWithCommit: async () => ({
+          data: [{ number: 45, state: "open", head: { sha: "head-sha" } }],
+        }),
+      },
+      pulls: {
+        get: async () => ({ data: { head: { sha: "head-sha" } } }),
+      },
+      actions: {
+        listJobsForWorkflowRun: async () => ({
+          data: [{ name: "frontend", conclusion: "success", steps: [] }],
+        }),
+      },
+      issues: {
+        listComments: async () => ({ data: comments }),
+        updateComment: async () => {
+          assert.fail("There is no existing comment to update");
+        },
+        createComment: async ({ issue_number, body }) => {
+          comments.push({ issue_number, body });
+        },
+      },
+    },
+  };
+  const notices = [];
+  const context = {
+    repo: { owner: "GilbN", repo: "geometrikks" },
+    payload: {
+      workflow_run: {
+        id: 987,
+        event: "pull_request",
+        head_sha: "head-sha",
+        conclusion: "success",
+        html_url: "https://github.com/GilbN/geometrikks/actions/runs/987",
+        run_attempt: 1,
+        pull_requests: [],
+      },
+    },
+  };
+
+  await summary.main({
+    github,
+    context,
+    core: { notice(message) { notices.push(message); } },
+  });
+
+  assert.equal(comments.length, 0);
+  assert.deepEqual(notices, ["No pull request is associated with this workflow run."]);
+});

--- a/.github/scripts/pr-smoke-summary.test.cjs
+++ b/.github/scripts/pr-smoke-summary.test.cjs
@@ -1,20 +1,9 @@
 const assert = require("node:assert/strict");
 const test = require("node:test");
 
-let summary = {};
-try {
-  summary = require("./pr-smoke-summary.cjs");
-} catch {
-  // The first TDD run intentionally exercises the missing implementation.
-}
+const summary = require("./pr-smoke-summary.cjs");
 
 test("buildComment reports failures and steps that did not run", () => {
-  assert.equal(
-    typeof summary.buildComment,
-    "function",
-    "buildComment must be implemented",
-  );
-
   const body = summary.buildComment({
     workflowRun: {
       conclusion: "failure",
@@ -54,8 +43,6 @@ test("buildComment reports failures and steps that did not run", () => {
 });
 
 test("main updates the existing smoke comment instead of adding a duplicate", async () => {
-  assert.equal(typeof summary.main, "function", "main must be implemented");
-
   const comments = [
     {
       id: 7,
@@ -241,11 +228,6 @@ test("main skips runs whose payload has no PR association", async () => {
   const github = {
     paginate: async (method, parameters) => (await method(parameters)).data,
     rest: {
-      repos: {
-        listPullRequestsAssociatedWithCommit: async () => ({
-          data: [{ number: 45, state: "open", head: { sha: "head-sha" } }],
-        }),
-      },
       pulls: {
         get: async () => ({ data: { head: { sha: "head-sha" } } }),
       },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,26 @@ jobs:
 
   frontend:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      timescaledb:
+        image: timescale/timescaledb-ha:pg18
+        env:
+          POSTGRES_USER: geouser
+          POSTGRES_PASSWORD: geopass
+          POSTGRES_DB: geometrikks
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U geouser -d geometrikks"
+          --health-interval 5s --health-timeout 5s --health-retries 10
+    env:
+      SMOKE_IMAGE: geometrikks:ci
+      SMOKE_BASE_URL: http://127.0.0.1:8000
+      SMOKE_ADMIN_USER: admin
+      # Deliberately disposable and non-secret: Playwright traces are uploaded.
+      SMOKE_ADMIN_PASSWORD: ci-smoke-password
+      SMOKE_ARTIFACT_NAME: container-smoke-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -52,5 +72,142 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Run frontend tests
         run: bun run test
-      - name: Build (vite + tsc)
-        run: bun run build
+      - name: Test PR smoke summary helper
+        run: node --test .github/scripts/pr-smoke-summary.test.cjs
+      - uses: docker/setup-buildx-action@v3
+      - name: Build production image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ${{ env.SMOKE_IMAGE }}
+          build-args: |
+            APP_IMAGE_TAG=ci-${{ github.sha }}
+          cache-from: type=gha,scope=container-smoke
+          cache-to: type=gha,mode=max,scope=container-smoke
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+      - name: Prepare smoke-test fixtures
+        shell: bash
+        run: |
+          set -euo pipefail
+          fixture_dir="${RUNNER_TEMP}/geometrikks-smoke/geoip"
+          mkdir -p "${fixture_dir}" smoke-artifacts
+          cp tests/GeoLite2-City-Test.mmdb "${fixture_dir}/GeoLite2-City.mmdb"
+          echo "SMOKE_GEOIP_DIR=${fixture_dir}" >> "${GITHUB_ENV}"
+      - name: Start production image
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --detach \
+            --name geometrikks-smoke \
+            --publish 127.0.0.1:8000:8000 \
+            --add-host host.docker.internal:host-gateway \
+            --health-interval 2s \
+            --volume "${SMOKE_GEOIP_DIR}:/app/data/geoip" \
+            --env DB_HOST=host.docker.internal \
+            --env DB_PORT=5432 \
+            --env DB_USER=geouser \
+            --env DB_PASSWORD=geopass \
+            --env DB_NAME=geometrikks \
+            --env APP_ADMIN_USER="${SMOKE_ADMIN_USER}" \
+            --env APP_ADMIN_PASSWORD="${SMOKE_ADMIN_PASSWORD}" \
+            --env MAP_AUTO_DETECT_HOME=false \
+            "${SMOKE_IMAGE}"
+      - name: Run HTTP smoke checks
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ready=false
+          for _ in {1..60}; do
+            if curl --fail --silent --show-error \
+              "${SMOKE_BASE_URL}/health/ready" \
+              > smoke-artifacts/readiness.json; then
+              ready=true
+              break
+            fi
+            sleep 1
+          done
+          if [[ "${ready}" != "true" ]]; then
+            echo "Application did not become ready within 60 seconds."
+            exit 1
+          fi
+
+          docker_health=""
+          for _ in {1..20}; do
+            docker_health="$(docker inspect --format '{{.State.Health.Status}}' geometrikks-smoke)"
+            if [[ "${docker_health}" == "healthy" ]]; then
+              break
+            fi
+            if [[ "${docker_health}" == "unhealthy" ]]; then
+              echo "Docker health check reported unhealthy."
+              exit 1
+            fi
+            sleep 1
+          done
+          if [[ "${docker_health}" != "healthy" ]]; then
+            echo "Docker health check did not become healthy."
+            exit 1
+          fi
+
+          curl --fail --silent --show-error "${SMOKE_BASE_URL}/health" \
+            | tee smoke-artifacts/health.json \
+            | python3 -c 'import json, sys; body = json.load(sys.stdin); assert body["status"] == "healthy", body; assert body["database"]["reachable"] is True, body; assert body["geoip"]["available"] is True, body; assert body["ingestion"]["running"] is True, body'
+
+          curl --fail --silent --show-error "${SMOKE_BASE_URL}/" \
+            > smoke-artifacts/index.html
+          grep --quiet '<title>GeoMetrikks</title>' smoke-artifacts/index.html
+
+          unauthenticated_status="$(
+            curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+              "${SMOKE_BASE_URL}/api/v1/auth/me"
+          )"
+          if [[ "${unauthenticated_status}" != "401" ]]; then
+            echo "Expected unauthenticated API status 401, got ${unauthenticated_status}."
+            exit 1
+          fi
+      - name: Run browser smoke test
+        run: npm run test:smoke
+      - name: Write smoke-test summary
+        if: always()
+        shell: bash
+        env:
+          SMOKE_JOB_STATUS: ${{ job.status }}
+        run: |
+          {
+            echo "## Production image smoke test"
+            echo
+            echo "| Check | Result |"
+            echo "| --- | --- |"
+            echo "| Overall result | ${SMOKE_JOB_STATUS} |"
+            if [[ "${SMOKE_JOB_STATUS}" == "success" ]]; then
+              echo "| Docker health | healthy |"
+              echo "| Database readiness | ready |"
+              echo "| GeoIP fixture and ingestion | healthy |"
+              echo "| Authentication and dashboard | passed |"
+              echo "| Browser console/network errors | none |"
+            fi
+            echo
+            echo "Diagnostics and screenshots: artifact \`${SMOKE_ARTIFACT_NAME}\`."
+          } >> "${GITHUB_STEP_SUMMARY}"
+      - name: Collect smoke-test diagnostics
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p smoke-artifacts
+          docker inspect --format '{{json .State}}' geometrikks-smoke \
+            > smoke-artifacts/container-state.json 2>&1 || true
+          docker logs geometrikks-smoke \
+            > smoke-artifacts/container.log 2>&1 || true
+      - name: Upload smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SMOKE_ARTIFACT_NAME }}
+          path: smoke-artifacts
+          if-no-files-found: warn
+          retention-days: 14
+      - name: Stop production image
+        if: always()
+        run: docker rm --force geometrikks-smoke 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           --health-cmd "pg_isready -U geouser -d geometrikks"
           --health-interval 5s --health-timeout 5s --health-retries 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
@@ -66,7 +66,7 @@ jobs:
       SMOKE_ADMIN_PASSWORD: ci-smoke-password
       SMOKE_ARTIFACT_NAME: container-smoke-${{ github.run_attempt }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
       - name: Install
         run: bun install --frozen-lockfile
@@ -75,6 +75,9 @@ jobs:
       - name: Test PR smoke summary helper
         run: node --test .github/scripts/pr-smoke-summary.test.cjs
       - uses: docker/setup-buildx-action@v3
+      # The step names from here through "Upload smoke artifacts" are
+      # referenced verbatim by .github/scripts/pr-smoke-summary.cjs; renaming
+      # one silently shows it as "not run" in the sticky PR comment.
       - name: Build production image
         uses: docker/build-push-action@v6
         with:
@@ -85,6 +88,9 @@ jobs:
             APP_IMAGE_TAG=ci-${{ github.sha }}
           cache-from: type=gha,scope=container-smoke
           cache-to: type=gha,mode=max,scope=container-smoke
+      # npx/npm here is deliberate in this otherwise-bun repo: the Playwright
+      # test runner only supports the Node runtime, and bun re-executes
+      # node-shebang bins under bun.
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
       - name: Prepare smoke-test fixtures

--- a/.github/workflows/pr-smoke-summary.yml
+++ b/.github/workflows/pr-smoke-summary.yml
@@ -1,0 +1,32 @@
+name: PR smoke summary
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    steps:
+      # workflow_run is privileged, so only load the trusted default branch.
+      - name: Check out trusted comment helper
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+      - name: Create or update PR smoke summary
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { main } = require("./.github/scripts/pr-smoke-summary.cjs");
+            await main({ github, context, core });

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ docs/superpowers/
 .litestar.json
 /logs
 /nginx_logs
+/smoke-artifacts/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   expose the clipboard API to HTTPS and loopback origins, so copying now
   falls back to a hidden-textarea copy, and reports "Copy failed" instead of
   silently doing nothing when even that is refused.
+- Logging in no longer intermittently bounces straight back to the login
+  page. Session handling now applies only to `/api` and `/ws`: previously
+  every static-asset response also rewrote the session it had loaded, so an
+  asset request still in flight during login (the PWA precaches many at once)
+  could overwrite the fresh session with stale logged-out data and the next
+  API call would 401.
 
 ## [0.5.0] - 2026-07-25
 

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
       },
       "devDependencies": {
         "@hey-api/openapi-ts": "^0.88.0",
+        "@playwright/test": "^1.62.0",
         "@tailwindcss/vite": "^4.1.17",
         "@tanstack/react-query-devtools": "^5.91.1",
         "@tanstack/router-plugin": "^1.168.19",
@@ -438,6 +439,8 @@
     "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
+
+    "@playwright/test": ["@playwright/test@1.62.0", "", { "dependencies": { "playwright": "1.62.0" }, "bin": { "playwright": "cli.js" } }, "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
@@ -1489,6 +1492,10 @@
 
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, ""],
 
+    "playwright": ["playwright@1.62.0", "", { "dependencies": { "playwright-core": "1.62.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw=="],
+
+    "playwright-core": ["playwright-core@1.62.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA=="],
+
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, ""],
@@ -2108,6 +2115,8 @@
     "object.assign/es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 

--- a/geometrikks/server/auth.py
+++ b/geometrikks/server/auth.py
@@ -34,8 +34,12 @@ logger = get_logger(__name__)
 #   request. The (/|$) boundary keeps bare "/ws" and "/api" authenticated too,
 #   not just their slash-suffixed children.
 # - the login endpoint itself.
+# Everything that is not /api or /ws: the SPA shell, static assets, /health,
+# /schema. Shared by the auth middleware and the session middleware below.
+NON_API_PATTERN = "^/(?!api(/|$)|ws(/|$))"
+
 AUTH_EXCLUDE_PATTERNS: list[str] = [
-    "^/(?!api(/|$)|ws(/|$))",
+    NON_API_PATTERN,
     "^/api/v1/auth/login$",
 ]
 
@@ -113,6 +117,15 @@ def create_session_auth(settings: "Settings") -> SessionAuth[AdminUser, ServerSi
         session_backend_config=ServerSideSessionConfig(
             max_age=60 * 60 * 24 * 7,
             secure=settings.session_secure,
+            # Sessions exist only for /api and /ws. Without this exclusion the
+            # session middleware runs on the SPA shell and every static asset,
+            # and each response writes the session it loaded at request start
+            # back to the store. A slow asset response that started before
+            # login (the PWA precache fires dozens concurrently) then
+            # overwrites the fresh authenticated session with stale pre-login
+            # data, and the next API call 401s: the user bounces from a
+            # successful login straight back to /login.
+            exclude=NON_API_PATTERN,
         ),
         exclude=AUTH_EXCLUDE_PATTERNS,
     )

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "update": "npm update",
     "generate-types": "openapi-ts",
     "test": "vitest run",
+    "test:smoke": "playwright test --config=playwright.config.ts",
     "typecheck": "tsc -b --noEmit"
   },
   "dependencies": {
@@ -39,6 +40,7 @@
   },
   "devDependencies": {
     "@hey-api/openapi-ts": "^0.88.0",
+    "@playwright/test": "^1.62.0",
     "@tailwindcss/vite": "^4.1.17",
     "@tanstack/react-query-devtools": "^5.91.1",
     "@tanstack/router-plugin": "^1.168.19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./tests/browser",
+  testMatch: "**/*.pw.ts",
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 45_000,
+  expect: {
+    timeout: 10_000,
+  },
+  reporter: [
+    ["line"],
+    ["html", { outputFolder: "smoke-artifacts/playwright-report", open: "never" }],
+  ],
+  outputDir: "smoke-artifacts/test-results",
+  use: {
+    baseURL: process.env.SMOKE_BASE_URL ?? "http://127.0.0.1:8000",
+    trace: "retain-on-failure",
+  },
+})

--- a/tests/browser/container-smoke.pw.ts
+++ b/tests/browser/container-smoke.pw.ts
@@ -3,6 +3,19 @@ import path from "node:path"
 
 import { expect, test } from "@playwright/test"
 
+// A cold unauthenticated load fires several API calls (auth/me, settings,
+// crowdsec/status, analytics/summary) that all 401 before the router
+// redirects to /login, and Chromium logs each as a "Failed to load resource"
+// console error. Those 401s are expected only while logged out; after login
+// any 401 is a real failure.
+function isApiCall(url: string): boolean {
+  try {
+    return new URL(url).pathname.startsWith("/api/v1/")
+  } catch {
+    return false
+  }
+}
+
 test("production image serves the authenticated dashboard without browser errors", async ({
   page,
 }) => {
@@ -16,6 +29,42 @@ test("production image serves the authenticated dashboard without browser errors
   const pageErrors: string[] = []
   const failedRequests: string[] = []
   const badResponses: string[] = []
+
+  let authenticated = false
+  const isExpectedUnauthenticated401 = (url: string) =>
+    !authenticated && isApiCall(url)
+
+  page.on("console", (message) => {
+    if (message.type() !== "error") {
+      return
+    }
+    if (
+      message.text().includes("status of 401") &&
+      isExpectedUnauthenticated401(message.location().url)
+    ) {
+      return
+    }
+    consoleErrors.push(message.text())
+  })
+  page.on("pageerror", (error) => pageErrors.push(error.message))
+  page.on("requestfailed", (request) => {
+    const errorText = request.failure()?.errorText
+    // Navigations (the post-login reload) abort whatever is still in flight;
+    // that is expected teardown, not a broken request.
+    if (errorText === "net::ERR_ABORTED") {
+      return
+    }
+    failedRequests.push(`${request.method()} ${request.url()}: ${errorText}`)
+  })
+  page.on("response", (response) => {
+    if (response.status() < 400) {
+      return
+    }
+    if (response.status() === 401 && isExpectedUnauthenticated401(response.url())) {
+      return
+    }
+    badResponses.push(`${response.status()} ${response.url()}`)
+  })
 
   await page.goto("/")
   await expect(page).toHaveURL(/\/login$/)
@@ -31,26 +80,19 @@ test("production image serves the authenticated dashboard without browser errors
   await page.getByLabel("Username").fill(adminUser)
   await page.getByLabel("Password").fill(adminPassword)
 
-  page.on("console", (message) => {
-    if (message.type() === "error") {
-      consoleErrors.push(message.text())
-    }
-  })
-  page.on("pageerror", (error) => pageErrors.push(error.message))
-  page.on("requestfailed", (request) => {
-    failedRequests.push(`${request.method()} ${request.url()}: ${request.failure()?.errorText}`)
-  })
-  page.on("response", (response) => {
-    if (response.status() >= 400) {
-      badResponses.push(`${response.status()} ${response.url()}`)
-    }
-  })
-
   await Promise.all([
     page.waitForURL((url) => !url.pathname.endsWith("/login")),
     page.getByRole("button", { name: "Sign in" }).click(),
   ])
-  await page.reload({ waitUntil: "networkidle" })
+  authenticated = true
+  // Wait for the dashboard to render before reloading: reloading straight
+  // after the URL change races the router's post-login navigation and the
+  // reload gets aborted (net::ERR_ABORTED).
+  await expect(page.getByText("Live ingestion", { exact: true })).toBeVisible()
+  // Reload to prove the session cookie survives a fresh page load. The
+  // element assertions below do the waiting; "networkidle" would race the
+  // dashboard's live polling.
+  await page.reload()
 
   await expect(page.getByText("Live ingestion", { exact: true })).toBeVisible()
   await expect(page.getByRole("heading", { name: "Summary" })).toBeVisible()

--- a/tests/browser/container-smoke.pw.ts
+++ b/tests/browser/container-smoke.pw.ts
@@ -1,0 +1,69 @@
+import { mkdir } from "node:fs/promises"
+import path from "node:path"
+
+import { expect, test } from "@playwright/test"
+
+test("production image serves the authenticated dashboard without browser errors", async ({
+  page,
+}) => {
+  const adminUser = process.env.SMOKE_ADMIN_USER ?? "admin"
+  const adminPassword = process.env.SMOKE_ADMIN_PASSWORD
+  if (!adminPassword) {
+    throw new Error("SMOKE_ADMIN_PASSWORD is required")
+  }
+
+  const consoleErrors: string[] = []
+  const pageErrors: string[] = []
+  const failedRequests: string[] = []
+  const badResponses: string[] = []
+
+  await page.goto("/")
+  await expect(page).toHaveURL(/\/login$/)
+  await expect(page.getByText("GeoMetrikks", { exact: true })).toBeVisible()
+
+  const screenshotDir = path.resolve("smoke-artifacts/screenshots")
+  await mkdir(screenshotDir, { recursive: true })
+  await page.screenshot({
+    path: path.join(screenshotDir, "login.png"),
+    fullPage: true,
+  })
+
+  await page.getByLabel("Username").fill(adminUser)
+  await page.getByLabel("Password").fill(adminPassword)
+
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      consoleErrors.push(message.text())
+    }
+  })
+  page.on("pageerror", (error) => pageErrors.push(error.message))
+  page.on("requestfailed", (request) => {
+    failedRequests.push(`${request.method()} ${request.url()}: ${request.failure()?.errorText}`)
+  })
+  page.on("response", (response) => {
+    if (response.status() >= 400) {
+      badResponses.push(`${response.status()} ${response.url()}`)
+    }
+  })
+
+  await Promise.all([
+    page.waitForURL((url) => !url.pathname.endsWith("/login")),
+    page.getByRole("button", { name: "Sign in" }).click(),
+  ])
+  await page.reload({ waitUntil: "networkidle" })
+
+  await expect(page.getByText("Live ingestion", { exact: true })).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Summary" })).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Traffic Overview" })).toBeVisible()
+  await expect(page.getByText("Access Log Records", { exact: true })).toBeVisible()
+  await expect(page.getByText(/Failed to load analytics data/)).toHaveCount(0)
+  await page.screenshot({
+    path: path.join(screenshotDir, "dashboard.png"),
+    fullPage: true,
+  })
+
+  expect(consoleErrors, "browser console errors").toEqual([])
+  expect(pageErrors, "uncaught page errors").toEqual([])
+  expect(failedRequests, "failed browser requests").toEqual([])
+  expect(badResponses, "unexpected HTTP error responses").toEqual([])
+})

--- a/tests/test_auth_endpoints.py
+++ b/tests/test_auth_endpoints.py
@@ -174,6 +174,32 @@ def test_session_cookie_secure_flag_follows_setting():
         assert "secure" not in res.headers["set-cookie"].lower()
 
 
+def test_non_api_responses_never_touch_the_session():
+    """The session middleware must not run outside /api and /ws.
+
+    When it runs on the SPA shell and static assets, every such response
+    writes the session it loaded at request start back to the store. A slow
+    asset response that started before login then overwrites the fresh
+    authenticated session with stale pre-login data, and the next API call
+    401s: login bounces straight back to the login page.
+    """
+    with TestClient(app=make_app()) as client:
+        res = client.get("/health")
+        assert res.status_code == 200
+        assert "set-cookie" not in res.headers
+
+
+def test_session_survives_non_api_requests_after_login():
+    with TestClient(app=make_app()) as client:
+        res = client.post(
+            "/api/v1/auth/login",
+            json={"username": "admin", "password": "bestpasswordintheworldnojoke"},
+        )
+        assert res.status_code == 200
+        client.get("/health")
+        assert client.get("/api/v1/auth/me").status_code == 200
+
+
 def test_login_attempts_are_logged_with_client_ip():
     import structlog
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,12 @@
       "@/*": ["./resources/*"]
     }
   },
-  "include": ["resources/**/*", "vite.config.ts", "vitest.config.ts"],
+  "include": [
+    "resources/**/*",
+    "vite.config.ts",
+    "vitest.config.ts",
+    "playwright.config.ts",
+    "tests/browser/**/*"
+  ],
   "exclude": ["resources/generated/**"]
 }


### PR DESCRIPTION
## Summary

- build and load the exact production Docker image in the existing frontend CI job
- start it against TimescaleDB and verify readiness, health, database, GeoIP, ingestion, the frontend shell, and unauthenticated API behavior
- use Playwright to sign in through the real UI, verify dashboard analytics, and capture screenshots, traces, and an HTML report
- upload browser output and container diagnostics for 14 days, including on failures
- post or update a sticky smoke-test summary on pull requests through a separate trusted `workflow_run`

## Why

The existing frontend checks proved that unit tests and the source build worked, but they did not prove that the final Docker image could start and serve a usable authenticated application. This adds lightweight end-to-end coverage without introducing Jenkins or another CI system.

The PR commenter runs separately because Dependabot-triggered workflows normally have restricted tokens. It checks out only the trusted default branch, does not execute PR code, uses narrowly scoped permissions, and refuses to let an older run overwrite results from a newer PR head.

## Validation

- production Docker image build: passed
- HTTP and Docker health checks against the running image: passed
- Playwright production-image smoke test: 1 passed
- frontend Vitest suite: 86 passed
- PR-summary helper tests: 5 passed
- frozen Bun dependency installation: passed
- `actionlint`: passed
- `git diff --check`: passed

## Rollout note

This PR targets `develop`, matching the repository's current feature-PR convention and the branch it was developed from. GitHub only activates a `workflow_run` workflow once that workflow exists on the repository's default branch, so the sticky PR commenter will become active when this change is promoted to `main`.
