### PR TITLE
feat(frontend): banned indicator in Debug Logs, Geo Logs and map popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Debug Logs and Geo Logs tables now show the Banned badge and ban/unban
+  controls next to IP addresses, matching Access Logs and Alert History.
+  The debug-line detail dialog shows them on its IP row as well.
+
 ### Changed
+
+- Map popup ban buttons (location top-IPs and live-request popups) now open
+  the same duration dropdown as the log tables instead of immediately banning
+  with the default duration; unbanning asks for confirmation via the menu.
 
 - Analytics top lists (URLs, user agents, IPs, countries, cities) are now
   served from continuous aggregates on ranges over 24 hours instead of

--- a/resources/components/debug-logs/debug-log-detail-dialog.tsx
+++ b/resources/components/debug-logs/debug-log-detail-dialog.tsx
@@ -14,6 +14,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { copyText } from "@/lib/clipboard"
+import { IpBanControls } from "@/components/crowdsec/ip-ban-controls"
 import type { AccessLogDebugEntry } from "@/lib/api"
 
 function DetailRow({ label, value }: { label: string; value: ReactNode }) {
@@ -125,7 +126,17 @@ export function DebugLogDetailDialog({
                     label="Time"
                     value={entry.timestamp ? new Date(entry.timestamp).toLocaleString() : null}
                   />
-                  <DetailRow label="IP" value={entry.ipAddress} />
+                  <DetailRow
+                    label="IP"
+                    value={
+                      entry.ipAddress && (
+                        <>
+                          {entry.ipAddress}
+                          <IpBanControls ip={entry.ipAddress} />
+                        </>
+                      )
+                    }
+                  />
                   <DetailRow label="Method" value={entry.method} />
                   <DetailRow label="URL" value={entry.url} />
                   <DetailRow label="Host" value={entry.host} />

--- a/resources/components/debug-logs/debug-logs-table.tsx
+++ b/resources/components/debug-logs/debug-logs-table.tsx
@@ -43,7 +43,8 @@ import { PaginationFooter } from "@/components/ui/pagination-footer"
 import { FilterCombobox } from "@/components/ui/filter-combobox"
 import { FiltersDrawer, FilterSection } from "@/components/ui/filters-drawer"
 import { DebugLogDetailDialog } from "@/components/debug-logs/debug-log-detail-dialog"
-import { useAccessLogDebug, useAccessLogFacets } from "@/lib/queries"
+import { IpBanControls } from "@/components/crowdsec/ip-ban-controls"
+import { useAccessLogDebug, useAccessLogFacets, useCrowdsecLiveUpdates } from "@/lib/queries"
 import { useDebouncedValue } from "@/hooks/use-debounced-value"
 import { isValidIp } from "@/lib/crowdsec"
 import { useIsMobile } from "@/hooks/use-mobile"
@@ -244,6 +245,9 @@ export function DebugLogsTable() {
 
   // Detail dialog.
   const [selected, setSelected] = useState<AccessLogDebugEntry | null>(null)
+
+  // Keep banned badges in sync with external cscli/console decisions.
+  useCrowdsecLiveUpdates()
 
   // Any filter/sort/page-size change returns to the first page.
   useEffect(() => {
@@ -475,7 +479,16 @@ export function DebugLogsTable() {
                     onClick={() => setSelected(row)}
                   >
                     {shownColumns.map((c) => (
-                      <TableCell key={c.key}>{c.render(row)}</TableCell>
+                      <TableCell key={c.key}>
+                        {c.render(row)}
+                        {c.key === "ipAddress" && row.ipAddress && (
+                          // Rows open the detail dialog on click; keep the
+                          // ban/unban dropdown from also triggering it.
+                          <span onClick={(e) => e.stopPropagation()}>
+                            <IpBanControls ip={row.ipAddress} />
+                          </span>
+                        )}
+                      </TableCell>
                     ))}
                   </TableRow>
                 ))}

--- a/resources/components/geo-logs/geo-logs-table.tsx
+++ b/resources/components/geo-logs/geo-logs-table.tsx
@@ -31,6 +31,7 @@ import {
 import { PaginationFooter } from "@/components/ui/pagination-footer"
 import type { GeoLogEntry } from "@/generated/api/types.gen"
 import { formatNumber, type GeoLogSortOrder } from "@/lib/api"
+import { IpBanControls } from "@/components/crowdsec/ip-ban-controls"
 import { useGeoLogs } from "@/lib/queries"
 import { cn, isMobileViewport } from "@/lib/utils"
 
@@ -248,6 +249,7 @@ export function GeoLogsTable({
                         className={cn(c.align === "right" && "text-right")}
                       >
                         {c.render(row)}
+                        {c.key === "ipAddress" && <IpBanControls ip={row.ipAddress} />}
                       </TableCell>
                     ))}
                   </TableRow>

--- a/resources/components/geo-logs/geo-top-ips-table.tsx
+++ b/resources/components/geo-logs/geo-top-ips-table.tsx
@@ -12,15 +12,13 @@ import {
 } from "@/components/ui/table"
 import { Skeleton } from "@/components/ui/skeleton"
 import { formatNumber } from "@/lib/api"
-import { useCrowdsecLiveUpdates, useGeoLogTopIps } from "@/lib/queries"
+import { useGeoLogTopIps } from "@/lib/queries"
 import { IpBanControls } from "@/components/crowdsec/ip-ban-controls"
 import { TablePaginationFooter, usePagedRows } from "@/components/analytics/table-pagination"
 
 export function GeoTopIpsTable() {
   const { data, isLoading } = useGeoLogTopIps({ limit: 10 })
   const { pageItems, ...pagination } = usePagedRows(data?.items)
-  // Keep banned badges in sync with external cscli/console decisions.
-  useCrowdsecLiveUpdates()
 
   return (
     <Card>

--- a/resources/components/map/IpBanControls.tsx
+++ b/resources/components/map/IpBanControls.tsx
@@ -1,5 +1,5 @@
 /**
- * Ban badge + ban/unban button for one IP. Renders nothing unless the IP is
+ * Ban badge + ban/unban dropdown for one IP. Renders nothing unless the IP is
  * already banned or CrowdSec write access is enabled. Shared by MapPopup's
  * top-IPs rows and LiveRequestPopup's request footer - the two call sites
  * differ only in layout (an inline icon-only button in a list row vs a
@@ -7,7 +7,15 @@
  * state is available before the banned-IP query resolves.
  */
 import { Loader2, ShieldBan, ShieldOff } from "lucide-react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { useBanIp, useBannedIps, useCrowdsecStatus, useUnbanIp } from "@/lib/queries"
+import { BAN_DURATIONS } from "@/lib/crowdsec"
 
 export function IpBanControls({
   ip,
@@ -65,46 +73,68 @@ export function IpBanControls({
         </span>
       )}
       {status?.write_enabled && (
-        <button
-          onClick={() => (banned ? unban.mutate(ip) : ban.mutate({ ip }))}
-          disabled={isPending}
-          title={isFooter ? undefined : banned ? `Unban ${ip}` : `Ban ${ip} (default duration)`}
-          aria-label={banned ? `Unban ${ip}` : `Ban ${ip}`}
-          style={
-            isFooter
-              ? {
-                  marginLeft: "auto",
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: "4px",
-                  background: "transparent",
-                  border: "1px solid var(--popup-border)",
-                  borderRadius: "4px",
-                  padding: "2px 8px",
-                  fontSize: "10px",
-                  cursor: isPending ? "wait" : "pointer",
-                  color: "var(--popup-muted)",
-                }
-              : {
-                  display: "inline-flex",
-                  alignItems: "center",
-                  background: "transparent",
-                  border: "none",
-                  padding: "2px",
-                  cursor: isPending ? "wait" : "pointer",
-                  color: isPending ? "#22d3ee" : "var(--popup-muted)",
-                }
-          }
-        >
-          {isPending ? (
-            <Loader2 style={{ width: 12, height: 12, animation: "spin 1s linear infinite" }} />
-          ) : banned ? (
-            <ShieldOff style={{ width: 12, height: 12 }} />
-          ) : (
-            <ShieldBan style={{ width: 12, height: 12 }} />
-          )}
-          {isFooter && (banned ? "Unban" : "Ban")}
-        </button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              disabled={isPending}
+              title={isFooter ? undefined : banned ? `Unban ${ip}` : `Ban ${ip}`}
+              aria-label={banned ? `Unban ${ip}` : `Ban ${ip}`}
+              style={
+                isFooter
+                  ? {
+                      marginLeft: "auto",
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: "4px",
+                      background: "transparent",
+                      border: "1px solid var(--popup-border)",
+                      borderRadius: "4px",
+                      padding: "2px 8px",
+                      fontSize: "10px",
+                      cursor: isPending ? "wait" : "pointer",
+                      color: "var(--popup-muted)",
+                    }
+                  : {
+                      display: "inline-flex",
+                      alignItems: "center",
+                      background: "transparent",
+                      border: "none",
+                      padding: "2px",
+                      cursor: isPending ? "wait" : "pointer",
+                      color: isPending ? "#22d3ee" : "var(--popup-muted)",
+                    }
+              }
+            >
+              {isPending ? (
+                <Loader2 style={{ width: 12, height: 12, animation: "spin 1s linear infinite" }} />
+              ) : banned ? (
+                <ShieldOff style={{ width: 12, height: 12 }} />
+              ) : (
+                <ShieldBan style={{ width: 12, height: 12 }} />
+              )}
+              {isFooter && (banned ? "Unban" : "Ban")}
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            {banned ? (
+              <DropdownMenuItem onClick={() => unban.mutate(ip)}>
+                Unban {ip}
+              </DropdownMenuItem>
+            ) : (
+              <>
+                <DropdownMenuLabel>Ban {ip}</DropdownMenuLabel>
+                {BAN_DURATIONS.map((d) => (
+                  <DropdownMenuItem
+                    key={d.value}
+                    onClick={() => ban.mutate({ ip, duration: d.value })}
+                  >
+                    {d.label}
+                  </DropdownMenuItem>
+                ))}
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
       )}
     </Wrapper>
   )

--- a/resources/routes/geo-logs.tsx
+++ b/resources/routes/geo-logs.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/lib/geo-log-filters-context"
 import { useUrlFilters } from "@/hooks/use-url-filters"
 import { arrayParam, dropDefault } from "@/lib/url-filters"
+import { useCrowdsecLiveUpdates } from "@/lib/queries"
 import type { GeoLogSortOrder } from "@/lib/api"
 
 const GeoLogsMap = lazy(() => import("@/components/geo-logs/geo-logs-map"))
@@ -82,6 +83,9 @@ const RESET_ON_CHANGE: Partial<GeoLogsSearch> = { page: undefined }
 function GeoLogsPage() {
   const search = Route.useSearch()
   const navigate = Route.useNavigate()
+  // Keep banned badges (Top IPs card + geo-logs table) in sync with external
+  // cscli/console decisions; one subscription for the whole page.
+  useCrowdsecLiveUpdates()
 
   const { filters, setFilters, patchSearch } = useUrlFilters({
     search,


### PR DESCRIPTION
## Summary

Closes #83.

- Debug Logs table: shows the CrowdSec Banned badge and ban/unban dropdown next to the IP, reusing the shared `IpBanControls` component from Access Logs / Alert History. Rows without an IP (unparsed/malformed lines) render unchanged, and the dropdown click is isolated from the row's detail-dialog click handler.
- Debug-line detail dialog: the IP row shows the badge and controls as well.
- Geo Logs grouped table: same badge and controls in the IP column.
- The `useCrowdsecLiveUpdates()` WebSocket subscription moved from the Geo Logs Top IPs card up to the route (same pattern as the Security route), so the page keeps a single `/ws/crowdsec` connection now that two components on it show badges. Debug Logs subscribes in its table like Access Logs does.
- While at it: the map popup ban buttons (location top-IPs rows and the live-request footer) now open the same Radix duration dropdown as the log tables instead of immediately banning with the default duration; unbanning is confirmed via the menu. Trigger styling inside the popups is unchanged.

No backend changes: ban state comes from the existing shared banned-IP set (`GET /crowdsec/banned-ips` + live WS deltas).

## Testing

- `bun run typecheck` passes
- `bun run test` passes (93 tests)
- Manual click-through: badges on both views, dropdown does not open the debug row dialog, single WS connection on the Geo Logs page, map popup dropdowns work in both popups