### PR TITLE
feat(crowdsec): graceful degradation when the LAPI is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Geo Events by Location and IP table gained a Last seen column showing
   each (location, IP) pair's most recent event (day-granular on ranges over
   24 hours).
+- The Security page now shows a warning banner while the CrowdSec LAPI is
+  unreachable and keeps the last known decisions and alerts visible instead
+  of hanging on loading skeletons. Reachability changes are pushed live over
+  the CrowdSec WebSocket feed, reported in /health, and flagged with a
+  warning dot on the Security sidebar item.
+- Ban and unban actions now show an error toast when they fail (for example
+  while the LAPI is down) instead of failing silently.
 
 ### Changed
 
@@ -71,6 +78,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   asset request still in flight during login (the PWA precaches many at once)
   could overwrite the fresh session with stale logged-out data and the next
   API call would 401.
+- A failing CrowdSec stats request no longer hides the entire Security stat
+  card row behind permanent loading skeletons, and the decisions table no
+  longer claims "No active decisions" when the decision list could not be
+  fetched.
+- /api/v1/crowdsec/status no longer performs a live LAPI probe on every
+  request (which could block for the full request timeout); it reads the
+  stream poller's cached reachability instead.
 
 ## [0.5.0] - 2026-07-25
 

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "react-map-gl": "^8.1.2",
         "recharts": "^2.15.4",
         "shadcn": "^3.8.5",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
         "vaul": "^1.1.2",
         "zod": "^4.4.3",
@@ -1676,6 +1677,8 @@
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "smob": ["smob@1.6.2", "", {}, "sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw=="],
+
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "sort-asc": ["sort-asc@0.2.0", "", {}, "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA=="],
 

--- a/geometrikks/api/health.py
+++ b/geometrikks/api/health.py
@@ -48,6 +48,8 @@ async def health(
     is_running = ingestion_service.is_running if ingestion_service else False
     db_reachable = await _database_reachable()
 
+    poller = getattr(request.app.state, "crowdsec_stream_poller", None)
+
     return {
         # geoip does not flip status on its own: without a GeoLite2 database
         # file, ingestion refuses to start and ingestion.running reflects that.
@@ -59,6 +61,13 @@ async def health(
         },
         "database": {"reachable": db_reachable},
         "geoip": {"available": getattr(request.app.state, "geoip_available", True)},
+        # CrowdSec is an optional integration: a down LAPI never flips
+        # `status`. lapi_reachable is the stream poller's cached verdict;
+        # null when disabled, DB-degraded, or before the first poll.
+        "crowdsec": {
+            "enabled": getattr(request.app.state, "crowdsec_service", None) is not None,
+            "lapi_reachable": poller.lapi_reachable if poller is not None else None,
+        },
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 

--- a/geometrikks/api/v1/crowdsec_controller.py
+++ b/geometrikks/api/v1/crowdsec_controller.py
@@ -191,17 +191,24 @@ class CrowdSecController(Controller):
 
     @get("/status")
     async def get_status(
-        self, crowdsec: NamedDependency[CrowdSecService | None]
+        self, crowdsec: NamedDependency[CrowdSecService | None], request: Request
     ) -> CrowdSecStatusResponse:
         """Integration state; the frontend gates the security page on this."""
         if crowdsec is None:
             return CrowdSecStatusResponse(
                 enabled=False, write_enabled=False, lapi_reachable=False
             )
+        # The stream poller probes the LAPI every poll interval; its cached
+        # verdict avoids a live ping per status request (which can block for
+        # the full request timeout against a black-holed host). Live ping
+        # remains the fallback when the poller is absent (DB-degraded mode)
+        # or has not completed a poll yet.
+        poller = getattr(request.app.state, "crowdsec_stream_poller", None)
+        cached: bool | None = poller.lapi_reachable if poller is not None else None
         return CrowdSecStatusResponse(
             enabled=True,
             write_enabled=get_settings().crowdsec.write_enabled,
-            lapi_reachable=await crowdsec.ping(),
+            lapi_reachable=cached if cached is not None else await crowdsec.ping(),
         )
 
     @get("/decisions")

--- a/geometrikks/api/v1/live_controller.py
+++ b/geometrikks/api/v1/live_controller.py
@@ -96,6 +96,8 @@ async def crowdsec_feed(socket: WebSocket) -> None:
 
     One JSON frame per delta:
       {"type": "crowdsec_decisions", "added": [...], "deleted": [...]}
+    LAPI reachability transitions (and one snapshot on connect):
+      {"type": "crowdsec_status", "lapi_reachable": bool}
     Auth: same session-authenticated handshake as /ws/live.
     """
     poller = getattr(socket.app.state, "crowdsec_stream_poller", None)
@@ -107,6 +109,14 @@ async def crowdsec_feed(socket: WebSocket) -> None:
 
     queue = poller.subscribe()
     logger.info("ws_client_connected", endpoint="/ws/crowdsec")
+
+    # A freshly loaded page must not wait for the next reachability
+    # transition to learn the current state.
+    if poller.lapi_reachable is not None:
+        await socket.send_json(
+            {"type": "crowdsec_status", "lapi_reachable": poller.lapi_reachable}
+        )
+
     watcher = asyncio.create_task(_watch_disconnect(socket))
     try:
         loop = asyncio.get_running_loop()

--- a/geometrikks/api/v1/live_controller.py
+++ b/geometrikks/api/v1/live_controller.py
@@ -110,15 +110,15 @@ async def crowdsec_feed(socket: WebSocket) -> None:
     queue = poller.subscribe()
     logger.info("ws_client_connected", endpoint="/ws/crowdsec")
 
-    # A freshly loaded page must not wait for the next reachability
-    # transition to learn the current state.
-    if poller.lapi_reachable is not None:
-        await socket.send_json(
-            {"type": "crowdsec_status", "lapi_reachable": poller.lapi_reachable}
-        )
-
     watcher = asyncio.create_task(_watch_disconnect(socket))
     try:
+        # A freshly loaded page must not wait for the next reachability
+        # transition to learn the current state.
+        if poller.lapi_reachable is not None:
+            await socket.send_json(
+                {"type": "crowdsec_status", "lapi_reachable": poller.lapi_reachable}
+            )
+
         loop = asyncio.get_running_loop()
         last_send = loop.time()
         while not watcher.done():

--- a/geometrikks/services/crowdsec/stream.py
+++ b/geometrikks/services/crowdsec/stream.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from geometrikks.services.crowdsec.schemas import DecisionStreamDelta
 
 import asyncio
+from datetime import datetime, timezone
 from typing import Any
 
 from geometrikks.server.logging import get_logger
@@ -26,7 +27,8 @@ class CrowdSecStreamPoller:
     def __init__(self, service: CrowdSecService) -> None:
         self._service = service
         self._started = False
-        self._had_failure = False
+        self._lapi_reachable: bool | None = None
+        self._last_success: datetime | None = None
         self._subscribers: set[asyncio.Queue[DecisionFrame]] = set()
 
     def subscribe(self, maxsize: int = 100) -> asyncio.Queue[DecisionFrame]:
@@ -38,6 +40,41 @@ class CrowdSecStreamPoller:
     def unsubscribe(self, queue: asyncio.Queue[DecisionFrame]) -> None:
         self._subscribers.discard(queue)
 
+    @property
+    def lapi_reachable(self) -> bool | None:
+        """Cached LAPI verdict from the last poll; None until the first poll.
+
+        The single source of truth for reachability: /crowdsec/status and
+        /health read this instead of probing the LAPI themselves.
+        """
+        return self._lapi_reachable
+
+    @property
+    def last_success(self) -> datetime | None:
+        return self._last_success
+
+    def _broadcast(self, frame: DecisionFrame) -> None:
+        for queue in self._subscribers:
+            try:
+                queue.put_nowait(frame)
+            except asyncio.QueueFull:
+                # A stalled browser must not backpressure the poller; it will
+                # resync from /banned-ips on its next refetch.
+                logger.debug("Dropping frame for slow subscriber")
+
+    def _set_reachable(self, reachable: bool) -> None:
+        """Record a poll outcome; broadcast a status frame on any transition.
+
+        None -> X counts: a page that connected before the first poll must
+        still learn the state.
+        """
+        changed = self._lapi_reachable != reachable
+        self._lapi_reachable = reachable
+        if reachable:
+            self._last_success = datetime.now(timezone.utc)
+        if changed:
+            self._broadcast({"type": "crowdsec_status", "lapi_reachable": reachable})
+
     async def poll(self) -> None:
         """One stream poll; scheduler-driven. Never raises: the LAPI being
 
@@ -47,11 +84,11 @@ class CrowdSecStreamPoller:
             delta: DecisionStreamDelta = await self._service.get_decisions_stream(startup=not self._started)
         except CrowdSecError as exc:
             logger.warning("CrowdSec stream poll failed: %s", exc)
-            self._had_failure = True
+            self._set_reachable(False)
             return
-        if self._had_failure:
+        if self._lapi_reachable is False:
             logger.success("crowdsec_stream_connected")  # ty: ignore[unresolved-attribute]
-            self._had_failure = False
+        self._set_reachable(True)
         first_poll = not self._started
         self._started = True
         if first_poll:
@@ -71,11 +108,4 @@ class CrowdSecStreamPoller:
         logger.info(
             "CrowdSec decision stream: %d added, %d expired/removed", len(added), len(deleted)
         )
-        frame: DecisionFrame = {"type": "crowdsec_decisions", "added": added, "deleted": deleted}
-        for queue in self._subscribers:
-            try:
-                queue.put_nowait(frame)
-            except asyncio.QueueFull:
-                # A stalled browser must not backpressure the poller; it will
-                # resync from /banned-ips on its next refetch.
-                logger.debug("Dropping decision frame for slow subscriber")
+        self._broadcast({"type": "crowdsec_decisions", "added": added, "deleted": deleted})

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-map-gl": "^8.1.2",
     "recharts": "^2.15.4",
     "shadcn": "^3.8.5",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "vaul": "^1.1.2",
     "zod": "^4.4.3"

--- a/resources/components/app-sidebar.tsx
+++ b/resources/components/app-sidebar.tsx
@@ -507,6 +507,7 @@ export function AppSidebar() {
     queryKey: ["health"],
     queryFn: fetchHealth,
     refetchInterval: 30000,
+    retry: 1,
   })
   const crowdsecDown =
     health?.crowdsec?.enabled === true && health.crowdsec.lapi_reachable === false

--- a/resources/components/app-sidebar.tsx
+++ b/resources/components/app-sidebar.tsx
@@ -152,9 +152,11 @@ function GeoLogo({ collapsed }: { collapsed: boolean }) {
 function NavItem({
   item,
   isActive,
+  warning,
 }: {
   item: (typeof navigationItems)[0]
   isActive: boolean
+  warning?: string
 }) {
   const Icon = item.icon
 
@@ -165,9 +167,12 @@ function NavItem({
         isActive={isActive}
         tooltip={{
           children: (
-            <span className="flex items-center gap-2">
-              <span>{item.title}</span>
-              <span className="text-muted-foreground text-xs">{item.description}</span>
+            <span className="flex flex-col gap-0.5">
+              <span className="flex items-center gap-2">
+                <span>{item.title}</span>
+                <span className="text-muted-foreground text-xs">{item.description}</span>
+              </span>
+              {warning && <span className="text-amber-500 text-xs">{warning}</span>}
             </span>
           ),
         }}
@@ -193,6 +198,12 @@ function NavItem({
             />
             {isActive && (
               <div className="absolute inset-0 blur-sm bg-geo-cyan/30 rounded-full" />
+            )}
+            {warning && (
+              <span
+                className="absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-amber-400"
+                aria-hidden="true"
+              />
             )}
           </div>
           <span
@@ -491,6 +502,15 @@ export function AppSidebar() {
     (item) => !("requiresCrowdsec" in item) || crowdsecStatus?.enabled === true,
   )
 
+  // Shares the ["health"] cache with LiveIndicator's 10s poll.
+  const { data: health } = useQuery({
+    queryKey: ["health"],
+    queryFn: fetchHealth,
+    refetchInterval: 30000,
+  })
+  const crowdsecDown =
+    health?.crowdsec?.enabled === true && health.crowdsec.lapi_reachable === false
+
   // The mobile sidebar is a full-height sheet; leaving it open after a nav
   // tap would cover the page the user just navigated to.
   useEffect(() => {
@@ -530,6 +550,11 @@ export function AppSidebar() {
                     item.url === "/"
                       ? currentPath === "/"
                       : currentPath.startsWith(item.url)
+                  }
+                  warning={
+                    item.url === "/security" && crowdsecDown
+                      ? "CrowdSec LAPI unreachable"
+                      : undefined
                   }
                 />
               ))}

--- a/resources/components/crowdsec/ip-ban-controls.tsx
+++ b/resources/components/crowdsec/ip-ban-controls.tsx
@@ -15,13 +15,14 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { toast } from "sonner"
 import {
   useBanIp,
   useBannedIps,
   useCrowdsecStatus,
   useUnbanIp,
 } from "@/lib/queries"
-import { BAN_DURATIONS } from "@/lib/crowdsec"
+import { BAN_DURATIONS, crowdsecErrorMessage } from "@/lib/crowdsec"
 
 /** Ban/unban dropdown on the IP cell; hidden unless machine credentials
  *  enable write access on the CrowdSec integration. */
@@ -46,7 +47,16 @@ export function IpBanAction({ ip, banned }: { ip: string; banned: boolean }) {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
         {banned ? (
-          <DropdownMenuItem onClick={() => unban.mutate(ip)}>
+          <DropdownMenuItem
+            onClick={() =>
+              unban.mutate(ip, {
+                onError: (err) =>
+                  toast.error(
+                    crowdsecErrorMessage(err, `Unban failed for ${ip}; the LAPI may be unreachable.`),
+                  ),
+              })
+            }
+          >
             Unban {ip}
           </DropdownMenuItem>
         ) : (
@@ -55,7 +65,17 @@ export function IpBanAction({ ip, banned }: { ip: string; banned: boolean }) {
             {BAN_DURATIONS.map((d) => (
               <DropdownMenuItem
                 key={d.value}
-                onClick={() => ban.mutate({ ip, duration: d.value })}
+                onClick={() =>
+                  ban.mutate(
+                    { ip, duration: d.value },
+                    {
+                      onError: (err) =>
+                        toast.error(
+                          crowdsecErrorMessage(err, `Ban failed for ${ip}; the LAPI may be unreachable.`),
+                        ),
+                    },
+                  )
+                }
               >
                 {d.label}
               </DropdownMenuItem>

--- a/resources/components/map/IpBanControls.tsx
+++ b/resources/components/map/IpBanControls.tsx
@@ -7,6 +7,7 @@
  * state is available before the banned-IP query resolves.
  */
 import { Loader2, ShieldBan, ShieldOff } from "lucide-react"
+import { toast } from "sonner"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -15,7 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { useBanIp, useBannedIps, useCrowdsecStatus, useUnbanIp } from "@/lib/queries"
-import { BAN_DURATIONS } from "@/lib/crowdsec"
+import { BAN_DURATIONS, crowdsecErrorMessage } from "@/lib/crowdsec"
 
 export function IpBanControls({
   ip,
@@ -117,7 +118,16 @@ export function IpBanControls({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start">
             {banned ? (
-              <DropdownMenuItem onClick={() => unban.mutate(ip)}>
+              <DropdownMenuItem
+                onClick={() =>
+                  unban.mutate(ip, {
+                    onError: (err) =>
+                      toast.error(
+                        crowdsecErrorMessage(err, `Unban failed for ${ip}; the LAPI may be unreachable.`),
+                      ),
+                  })
+                }
+              >
                 Unban {ip}
               </DropdownMenuItem>
             ) : (
@@ -126,7 +136,17 @@ export function IpBanControls({
                 {BAN_DURATIONS.map((d) => (
                   <DropdownMenuItem
                     key={d.value}
-                    onClick={() => ban.mutate({ ip, duration: d.value })}
+                    onClick={() =>
+                      ban.mutate(
+                        { ip, duration: d.value },
+                        {
+                          onError: (err) =>
+                            toast.error(
+                              crowdsecErrorMessage(err, `Ban failed for ${ip}; the LAPI may be unreachable.`),
+                            ),
+                        },
+                      )
+                    }
                   >
                     {d.label}
                   </DropdownMenuItem>

--- a/resources/components/security/alerts-table.tsx
+++ b/resources/components/security/alerts-table.tsx
@@ -27,7 +27,7 @@ type SinceKey = (typeof SINCE_OPTIONS)[number]["key"]
 
 export function AlertsTable() {
   const [since, setSince] = useState<SinceKey>("24h")
-  const { data: alerts, isLoading } = useCrowdsecAlerts({ since, limit: 50 })
+  const { data: alerts, isLoading, isError } = useCrowdsecAlerts({ since, limit: 50 })
 
   return (
     <Card className="py-4">
@@ -99,7 +99,14 @@ export function AlertsTable() {
                       </TableCell>
                     </TableRow>
                   ))}
-              {!isLoading && alerts?.length === 0 && (
+              {!isLoading && isError && !alerts && (
+                <TableRow>
+                  <TableCell colSpan={8} className="h-24 text-center text-destructive">
+                    Failed to load alerts; the CrowdSec LAPI may be unreachable.
+                  </TableCell>
+                </TableRow>
+              )}
+              {!isLoading && !isError && alerts?.length === 0 && (
                 <TableRow>
                   <TableCell colSpan={8} className="h-24 text-center text-muted-foreground">
                     No alerts in this window.

--- a/resources/components/security/ban-ip-dialog.tsx
+++ b/resources/components/security/ban-ip-dialog.tsx
@@ -3,7 +3,6 @@
  * client-side before the request; the server re-validates against INET.
  */
 import { useState } from "react"
-import { isAxiosError } from "axios"
 import { Loader2, ShieldBan } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
@@ -25,7 +24,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { useBanIp } from "@/lib/queries"
-import { BAN_DURATIONS, isValidIp } from "@/lib/crowdsec"
+import { BAN_DURATIONS, crowdsecErrorMessage, isValidIp } from "@/lib/crowdsec"
 
 export function BanIpDialog() {
   const [open, setOpen] = useState(false)
@@ -58,10 +57,7 @@ export function BanIpDialog() {
           reset()
         },
         onError: (err) => {
-          const detail = isAxiosError(err)
-            ? (err.response?.data as { detail?: string } | undefined)?.detail
-            : null
-          setError(detail ?? "Ban failed; the LAPI may be unreachable.")
+          setError(crowdsecErrorMessage(err, "Ban failed; the LAPI may be unreachable."))
         },
       },
     )

--- a/resources/components/security/crowdsec-unreachable-banner.tsx
+++ b/resources/components/security/crowdsec-unreachable-banner.tsx
@@ -1,0 +1,21 @@
+/**
+ * Destructive strip shown while the CrowdSec LAPI is unreachable. The
+ * tables below keep rendering their last-known data; this strip is the
+ * page's single "why is everything stale" explanation.
+ */
+import { AlertTriangle } from "lucide-react"
+import { useCrowdsecStatus } from "@/lib/queries"
+
+export function CrowdsecUnreachableBanner() {
+  const { data: status } = useCrowdsecStatus()
+  if (!status?.enabled || status.lapi_reachable) return null
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+      <AlertTriangle className="h-4 w-4 shrink-0" />
+      <span>
+        CrowdSec LAPI is unreachable. Showing last known data; bans and
+        unbans will fail until the connection recovers.
+      </span>
+    </div>
+  )
+}

--- a/resources/components/security/crowdsec-unreachable-banner.tsx
+++ b/resources/components/security/crowdsec-unreachable-banner.tsx
@@ -10,7 +10,7 @@ export function CrowdsecUnreachableBanner() {
   const { data: status } = useCrowdsecStatus()
   if (!status?.enabled || status.lapi_reachable) return null
   return (
-    <div className="flex items-center gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+    <div role="alert" className="flex items-center gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
       <AlertTriangle className="h-4 w-4 shrink-0" />
       <span>
         CrowdSec LAPI is unreachable. Showing last known data; bans and

--- a/resources/components/security/decisions-table.tsx
+++ b/resources/components/security/decisions-table.tsx
@@ -5,6 +5,7 @@
  * /crowdsec/decisions; origin scope toggles between local and crowd bans.
  */
 import { useState } from "react"
+import { toast } from "sonner"
 import { Loader2, ShieldOff } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -21,6 +22,7 @@ import {
 } from "@/components/ui/table"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useCrowdsecDecisions, useCrowdsecStatus, useUnbanIp } from "@/lib/queries"
+import { crowdsecErrorMessage } from "@/lib/crowdsec"
 import { cn } from "@/lib/utils"
 import { BanIpDialog } from "./ban-ip-dialog"
 
@@ -146,7 +148,14 @@ export function DecisionsTable() {
                               className="text-muted-foreground"
                               title={`Unban ${d.ip}`}
                               disabled={unban.isPending}
-                              onClick={() => unban.mutate(d.ip)}
+                              onClick={() =>
+                                unban.mutate(d.ip, {
+                                  onError: (err) =>
+                                    toast.error(
+                                      crowdsecErrorMessage(err, `Unban failed for ${d.ip}; the LAPI may be unreachable.`),
+                                    ),
+                                })
+                              }
                             >
                               {unban.isPending && unban.variables === d.ip ? (
                                 <Loader2 className="animate-spin" />

--- a/resources/components/security/decisions-table.tsx
+++ b/resources/components/security/decisions-table.tsx
@@ -44,7 +44,7 @@ export function DecisionsTable() {
   const [pageSize, setPageSize] = useState<number>(10)
   const origins = ORIGIN_SCOPES.find((s) => s.key === scope)?.origins
 
-  const { data, isLoading, isPlaceholderData } = useCrowdsecDecisions({
+  const { data, isLoading, isError, isPlaceholderData } = useCrowdsecDecisions({
     origins,
     currentPage: page,
     pageSize,
@@ -168,7 +168,17 @@ export function DecisionsTable() {
                       )}
                     </TableRow>
                   ))}
-              {!isLoading && total === 0 && (
+              {!isLoading && isError && !data && (
+                <TableRow>
+                  <TableCell
+                    colSpan={colCount}
+                    className="h-24 text-center text-destructive"
+                  >
+                    Failed to load decisions; the CrowdSec LAPI may be unreachable.
+                  </TableCell>
+                </TableRow>
+              )}
+              {!isLoading && !isError && total === 0 && (
                 <TableRow>
                   <TableCell
                     colSpan={colCount}

--- a/resources/components/security/security-stat-cards.tsx
+++ b/resources/components/security/security-stat-cards.tsx
@@ -11,9 +11,12 @@ const LOCAL_ORIGINS = new Set(["crowdsec", "cscli", "geometrikks"])
 
 export function SecurityStatCards() {
   const { data: status } = useCrowdsecStatus()
-  const { data: stats, isLoading } = useCrowdsecStats()
+  const { data: stats, isPending } = useCrowdsecStats()
 
-  if (isLoading || !stats || !status) {
+  // Skeletons only while genuinely loading. On a stats error the row must
+  // still render: the LAPI card below is exactly the widget that has to
+  // stay visible while the LAPI is down.
+  if (!status || (isPending && !stats)) {
     return (
       <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
         {Array.from({ length: 4 }).map((_, i) => (
@@ -23,25 +26,29 @@ export function SecurityStatCards() {
     )
   }
 
-  const localCount = stats.by_origin
-    .filter((o) => LOCAL_ORIGINS.has(o.origin))
-    .reduce((sum, o) => sum + o.count, 0)
-  const crowdCount = stats.total - localCount
-  const topScenario = stats.top_scenarios[0]
+  const localCount = stats
+    ? stats.by_origin
+        .filter((o) => LOCAL_ORIGINS.has(o.origin))
+        .reduce((sum, o) => sum + o.count, 0)
+    : null
+  const crowdCount = stats && localCount !== null ? stats.total - localCount : null
+  const topScenario = stats?.top_scenarios[0]
 
   return (
     <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
       <StatCard
         title="Active decisions"
-        value={stats.total.toLocaleString()}
-        subtitle={`${crowdCount.toLocaleString()} from the crowd`}
+        value={stats ? stats.total.toLocaleString() : "-"}
+        subtitle={
+          crowdCount !== null ? `${crowdCount.toLocaleString()} from the crowd` : "unavailable"
+        }
         icon={ShieldBan}
         iconClassName="text-red-400"
       />
       <StatCard
         title="Local bans"
-        value={localCount.toLocaleString()}
-        subtitle="decided on this box"
+        value={localCount !== null ? localCount.toLocaleString() : "-"}
+        subtitle={localCount !== null ? "decided on this box" : "unavailable"}
         icon={UserRound}
       />
       <StatCard
@@ -49,7 +56,11 @@ export function SecurityStatCards() {
         value={topScenario ? shortScenario(topScenario.scenario) : "-"}
         valueClassName="text-lg truncate"
         subtitle={
-          topScenario ? `${topScenario.count.toLocaleString()} decisions` : "no decisions"
+          topScenario
+            ? `${topScenario.count.toLocaleString()} decisions`
+            : stats
+              ? "no decisions"
+              : "unavailable"
         }
         icon={Radio}
       />

--- a/resources/components/ui/sonner.tsx
+++ b/resources/components/ui/sonner.tsx
@@ -1,0 +1,9 @@
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { useTheme } from "@/components/theme-provider"
+
+/** App-wide toast outlet, following the shadcn sonner wrapper: sonner's
+ * theme prop takes the same "light" | "dark" | "system" values as ours. */
+export function Toaster(props: ToasterProps) {
+  const { theme } = useTheme()
+  return <Sonner theme={theme} richColors closeButton {...props} />
+}

--- a/resources/lib/api.ts
+++ b/resources/lib/api.ts
@@ -102,6 +102,7 @@ export interface HealthResponse {
   ingestion: HealthIngestionStatus
   database: { reachable: boolean }
   geoip: { available: boolean }
+  crowdsec: { enabled: boolean; lapi_reachable: boolean | null }
   timestamp: string
 }
 

--- a/resources/lib/crowdsec-live.test.ts
+++ b/resources/lib/crowdsec-live.test.ts
@@ -25,6 +25,8 @@ describe("parseCrowdsecFrame", () => {
     expect(parseCrowdsecFrame(new ArrayBuffer(4))).toBeNull()
     expect(parseCrowdsecFrame("not json")).toBeNull()
     expect(parseCrowdsecFrame(JSON.stringify({ type: "batch", events: [] }))).toBeNull()
+    expect(parseCrowdsecFrame("null")).toBeNull()
+    expect(parseCrowdsecFrame("42")).toBeNull()
   })
 })
 

--- a/resources/lib/crowdsec-live.test.ts
+++ b/resources/lib/crowdsec-live.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import {
+  applyBannedIpsDelta,
+  applyStatusFrame,
+  parseCrowdsecFrame,
+  type CrowdsecDecisionsFrame,
+  type CrowdsecStatusFrame,
+} from "./crowdsec-live"
+
+const decisionsFrame: CrowdsecDecisionsFrame = {
+  type: "crowdsec_decisions",
+  added: [{ ip: "1.2.3.4", origin: "cscli", scenario: "manual ban", duration: "4h" }],
+  deleted: [{ ip: "5.6.7.8", origin: "cscli" }],
+}
+
+const statusFrame: CrowdsecStatusFrame = { type: "crowdsec_status", lapi_reachable: false }
+
+describe("parseCrowdsecFrame", () => {
+  it("parses decisions and status frames", () => {
+    expect(parseCrowdsecFrame(JSON.stringify(decisionsFrame))).toEqual(decisionsFrame)
+    expect(parseCrowdsecFrame(JSON.stringify(statusFrame))).toEqual(statusFrame)
+  })
+
+  it("rejects non-strings, malformed JSON, and unknown types", () => {
+    expect(parseCrowdsecFrame(new ArrayBuffer(4))).toBeNull()
+    expect(parseCrowdsecFrame("not json")).toBeNull()
+    expect(parseCrowdsecFrame(JSON.stringify({ type: "batch", events: [] }))).toBeNull()
+  })
+})
+
+describe("applyBannedIpsDelta", () => {
+  it("adds and removes IPs without duplicating", () => {
+    expect(applyBannedIpsDelta(["5.6.7.8", "1.2.3.4"], decisionsFrame)).toEqual(["1.2.3.4"])
+  })
+
+  it("passes undefined through (cache not populated yet)", () => {
+    expect(applyBannedIpsDelta(undefined, decisionsFrame)).toBeUndefined()
+  })
+})
+
+describe("applyStatusFrame", () => {
+  it("patches lapi_reachable and preserves the other fields", () => {
+    const status = { enabled: true, write_enabled: true, lapi_reachable: true }
+    expect(applyStatusFrame(status, statusFrame)).toEqual({
+      enabled: true,
+      write_enabled: true,
+      lapi_reachable: false,
+    })
+  })
+
+  it("passes undefined through (status not fetched yet)", () => {
+    expect(applyStatusFrame(undefined, statusFrame)).toBeUndefined()
+  })
+})

--- a/resources/lib/crowdsec-live.ts
+++ b/resources/lib/crowdsec-live.ts
@@ -1,0 +1,57 @@
+/**
+ * Wire contract and pure cache-patch helpers for the /ws/crowdsec feed.
+ * Kept free of React/query imports so vitest can cover the frame handling
+ * that useCrowdsecLiveUpdates wires into the query cache.
+ */
+import type { CrowdSecStatusResponse } from "@/generated/api/types.gen"
+
+/** Ban/unban delta pushed by the decision-stream poller. */
+export interface CrowdsecDecisionsFrame {
+  type: "crowdsec_decisions"
+  added: { ip: string; origin: string; scenario: string; duration: string }[]
+  deleted: { ip: string; origin: string }[]
+}
+
+/** LAPI reachability transition; also sent once as a snapshot on connect. */
+export interface CrowdsecStatusFrame {
+  type: "crowdsec_status"
+  lapi_reachable: boolean
+}
+
+export type CrowdsecFrame = CrowdsecDecisionsFrame | CrowdsecStatusFrame
+
+/** Parse one raw WS message; null for non-JSON payloads or unknown types. */
+export function parseCrowdsecFrame(data: unknown): CrowdsecFrame | null {
+  if (typeof data !== "string") return null
+  let frame: { type?: string }
+  try {
+    frame = JSON.parse(data) as { type?: string }
+  } catch {
+    return null
+  }
+  if (frame.type === "crowdsec_decisions" || frame.type === "crowdsec_status") {
+    return frame as CrowdsecFrame
+  }
+  return null
+}
+
+/** Apply a decisions delta to the cached banned-IP list. */
+export function applyBannedIpsDelta(
+  ips: string[] | undefined,
+  frame: CrowdsecDecisionsFrame,
+): string[] | undefined {
+  if (!ips) return ips
+  const next = new Set(ips)
+  for (const d of frame.added) next.add(d.ip)
+  for (const d of frame.deleted) next.delete(d.ip)
+  return [...next]
+}
+
+/** Patch the cached /crowdsec/status query with a pushed reachability change. */
+export function applyStatusFrame(
+  status: CrowdSecStatusResponse | undefined,
+  frame: CrowdsecStatusFrame,
+): CrowdSecStatusResponse | undefined {
+  if (!status) return status
+  return { ...status, lapi_reachable: frame.lapi_reachable }
+}

--- a/resources/lib/crowdsec-live.ts
+++ b/resources/lib/crowdsec-live.ts
@@ -23,12 +23,14 @@ export type CrowdsecFrame = CrowdsecDecisionsFrame | CrowdsecStatusFrame
 /** Parse one raw WS message; null for non-JSON payloads or unknown types. */
 export function parseCrowdsecFrame(data: unknown): CrowdsecFrame | null {
   if (typeof data !== "string") return null
-  let frame: { type?: string }
+  let parsed: unknown
   try {
-    frame = JSON.parse(data) as { type?: string }
+    parsed = JSON.parse(data)
   } catch {
     return null
   }
+  if (typeof parsed !== "object" || parsed === null) return null
+  const frame = parsed as { type?: string }
   if (frame.type === "crowdsec_decisions" || frame.type === "crowdsec_status") {
     return frame as CrowdsecFrame
   }

--- a/resources/lib/crowdsec.test.ts
+++ b/resources/lib/crowdsec.test.ts
@@ -1,0 +1,23 @@
+import { AxiosError } from "axios"
+import { describe, expect, it } from "vitest"
+import { crowdsecErrorMessage } from "./crowdsec"
+
+describe("crowdsecErrorMessage", () => {
+  it("prefers the backend detail from an axios error", () => {
+    const err = new AxiosError(
+      "Request failed with status code 502",
+      "ERR_BAD_RESPONSE",
+      undefined,
+      undefined,
+      // Minimal AxiosResponse shape; only .data is read
+      { data: { detail: "CrowdSec LAPI is unreachable" }, status: 502 } as never,
+    )
+    expect(crowdsecErrorMessage(err, "fallback")).toBe("CrowdSec LAPI is unreachable")
+  })
+
+  it("falls back for non-axios errors and missing detail", () => {
+    expect(crowdsecErrorMessage(new Error("boom"), "fallback")).toBe("fallback")
+    const bare = new AxiosError("network down", "ERR_NETWORK")
+    expect(crowdsecErrorMessage(bare, "fallback")).toBe("fallback")
+  })
+})

--- a/resources/lib/crowdsec.ts
+++ b/resources/lib/crowdsec.ts
@@ -3,6 +3,7 @@
  * IP validation, used by the access-logs row actions, the map popup, and
  * the Security page's ban form.
  */
+import { isAxiosError } from "axios"
 
 /** Go duration strings the LAPI accepts; "Forever" is modeled as 10 years. */
 export const BAN_DURATIONS = [
@@ -33,4 +34,14 @@ function isValidIpv6(value: string): boolean {
 
 export function isValidIp(value: string): boolean {
   return IPV4_RE.test(value) || isValidIpv6(value)
+}
+
+/** Human-readable message for a failed CrowdSec API call: the backend's
+ * `detail` (e.g. "CrowdSec LAPI is unreachable") when present, else the
+ * caller's fallback. */
+export function crowdsecErrorMessage(err: unknown, fallback: string): string {
+  const detail = isAxiosError(err)
+    ? (err.response?.data as { detail?: string } | undefined)?.detail
+    : null
+  return detail ?? fallback
 }

--- a/resources/lib/queries.ts
+++ b/resources/lib/queries.ts
@@ -53,12 +53,18 @@ import {
   type AccessLogFacets,
   type AccessLogSortField,
   type SortOrder,
+  type CrowdSecStatusResponse,
   fetchAccessLogDebug,
   fetchAccessLogDebugStats,
   type AccessLogDebugPage,
   type AccessLogDebugSortField,
   type AccessLogDebugStats,
 } from "./api"
+import {
+  applyBannedIpsDelta,
+  applyStatusFrame,
+  parseCrowdsecFrame,
+} from "./crowdsec-live"
 import { apiV1LogsFilesListFiles, apiV1LogsTailTail } from "@/generated/api/sdk.gen"
 import { useTimeRange } from "./time-range-context"
 import { useAnalyticsFilters } from "./analytics-filters-context"
@@ -197,12 +203,15 @@ export function useAbout() {
 // CrowdSec
 // ============================================================================
 
-/** Whether the CrowdSec integration is configured; gates all CrowdSec UI. */
+/** Whether the CrowdSec integration is configured; gates all CrowdSec UI.
+ *  The 30s poll is a safety net for blocked WebSockets; live reachability
+ *  changes arrive over /ws/crowdsec and are patched into this cache. */
 export function useCrowdsecStatus() {
   return useQuery({
     queryKey: queryKeys.crowdsec.status,
     queryFn: fetchCrowdsecStatus,
     staleTime: 60_000,
+    refetchInterval: 30_000,
   })
 }
 
@@ -305,17 +314,11 @@ export function useUnbanIp() {
   })
 }
 
-/** Ban/unban delta pushed on /ws/crowdsec by the decision-stream poller. */
-interface CrowdsecDecisionsFrame {
-  type: "crowdsec_decisions"
-  added: { ip: string; origin: string; scenario: string; duration: string }[]
-  deleted: { ip: string; origin: string }[]
-}
-
-/** Live badge updates: subscribes to /ws/crowdsec while the integration is
- *  enabled and patches the cached banned-IP list on each delta, so badges
- *  react within the stream-poll interval instead of the 60s refetch.
- *  Reconnects with capped exponential backoff, same policy as /ws/live. */
+/** Live badge + reachability updates: subscribes to /ws/crowdsec while the
+ *  integration is enabled, patches the cached banned-IP list on each delta,
+ *  and patches cached /crowdsec/status on reachability frames (invalidating
+ *  all CrowdSec queries on recovery). Reconnects with capped exponential
+ *  backoff, same policy as /ws/live. */
 export function useCrowdsecLiveUpdates() {
   const { data: status } = useCrowdsecStatus()
   const queryClient = useQueryClient()
@@ -332,29 +335,30 @@ export function useCrowdsecLiveUpdates() {
       const proto = window.location.protocol === "https:" ? "wss" : "ws"
       ws = new WebSocket(`${proto}://${window.location.host}/ws/crowdsec`)
       ws.onmessage = (msg) => {
-        // The server only ever sends JSON text frames; ignore anything else
-        // (a Blob/ArrayBuffer or malformed payload) rather than throwing.
-        if (typeof msg.data !== "string") return
-        let frame: CrowdsecDecisionsFrame
-        try {
-          frame = JSON.parse(msg.data) as CrowdsecDecisionsFrame
-        } catch {
-          return
-        }
-        if (frame.type !== "crowdsec_decisions") return
+        const frame = parseCrowdsecFrame(msg.data)
+        if (!frame) return
         // Reset backoff only on a valid frame, not onopen: the server accepts
         // and immediately closes 1013 while the poller is down, so an onopen
         // reset would pin the reconnect loop at the 1s floor.
         retryMs = 1000
+        if (frame.type === "crowdsec_status") {
+          const previous = queryClient.getQueryData<CrowdSecStatusResponse>(
+            queryKeys.crowdsec.status,
+          )
+          queryClient.setQueryData<CrowdSecStatusResponse>(
+            queryKeys.crowdsec.status,
+            (status) => applyStatusFrame(status, frame),
+          )
+          // Recovery: refetch decisions/alerts/stats immediately so the page
+          // leaves its stale state without waiting for the 60s intervals.
+          if (frame.lapi_reachable && previous?.lapi_reachable === false) {
+            queryClient.invalidateQueries({ queryKey: ["crowdsec"] })
+          }
+          return
+        }
         queryClient.setQueryData<string[]>(
           queryKeys.crowdsec.bannedIps,
-          (ips) => {
-            if (!ips) return ips
-            const next = new Set(ips)
-            for (const d of frame.added) next.add(d.ip)
-            for (const d of frame.deleted) next.delete(d.ip)
-            return [...next]
-          },
+          (ips) => applyBannedIpsDelta(ips, frame),
         )
       }
       ws.onclose = () => {

--- a/resources/routes/__root.tsx
+++ b/resources/routes/__root.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query"
 import { fetchHealth } from "@/lib/api"
 import { ThemeProvider } from "@/components/theme-provider"
 import { TooltipProvider } from "@/components/ui/tooltip"
+import { Toaster } from "@/components/ui/sonner"
 import {
   SidebarProvider,
   SidebarInset,
@@ -158,6 +159,7 @@ function RootLayout() {
           </LiveFeedProvider>
         </TimeRangeProvider>
       </TooltipProvider>
+      <Toaster />
     </ThemeProvider>
   )
 }

--- a/resources/routes/security.tsx
+++ b/resources/routes/security.tsx
@@ -30,7 +30,7 @@ function SecurityPage() {
   if (isError || !status) {
     return (
       <div className="p-4">
-        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+        <div role="alert" className="rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
           Failed to load CrowdSec status from the GeoMetrikks backend. It will
           retry automatically.
         </div>

--- a/resources/routes/security.tsx
+++ b/resources/routes/security.tsx
@@ -3,6 +3,7 @@ import { ShieldBan } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { AlertsTable } from "@/components/security/alerts-table"
+import { CrowdsecUnreachableBanner } from "@/components/security/crowdsec-unreachable-banner"
 import { DecisionsTable } from "@/components/security/decisions-table"
 import { SecurityStatCards } from "@/components/security/security-stat-cards"
 import { useCrowdsecLiveUpdates, useCrowdsecStatus } from "@/lib/queries"
@@ -12,7 +13,7 @@ export const Route = createFileRoute("/security")({
 })
 
 function SecurityPage() {
-  const { data: status, isLoading } = useCrowdsecStatus()
+  const { data: status, isLoading, isError } = useCrowdsecStatus()
   useCrowdsecLiveUpdates()
 
   if (isLoading) {
@@ -24,7 +25,20 @@ function SecurityPage() {
     )
   }
 
-  if (!status?.enabled) {
+  // A failed status request means the GeoMetrikks backend itself is
+  // unreachable or erroring, which is not "integration not configured".
+  if (isError || !status) {
+    return (
+      <div className="p-4">
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+          Failed to load CrowdSec status from the GeoMetrikks backend. It will
+          retry automatically.
+        </div>
+      </div>
+    )
+  }
+
+  if (!status.enabled) {
     return (
       <div className="p-4">
         <Card>
@@ -45,6 +59,7 @@ function SecurityPage() {
 
   return (
     <div className="p-4 space-y-4">
+      <CrowdsecUnreachableBanner />
       <SecurityStatCards />
       <DecisionsTable />
       {status.write_enabled && <AlertsTable />}

--- a/tests/test_crowdsec_controller.py
+++ b/tests/test_crowdsec_controller.py
@@ -535,3 +535,38 @@ async def test_banned_locations_defaults_to_no_window():
 async def test_banned_locations_404_when_disabled():
     async with AsyncTestClient(app=make_app(None)) as client:
         assert (await client.get("/api/v1/crowdsec/banned-locations")).status_code == 404
+
+
+# -- poller state fallback --------------------------------------------------
+
+
+class StubPoller:
+    def __init__(self, lapi_reachable: bool | None) -> None:
+        self.lapi_reachable = lapi_reachable
+
+
+class PingBomb(FakeCrowdSec):
+    async def ping(self) -> bool:
+        raise AssertionError("ping must not be called when poller state exists")
+
+
+async def test_status_uses_poller_state_without_ping(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CROWDSEC_LAPI_URL", "http://crowdsec:8080")
+    monkeypatch.setenv("CROWDSEC_BOUNCER_API_KEY", "key")
+    app = make_app(PingBomb([]))
+    app.state.crowdsec_stream_poller = StubPoller(lapi_reachable=False)
+    async with AsyncTestClient(app=app) as client:
+        resp = await client.get("/api/v1/crowdsec/status")
+    assert resp.json()["lapi_reachable"] is False
+
+
+async def test_status_falls_back_to_ping_before_first_poll(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CROWDSEC_LAPI_URL", "http://crowdsec:8080")
+    monkeypatch.setenv("CROWDSEC_BOUNCER_API_KEY", "key")
+    app = make_app(FakeCrowdSec([], reachable=True))
+    app.state.crowdsec_stream_poller = StubPoller(lapi_reachable=None)
+    async with AsyncTestClient(app=app) as client:
+        resp = await client.get("/api/v1/crowdsec/status")
+    assert resp.json()["lapi_reachable"] is True

--- a/tests/test_crowdsec_stream.py
+++ b/tests/test_crowdsec_stream.py
@@ -57,7 +57,10 @@ async def test_first_poll_is_startup_and_silent():
 
     await poller.poll()
     assert respond.calls[0]["params"] == {"startup": "true"}
-    assert queue.empty()  # startup snapshot is state, not news
+    # The reachability transition (None -> True) broadcasts, the startup
+    # decision snapshot does not: it is state, not news.
+    assert queue.get_nowait() == {"type": "crowdsec_status", "lapi_reachable": True}
+    assert queue.empty()
     await service.aclose()
 
 
@@ -82,6 +85,7 @@ async def test_later_polls_broadcast_ip_deltas():
     await poller.poll()
     assert respond.calls[1]["params"] == {}
 
+    assert queue.get_nowait()["type"] == "crowdsec_status"  # first-poll transition
     frame = queue.get_nowait()
     assert frame["type"] == "crowdsec_decisions"
     # Range-scope decisions are not badgeable; only Ip values broadcast
@@ -100,6 +104,7 @@ async def test_empty_delta_broadcasts_nothing():
     queue = poller.subscribe()
     await poller.poll()
     await poller.poll()
+    assert queue.get_nowait()["type"] == "crowdsec_status"  # first-poll transition
     assert queue.empty()
     await service.aclose()
 
@@ -112,6 +117,54 @@ async def test_poll_survives_lapi_errors():
     poller = make_poller(service)
     queue = poller.subscribe()
     await poller.poll()  # must not raise
+    assert queue.get_nowait() == {"type": "crowdsec_status", "lapi_reachable": False}
+    assert queue.empty()
+    await service.aclose()
+
+
+def flaky_responder(failures: int, payload: dict):
+    """Raise ConnectError for the first `failures` calls, then return payload."""
+    calls = {"n": 0}
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] <= failures:
+            raise httpx.ConnectError("boom")
+        return httpx.Response(200, json=payload)
+
+    return respond
+
+
+async def test_poller_tracks_reachability_state():
+    respond = flaky_responder(1, {"new": None, "deleted": None})
+    service = make_service(respond)
+    poller = make_poller(service)
+    assert poller.lapi_reachable is None
+    assert poller.last_success is None
+
+    await poller.poll()  # fails
+    assert poller.lapi_reachable is False
+    assert poller.last_success is None
+
+    await poller.poll()  # succeeds
+    assert poller.lapi_reachable is True
+    assert poller.last_success is not None
+    await service.aclose()
+
+
+async def test_status_frame_only_on_transitions():
+    # fail, fail, succeed -> exactly two status frames: False then True
+    respond = flaky_responder(2, {"new": None, "deleted": None})
+    service = make_service(respond)
+    poller = make_poller(service)
+    queue = poller.subscribe()
+
+    await poller.poll()
+    await poller.poll()
+    await poller.poll()
+
+    assert queue.get_nowait() == {"type": "crowdsec_status", "lapi_reachable": False}
+    assert queue.get_nowait() == {"type": "crowdsec_status", "lapi_reachable": True}
     assert queue.empty()
     await service.aclose()
 

--- a/tests/test_crowdsec_stream.py
+++ b/tests/test_crowdsec_stream.py
@@ -205,6 +205,8 @@ async def test_scheduler_registers_stream_poll_job(monkeypatch, tmp_path):
 class FakePoller:
     """subscribe/unsubscribe stub the WS handler can drive."""
 
+    lapi_reachable = None  # class attr: existing tests get no initial frame
+
     def __init__(self) -> None:
         import asyncio
 
@@ -267,3 +269,14 @@ def test_ws_closes_without_poller():
         with pytest.raises(WebSocketDisconnect):
             with client.websocket_connect("/ws/crowdsec") as ws:
                 ws.receive_json(timeout=2)
+
+
+def test_ws_sends_initial_status_frame():
+    from litestar.testing import TestClient
+
+    poller = FakePoller()
+    poller.lapi_reachable = False
+    with TestClient(app=make_ws_app(poller)) as client:
+        with client.websocket_connect("/ws/crowdsec") as ws:
+            frame = ws.receive_json(timeout=5)
+    assert frame == {"type": "crowdsec_status", "lapi_reachable": False}

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,6 +1,8 @@
 """/health is liveness (always 200); /health/ready is readiness (503 without DB)."""
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from litestar import Litestar
 from litestar.testing import TestClient
 
@@ -45,3 +47,28 @@ def test_ready_200_when_db_reachable(monkeypatch):
         res = client.get("/health/ready")
         assert res.status_code == 200
         assert res.json() == {"ready": True}
+
+
+def test_health_crowdsec_disabled_by_default(monkeypatch):
+    async def db_up(timeout: float = 2.0) -> bool:
+        return True
+    monkeypatch.setattr(health_module, "_database_reachable", db_up)
+
+    with TestClient(app=make_app()) as client:
+        body = client.get("/health").json()
+    assert body["crowdsec"] == {"enabled": False, "lapi_reachable": None}
+
+
+def test_health_crowdsec_enabled_and_down(monkeypatch):
+    async def db_up(timeout: float = 2.0) -> bool:
+        return True
+    monkeypatch.setattr(health_module, "_database_reachable", db_up)
+
+    app = make_app()
+    app.state.crowdsec_service = object()
+    app.state.crowdsec_stream_poller = SimpleNamespace(lapi_reachable=False)
+    with TestClient(app=app) as client:
+        body = client.get("/health").json()
+    assert body["crowdsec"] == {"enabled": True, "lapi_reachable": False}
+    # CrowdSec being down must not degrade the app status by itself
+    assert body["status"] == "degraded"  # degraded because no ingestion in make_app


### PR DESCRIPTION
## Summary

When the CrowdSec LAPI goes down, the Security page previously hung on permanent skeletons, showed a false "No active decisions" empty state, kept a stale "Connected" LAPI card, and ban/unban actions failed silently. This branch makes the outage visible everywhere it matters.

### Backend

- The decision-stream poller is now the single source of truth for LAPI reachability: it tracks `lapi_reachable`/`last_success` and broadcasts `{"type": "crowdsec_status", "lapi_reachable": bool}` over `/ws/crowdsec` on every transition (including the first poll).
- `/ws/crowdsec` sends a status snapshot right after connect, inside the cleanup scope so early disconnects cannot leak subscriber queues.
- `GET /api/v1/crowdsec/status` reads the poller's cached verdict instead of doing a live LAPI probe per request (which could block for the full request timeout against a black-holed host); the live `ping()` remains only as a fallback when the poller is absent or has not polled yet.
- `/health` gains `crowdsec: {enabled, lapi_reachable}`. A down LAPI never flips the top-level `status`; CrowdSec is an optional integration.

### Frontend

- New `crowdsec_status` WS frames patch the cached status query in place; recovery invalidates all CrowdSec queries so tables refresh immediately. `useCrowdsecStatus` also polls every 30s as a safety net.
- Security page: destructive "CrowdSec LAPI is unreachable" banner, stat cards render through a stats failure (LAPI card flips to "Unreachable" instead of hiding behind skeletons), both tables get real error states while keeping last-known data, and a failed status request no longer shows the misleading "not configured" card.
- Sidebar: amber warning dot on the Security item (driven by the new /health key) while the LAPI is down.
- Ban/unban failures now show sonner error toasts from every call site (log tables, security tables, map popups); the Ban IP dialog keeps its inline error.

## Testing

- Backend: new pytest coverage for poller state transitions and transition-only frame broadcast, the WS connect snapshot, the status endpoint's cached/fallback paths, and the /health crowdsec key (550 passing).
- Frontend: WS frame parsing/cache-patch logic extracted into `resources/lib/crowdsec-live.ts` and unit-tested, plus the error-message helper (101 passing). Visual states verified manually: outage banner, card flip, sidebar dot, toasts, and recovery all confirmed against a stopped/restarted CrowdSec container.
- `ty check`, `tsc` typecheck, and the production build are green; TS client typegen verified no drift.