### PR TITLE
refactor(health): use geoip_info() mmdb build date instead of file mtime

### DIFF
--- a/geometrikks/api/health.py
+++ b/geometrikks/api/health.py
@@ -15,6 +15,8 @@ from litestar.di import NamedDependency, Provide
 from litestar.status_codes import HTTP_200_OK, HTTP_503_SERVICE_UNAVAILABLE
 from sqlalchemy import text
 
+from geometrikks.config.settings import get_settings
+from geometrikks.lib.utils import geoip_info
 from geometrikks.services.ingestion import LogIngestionService
 from geometrikks.api.dependencies import provide_ingestion_service as pis
 
@@ -48,16 +50,6 @@ async def health(
     def _iso(dt: datetime | None) -> str | None:
         return dt.isoformat() if dt else None
 
-    def _geoip_modified_at() -> str | None:
-        """Modified time of the GeoLite2 file; None when absent/unreadable."""
-        try:
-            from geometrikks.config.settings import get_settings
-
-            mtime = get_settings().geoip.db_path.stat().st_mtime
-            return datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
-        except Exception:
-            return None
-
     is_running = ingestion_service.is_running if ingestion_service else False
     # Tailed files that disappeared mid-flight: the tailer keeps waiting for
     # them (log rotation resilience), so `running` stays true, but nothing is
@@ -84,9 +76,11 @@ async def health(
             ),
         },
         "database": {"reachable": db_reachable},
+        # build_date comes from the mmdb metadata (geoip_info), the actual
+        # GeoLite2 build, not the file's mtime.
         "geoip": {
             "available": getattr(request.app.state, "geoip_available", True),
-            "db_modified_at": _geoip_modified_at(),
+            "db_build_date": _iso(geoip_info(get_settings().geoip.db_path).build_date),
         },
         # CrowdSec is an optional integration: a down LAPI never flips
         # `status`. lapi_reachable is the stream poller's cached verdict;

--- a/resources/components/settings/status-logic.test.ts
+++ b/resources/components/settings/status-logic.test.ts
@@ -37,7 +37,7 @@ function makeHealth(overrides: Partial<HealthResponse> = {}): HealthResponse {
       last_record_at: "2026-07-31T09:59:00+00:00",
     },
     database: { reachable: true },
-    geoip: { available: true, db_modified_at: "2026-07-28T00:00:00+00:00" },
+    geoip: { available: true, db_build_date: "2026-07-28T00:00:00+00:00" },
     crowdsec: { enabled: true, lapi_reachable: true },
     timestamp: "2026-07-31T10:00:00+00:00",
     ...overrides,
@@ -115,7 +115,7 @@ describe("databaseState / geoipState", () => {
     expect(databaseState(makeHealth())).toMatchObject({ tone: "emerald", label: "Reachable" })
   })
   it("geoip missing is amber", () => {
-    expect(geoipState(makeHealth({ geoip: { available: false, db_modified_at: null } }))).toMatchObject({
+    expect(geoipState(makeHealth({ geoip: { available: false, db_build_date: null } }))).toMatchObject({
       tone: "amber",
       label: "Missing",
     })

--- a/resources/components/settings/status-overview.tsx
+++ b/resources/components/settings/status-overview.tsx
@@ -237,8 +237,8 @@ export function StatusOverview() {
           <CardContent className="space-y-2">
             <StateLine state={geoipState(health)} />
             <div className="space-y-1 text-xs text-muted-foreground">
-              {health?.geoip.db_modified_at && (
-                <p>Database updated {relativeTime(health.geoip.db_modified_at, now)}</p>
+              {health?.geoip.db_build_date && (
+                <p>Database built {relativeTime(health.geoip.db_build_date, now)}</p>
               )}
               {geoipRefreshJob?.next_run_time && (
                 <p>Next refresh {relativeTime(geoipRefreshJob.next_run_time, now)}</p>

--- a/resources/lib/api.ts
+++ b/resources/lib/api.ts
@@ -107,7 +107,8 @@ export interface HealthResponse {
   started_at: string | null
   ingestion: HealthIngestionStatus
   database: { reachable: boolean }
-  geoip: { available: boolean; db_modified_at: string | null }
+  /** db_build_date is the GeoLite2 build from the mmdb metadata. */
+  geoip: { available: boolean; db_build_date: string | null }
   crowdsec: { enabled: boolean; lapi_reachable: boolean | null }
   timestamp: string
 }

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -91,7 +91,7 @@ def test_health_exposes_uptime_and_activity_fields(monkeypatch):
     # make_app has no started_at in state and no ingestion service
     assert body["started_at"] is None
     assert body["ingestion"]["last_record_at"] is None
-    assert "db_modified_at" in body["geoip"]
+    assert "db_build_date" in body["geoip"]
 
 
 def test_health_started_at_from_app_state(monkeypatch):


### PR DESCRIPTION
The geoip field is now db_build_date from the GeoLite2 metadata (same helper the About endpoint uses), which reports the actual database build rather than when the file was downloaded. Status page shows it as 'Database built Xd ago'.