### PR TITLE
GeoMetrikks 0.7 phase 2: hermetic composition and testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `GEOMETRIKKS_ENV_FILE` environment variable to override the `.env` file
+  path; an empty value disables dotenv loading entirely (the test suite uses
+  this so results never depend on a local `.env`).
+
 ### Changed
+
+- `create_app()` accepts an explicit settings object and app-level dependency
+  overrides, and request handlers now receive settings through dependency
+  injection instead of resolving the process-cached factory inline.
+- The backend test suite runs async tests on AnyIO (pytest-asyncio removed),
+  is fully isolated from `.env` and ambient environment values, and gained
+  WebSocket feed coverage for degraded-mode 1013 closures, overflow/drop
+  counting, heartbeats, unsubscribe cleanup, cancellation, the session-auth
+  handshake boundary, and the inbound-frame policy.
 
 - All API query and path parameters now use Litestar's explicit
   `QueryParameter`/`FromPath` declarations (Litestar 3.0 readiness). Wire

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `create_app()` accepts an explicit settings object and app-level dependency
   overrides, and request handlers now receive settings through dependency
-  injection instead of resolving the process-cached factory inline.
+  injection instead of resolving the process-cached factory inline. The
+  SQLAlchemy engine, startup migrations, scheduled aggregate jobs, and
+  trusted-proxy client-IP resolution all bind to the composed settings; the
+  `settings` dependency name is reserved (overriding it would split
+  configuration between request handlers and the rest of the app).
 - The backend test suite runs async tests on AnyIO (pytest-asyncio removed),
   is fully isolated from `.env` and ambient environment values, and gained
   WebSocket feed coverage for degraded-mode 1013 closures, overflow/drop

--- a/README.md
+++ b/README.md
@@ -446,6 +446,10 @@ credentials, MaxMind key, log paths, DB password). For the full set of
 environment variables - every default, every setting - see
 [`docs/configuration.md`](docs/configuration.md).
 
+Set `GEOMETRIKKS_ENV_FILE` to load a different `.env` path, or to an empty
+value to disable dotenv loading and configure through real environment
+variables only.
+
 ### PUID and PGID
 
 The container starts as root just long enough to re-map its internal user to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,6 +5,11 @@
 All settings are environment variables (or `.env` entries). The short
 list most users need is in `.env.example`; everything below is available.
 
+`GEOMETRIKKS_ENV_FILE` overrides the path of the `.env` file itself
+(default: `.env` in the working directory); setting it to an empty
+value disables dotenv loading entirely, so configuration comes only
+from real environment variables. It is read once at import time.
+
 ## Application
 
 | Variable | Default | Description |

--- a/geometrikks/api/dependencies.py
+++ b/geometrikks/api/dependencies.py
@@ -6,15 +6,30 @@ from typing import Annotated
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from litestar import Request
-from litestar.di import NamedDependency
+from litestar.di import NamedDependency, Provide
 from litestar.params import QueryParameter
 from advanced_alchemy.extensions.litestar import filters
 
+from geometrikks.config.settings import Settings
 from geometrikks.services.crowdsec import CrowdSecService
 from geometrikks.services.ingestion import LogIngestionService
 from geometrikks.domain.geo.repositories import GeoLocationRepository
 from geometrikks.domain.analytics.repositories import LiveStatsRepository, SummaryStatsRepository
 from geometrikks.domain.security.repositories import SecurityEnrichmentRepository
+
+
+def create_settings_provider(settings: Settings) -> Provide:
+    """Build the app-level ``settings`` dependency around an explicit object.
+
+    ``create_app()`` registers this so request handlers receive the exact
+    settings the app was composed with; tests can pass their own ``Settings``
+    to ``create_app(settings=...)`` instead of mutating process state.
+    """
+
+    def provide_settings() -> Settings:
+        return settings
+
+    return Provide(provide_settings, sync_to_thread=False)
 
 
 def provide_ingestion_service(request: Request) -> LogIngestionService | None:

--- a/geometrikks/api/health.py
+++ b/geometrikks/api/health.py
@@ -12,10 +12,11 @@ from typing import Any
 
 from litestar import Request, Response, get
 from litestar.di import NamedDependency, Provide
+from litestar.params import SkipValidation
 from litestar.status_codes import HTTP_200_OK, HTTP_503_SERVICE_UNAVAILABLE
 from sqlalchemy import text
 
-from geometrikks.config.settings import get_settings
+from geometrikks.config.settings import Settings
 from geometrikks.lib.utils import geoip_info
 from geometrikks.services.ingestion import LogIngestionService
 from geometrikks.api.dependencies import provide_ingestion_service as pis
@@ -44,7 +45,9 @@ async def _database_reachable(timeout: float = 2.0) -> bool:
     dependencies={"ingestion_service": Provide(pis, sync_to_thread=False)},
 )
 async def health(
-    request: Request, ingestion_service: NamedDependency[LogIngestionService | None]
+    request: Request,
+    ingestion_service: NamedDependency[LogIngestionService | None],
+    settings: NamedDependency[SkipValidation[Settings]],
 ) -> dict[str, Any]:
     """Liveness + component detail. Always 200 while the app is up."""
     def _iso(dt: datetime | None) -> str | None:
@@ -80,7 +83,7 @@ async def health(
         # GeoLite2 build, not the file's mtime.
         "geoip": {
             "available": getattr(request.app.state, "geoip_available", True),
-            "db_build_date": _iso(geoip_info(get_settings().geoip.db_path).build_date),
+            "db_build_date": _iso(geoip_info(settings.geoip.db_path).build_date),
         },
         # CrowdSec is an optional integration: a down LAPI never flips
         # `status`. lapi_reachable is the stream poller's cached verdict;

--- a/geometrikks/api/health.py
+++ b/geometrikks/api/health.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from litestar import Request, Response, get
+from litestar import Litestar, Request, Response, get
 from litestar.di import NamedDependency, Provide
 from litestar.params import SkipValidation
 from litestar.status_codes import HTTP_200_OK, HTTP_503_SERVICE_UNAVAILABLE
@@ -22,15 +22,15 @@ from geometrikks.services.ingestion import LogIngestionService
 from geometrikks.api.dependencies import provide_ingestion_service as pis
 
 
-async def _database_reachable(timeout: float = 2.0) -> bool:
-    """SELECT 1 with a short timeout; False on any failure."""
+async def _database_reachable(app: Litestar, timeout: float = 2.0) -> bool:
+    """SELECT 1 against the app's database with a short timeout; False on any failure."""
     import asyncio
 
-    from geometrikks.server.plugins import get_sqlalchemy_config
+    from geometrikks.server.plugins import get_app_db_config
 
     try:
         async def _probe() -> None:
-            async with get_sqlalchemy_config().get_engine().connect() as conn:
+            async with get_app_db_config(app).get_engine().connect() as conn:
                 await conn.execute(text("SELECT 1"))
 
         await asyncio.wait_for(_probe(), timeout=timeout)
@@ -58,7 +58,7 @@ async def health(
     # them (log rotation resilience), so `running` stays true, but nothing is
     # being ingested from those files and status must not read as healthy.
     missing_files = ingestion_service.missing_files if ingestion_service else []
-    db_reachable = await _database_reachable()
+    db_reachable = await _database_reachable(request.app)
 
     poller = getattr(request.app.state, "crowdsec_stream_poller", None)
 
@@ -97,8 +97,8 @@ async def health(
 
 
 @get("/health/ready", tags=["Health"])
-async def health_ready() -> Response[dict[str, Any]]:
+async def health_ready(request: Request) -> Response[dict[str, Any]]:
     """Readiness: 200 only when the database answers."""
-    if await _database_reachable():
+    if await _database_reachable(request.app):
         return Response({"ready": True}, status_code=HTTP_200_OK)
     return Response({"ready": False}, status_code=HTTP_503_SERVICE_UNAVAILABLE)

--- a/geometrikks/api/v1/crowdsec_controller.py
+++ b/geometrikks/api/v1/crowdsec_controller.py
@@ -23,14 +23,14 @@ from litestar.exceptions import (
     PermissionDeniedException,
     ValidationException,
 )
-from litestar.params import QueryParameter
+from litestar.params import QueryParameter, SkipValidation
 from litestar.status_codes import HTTP_200_OK, HTTP_204_NO_CONTENT
 
 from geometrikks.api.dependencies import (
     provide_crowdsec_service,
     provide_security_enrichment_repo,
 )
-from geometrikks.config.settings import get_settings
+from geometrikks.config.settings import Settings
 from geometrikks.domain.security.repositories import SecurityEnrichmentRepository
 from geometrikks.domain.security.schemas import IpEnrichment, IpLocation
 from geometrikks.server.logging import get_logger
@@ -148,9 +148,9 @@ def _require_service(crowdsec: CrowdSecService | None) -> CrowdSecService:
     return crowdsec
 
 
-def _require_write(crowdsec: CrowdSecService | None) -> CrowdSecService:
+def _require_write(crowdsec: CrowdSecService | None, settings: Settings) -> CrowdSecService:
     service = _require_service(crowdsec)
-    if not get_settings().crowdsec.write_enabled:
+    if not settings.crowdsec.write_enabled:
         raise PermissionDeniedException(
             detail="Ban/unban requires CROWDSEC_MACHINE_ID and CROWDSEC_MACHINE_PASSWORD"
         )
@@ -191,7 +191,10 @@ class CrowdSecController(Controller):
 
     @get("/status")
     async def get_status(
-        self, crowdsec: NamedDependency[CrowdSecService | None], request: Request
+        self,
+        crowdsec: NamedDependency[CrowdSecService | None],
+        request: Request,
+        settings: NamedDependency[SkipValidation[Settings]],
     ) -> CrowdSecStatusResponse:
         """Integration state; the frontend gates the security page on this."""
         if crowdsec is None:
@@ -207,7 +210,7 @@ class CrowdSecController(Controller):
         cached: bool | None = poller.lapi_reachable if poller is not None else None
         return CrowdSecStatusResponse(
             enabled=True,
-            write_enabled=get_settings().crowdsec.write_enabled,
+            write_enabled=settings.crowdsec.write_enabled,
             lapi_reachable=cached if cached is not None else await crowdsec.ping(),
         )
 
@@ -295,6 +298,7 @@ class CrowdSecController(Controller):
         self,
         crowdsec: NamedDependency[CrowdSecService | None],
         enrichment_repo: NamedDependency[SecurityEnrichmentRepository],
+        settings: NamedDependency[SkipValidation[Settings]],
         limit: Annotated[int, QueryParameter(ge=1, le=500, required=False)] = 50,
         ip: Annotated[str | None, QueryParameter(required=False)] = None,
         scenario: Annotated[str | None, QueryParameter(required=False)] = None,
@@ -309,7 +313,7 @@ class CrowdSecController(Controller):
         bans carry a bare IP. Ip-scope sources missing LAPI geo are filled
         from GeoMetrikks' own stored traffic instead.
         """
-        service = _require_write(crowdsec)
+        service = _require_write(crowdsec, settings)
         if ip is not None:
             _validate_ip(ip)
         if since is not None:
@@ -352,12 +356,13 @@ class CrowdSecController(Controller):
         crowdsec: NamedDependency[CrowdSecService | None],
         data: BanRequest,
         request: Request,
+        settings: NamedDependency[SkipValidation[Settings]],
     ) -> None:
         """Create a manual ban decision for one IP.
 
         Enforcement still depends on a bouncer attached to the LAPI.
         """
-        service = _require_write(crowdsec)
+        service = _require_write(crowdsec, settings)
         _validate_ip(data.ip)
         duration = data.duration and _validate_duration(data.duration)
         await service.ban_ip(data.ip, duration=duration, reason=data.reason)
@@ -365,7 +370,7 @@ class CrowdSecController(Controller):
             "CrowdSec ban by %s: ip=%s duration=%s reason=%s",
             _actor(request),
             data.ip,
-            duration or get_settings().crowdsec.default_ban_duration,
+            duration or settings.crowdsec.default_ban_duration,
             data.reason,
         )
 
@@ -375,9 +380,10 @@ class CrowdSecController(Controller):
         crowdsec: NamedDependency[CrowdSecService | None],
         data: UnbanRequest,
         request: Request,
+        settings: NamedDependency[SkipValidation[Settings]],
     ) -> UnbanResponse:
         """Delete all active decisions for one IP."""
-        service = _require_write(crowdsec)
+        service = _require_write(crowdsec, settings)
         _validate_ip(data.ip)
         deleted = await service.unban_ip(data.ip)
         logger.info(

--- a/geometrikks/api/v1/logs_controller.py
+++ b/geometrikks/api/v1/logs_controller.py
@@ -7,10 +7,12 @@ from datetime import datetime
 from typing import Annotated, Any, Literal
 
 from litestar import Controller, get, post
+from litestar.di import NamedDependency
 from litestar.exceptions import NotFoundException
-from litestar.params import FromPath, QueryParameter
+from litestar.params import FromPath, QueryParameter, SkipValidation
 from litestar.response import File
 
+from geometrikks.config.settings import Settings
 from geometrikks.server.logging import rotate_log_files
 from geometrikks.services.logfiles import LogFileKind, create_log_files_service
 
@@ -50,13 +52,14 @@ class LogsController(Controller):
     @get("/tail", sync_to_thread=True)
     def tail(
         self,
+        settings: NamedDependency[SkipValidation[Settings]],
         lines: Annotated[int, QueryParameter(description="Number of records to return (capped)")] = 500,
         source: Annotated[
             Literal["app", "login"], QueryParameter(description="Which log to tail")
         ] = "app",
     ) -> LogTailResponse:
         clamped = max(1, min(lines, MAX_TAIL_LINES))
-        service = create_log_files_service()
+        service = create_log_files_service(settings)
         if source == "login":
             records = service.tail_login(lines=clamped)
         else:
@@ -64,7 +67,9 @@ class LogsController(Controller):
         return LogTailResponse(records=records)
 
     @get("/files", sync_to_thread=True)
-    def list_files(self) -> LogFilesResponse:
+    def list_files(
+        self, settings: NamedDependency[SkipValidation[Settings]]
+    ) -> LogFilesResponse:
         return LogFilesResponse(
             files=[
                 LogFileView(
@@ -74,13 +79,18 @@ class LogsController(Controller):
                     modified_at=e.modified_at,
                     available=e.available,
                 )
-                for e in create_log_files_service().list_files()
+                for e in create_log_files_service(settings).list_files()
             ]
         )
 
     @get("/files/{kind:str}/{name:str}", sync_to_thread=True)
-    def download(self, kind: FromPath[str], name: FromPath[str]) -> File:
-        path = create_log_files_service().resolve(kind, name)
+    def download(
+        self,
+        kind: FromPath[str],
+        name: FromPath[str],
+        settings: NamedDependency[SkipValidation[Settings]],
+    ) -> File:
+        path = create_log_files_service(settings).resolve(kind, name)
         if path is None:
             raise NotFoundException(detail="No such log file")
         return File(

--- a/geometrikks/api/v1/settings.py
+++ b/geometrikks/api/v1/settings.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from litestar import Request, get
+from litestar.di import NamedDependency
+from litestar.params import SkipValidation
 
-from geometrikks.config.settings import get_settings
+from geometrikks.config.settings import Settings
 from geometrikks.services.geoip.home import HomeLocation, HomeLocationSource
 
 
@@ -57,9 +59,11 @@ class SafeSettingsResponse:
 
 
 @get("/api/v1/settings", tags=["Settings"])
-async def read_settings(request: Request) -> SafeSettingsResponse:
+async def read_settings(
+    request: Request, settings: NamedDependency[SkipValidation[Settings]]
+) -> SafeSettingsResponse:
     """Whitelisted runtime settings (no credentials, ever)."""
-    s = get_settings()
+    s = settings
     home: HomeLocation | None = getattr(request.app.state, "map_home_location", None)
     if home is None and s.map.home_latitude is not None and s.map.home_longitude is not None:
         home = HomeLocation(

--- a/geometrikks/api/v1/system_controller.py
+++ b/geometrikks/api/v1/system_controller.py
@@ -16,8 +16,9 @@ from typing import TYPE_CHECKING
 import maxminddb
 from litestar import Controller, Request, get, post
 from litestar.datastructures import State
+from litestar.di import NamedDependency
 from litestar.exceptions import NotFoundException
-from litestar.params import FromPath
+from litestar.params import FromPath, SkipValidation
 from litestar.status_codes import HTTP_202_ACCEPTED
 from sqlalchemy import text
 
@@ -26,7 +27,7 @@ from geometrikks.config.introspection import (
     SystemSettingsResponse,
     build_settings_overview,
 )
-from geometrikks.config.settings import Settings, get_settings
+from geometrikks.config.settings import Settings
 from geometrikks.server.logging import get_logger
 from geometrikks.server.scheduler_tracking import JobRunTracker, JobStatus
 from geometrikks.lib.utils import GeoIPInfoView, geoip_info
@@ -264,20 +265,23 @@ class SystemController(Controller):
     tags = ["System"]
 
     @get("/settings")
-    async def get_system_settings(self, request: Request) -> SystemSettingsResponse:
+    async def get_system_settings(
+        self, request: Request, settings: NamedDependency[SkipValidation[Settings]]
+    ) -> SystemSettingsResponse:
         """Full settings tree with descriptions; secrets structurally redacted.
 
         Overlays runtime-resolved values (auto-detected map home, GeoIP
         availability, CrowdSec effective status) that the raw config omits.
         """
-        settings = get_settings()
         overlay = _computed_settings_overlay(settings, request.app.state)
         return build_settings_overview(settings, computed=overlay)
 
     @get("/about")
-    async def get_about(self, request: Request) -> AboutResponse:
+    async def get_about(
+        self, request: Request, settings: NamedDependency[SkipValidation[Settings]]
+    ) -> AboutResponse:
         """App, runtime, database, and GeoIP metadata for the About page."""
-        s = get_settings()
+        s = settings
         return AboutResponse(
             app=AboutAppView(
                 name=s.name,
@@ -298,12 +302,14 @@ class SystemController(Controller):
         )
 
     @get("/database")
-    async def get_database_info(self) -> DatabaseInfoResponse:
+    async def get_database_info(
+        self, settings: NamedDependency[SkipValidation[Settings]]
+    ) -> DatabaseInfoResponse:
         """Size, versions, retention and hypertable stats for the Status page.
 
         Renders nulls instead of failing in DB-degraded mode.
         """
-        s = get_settings()
+        s = settings
         versions = await _database_versions()
         size_bytes, hypertables = await _database_stats()
         return DatabaseInfoResponse(
@@ -317,7 +323,9 @@ class SystemController(Controller):
         )
 
     @get("/scheduler/jobs")
-    async def get_scheduler_jobs(self, request: Request) -> SchedulerJobsResponse:
+    async def get_scheduler_jobs(
+        self, request: Request, settings: NamedDependency[SkipValidation[Settings]]
+    ) -> SchedulerJobsResponse:
         """All scheduled jobs with next-run and tracked last-run state."""
         scheduler: AsyncIOScheduler | None = getattr(request.app.state, "scheduler", None)
         if scheduler is None:
@@ -328,7 +336,7 @@ class SystemController(Controller):
             getattr(request.app.state, "scheduler_tracker", None) or JobRunTracker()
         )
         return SchedulerJobsResponse(
-            scheduler_enabled=get_settings().scheduler.enabled,
+            scheduler_enabled=settings.scheduler.enabled,
             scheduler_running=scheduler.running,
             jobs=[_job_view(job, tracker) for job in scheduler.get_jobs()],
         )

--- a/geometrikks/api/v1/system_controller.py
+++ b/geometrikks/api/v1/system_controller.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import maxminddb
-from litestar import Controller, Request, get, post
+from litestar import Controller, Litestar, Request, get, post
 from litestar.datastructures import State
 from litestar.di import NamedDependency
 from litestar.exceptions import NotFoundException
@@ -108,12 +108,12 @@ def _dist_version(name: str) -> str | None:
         return None
 
 
-async def _database_versions() -> DatabaseVersionsView:
+async def _database_versions(app: Litestar) -> DatabaseVersionsView:
     """Server and extension versions; nulls when the DB is unreachable."""
-    from geometrikks.server.plugins import get_sqlalchemy_config
+    from geometrikks.server.plugins import get_app_db_config
 
     try:
-        engine = get_sqlalchemy_config().get_engine()
+        engine = get_app_db_config(app).get_engine()
         async with engine.connect() as conn:
             pg = (await conn.execute(text("SHOW server_version"))).scalar_one()
             rows = (
@@ -162,17 +162,17 @@ class DatabaseInfoResponse:
 HYPERTABLE_NAMES = ("geo_events", "access_logs", "access_log_debug")
 
 
-async def _database_stats() -> tuple[int | None, list[HypertableStatsView]]:
+async def _database_stats(app: Litestar) -> tuple[int | None, list[HypertableStatsView]]:
     """Database size and per-hypertable stats; (None, []) when unreachable.
 
     Uses TimescaleDB catalog-backed functions (approximate_row_count,
     hypertable_size, hypertable_compression_stats), so this stays fast at
     tens of millions of rows.
     """
-    from geometrikks.server.plugins import get_sqlalchemy_config
+    from geometrikks.server.plugins import get_app_db_config
 
     try:
-        engine = get_sqlalchemy_config().get_engine()
+        engine = get_app_db_config(app).get_engine()
         async with engine.connect() as conn:
             size = (
                 await conn.execute(text("SELECT pg_database_size(current_database())"))
@@ -296,22 +296,22 @@ class SystemController(Controller):
                 litestar_version=_dist_version("litestar"),
                 apscheduler_version=_dist_version("apscheduler"),
             ),
-            database=await _database_versions(),
+            database=await _database_versions(request.app),
             geoip=geoip_info(s.geoip.db_path),
             links=AboutLinksView(repository=REPO_URL, issues=f"{REPO_URL}/issues"),
         )
 
     @get("/database")
     async def get_database_info(
-        self, settings: NamedDependency[SkipValidation[Settings]]
+        self, request: Request, settings: NamedDependency[SkipValidation[Settings]]
     ) -> DatabaseInfoResponse:
         """Size, versions, retention and hypertable stats for the Status page.
 
         Renders nulls instead of failing in DB-degraded mode.
         """
         s = settings
-        versions = await _database_versions()
-        size_bytes, hypertables = await _database_stats()
+        versions = await _database_versions(request.app)
+        size_bytes, hypertables = await _database_stats(request.app)
         return DatabaseInfoResponse(
             reachable=size_bytes is not None,
             size_bytes=size_bytes,

--- a/geometrikks/config/settings.py
+++ b/geometrikks/config/settings.py
@@ -1,4 +1,5 @@
 import json
+import os
 import socket
 import warnings
 from functools import lru_cache
@@ -11,6 +12,18 @@ from urllib.parse import quote
 from pydantic import Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 from geometrikks.services.logparser.constants import ALLOWED_GEOIP_LOCALES
+
+
+def _env_file() -> str | None:
+    """Resolve the dotenv path used by every settings section.
+
+    GEOMETRIKKS_ENV_FILE overrides the default ``.env``; an empty value
+    disables dotenv loading entirely. The test suite sets it empty before
+    this module is imported so results never depend on a developer's local
+    ``.env``. Evaluated at class-creation time, like the rest of
+    ``model_config``.
+    """
+    return os.environ.get("GEOMETRIKKS_ENV_FILE", ".env") or None
 
 
 def get_installed_version() -> str:
@@ -33,7 +46,7 @@ class DatabaseSettings(BaseSettings):
     GeoAlchemy2 spatial features and high-volume log ingestion.
     """
 
-    model_config = SettingsConfigDict(env_prefix="DB_", env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(env_prefix="DB_", env_file=_env_file(), extra="ignore")
 
     echo: bool = Field(default=False, description="Enable SQLAlchemy query logging")
     echo_pool: bool = Field(default=False, description="Enable SQLAlchemy pool logging")
@@ -81,7 +94,7 @@ class GeoIPSettings(BaseSettings):
     # populate_by_name: account_id/license_key use MAXMINDDB_* validation
     # aliases for the env vars but must stay constructible by field name.
     model_config = SettingsConfigDict(
-        env_prefix="GEOIP_", env_file=".env", extra="ignore", populate_by_name=True
+        env_prefix="GEOIP_", env_file=_env_file(), extra="ignore", populate_by_name=True
     )
 
     db_path: Path = Field(
@@ -151,7 +164,7 @@ class GeoIPSettings(BaseSettings):
 class APISettings(BaseSettings):
     """API server configuration settings."""
 
-    model_config = SettingsConfigDict(env_prefix="API_", env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(env_prefix="API_", env_file=_env_file(), extra="ignore")
 
     host: str = Field(default="0.0.0.0", description="API server host")
     port: int = Field(default=8000, description="API server port")
@@ -164,7 +177,7 @@ class APISettings(BaseSettings):
 class LogSettings(BaseSettings):
     """Application logging configuration (files, rotation, level)."""
 
-    model_config = SettingsConfigDict(env_prefix="LOG_", env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(env_prefix="LOG_", env_file=_env_file(), extra="ignore")
 
     dir: Path = Field(default=Path("logs"), description="Directory for application log files")
     level: Literal["DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL"] | None = Field(
@@ -190,7 +203,7 @@ class LogSettings(BaseSettings):
 class LogParserSettings(BaseSettings):
     """Log parser configuration settings."""
 
-    model_config = SettingsConfigDict(env_prefix="LOGPARSER_", env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(env_prefix="LOGPARSER_", env_file=_env_file(), extra="ignore")
 
     log_paths: Annotated[list[Path], NoDecode] = Field(
         default_factory=lambda: [Path("/var/log/nginx/access.log")],
@@ -282,7 +295,7 @@ class AnalyticsSettings(BaseSettings):
     These settings define the default retention periods.
     """
 
-    model_config = SettingsConfigDict(env_prefix="ANALYTICS_", env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(env_prefix="ANALYTICS_", env_file=_env_file(), extra="ignore")
 
     # Retention periods for TimescaleDB policies
     raw_retention_days: int = Field(
@@ -316,7 +329,7 @@ class AnalyticsSettings(BaseSettings):
 class SchedulerSettings(BaseSettings):
     """APScheduler configuration for periodic background tasks."""
 
-    model_config = SettingsConfigDict(env_prefix="SCHEDULER_", env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(env_prefix="SCHEDULER_", env_file=_env_file(), extra="ignore")
 
     enabled: bool = Field(
         default=True,
@@ -331,7 +344,7 @@ class SchedulerSettings(BaseSettings):
 class MapSettings(BaseSettings):
     """Map presentation settings shared with the web client."""
 
-    model_config = SettingsConfigDict(env_prefix="MAP_", env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(env_prefix="MAP_", env_file=_env_file(), extra="ignore")
 
     home_latitude: float | None = Field(
         default=None,
@@ -388,7 +401,7 @@ class CrowdSecSettings(BaseSettings):
     credentials additionally enable ban/unban actions.
     """
 
-    model_config = SettingsConfigDict(env_prefix="CROWDSEC_", env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(env_prefix="CROWDSEC_", env_file=_env_file(), extra="ignore")
 
     lapi_url: str | None = Field(
         default=None,
@@ -445,7 +458,7 @@ class CrowdSecSettings(BaseSettings):
 class ViteSettings(BaseSettings):
     """Vite server configuration settings."""
 
-    model_config = SettingsConfigDict(env_prefix="VITE_", env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(env_prefix="VITE_", env_file=_env_file(), extra="ignore")
 
     dev_mode: bool = Field(
         default=False,
@@ -497,7 +510,7 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(
         env_prefix="APP_",
-        env_file=".env",
+        env_file=_env_file(),
         env_file_encoding="utf-8",
         case_sensitive=False,
         extra="ignore",

--- a/geometrikks/lib/client_ip.py
+++ b/geometrikks/lib/client_ip.py
@@ -39,16 +39,20 @@ def resolve_client_ip(
     Args:
         connection: The request or WebSocket connection.
         trusted_networks: Networks whose X-Forwarded-For is trusted. When
-            None, built from ``get_settings().trusted_proxies``.
+            None, built from the app's composed settings (falling back to
+            the ambient cached settings for apps built outside create_app).
 
     Returns:
         The resolved client address, or None when the peer is unknown.
     """
     if trusted_networks is None:
-        from geometrikks.config.settings import get_settings
+        settings = getattr(connection.app.state, "settings", None)
+        if settings is None:
+            from geometrikks.config.settings import get_settings
 
+            settings = get_settings()
         trusted_networks = [
-            ip_network(entry, strict=False) for entry in get_settings().trusted_proxies
+            ip_network(entry, strict=False) for entry in settings.trusted_proxies
         ]
 
     peer = connection.client.host if connection.client else None

--- a/geometrikks/server/core.py
+++ b/geometrikks/server/core.py
@@ -45,6 +45,18 @@ def create_app(
     """
     if settings is None:
         settings = get_settings()
+    if dependencies and "settings" in dependencies:
+        # A request-level override would diverge from the settings the
+        # plugins, auth, and lifecycle were composed with (split-brain
+        # configuration). The settings= argument is the one way in.
+        raise ValueError(
+            "The 'settings' dependency is reserved; pass create_app(settings=...) instead."
+        )
+
+    # One engine per app: the same config feeds the SQLAlchemy plugin and,
+    # via app.state, every non-request code path (lifecycle, health probes,
+    # system inspection).
+    db_config = plugins.create_sqlalchemy_config(settings)
 
     from geometrikks.server.auth import build_auth_state, create_session_auth, warn_auth_disabled
 
@@ -87,7 +99,7 @@ def create_app(
         route_handlers=get_route_handlers(include_auth=not settings.auth_disabled),
         on_startup=[on_startup],
         on_shutdown=[on_shutdown],
-        plugins=plugins.create_plugins(settings),
+        plugins=plugins.create_plugins(settings, db_config=db_config),
         dependencies=dependency_map,
         openapi_config=openapi_config,
         compression_config=compression_config,
@@ -96,7 +108,9 @@ def create_app(
     )
     app.state.auth_state = auth_state
     # Lifecycle hooks and other non-request code read the composed settings
-    # from state instead of re-resolving the process-cached factory.
+    # and database config from state instead of re-resolving the
+    # process-cached factories.
     app.state.settings = settings
+    app.state.db_config = db_config
 
     return app

--- a/geometrikks/server/core.py
+++ b/geometrikks/server/core.py
@@ -2,31 +2,49 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 
 from litestar import Litestar
 from litestar.di import Provide
 from litestar.openapi import OpenAPIConfig
 from litestar.config.compression import CompressionConfig
 
-from geometrikks.config.settings import get_settings
+from geometrikks.config.settings import Settings, get_settings
 from geometrikks.server import plugins
 from geometrikks.server.exceptions import CROWDSEC_EXCEPTION_HANDLERS
 from geometrikks.server.lifecycle import on_startup, on_shutdown
 from geometrikks.server.routes import get_route_handlers
-from geometrikks.api.dependencies import provide_limit_offset_pagination
+from geometrikks.api.dependencies import (
+    create_settings_provider,
+    provide_limit_offset_pagination,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
-def create_app() -> Litestar:
+def create_app(
+    settings: Settings | None = None,
+    dependencies: Mapping[str, Provide] | None = None,
+) -> Litestar:
     """Create and configure the Litestar application.
-    
+
     This factory function loads configuration and initializes the app
     with proper settings for CORS, OpenAPI, dependency injection, etc.
-    
+
+    Args:
+        settings: Explicit settings for the app. Defaults to the cached
+            process settings; tests pass their own instance for hermetic
+            composition.
+        dependencies: Extra or replacement app-level dependency providers,
+            merged over the defaults. Intended for tests that substitute
+            services without patching modules.
+
     Returns:
         Litestar: Configured application instance
     """
-    # Load settings once at app creation
-    settings = get_settings()
+    if settings is None:
+        settings = get_settings()
 
     from geometrikks.server.auth import build_auth_state, create_session_auth, warn_auth_disabled
 
@@ -56,21 +74,29 @@ def create_app() -> Litestar:
         ],
     )
     
+    dependency_map: dict[str, Provide] = {
+        "limit_offset": Provide(provide_limit_offset_pagination, sync_to_thread=False),
+        "settings": create_settings_provider(settings),
+    }
+    if dependencies:
+        dependency_map.update(dependencies)
+
     # Create app with configuration
     app = Litestar(
         debug=settings.debug,
         route_handlers=get_route_handlers(include_auth=not settings.auth_disabled),
         on_startup=[on_startup],
         on_shutdown=[on_shutdown],
-        plugins=plugins.create_plugins(),
-        dependencies={
-            "limit_offset": Provide(provide_limit_offset_pagination, sync_to_thread=False),
-        },
+        plugins=plugins.create_plugins(settings),
+        dependencies=dependency_map,
         openapi_config=openapi_config,
         compression_config=compression_config,
         exception_handlers=CROWDSEC_EXCEPTION_HANDLERS,
         on_app_init=on_app_init,
     )
     app.state.auth_state = auth_state
+    # Lifecycle hooks and other non-request code read the composed settings
+    # from state instead of re-resolving the process-cached factory.
+    app.state.settings = settings
 
     return app

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -61,7 +61,9 @@ async def on_startup(app: "Litestar") -> None:
     from geometrikks.server.logging import log_broadcaster
     log_broadcaster.bind_loop(asyncio.get_running_loop())
 
-    settings = get_settings()
+    # create_app() stores its composed settings on state; the fallback keeps
+    # hand-built test apps that attach this hook directly working.
+    settings = getattr(app.state, "settings", None) or get_settings()
 
     if settings.api.log_level is not None:
         logger.warning(

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -13,7 +13,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from geometrikks.config.settings import get_settings
 from geometrikks.server.logging import get_logger
 from geometrikks.server.migrations import migrate_database
-from geometrikks.server.plugins import get_sqlalchemy_config
+from geometrikks.server.plugins import get_app_db_config
 from geometrikks.server.timescale import setup_timescaledb
 
 from geometrikks.services.crowdsec import CrowdSecService
@@ -31,11 +31,11 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-async def _db_available(timeout: float = 10.0) -> bool:
-    """Return True if the database accepts connections; False otherwise."""
+async def _db_available(app: "Litestar", timeout: float = 10.0) -> bool:
+    """Return True if the app's database accepts connections; False otherwise."""
     try:
         async def _probe():
-            async with get_sqlalchemy_config().get_engine().connect() as conn:
+            async with get_app_db_config(app).get_engine().connect() as conn:
                 await conn.execute(text("SELECT 1"))
 
         await asyncio.wait_for(_probe(), timeout=timeout)
@@ -100,7 +100,7 @@ async def on_startup(app: "Litestar") -> None:
         app.state.crowdsec_service = None
         app.state.crowdsec_stream_poller = None
 
-    if not await _db_available():
+    if not await _db_available(app):
         logger.warning("Starting without database: skipping migrations and ingestion.")
         if app.state.crowdsec_stream_poller is not None:
             # The poll job runs on the scheduler, which never starts without a
@@ -113,7 +113,8 @@ async def on_startup(app: "Litestar") -> None:
             )
         return
 
-    engine = get_sqlalchemy_config().get_engine()
+    db_config = get_app_db_config(app)
+    engine = db_config.get_engine()
 
     # Schema is owned by alembic (migrations/versions). A failed upgrade
     # raises and fails startup deliberately: a reachable DB with a broken
@@ -126,7 +127,7 @@ async def on_startup(app: "Litestar") -> None:
     await setup_timescaledb(engine, settings.analytics)
 
     # Session factory: ingestion opens a short-lived session per batch flush
-    session_maker: Callable[[], AsyncSession] = get_sqlalchemy_config().create_session_maker()
+    session_maker: Callable[[], AsyncSession] = db_config.create_session_maker()
 
     parsers = [
         LogParser(

--- a/geometrikks/server/migrations.py
+++ b/geometrikks/server/migrations.py
@@ -26,16 +26,17 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-def upgrade_to_head() -> None:
+def upgrade_to_head(database_url: str | None = None) -> None:
     """Run ``alembic upgrade head`` synchronously; call via asyncio.to_thread().
 
-    Builds a dedicated migration config from the settings URL instead of
-    reusing get_sqlalchemy_config(): alembic's env.py starts its own event
-    loop (asyncio.run), and sharing the app engine would let connections
-    bound to that throwaway loop land back in the app's pool.
+    Builds a dedicated migration config from the given URL (falling back to
+    ambient settings) instead of reusing the app engine: alembic's env.py
+    starts its own event loop (asyncio.run), and sharing the app engine
+    would let connections bound to that throwaway loop land back in the
+    app's pool.
     """
     config = SQLAlchemyAsyncConfig(
-        connection_string=get_settings().database.url,
+        connection_string=database_url or get_settings().database.url,
         alembic_config=AlembicAsyncConfig(
             script_config="alembic.ini",
             script_location="migrations",
@@ -68,4 +69,4 @@ async def migrate_database(engine: AsyncEngine, settings: Settings) -> None:
                 "development).",
                 settings.environment,
             )
-    await asyncio.to_thread(upgrade_to_head)
+    await asyncio.to_thread(upgrade_to_head, settings.database.url)

--- a/geometrikks/server/plugins.py
+++ b/geometrikks/server/plugins.py
@@ -143,10 +143,12 @@ def create_plugins(
     """Instantiate all app plugins; called once from create_app()."""
     from geometrikks.cli import ImportLogsCLIPlugin
 
+    if db_config is None:
+        # Explicit settings must also govern the SQLAlchemy plugin; only a
+        # fully ambient call may use the process-cached config.
+        db_config = get_sqlalchemy_config() if settings is None else create_sqlalchemy_config(settings)
     if settings is None:
         settings = get_settings()
-    if db_config is None:
-        db_config = get_sqlalchemy_config()
     return [
         SQLAlchemyInitPlugin(config=db_config),
         GeoAlchemyPlugin(),  # GeoAlchemy plugin for PostGIS support

--- a/geometrikks/server/plugins.py
+++ b/geometrikks/server/plugins.py
@@ -110,13 +110,14 @@ def create_structlog_plugin(settings: Settings) -> StructlogPlugin:
     )
 
 
-def create_plugins() -> list[
+def create_plugins(settings: Settings | None = None) -> list[
     SQLAlchemyInitPlugin | GeoAlchemyPlugin | GranianPlugin | VitePlugin | CLIPlugin | StructlogPlugin
 ]:
     """Instantiate all app plugins; called once from create_app()."""
     from geometrikks.cli import ImportLogsCLIPlugin
 
-    settings = get_settings()
+    if settings is None:
+        settings = get_settings()
     return [
         SQLAlchemyInitPlugin(config=get_sqlalchemy_config()),
         GeoAlchemyPlugin(),  # GeoAlchemy plugin for PostGIS support

--- a/geometrikks/server/plugins.py
+++ b/geometrikks/server/plugins.py
@@ -11,6 +11,7 @@ import platform
 import shutil
 from functools import lru_cache
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from litestar.middleware.logging import LoggingMiddlewareConfig
 from litestar.plugins.structlog import StructlogConfig, StructlogPlugin
@@ -34,11 +35,12 @@ from litestar_vite.config import RuntimeConfig, TypeGenConfig, PathConfig
 from geometrikks.config.settings import get_settings, Settings
 from geometrikks.server.logging import create_logging_config
 
+if TYPE_CHECKING:
+    from litestar import Litestar
 
-@lru_cache(maxsize=1)
-def get_sqlalchemy_config() -> SQLAlchemyAsyncConfig:
-    """Build (once per process) the async engine and SQLAlchemy config."""
-    settings = get_settings()
+
+def create_sqlalchemy_config(settings: Settings) -> SQLAlchemyAsyncConfig:
+    """Build an async engine and SQLAlchemy config from explicit settings."""
     engine = create_async_engine(
         url=settings.database.url,
         echo=settings.database.echo,
@@ -60,6 +62,28 @@ def get_sqlalchemy_config() -> SQLAlchemyAsyncConfig:
         create_all=False,
         metadata=base.DefaultBase.metadata,
     )
+
+
+@lru_cache(maxsize=1)
+def get_sqlalchemy_config() -> SQLAlchemyAsyncConfig:
+    """Process-cached engine/config from ambient settings.
+
+    For contexts with no composed app (the import-logs CLI, hand-built test
+    apps). App code paths should resolve the app-bound config through
+    get_app_db_config() so create_app(settings=...) governs the database.
+    """
+    return create_sqlalchemy_config(get_settings())
+
+
+def get_app_db_config(app: Litestar) -> SQLAlchemyAsyncConfig:
+    """The SQLAlchemy config the app was composed with.
+
+    create_app() stores its config on app.state; the fallback keeps
+    hand-built test apps (which never went through create_app) working
+    against the process-cached config.
+    """
+    config = getattr(app.state, "db_config", None)
+    return config if config is not None else get_sqlalchemy_config()
 
 
 def create_vite_config(settings: Settings) -> ViteConfig:
@@ -110,7 +134,10 @@ def create_structlog_plugin(settings: Settings) -> StructlogPlugin:
     )
 
 
-def create_plugins(settings: Settings | None = None) -> list[
+def create_plugins(
+    settings: Settings | None = None,
+    db_config: SQLAlchemyAsyncConfig | None = None,
+) -> list[
     SQLAlchemyInitPlugin | GeoAlchemyPlugin | GranianPlugin | VitePlugin | CLIPlugin | StructlogPlugin
 ]:
     """Instantiate all app plugins; called once from create_app()."""
@@ -118,8 +145,10 @@ def create_plugins(settings: Settings | None = None) -> list[
 
     if settings is None:
         settings = get_settings()
+    if db_config is None:
+        db_config = get_sqlalchemy_config()
     return [
-        SQLAlchemyInitPlugin(config=get_sqlalchemy_config()),
+        SQLAlchemyInitPlugin(config=db_config),
         GeoAlchemyPlugin(),  # GeoAlchemy plugin for PostGIS support
         GranianPlugin(),
         VitePlugin(config=create_vite_config(settings)),

--- a/geometrikks/server/routes.py
+++ b/geometrikks/server/routes.py
@@ -3,7 +3,9 @@ from pathlib import Path
 
 from litestar import get
 from litestar.datastructures import ResponseHeader
+from litestar.di import NamedDependency
 from litestar.exceptions import NotFoundException
+from litestar.params import SkipValidation
 from litestar.response import File
 from litestar.types import ControllerRouterHandler
 
@@ -20,7 +22,7 @@ from geometrikks.api.v1.live_controller import crowdsec_feed, live_feed, logs_fe
 from geometrikks.api.v1.settings import read_settings
 from geometrikks.api.v1.stats import stats
 from geometrikks.api.health import health, health_ready
-from geometrikks.config.settings import get_settings
+from geometrikks.config.settings import Settings
 
 
 @get(
@@ -31,10 +33,10 @@ from geometrikks.config.settings import get_settings
     # stall; never serve it with a long-lived cache header.
     response_headers=[ResponseHeader(name="Cache-Control", value="no-cache")],
 )
-def service_worker() -> File:
+def service_worker(settings: NamedDependency[SkipValidation[Settings]]) -> File:
     # No worker in dev mode: it would cache the dev shell and break the next
     # production run on the same origin.
-    if get_settings().vite.dev_mode:
+    if settings.vite.dev_mode:
         raise NotFoundException(detail="Service worker is not served in dev mode")
     sw_path = Path("public/sw.js")
     if not sw_path.is_file():

--- a/geometrikks/server/scheduler.py
+++ b/geometrikks/server/scheduler.py
@@ -16,9 +16,9 @@ from typing import TYPE_CHECKING, Callable
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from geometrikks.server.logging import get_logger
-from geometrikks.server.plugins import get_sqlalchemy_config
 from geometrikks.server.timescale import ALL_CAGGS
 
 if TYPE_CHECKING:
@@ -56,13 +56,23 @@ async def refresh_location_last_hits_job(
             logger.info("Refreshed last_hit for %d locations", updated)
 
 
-async def _execute_call_outside_transaction(sql: str, *args: object) -> None:
+async def _execute_call_outside_transaction(
+    session_factory: "Callable[[], AsyncSession]", sql: str, *args: object
+) -> None:
     """Execute a CALL statement outside of any transaction.
 
     PostgreSQL CALL statements (like refresh_continuous_aggregate) cannot
     run inside a transaction block. Positional args are bound by asyncpg.
+    The engine comes from the job's session factory so scheduled work runs
+    against the same database the app was composed with.
     """
-    engine = get_sqlalchemy_config().get_engine()
+    session = session_factory()
+    try:
+        engine = session.bind
+    finally:
+        await session.close()
+    if not isinstance(engine, AsyncEngine):
+        raise RuntimeError("Session factory has no bound engine for CALL statement")
     async with engine.connect() as conn:
         raw_conn = await conn.get_raw_connection()
         driver_conn = raw_conn.driver_connection
@@ -83,7 +93,7 @@ async def refresh_continuous_aggregate_job(
     against the ALL_CAGGS allowlist (identifiers cannot be parameters).
 
     Args:
-        session_factory: Unused, kept for scheduler job signature consistency.
+        session_factory: SQLAlchemy async session factory; supplies the engine.
         cagg_name: Name of the continuous aggregate to refresh.
         start: Start of refresh window (None = beginning of time).
         end: End of refresh window (None = now).
@@ -92,6 +102,7 @@ async def refresh_continuous_aggregate_job(
         raise ValueError(f"Unknown CAGG name: {cagg_name}")
 
     await _execute_call_outside_transaction(
+        session_factory,
         f"CALL refresh_continuous_aggregate('{cagg_name}', $1::timestamptz, $2::timestamptz)",
         start,
         end,
@@ -115,7 +126,8 @@ async def refresh_all_caggs_job(
     for cagg_name in ALL_CAGGS:
         try:
             await _execute_call_outside_transaction(
-                f"CALL refresh_continuous_aggregate('{cagg_name}', NULL, NULL)"
+                session_factory,
+                f"CALL refresh_continuous_aggregate('{cagg_name}', NULL, NULL)",
             )
             logger.info("Refreshed %s", cagg_name)
         except Exception as e:

--- a/geometrikks/services/logfiles.py
+++ b/geometrikks/services/logfiles.py
@@ -14,9 +14,12 @@ from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from geometrikks.server.logging import LOGIN_LOG_NAME, LOGIN_LOGGER_NAME, MAIN_LOG_NAME
+
+if TYPE_CHECKING:
+    from geometrikks.config.settings import Settings
 
 _LOGIN_LINE_RE = re.compile(
     r'^(?P<timestamp>\S+) (?P<event>[A-Za-z0-9_]+) user="(?P<user>[^"]*)" ip=(?P<ip>\S+)$'
@@ -132,10 +135,11 @@ class LogFilesService:
         return records
 
 
-def create_log_files_service() -> LogFilesService:
-    from geometrikks.config.settings import get_settings
+def create_log_files_service(settings: Settings | None = None) -> LogFilesService:
+    if settings is None:
+        from geometrikks.config.settings import get_settings
 
-    settings = get_settings()
+        settings = get_settings()
     return LogFilesService(
         log_dir=settings.log.dir,
         nginx_paths=list(settings.logparser.log_paths),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "pytest>=9.1.1",
-    "pytest-asyncio>=1.4.0",
     "pytest-cov>=7.1.0",
     "ty>=0.0.63",
     "faker>=40.36.0",
@@ -39,7 +38,6 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-asyncio_mode = "auto"
 testpaths = ["tests"]
 markers = [
     "integration: needs a live TimescaleDB (docker compose up -d timescale_db); auto-skipped when unreachable",
@@ -57,8 +55,6 @@ filterwarnings = [
     # Drop once a fixed AA release ships; this is the external gate for
     # Litestar 3.0.
     "ignore:\\[paths='/', handler='(list_access_log_debug|list_access_logs|list_geo_events)', dependencies='filters'\\] Inferred dependency field '(limit_offset_filter|order_by_filter|search_filter)'.*:litestar.exceptions.LitestarDeprecationWarning",
-    # Reduce noise from third-party libs; keep real test warnings visible
-    "ignore:There is no current event loop:DeprecationWarning",
     # False positive: our auth exclude pattern deliberately matches everything
     # outside /api/ (SPA shell, assets, /health). The boundary is verified by
     # tests/test_auth_endpoints.py (401 on /api/*, 200 on excluded paths).

--- a/scripts/generate_config_docs.py
+++ b/scripts/generate_config_docs.py
@@ -98,6 +98,11 @@ def build() -> str:
         "All settings are environment variables (or `.env` entries). The short",
         "list most users need is in `.env.example`; everything below is available.",
         "",
+        "`GEOMETRIKKS_ENV_FILE` overrides the path of the `.env` file itself",
+        "(default: `.env` in the working directory); setting it to an empty",
+        "value disables dotenv loading entirely, so configuration comes only",
+        "from real environment variables. It is read once at import time.",
+        "",
     ]
     parts.extend(render_section(*section) for section in SECTIONS)
     return "\n".join(parts) + "\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
 import os
 import pytest
 
+# Tests must never read a developer's .env. Every settings section resolves
+# its dotenv path through GEOMETRIKKS_ENV_FILE at class-creation time (empty
+# disables it), so this must run before geometrikks.config.settings is
+# imported anywhere; conftest module import precedes test collection.
+os.environ["GEOMETRIKKS_ENV_FILE"] = ""
+
 
 @pytest.fixture(scope="session", autouse=True)
 def disable_wait_env():
@@ -44,6 +50,11 @@ def baseline_settings_env():
         # Log parser
         "LOGPARSER_LOG_PATHS": "/var/log/nginx/access.log",
     })
+    # Representative developer values that default-asserting tests are
+    # sensitive to; scrub them so an exported shell environment cannot leak
+    # into the suite. Tests that need them set them via monkeypatch.
+    for var in ("MAP_HOME_LATITUDE", "MAP_HOME_LONGITUDE", "LOGPARSER_IGNORE_IPS"):
+        os.environ.pop(var, None)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,12 @@ import pytest
 os.environ["GEOMETRIKKS_ENV_FILE"] = ""
 
 
+@pytest.fixture
+def anyio_backend() -> str:
+    """Async tests run on asyncio; Litestar's runtime is AnyIO-based."""
+    return "asyncio"
+
+
 @pytest.fixture(scope="session", autouse=True)
 def disable_wait_env():
     """Ensure retry loops are disabled during test runs.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,18 @@ import pytest
 # imported anywhere; conftest module import precedes test collection.
 os.environ["GEOMETRIKKS_ENV_FILE"] = ""
 
+# The app's entire configuration namespace is scrubbed from the inherited
+# environment for the same reason: a developer shell exporting perfectly
+# valid values (SCHEDULER_ENABLED=false, CROWDSEC_MACHINE_ID=..., MAP_HOME_*)
+# must not change test results. Values tests do rely on are re-set in
+# baseline_settings_env below; tests needing others use monkeypatch.setenv.
+_SETTINGS_ENV_PREFIXES = (
+    "APP_", "API_", "DB_", "GEOIP_", "LOG_", "LOGPARSER_", "ANALYTICS_",
+    "SCHEDULER_", "MAP_", "CROWDSEC_", "VITE_", "MAXMINDDB_",
+)
+for _key in [k for k in os.environ if k.startswith(_SETTINGS_ENV_PREFIXES)]:
+    del os.environ[_key]
+
 
 @pytest.fixture
 def anyio_backend() -> str:
@@ -56,11 +68,6 @@ def baseline_settings_env():
         # Log parser
         "LOGPARSER_LOG_PATHS": "/var/log/nginx/access.log",
     })
-    # Representative developer values that default-asserting tests are
-    # sensitive to; scrub them so an exported shell environment cannot leak
-    # into the suite. Tests that need them set them via monkeypatch.
-    for var in ("MAP_HOME_LATITUDE", "MAP_HOME_LONGITUDE", "LOGPARSER_IGNORE_IPS"):
-        os.environ.pop(var, None)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_access_log_debug_pg.py
+++ b/tests/integration/test_access_log_debug_pg.py
@@ -15,6 +15,8 @@ from sqlalchemy import text
 
 from geometrikks.domain.logs.services import AccessLogDebugService
 
+pytestmark = pytest.mark.anyio
+
 # Wall-clock-relative so seeds stay inside the retention window.
 NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
 

--- a/tests/integration/test_access_logs_list_pg.py
+++ b/tests/integration/test_access_logs_list_pg.py
@@ -17,6 +17,10 @@ from sqlalchemy import or_, text
 from geometrikks.domain.logs.services import AccessLogService
 from geometrikks.server.timescale import refresh_caggs_range
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 # Wall-clock-relative so seeds stay inside the raw-retention window (see conftest).
 NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
 

--- a/tests/integration/test_analytics_endpoints.py
+++ b/tests/integration/test_analytics_endpoints.py
@@ -11,6 +11,10 @@ from sqlalchemy import text
 
 from geometrikks.domain.analytics.repositories import AnalyticsFilters, LiveStatsRepository
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 # Wall-clock derived, hour-aligned (see test_repositories_pg.py for why).
 NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
 

--- a/tests/integration/test_cagg_backfill.py
+++ b/tests/integration/test_cagg_backfill.py
@@ -12,6 +12,10 @@ from sqlalchemy import text
 
 from geometrikks.domain.analytics.repositories import SummaryStatsRepository
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
 OLD = NOW - timedelta(days=10)
 # Inside the simulated policy refresh window: without a row here, the

--- a/tests/integration/test_crowdsec_enrichment_pg.py
+++ b/tests/integration/test_crowdsec_enrichment_pg.py
@@ -7,6 +7,10 @@ from sqlalchemy import text
 
 from geometrikks.domain.security.repositories import SecurityEnrichmentRepository
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
 
 

--- a/tests/integration/test_geo_logs_pg.py
+++ b/tests/integration/test_geo_logs_pg.py
@@ -17,6 +17,8 @@ from geometrikks.domain.geo.schemas import GeoEventFilters
 from geometrikks.domain.geo.services import GeoEventService
 from geometrikks.server.timescale import refresh_caggs_range
 
+pytestmark = pytest.mark.anyio
+
 # Wall-clock derived, hour-aligned (see test_repositories_pg.py for why).
 NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
 

--- a/tests/integration/test_import_pg.py
+++ b/tests/integration/test_import_pg.py
@@ -12,6 +12,10 @@ from geometrikks.services.importer import import_file
 from geometrikks.services.ingestion.service import LogIngestionService
 from geometrikks.services.logparser.logparser import LogParser
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 GEOIP_DB_PATH = "tests/GeoLite2-City-Test.mmdb"
 TEST_IP = "2.125.160.216"
 

--- a/tests/integration/test_ingestion_pg.py
+++ b/tests/integration/test_ingestion_pg.py
@@ -20,6 +20,10 @@ from geometrikks.domain.logs.models import AccessLog, AccessLogDebug
 from geometrikks.services.ingestion.service import LogIngestionService
 from geometrikks.services.logparser.logparser import LogParser
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 GEOIP_DB_PATH = "tests/GeoLite2-City-Test.mmdb"
 TEST_IP = "2.125.160.216"   # resolves in the MaxMind test DB
 TEST_IP_2 = "81.2.69.142"   # second location in the test DB

--- a/tests/integration/test_percentile_caggs.py
+++ b/tests/integration/test_percentile_caggs.py
@@ -7,6 +7,10 @@ from sqlalchemy import text
 
 from geometrikks.server.timescale import refresh_caggs_range
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 # Derived from the wall clock, not hard-coded: the scratch DB has live
 # retention/refresh policies, so a fixed date would age out of their windows
 # (see test_repositories_pg.py). Hour-aligned for deterministic bucketing.

--- a/tests/integration/test_repositories_pg.py
+++ b/tests/integration/test_repositories_pg.py
@@ -14,6 +14,10 @@ from geometrikks.domain.geo.repositories import GeoLocationRepository
 from geometrikks.server.timescale import refresh_caggs_range
 from tests.seed.factories import AccessLogFactory, GeoLocationFactory, seed_factories
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 # Derived from the wall clock, not hard-coded: the scratch DB has live
 # retention policies (raw data > 180 days is droppable), so a fixed date
 # would eventually age out of the window and let a policy job drop seeded

--- a/tests/integration/test_startup_pg.py
+++ b/tests/integration/test_startup_pg.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 from sqlalchemy import text
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 EXPECTED_TABLES = {"geo_locations", "geo_events", "access_logs", "access_log_debug"}
 EXPECTED_HYPERTABLES = {"geo_events", "access_logs", "access_log_debug"}
 EXPECTED_CAGGS = {

--- a/tests/integration/test_top_caggs_pg.py
+++ b/tests/integration/test_top_caggs_pg.py
@@ -60,6 +60,10 @@ from geometrikks.domain.analytics.repositories import (
     SummaryStatsRepository,
 )
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 
 async def _insert_log(
     session, *, ts, url="/page", user_agent="ua/1.0", status=200,

--- a/tests/support.py
+++ b/tests/support.py
@@ -1,0 +1,17 @@
+"""Shared helpers for hand-built test apps."""
+from __future__ import annotations
+
+from litestar.di import Provide
+
+from geometrikks.config.settings import get_settings
+
+
+def ambient_settings_dependency() -> dict[str, Provide]:
+    """App-level ``settings`` dependency for hand-built test apps.
+
+    Resolves ``get_settings()`` per request so tests that monkeypatch env
+    vars (with the autouse cache-clear fixture) keep seeing fresh values,
+    exactly as handlers did when they called ``get_settings()`` inline.
+    Full-app tests should prefer ``create_app(settings=...)`` instead.
+    """
+    return {"settings": Provide(get_settings, sync_to_thread=False)}

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -85,3 +85,18 @@ def test_database_stack_binds_to_explicit_settings(monkeypatch):
     url = str(app.state.db_config.get_engine().url)
     assert "127.0.0.1" in url
     assert "ambient.invalid" not in url
+
+
+def test_create_plugins_derives_db_config_from_explicit_settings(monkeypatch):
+    """create_plugins(settings=...) without a db_config must not fall back to
+    the ambient process-cached engine (split-brain configuration)."""
+    from advanced_alchemy.extensions.litestar import SQLAlchemyInitPlugin
+
+    from geometrikks.server import plugins as plugins_mod
+
+    monkeypatch.setenv("DB_HOST", "ambient.invalid")
+    plugin_list = plugins_mod.create_plugins(settings=_hermetic_settings())
+    init_plugin = next(p for p in plugin_list if isinstance(p, SQLAlchemyInitPlugin))
+    url = str(init_plugin.config[0].get_engine().url)
+    assert "127.0.0.1" in url
+    assert "ambient.invalid" not in url

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -52,17 +52,36 @@ async def test_request_handlers_receive_explicit_settings(monkeypatch):
     assert resp.json()["name"] == "Explicit Name"
 
 
-async def test_dependency_overrides_replace_defaults():
-    replaced = _hermetic_settings(name="Overridden")
+def test_settings_dependency_is_reserved():
+    """A request-level settings override would diverge from the settings the
+    plugins, auth, and lifecycle were composed with; settings= is the one way
+    in."""
+    def provide_other() -> Settings:
+        return _hermetic_settings()
 
-    def provide_replaced() -> Settings:
-        return replaced
+    with pytest.raises(ValueError, match="settings"):
+        create_app(
+            settings=_hermetic_settings(),
+            dependencies={"settings": Provide(provide_other, sync_to_thread=False)},
+        )
+
+
+def test_extra_dependencies_are_registered():
+    def provide_marker() -> str:
+        return "marker"
 
     app = create_app(
-        settings=_hermetic_settings(name="Composed"),
-        dependencies={"settings": Provide(provide_replaced, sync_to_thread=False)},
+        settings=_hermetic_settings(),
+        dependencies={"marker_service": Provide(provide_marker, sync_to_thread=False)},
     )
-    async with AsyncTestClient(app=app) as client:
-        resp = await client.get("/api/v1/settings")
-    assert resp.status_code == 200
-    assert resp.json()["name"] == "Overridden"
+    assert "marker_service" in app.dependencies
+
+
+def test_database_stack_binds_to_explicit_settings(monkeypatch):
+    """The SQLAlchemy engine must come from the explicit settings object,
+    never from ambient environment configuration."""
+    monkeypatch.setenv("DB_HOST", "ambient.invalid")
+    app = create_app(settings=_hermetic_settings())
+    url = str(app.state.db_config.get_engine().url)
+    assert "127.0.0.1" in url
+    assert "ambient.invalid" not in url

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,0 +1,68 @@
+"""create_app() composition: explicit settings and dependency overrides."""
+from __future__ import annotations
+
+import pytest
+import structlog
+from litestar.di import Provide
+from litestar.testing import AsyncTestClient
+
+from geometrikks.config.settings import DatabaseSettings, Settings
+from geometrikks.server.core import create_app
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture(autouse=True)
+def _reset_structlog_config():
+    """Undo the StructlogPlugin's global configuration after each test.
+
+    The plugin enables cache_logger_on_first_use; leaving that active would
+    let later-bound loggers bypass structlog.testing.capture_logs() in other
+    test modules.
+    """
+    yield
+    structlog.reset_defaults()
+
+
+def _hermetic_settings(**overrides) -> Settings:
+    return Settings(
+        auth_disabled=True,
+        # Unroutable database -> startup takes the degraded path immediately,
+        # so these tests never touch a real developer database.
+        database=DatabaseSettings(host="127.0.0.1", port=59999),
+        **overrides,
+    )
+
+
+def test_create_app_prefers_explicit_settings_over_env(monkeypatch):
+    monkeypatch.setenv("APP_NAME", "Ambient Name")
+    settings = _hermetic_settings(name="Explicit Name")
+    app = create_app(settings=settings)
+    assert app.state.settings is settings
+    assert app.openapi_config is not None
+    assert app.openapi_config.title == "Explicit Name"
+
+
+async def test_request_handlers_receive_explicit_settings(monkeypatch):
+    monkeypatch.setenv("APP_NAME", "Ambient Name")
+    app = create_app(settings=_hermetic_settings(name="Explicit Name"))
+    async with AsyncTestClient(app=app) as client:
+        resp = await client.get("/api/v1/settings")
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Explicit Name"
+
+
+async def test_dependency_overrides_replace_defaults():
+    replaced = _hermetic_settings(name="Overridden")
+
+    def provide_replaced() -> Settings:
+        return replaced
+
+    app = create_app(
+        settings=_hermetic_settings(name="Composed"),
+        dependencies={"settings": Provide(provide_replaced, sync_to_thread=False)},
+    )
+    async with AsyncTestClient(app=app) as client:
+        resp = await client.get("/api/v1/settings")
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Overridden"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,6 +5,8 @@ import pytest
 
 from geometrikks.config.settings import Settings
 
+pytestmark = pytest.mark.anyio
+
 
 def _settings(**kwargs) -> Settings:
     return Settings(**kwargs)

--- a/tests/test_auth_endpoints.py
+++ b/tests/test_auth_endpoints.py
@@ -9,7 +9,7 @@ from litestar.testing import TestClient
 
 from geometrikks.config.settings import Settings
 from geometrikks.api.v1.auth_controller import AuthController
-from geometrikks.api.v1.live_controller import live_feed
+from geometrikks.api.v1.live_controller import crowdsec_feed, live_feed, logs_feed
 from geometrikks.server.auth import build_auth_state, create_session_auth
 
 from tests.test_live_ws import FakeIngestion
@@ -34,7 +34,9 @@ def make_app(**settings_kwargs) -> Litestar:
     )
     session_auth = create_session_auth(settings)
     app = Litestar(
-        route_handlers=[AuthController, protected, fake_health, live_feed],
+        route_handlers=[
+            AuthController, protected, fake_health, live_feed, crowdsec_feed, logs_feed
+        ],
         on_app_init=[session_auth.on_app_init],
         logging_config=None,
     )
@@ -83,14 +85,15 @@ def test_login_logout_flow():
         assert client.get("/api/v1/protected").status_code == 401
 
 
-def test_ws_live_rejected_without_session():
+@pytest.mark.parametrize("path", ["/ws/live", "/ws/crowdsec", "/ws/logs"])
+def test_ws_feeds_rejected_without_session(path):
     from litestar.exceptions import WebSocketDisconnect
 
     with TestClient(app=make_app()) as client:
         # The middleware's NotAuthorizedException closes the handshake
         # (4000 + 401 = 4401), surfaced by the test client as a disconnect.
         with pytest.raises(WebSocketDisconnect):
-            with client.websocket_connect("/ws/live") as ws:
+            with client.websocket_connect(path) as ws:
                 ws.receive_json(timeout=2)
 
 

--- a/tests/test_crowdsec_controller.py
+++ b/tests/test_crowdsec_controller.py
@@ -14,6 +14,10 @@ from geometrikks.domain.security.schemas import IpEnrichment
 from geometrikks.services.crowdsec import CrowdSecService, Decision
 from tests.support import ambient_settings_dependency
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 
 def make_decision(**overrides: Any) -> Decision:
     values: dict[str, Any] = {

--- a/tests/test_crowdsec_controller.py
+++ b/tests/test_crowdsec_controller.py
@@ -12,6 +12,7 @@ from geometrikks.api.v1.crowdsec_controller import CrowdSecController
 from geometrikks.domain.security.repositories import SecurityEnrichmentRepository
 from geometrikks.domain.security.schemas import IpEnrichment
 from geometrikks.services.crowdsec import CrowdSecService, Decision
+from tests.support import ambient_settings_dependency
 
 
 def make_decision(**overrides: Any) -> Decision:
@@ -71,6 +72,7 @@ def make_app(
         route_handlers=[_TestController],
         dependencies={
             "limit_offset": Provide(provide_limit_offset_pagination, sync_to_thread=False),
+            **ambient_settings_dependency(),
         },
     )
     app.state.crowdsec_service = service

--- a/tests/test_crowdsec_enrichment.py
+++ b/tests/test_crowdsec_enrichment.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 from geometrikks.domain.security.repositories import SecurityEnrichmentRepository
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 
 async def test_enrich_empty_input_skips_query():
     repo = SecurityEnrichmentRepository(session=None)  # would crash if queried

--- a/tests/test_crowdsec_exception_handlers.py
+++ b/tests/test_crowdsec_exception_handlers.py
@@ -7,6 +7,10 @@ from litestar.testing import AsyncTestClient
 from geometrikks.server.exceptions import CROWDSEC_EXCEPTION_HANDLERS
 from geometrikks.services.crowdsec import CrowdSecAuthError, CrowdSecUnavailableError
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 
 @get("/boom-unavailable")
 async def raise_unavailable() -> None:

--- a/tests/test_crowdsec_lifecycle.py
+++ b/tests/test_crowdsec_lifecycle.py
@@ -7,6 +7,10 @@ from unittest.mock import AsyncMock
 from geometrikks.services.crowdsec import CrowdSecService
 from tests.test_lifecycle_geoip import _patch_startup_collaborators
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 
 def make_app() -> SimpleNamespace:
     return SimpleNamespace(state=SimpleNamespace())

--- a/tests/test_crowdsec_service.py
+++ b/tests/test_crowdsec_service.py
@@ -14,6 +14,8 @@ from geometrikks.services.crowdsec import (
     Decision,
 )
 
+pytestmark = pytest.mark.anyio
+
 DECISION_JSON = {
     "id": 42,
     "origin": "cscli",

--- a/tests/test_crowdsec_stream.py
+++ b/tests/test_crowdsec_stream.py
@@ -265,14 +265,16 @@ def test_ws_sends_empty_delta_heartbeat_when_idle(monkeypatch):
 
 
 def test_ws_closes_without_poller():
-    import pytest
+    """Degraded mode closes with 1013 (try again later) and a usable reason."""
     from litestar.exceptions import WebSocketDisconnect
     from litestar.testing import TestClient
 
     with TestClient(app=make_ws_app(None)) as client:
-        with pytest.raises(WebSocketDisconnect):
+        with pytest.raises(WebSocketDisconnect) as exc_info:
             with client.websocket_connect("/ws/crowdsec") as ws:
                 ws.receive_json(timeout=2)
+    assert exc_info.value.code == 1013
+    assert exc_info.value.detail == "crowdsec stream not running"
 
 
 def test_ws_sends_initial_status_frame():

--- a/tests/test_crowdsec_stream.py
+++ b/tests/test_crowdsec_stream.py
@@ -5,6 +5,10 @@ import httpx
 
 from tests.test_crowdsec_service import DECISION_JSON, make_service
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 
 def stream_responder(payloads: list[dict]):
     """Return each payload in turn for successive /v1/decisions/stream calls."""

--- a/tests/test_geo_events_controller.py
+++ b/tests/test_geo_events_controller.py
@@ -21,6 +21,8 @@ from geometrikks.api.v1.geo_events_controller import (
 )
 from geometrikks.domain.geo.schemas import GeoEventFilters, GeoLogPeriod
 
+pytestmark = pytest.mark.anyio
+
 
 class TestTimeWindow:
     def test_no_window_when_both_bounds_none(self) -> None:

--- a/tests/test_geo_routing.py
+++ b/tests/test_geo_routing.py
@@ -9,6 +9,10 @@ from geometrikks.domain.geo.repositories import StatsGranularity
 from geometrikks.domain.geo.schemas import GeoEventFilters
 from geometrikks.domain.geo.services import GeoEventService
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 NOW = datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc)
 WEEK_START = NOW - timedelta(days=7)
 

--- a/tests/test_geoip_downloader.py
+++ b/tests/test_geoip_downloader.py
@@ -11,6 +11,8 @@ import pytest
 
 from geometrikks.config.settings import GeoIPSettings
 
+pytestmark = pytest.mark.anyio
+
 
 @pytest.fixture(autouse=True)
 def no_local_maxmind_credentials(monkeypatch):

--- a/tests/test_geoip_home.py
+++ b/tests/test_geoip_home.py
@@ -7,6 +7,10 @@ import httpx
 from geometrikks.config.settings import GeoIPSettings, MapSettings
 from geometrikks.services.geoip.home import resolve_home_location
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 
 async def test_configured_home_skips_public_ip_lookup():
     home = await resolve_home_location(

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -10,11 +10,15 @@ from geometrikks.api import health as health_module
 from geometrikks.api.health import health, health_ready
 from geometrikks.services.ingestion import LogIngestionService
 from geometrikks.services.logparser.logparser import LogParser
+from tests.support import ambient_settings_dependency
 
 
 def make_app() -> Litestar:
     # No ingestion service in app.state -> degraded mode
-    return Litestar(route_handlers=[health, health_ready])
+    return Litestar(
+        route_handlers=[health, health_ready],
+        dependencies=ambient_settings_dependency(),
+    )
 
 
 def test_health_returns_200_even_when_degraded(monkeypatch):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -22,7 +22,7 @@ def make_app() -> Litestar:
 
 
 def test_health_returns_200_even_when_degraded(monkeypatch):
-    async def db_down(timeout: float = 2.0) -> bool:
+    async def db_down(app, timeout: float = 2.0) -> bool:
         return False
     monkeypatch.setattr(health_module, "_database_reachable", db_down)
 
@@ -36,7 +36,7 @@ def test_health_returns_200_even_when_degraded(monkeypatch):
 
 
 def test_ready_503_when_db_unreachable(monkeypatch):
-    async def db_down(timeout: float = 2.0) -> bool:
+    async def db_down(app, timeout: float = 2.0) -> bool:
         return False
     monkeypatch.setattr(health_module, "_database_reachable", db_down)
 
@@ -45,7 +45,7 @@ def test_ready_503_when_db_unreachable(monkeypatch):
 
 
 def test_ready_200_when_db_reachable(monkeypatch):
-    async def db_up(timeout: float = 2.0) -> bool:
+    async def db_up(app, timeout: float = 2.0) -> bool:
         return True
     monkeypatch.setattr(health_module, "_database_reachable", db_up)
 
@@ -69,7 +69,7 @@ def _running_service(file_missing: bool) -> "LogIngestionService":
 def test_health_degraded_when_tailed_file_missing(monkeypatch):
     """Ingestion running but a tailed log file has disappeared -> degraded,
     and the missing paths are surfaced in the payload."""
-    async def db_up(timeout: float = 2.0) -> bool:
+    async def db_up(app, timeout: float = 2.0) -> bool:
         return True
     monkeypatch.setattr(health_module, "_database_reachable", db_up)
 
@@ -86,7 +86,7 @@ def test_health_exposes_uptime_and_activity_fields(monkeypatch):
     """started_at, ingestion.last_record_at and geoip.db_modified_at are
     present and null-safe: no app state and no GeoIP file must not break the
     probe."""
-    async def db_up(timeout: float = 2.0) -> bool:
+    async def db_up(app, timeout: float = 2.0) -> bool:
         return True
     monkeypatch.setattr(health_module, "_database_reachable", db_up)
 
@@ -99,7 +99,7 @@ def test_health_exposes_uptime_and_activity_fields(monkeypatch):
 
 
 def test_health_started_at_from_app_state(monkeypatch):
-    async def db_up(timeout: float = 2.0) -> bool:
+    async def db_up(app, timeout: float = 2.0) -> bool:
         return True
     monkeypatch.setattr(health_module, "_database_reachable", db_up)
 
@@ -113,7 +113,7 @@ def test_health_started_at_from_app_state(monkeypatch):
 
 
 def test_health_no_missing_files_stays_healthy(monkeypatch):
-    async def db_up(timeout: float = 2.0) -> bool:
+    async def db_up(app, timeout: float = 2.0) -> bool:
         return True
     monkeypatch.setattr(health_module, "_database_reachable", db_up)
 
@@ -126,7 +126,7 @@ def test_health_no_missing_files_stays_healthy(monkeypatch):
 
 
 def test_health_crowdsec_disabled_by_default(monkeypatch):
-    async def db_up(timeout: float = 2.0) -> bool:
+    async def db_up(app, timeout: float = 2.0) -> bool:
         return True
     monkeypatch.setattr(health_module, "_database_reachable", db_up)
 
@@ -136,7 +136,7 @@ def test_health_crowdsec_disabled_by_default(monkeypatch):
 
 
 def test_health_crowdsec_enabled_and_down(monkeypatch):
-    async def db_up(timeout: float = 2.0) -> bool:
+    async def db_up(app, timeout: float = 2.0) -> bool:
         return True
     monkeypatch.setattr(health_module, "_database_reachable", db_up)
 

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -11,6 +11,8 @@ from geoip2.database import Reader
 
 from geometrikks.services.logparser.logparser import LogParser
 
+pytestmark = pytest.mark.anyio
+
 GEOIP_DB_PATH = "tests/GeoLite2-City-Test.mmdb"
 TEST_IP = "2.125.160.216"
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -16,6 +16,8 @@ from geometrikks.services.logparser.logparser import LogParser
 from geometrikks.services.logparser.schemas import ParsedLogRecord, ParsedGeoData, ParsedAccessLog
 from geometrikks.services.ingestion.service import IngestionRepos, LogIngestionService
 
+pytestmark = pytest.mark.anyio
+
 GEOIP_DB_PATH = "tests/GeoLite2-City-Test.mmdb"
 
 # IPs present in the redistributable MaxMind test database (both resolve with lat/long)
@@ -169,7 +171,6 @@ def append_line(path: Path, line: str) -> None:
         fh.write(line + "\n")
 
 
-@pytest.mark.asyncio
 async def test_multi_file_tailing_ingests_from_all_sources(tmp_path: Path) -> None:
     """One tail task per file; records from every file reach the repositories.
 
@@ -198,7 +199,6 @@ async def test_multi_file_tailing_ingests_from_all_sources(tmp_path: Path) -> No
     assert any(s.commits for s in sessions)
 
 
-@pytest.mark.asyncio
 async def test_stop_drains_queue_before_exit(tmp_path: Path) -> None:
     """Records already parsed are persisted on stop, not dropped."""
     log_file = tmp_path / "a.log"
@@ -218,7 +218,6 @@ async def test_stop_drains_queue_before_exit(tmp_path: Path) -> None:
     assert any(s.commits for s in sessions)  # final flush on stop
 
 
-@pytest.mark.asyncio
 async def test_missing_file_does_not_block_other_tails(tmp_path: Path) -> None:
     """A nonexistent log path is skipped (with an error log); other files still ingest.
 
@@ -241,7 +240,6 @@ async def test_missing_file_does_not_block_other_tails(tmp_path: Path) -> None:
     assert service.total_geo_records == 1
 
 
-@pytest.mark.asyncio
 async def test_all_tails_dead_stops_service_and_clears_is_running(tmp_path: Path) -> None:
     """When every tail task exits (all log files missing), the consumer must
     shut down and is_running must flip to False so /health reports degraded.
@@ -258,7 +256,6 @@ async def test_all_tails_dead_stops_service_and_clears_is_running(tmp_path: Path
         await service.stop(timeout=5.0)
 
 
-@pytest.mark.asyncio
 async def test_last_record_at_tracks_ingestion_activity(tmp_path: Path) -> None:
     """last_record_at is None until a record is consumed, then a recent UTC
     timestamp (surfaced in /health as the last-event-ingested signal)."""
@@ -282,7 +279,6 @@ async def test_last_record_at_tracks_ingestion_activity(tmp_path: Path) -> None:
         await service.stop(timeout=5.0)
 
 
-@pytest.mark.asyncio
 async def test_mid_flight_file_deletion_flags_missing_and_recovers(tmp_path: Path, caplog) -> None:
     """Deleting a tailed file mid-flight must not spam warnings or kill the
     tailer: the parser flags file_missing (surfaced as service.missing_files
@@ -321,7 +317,6 @@ async def test_mid_flight_file_deletion_flags_missing_and_recovers(tmp_path: Pat
         await service.stop(timeout=5.0)
 
 
-@pytest.mark.asyncio
 async def test_each_flush_uses_a_fresh_session(tmp_path: Path) -> None:
     """Two flush cycles → two distinct sessions, each committed and closed."""
     log_file = tmp_path / "a.log"
@@ -347,7 +342,6 @@ async def test_each_flush_uses_a_fresh_session(tmp_path: Path) -> None:
     assert sessions[0] is not sessions[1]
 
 
-@pytest.mark.asyncio
 async def test_no_session_opened_while_idle(tmp_path: Path) -> None:
     """Idle service (no records) never opens a database session."""
     log_file = tmp_path / "a.log"
@@ -361,7 +355,6 @@ async def test_no_session_opened_while_idle(tmp_path: Path) -> None:
     assert sessions == []
 
 
-@pytest.mark.asyncio
 async def test_start_twice_spawns_no_duplicate_tasks(tmp_path: Path) -> None:
     """Two back-to-back start() calls (no await in between) must not spawn a
     second set of tail tasks + consumer; the second call is a no-op."""
@@ -387,7 +380,6 @@ async def test_start_twice_spawns_no_duplicate_tasks(tmp_path: Path) -> None:
     await service.stop(timeout=5.0)
 
 
-@pytest.mark.asyncio
 async def test_poison_record_evicts_uncommitted_location_from_cache(tmp_path: Path) -> None:
     """A failed batch commit evicts locations cached during that flush, so the
     next occurrence of the same geohash re-creates the row instead of
@@ -425,7 +417,6 @@ async def test_poison_record_evicts_uncommitted_location_from_cache(tmp_path: Pa
     assert len(repos.geo_location.added) == 1
 
 
-@pytest.mark.asyncio
 async def test_rollback_evicts_all_uncommitted_geohashes_in_batch(tmp_path: Path) -> None:
     """Within one flush of a multi-record batch, a later record's failure must
     evict ALL uncommitted locations cached during that flush - not just its own.
@@ -477,7 +468,6 @@ async def test_rollback_evicts_all_uncommitted_geohashes_in_batch(tmp_path: Path
     assert len(repos.geo_location.added) == 1
 
 
-@pytest.mark.asyncio
 async def test_committed_locations_survive_in_cache_as_ids(tmp_path: Path) -> None:
     """After a successful commit the cache holds plain ids, and a repeat of the
     same geohash creates no second GeoLocation row."""
@@ -508,7 +498,6 @@ async def test_committed_locations_survive_in_cache_as_ids(tmp_path: Path) -> No
     assert len(repos.geo_location.added) == 1  # second event reused the cached id
 
 
-@pytest.mark.asyncio
 async def test_flush_records_writes_through_batch_machinery() -> None:
     """flush_records must reuse _flush_batch (cache + rollback semantics)."""
     service, _repos, sessions = make_service([])

--- a/tests/test_lifecycle_geoip.py
+++ b/tests/test_lifecycle_geoip.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 
 def _patch_startup_collaborators(monkeypatch, lc, *, db_available: bool, ensure: AsyncMock):
     async def fake_db_available(timeout: float = 10.0) -> bool:

--- a/tests/test_lifecycle_geoip.py
+++ b/tests/test_lifecycle_geoip.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.anyio
 
 
 def _patch_startup_collaborators(monkeypatch, lc, *, db_available: bool, ensure: AsyncMock):
-    async def fake_db_available(timeout: float = 10.0) -> bool:
+    async def fake_db_available(app, timeout: float = 10.0) -> bool:
         return db_available
 
     sqlalchemy_config = MagicMock()
@@ -21,7 +21,7 @@ def _patch_startup_collaborators(monkeypatch, lc, *, db_available: bool, ensure:
     ingestion.start = AsyncMock()
 
     monkeypatch.setattr(lc, "_db_available", fake_db_available)
-    monkeypatch.setattr(lc, "get_sqlalchemy_config", lambda: sqlalchemy_config)
+    monkeypatch.setattr(lc, "get_app_db_config", lambda app: sqlalchemy_config)
     monkeypatch.setattr(lc, "migrate_database", AsyncMock())
     monkeypatch.setattr(lc, "setup_timescaledb", AsyncMock())
     monkeypatch.setattr(lc, "ensure_geoip_database", ensure)

--- a/tests/test_live_ws.py
+++ b/tests/test_live_ws.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
+import pytest
 from litestar import Litestar
+from litestar.exceptions import WebSocketDisconnect
 from litestar.testing import TestClient
 
 from geometrikks.services.logparser.schemas import ParsedAccessLog, ParsedGeoData, ParsedLogRecord
@@ -107,13 +110,78 @@ def test_ws_sends_empty_batch_heartbeat_when_idle(monkeypatch):
 
 
 def test_ws_closes_when_no_ingestion_service():
-    import pytest
-    from litestar.exceptions import WebSocketDisconnect  # NOT starlette — litestar has no starlette dependency
-
+    """Degraded mode closes with 1013 (try again later) and a usable reason."""
     with TestClient(app=make_app(None)) as client:
-        with pytest.raises(WebSocketDisconnect):
+        with pytest.raises(WebSocketDisconnect) as exc_info:
             with client.websocket_connect("/ws/live") as ws:
                 ws.receive_json(timeout=2)
+    assert exc_info.value.code == 1013
+    assert exc_info.value.detail == "ingestion not running"
+
+
+def test_ws_counts_dropped_events_beyond_frame_cap():
+    """Overflow beyond MAX_EVENTS_PER_FRAME is counted, not silently lost."""
+    ingestion = FakeIngestion()
+    # 60 prefilled records -> 120 events; the first flush window drains them
+    # all, keeps 100 and counts 20 dropped.
+    for _ in range(60):
+        ingestion.queue.put_nowait(make_record())
+    with TestClient(app=make_app(ingestion)) as client:
+        with client.websocket_connect("/ws/live") as ws:
+            frame = ws.receive_json(timeout=5)
+    assert frame["type"] == "batch"
+    assert len(frame["events"]) == 100
+    assert frame["dropped"] == 20
+    assert ingestion.unsubscribed is True
+
+
+def test_ws_ignores_unexpected_inbound_frames():
+    """Policy: inbound client frames are consumed and ignored; the stream
+    keeps flowing on the same connection."""
+    ingestion = FakeIngestion()
+    with TestClient(app=make_app(ingestion)) as client:
+        with client.websocket_connect("/ws/live") as ws:
+            ws.send_text("unexpected")
+            ws.send_json({"also": "unexpected"})
+            ingestion.queue.put_nowait(make_record())
+            frame = ws.receive_json(timeout=5)
+    assert frame["type"] == "batch"
+    assert len(frame["events"]) == 2
+    assert ingestion.unsubscribed is True
+
+
+class FakeSocket:
+    """Bare-bones WebSocket standing in for a connected, quiet client."""
+
+    def __init__(self, state: SimpleNamespace) -> None:
+        self.app = SimpleNamespace(state=state)
+        self.sent: list[dict] = []
+
+    async def accept(self) -> None: ...
+
+    async def receive_data(self, mode: str = "text") -> str:
+        await asyncio.Event().wait()  # a quiet client never sends
+        return ""
+
+    async def send_json(self, data: dict) -> None:
+        self.sent.append(data)
+
+    async def close(self, code: int = 1000, reason: str = "") -> None: ...
+
+
+@pytest.mark.anyio
+async def test_ws_cancellation_still_unsubscribes():
+    """Server-side cancellation (shutdown) must run the cleanup path."""
+    from geometrikks.api.v1.live_controller import live_feed
+
+    ingestion = FakeIngestion()
+    socket = FakeSocket(SimpleNamespace(ingestion_service=ingestion))
+    task = asyncio.create_task(live_feed.fn(socket))
+    await asyncio.sleep(0.05)  # let the handler subscribe and enter its loop
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert ingestion.unsubscribed is True
 
 
 class TestLogsFeed:
@@ -160,3 +228,46 @@ class TestLogsFeed:
                 frame = self._receive_data_frame(ws, publish)
                 events = [r["event"] for r in frame["records"]]
                 assert "boom" in events and "noise" not in events
+
+    def test_sends_empty_log_batch_heartbeat_when_idle(self, monkeypatch):
+        from geometrikks.api.v1 import live_controller
+
+        monkeypatch.setattr(live_controller, "HEARTBEAT_INTERVAL", 0.3, raising=False)
+        with TestClient(app=self._make_app()) as client:
+            with client.websocket_connect("/ws/logs") as ws:
+                frame = ws.receive_json(timeout=5)
+        assert frame == {"type": "log_batch", "records": [], "dropped": 0}
+
+    def test_counts_dropped_records_beyond_frame_cap(self, monkeypatch):
+        from geometrikks.api.v1 import live_controller
+        from geometrikks.server.logging import log_broadcaster
+
+        monkeypatch.setattr(live_controller, "MAX_RECORDS_PER_FRAME", 3, raising=False)
+        import time
+
+        with TestClient(app=self._make_app()) as client:
+            with client.websocket_connect("/ws/logs") as ws:
+                deadline = time.time() + 5
+                while time.time() < deadline:
+                    # A burst larger than the frame cap; retried because a
+                    # publish can race the handler's subscribe.
+                    for i in range(10):
+                        log_broadcaster.publish_threadsafe(
+                            {"level": "info", "event": f"burst{i}"}
+                        )
+                    frame = ws.receive_json(timeout=2)
+                    if frame["dropped"]:
+                        break
+                else:
+                    raise AssertionError("no frame with dropped records received")
+        assert len(frame["records"]) == 3
+        assert frame["dropped"] > 0
+
+    def test_unsubscribes_on_disconnect(self):
+        from geometrikks.server.logging import log_broadcaster
+
+        baseline = len(log_broadcaster._subscribers)
+        with TestClient(app=self._make_app()) as client:
+            with client.websocket_connect("/ws/logs"):
+                pass
+        assert len(log_broadcaster._subscribers) == baseline

--- a/tests/test_logparser.py
+++ b/tests/test_logparser.py
@@ -17,6 +17,8 @@ from geometrikks.services.logparser.logparser import (
 )
 from geometrikks.services.logparser.schemas import ParsedAccessLog
 
+pytestmark = pytest.mark.anyio
+
 
 def make_log_line(ip: str) -> str:
     """A line in the project's custom nginx log format (mirrors tests/valid_ipv4_log.txt)."""
@@ -249,7 +251,6 @@ def test_binary_probe_flagged_malformed(log_parser: LogParser, load_nonstandard_
     assert is_malformed is True
     assert error == "No HTTP method in request"
 
-@pytest.mark.asyncio
 async def test_is_rotated_truncation_99pct(tmp_path: Path, log_parser: LogParser, monkeypatch) -> None:
     """Rotation detected when size shrinks by >=99%."""
     # Create file and obtain real previous stat
@@ -272,7 +273,6 @@ async def test_is_rotated_truncation_99pct(tmp_path: Path, log_parser: LogParser
     assert is_rotated is True
 
 
-@pytest.mark.asyncio
 async def test_is_rotated_inode_change(tmp_path: Path, log_parser: LogParser, monkeypatch) -> None:
     """Rotation detected when inode changes."""
     log_file = tmp_path / "access.log"
@@ -291,7 +291,6 @@ async def test_is_rotated_inode_change(tmp_path: Path, log_parser: LogParser, mo
     assert await log_parser._is_rotated_async(prev) is True
 
 
-@pytest.mark.asyncio
 async def test_is_rotated_disabled(tmp_path: Path, log_parser: LogParser, monkeypatch) -> None:
     """Rotation check can be disabled via env."""
     monkeypatch.setenv("DISABLE_ROTATION_CHECK", "true")
@@ -347,7 +346,6 @@ def test_create_access_log_sqlalchemy_geoip_failure(log_parser: LogParser, monke
     assert result is None
 
 
-@pytest.mark.asyncio
 async def test_iter_log_events_async_unmatched(tmp_path: Path, log_parser: LogParser, geoip_reader: Reader) -> None:
     """Async generator yields record with matched=None for invalid line; increments skipped."""
     log_file = tmp_path / "access.log"
@@ -369,7 +367,6 @@ async def test_iter_log_events_async_unmatched(tmp_path: Path, log_parser: LogPa
     assert log_parser.skipped_lines_count() >= 1
 
 
-@pytest.mark.asyncio
 async def test_iter_log_events_async_matched(tmp_path: Path, log_parser: LogParser, geoip_reader: Reader) -> None:
     """Async generator yields parsed record for a valid line; access_log when send_logs=True."""
     log_file = tmp_path / "access.log"
@@ -396,7 +393,6 @@ async def test_iter_log_events_async_matched(tmp_path: Path, log_parser: LogPars
     assert log_parser.parsed_lines_count() >= 1
 
 
-@pytest.mark.asyncio
 async def test_iter_log_events_async_rotation_restart(tmp_path: Path, log_parser: LogParser, geoip_reader: Reader, monkeypatch) -> None:
     """When rotation is detected, async generator delegates to a new stream (restart)."""
     log_file = tmp_path / "access.log"
@@ -452,7 +448,6 @@ def test_parse_geo_data(log_parser: LogParser, geoip_reader: Reader) -> None:
     assert parsed.geohash is not None
 
 
-@pytest.mark.asyncio
 async def test_iter_parsed_records_tags_source(tmp_path: Path, log_parser: LogParser, geoip_reader: Reader) -> None:
     """Every yielded record carries the source file path it was read from."""
     log_file = tmp_path / "access.log"
@@ -467,7 +462,6 @@ async def test_iter_parsed_records_tags_source(tmp_path: Path, log_parser: LogPa
     assert record.source == str(log_file)
 
 
-@pytest.mark.asyncio
 async def test_rotation_reopens_from_start_twice(tmp_path: Path, log_parser: LogParser, geoip_reader: Reader) -> None:
     """Two consecutive real rotations (inode change) keep records flowing, reading each new file from the start."""
     valid_lines = Path(VALID_LOG_PATH).read_text(encoding="utf-8").splitlines()

--- a/tests/test_logs_controller.py
+++ b/tests/test_logs_controller.py
@@ -8,6 +8,7 @@ from litestar import Litestar
 from litestar.testing import TestClient
 
 from geometrikks.api.v1.logs_controller import LogsController
+from tests.support import ambient_settings_dependency
 
 
 @pytest.fixture()
@@ -25,7 +26,11 @@ def client(tmp_path, monkeypatch):
     monkeypatch.setenv("LOGPARSER_LOG_PATHS", str(nginx))
     from geometrikks.config.settings import get_settings
     get_settings.cache_clear()
-    with TestClient(app=Litestar(route_handlers=[LogsController])) as c:
+    with TestClient(
+        app=Litestar(
+            route_handlers=[LogsController], dependencies=ambient_settings_dependency()
+        )
+    ) as c:
         yield c
 
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -158,6 +158,8 @@ def test_upgrade_to_head_uses_dedicated_url_config(monkeypatch) -> None:
 
 from types import SimpleNamespace
 
+pytestmark = pytest.mark.anyio
+
 
 async def test_on_startup_migrates_before_timescale(monkeypatch) -> None:
     """Migrations own the schema; setup_timescaledb depends on the tables

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -81,7 +81,9 @@ def migration_mocks(monkeypatch):
     from geometrikks.server import migrations as mod
 
     order: list[str] = []
-    monkeypatch.setattr(mod, "upgrade_to_head", lambda: order.append("upgrade"))
+    monkeypatch.setattr(
+        mod, "upgrade_to_head", lambda database_url=None: order.append("upgrade")
+    )
 
     async def fake_teardown(conn) -> None:
         order.append("teardown")
@@ -130,7 +132,7 @@ async def test_no_drop_flag_goes_straight_to_upgrade(migration_mocks) -> None:
 async def test_upgrade_failure_propagates(monkeypatch) -> None:
     from geometrikks.server import migrations as mod
 
-    def boom() -> None:
+    def boom(database_url=None) -> None:
         raise RuntimeError("broken migration")
 
     monkeypatch.setattr(mod, "upgrade_to_head", boom)
@@ -156,6 +158,19 @@ def test_upgrade_to_head_uses_dedicated_url_config(monkeypatch) -> None:
     commands.return_value.upgrade.assert_called_once_with(revision="head")
 
 
+def test_upgrade_to_head_honors_explicit_url(monkeypatch) -> None:
+    """migrate_database passes the app-bound URL; ambient settings must not win."""
+    from geometrikks.server import migrations as mod
+
+    commands = MagicMock()
+    monkeypatch.setattr(mod, "AlembicCommands", commands)
+
+    mod.upgrade_to_head("postgresql+asyncpg://x:y@explicit.invalid:5432/appdb")
+
+    (config,), _ = commands.call_args
+    assert config.connection_string == "postgresql+asyncpg://x:y@explicit.invalid:5432/appdb"
+
+
 from types import SimpleNamespace
 
 pytestmark = pytest.mark.anyio
@@ -168,7 +183,7 @@ async def test_on_startup_migrates_before_timescale(monkeypatch) -> None:
 
     order: list[str] = []
 
-    async def fake_db_available(timeout: float = 10.0) -> bool:
+    async def fake_db_available(app, timeout: float = 10.0) -> bool:
         return True
 
     async def fake_migrate(engine, settings) -> None:
@@ -194,7 +209,7 @@ async def test_on_startup_migrates_before_timescale(monkeypatch) -> None:
     sqlalchemy_config.create_session_maker.return_value = MagicMock()
 
     monkeypatch.setattr(lc, "_db_available", fake_db_available)
-    monkeypatch.setattr(lc, "get_sqlalchemy_config", lambda: sqlalchemy_config)
+    monkeypatch.setattr(lc, "get_app_db_config", lambda app: sqlalchemy_config)
     monkeypatch.setattr(lc, "migrate_database", fake_migrate)
     monkeypatch.setattr(lc, "setup_timescaledb", fake_timescale)
     monkeypatch.setattr(lc, "create_scheduler", fake_create_scheduler)

--- a/tests/test_settings_endpoint.py
+++ b/tests/test_settings_endpoint.py
@@ -6,10 +6,13 @@ from litestar.testing import TestClient
 
 from geometrikks.api.v1.settings import read_settings
 from geometrikks.services.geoip.home import HomeLocation
+from tests.support import ambient_settings_dependency
 
 
 def make_app() -> Litestar:
-    app = Litestar(route_handlers=[read_settings])
+    app = Litestar(
+        route_handlers=[read_settings], dependencies=ambient_settings_dependency()
+    )
     app.state.map_home_location = HomeLocation(40.7128, -74.006, "external_ip")
     return app
 

--- a/tests/test_system_controller.py
+++ b/tests/test_system_controller.py
@@ -11,6 +11,7 @@ from litestar.testing import AsyncTestClient
 
 from geometrikks.api.v1.system_controller import SystemController
 from geometrikks.server.scheduler_tracking import JobRunTracker
+from tests.support import ambient_settings_dependency
 
 FUTURE = datetime(2030, 1, 1, tzinfo=timezone.utc)
 
@@ -59,7 +60,11 @@ def make_app(*, with_scheduler: bool = True) -> Litestar:
         app.state.scheduler = scheduler
         app.state.scheduler_tracker = tracker
 
-    return Litestar(route_handlers=[SystemController], on_startup=[startup])
+    return Litestar(
+        route_handlers=[SystemController],
+        on_startup=[startup],
+        dependencies=ambient_settings_dependency(),
+    )
 
 
 async def test_lists_jobs_with_run_info():
@@ -189,7 +194,11 @@ async def test_system_settings_surface_computed_values(monkeypatch):
         )
         app.state.geoip_available = True
 
-    app = Litestar(route_handlers=[SystemController], on_startup=[startup])
+    app = Litestar(
+        route_handlers=[SystemController],
+        on_startup=[startup],
+        dependencies=ambient_settings_dependency(),
+    )
     async with AsyncTestClient(app=app) as client:
         resp = await client.get("/api/v1/system/settings")
     assert resp.status_code == 200

--- a/tests/test_system_controller.py
+++ b/tests/test_system_controller.py
@@ -13,6 +13,8 @@ from geometrikks.api.v1.system_controller import SystemController
 from geometrikks.server.scheduler_tracking import JobRunTracker
 from tests.support import ambient_settings_dependency
 
+pytestmark = pytest.mark.anyio
+
 FUTURE = datetime(2030, 1, 1, tzinfo=timezone.utc)
 
 

--- a/tests/test_timescale_refresh.py
+++ b/tests/test_timescale_refresh.py
@@ -87,7 +87,7 @@ async def test_scheduler_job_binds_timestamps(monkeypatch):
 
     calls: list = []
 
-    async def fake_exec(sql, *args):
+    async def fake_exec(session_factory, sql, *args):
         calls.append((sql, args))
 
     monkeypatch.setattr(sched, "_execute_call_outside_transaction", fake_exec)

--- a/tests/test_timescale_refresh.py
+++ b/tests/test_timescale_refresh.py
@@ -8,6 +8,8 @@ import pytest
 
 from geometrikks.server.timescale import refresh_caggs_range
 
+pytestmark = pytest.mark.anyio
+
 START = datetime(2026, 1, 1, tzinfo=timezone.utc)
 END = datetime(2026, 2, 1, tzinfo=timezone.utc)
 

--- a/tests/test_top_stats_routing.py
+++ b/tests/test_top_stats_routing.py
@@ -13,6 +13,10 @@ from geometrikks.domain.analytics.repositories import (
     SummaryStatsRepository,
 )
 
+import pytest
+
+pytestmark = pytest.mark.anyio
+
 NOW = datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc)
 SHORT_START = NOW - timedelta(hours=6)     # RAW routing
 WEEK_START = NOW - timedelta(days=7)       # HOURLY routing

--- a/uv.lock
+++ b/uv.lock
@@ -521,7 +521,6 @@ dev = [
     { name = "faker" },
     { name = "polyfactory" },
     { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ty" },
 ]
@@ -552,7 +551,6 @@ dev = [
     { name = "faker", specifier = ">=40.36.0" },
     { name = "polyfactory", specifier = ">=3.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
-    { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "ty", specifier = ">=0.0.63" },
 ]
@@ -1210,18 +1208,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
-]
-
-[[package]]
-name = "pytest-asyncio"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Phase 2 of the 0.7.0 plan: hermetic composition and testing.

## What changed

### Explicit app composition
- `create_app()` now accepts `settings: Settings | None` and `dependencies: Mapping[str, Provide] | None`. The composed settings object is canonical for the whole app: it is stored on `app.state.settings`, provided to request handlers via a `settings` DI dependency, and now also governs the SQLAlchemy engine, migrations, scheduled CAGG jobs, health/system database probes, and trusted-proxy client-IP resolution.
- The database stack follows the app, not the process: `create_sqlalchemy_config(settings)` builds one config per app, stored on `app.state.db_config` and resolved everywhere through `get_app_db_config(app)`. The process-cached `get_sqlalchemy_config()` remains for the import-logs CLI and as a fallback for hand-built test apps. `upgrade_to_head()` takes an explicit database URL; scheduler `CALL` statements derive their engine from the job's session factory.
- The `settings` dependency name is reserved: passing it via `dependencies` raises `ValueError` so an app cannot end up with request handlers seeing different settings than the lifecycle.
- Request paths that previously reached for ambient `get_settings()` (health, system, crowdsec, settings, logs controllers, service-worker route, client-IP resolution) now use the injected/app-bound settings.

### Test isolation
- New `GEOMETRIKKS_ENV_FILE` env var controls which dotenv file settings load (empty value disables dotenv entirely). Documented in the generated `docs/configuration.md` and the README.
- The test suite sets `GEOMETRIKKS_ENV_FILE=""` and scrubs every `APP_`/`DB_`/`SCHEDULER_`/... prefixed variable at conftest import, so developer `.env` files and shell exports can no longer flip test outcomes. Verified by running the full suite with hostile values for all previously-leaking variables.

### AnyIO migration
- Async tests run on AnyIO via `pytest.mark.anyio`; pytest-asyncio is removed from the dev dependencies (it conflicts with Litestar's AnyIO-based runtime and is unmaintained territory for Litestar 3).

### WebSocket coverage
- Expanded feed tests ahead of the Phase 5 shared-helper refactor: 1013 close code/detail assertions, backpressure overflow, heartbeat, inbound-frame policy, subscriber cleanup on disconnect and on task cancellation, and auth rejection parametrized over all three `/ws` feeds.

## Verification
- 572 passed (455 unit + 117 integration), including a run with hostile env values (`SCHEDULER_ENABLED=false CROWDSEC_MACHINE_ID=... DB_HOST=ambient.invalid MAP_HOME_LATITUDE=... LOGPARSER_IGNORE_IPS=...`) active simultaneously
- `uv run ty check geometrikks` clean
- Config-docs freshness gate passes
- Frontend: 127 vitest tests and `tsc` clean (no frontend code changes; docs only)
