### PR TITLE
feat!: 0.7 phase 4 - versioned /api/v1 router, camelCase wire format, pinned error contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** all REST API JSON fields and query parameters are now
+  camelCase (`totalRequests`, `startedAt`, `fromTimestamp`, `startDate`,
+  `comparePrevious`, ...); previously the dataclass-backed endpoints
+  (analytics, system, settings, stats, health, CrowdSec, geo top-IPs/GeoJSON,
+  log files) used snake_case. Digit-adjacent fields are `status2xx`-style and
+  `requestCount24h`. Path segments (`{location_id}`, `{job_id}`), WebSocket
+  frame payloads, `orderBy` column values, and the error envelope are
+  unchanged. External API consumers must rename fields; the bundled frontend
+  is already migrated. The full policy is documented in
+  `docs/api-conventions.md`.
+- Errors on API paths that previously returned an empty 404 body (unknown
+  routes, CrowdSec-disabled lookups) now return the standard
+  `{status_code, detail}` JSON envelope; non-API 404s are unchanged.
+- All REST endpoints are mounted through a single versioned `/api/v1` router;
+  URLs, operation IDs, and generated client method names are unchanged.
 - `create_app()` accepts an explicit settings object and app-level dependency
   overrides, and request handlers now receive settings through dependency
   injection instead of resolving the process-cached factory inline. The

--- a/docs/api-conventions.md
+++ b/docs/api-conventions.md
@@ -62,7 +62,9 @@ Errors use Litestar's native HTTP-exception envelope, unchanged:
 - Domain exceptions (`DomainValidationError`, CrowdSec errors) are translated
   centrally in `geometrikks/server/exceptions.py` into the same envelope.
 - API-path 404s render this envelope too; non-API 404s (static-asset misses)
-  keep litestar-vite's empty-body behavior.
+  keep litestar-vite's empty-body behavior. The 404 handler treats the whole
+  `/api/` namespace as API surface, matching the auth boundary: an unknown or
+  unversioned `/api/` path is an API consumer's mistake and gets JSON.
 
 ## Operation IDs
 

--- a/docs/api-conventions.md
+++ b/docs/api-conventions.md
@@ -1,0 +1,61 @@
+# API conventions
+
+The wire-format policy for the GeoMetrikks HTTP API, decided for 0.7.0.
+`tests/test_error_contract.py` and the generated OpenAPI document
+(`resources/generated/openapi.json`) pin these rules; change them only with a
+coordinated client regeneration and a changelog migration note.
+
+## Versioning
+
+Every REST endpoint lives under `/api/v1`, mounted as a single Litestar
+`Router` in `geometrikks/server/routes.py`. Controllers own only their domain
+segment (`/analytics`, `/crowdsec`, ...). Outside the router:
+
+- `/health` and `/health/ready`: unauthenticated probe endpoints.
+- `/ws/live`, `/ws/logs`, `/ws/crowdsec`: WebSocket feeds.
+- `/schema`, `/sw.js`, and the SPA shell.
+
+## Field casing: camelCase
+
+All request and response JSON fields are camelCase on the wire; Python
+attributes stay snake_case.
+
+- SQLAlchemy-model responses use Advanced Alchemy DTOs with
+  `rename_strategy="camel"`.
+- Bespoke response models are msgspec Structs declared with
+  `rename="camel"` (see `geometrikks/domain/geo/schemas.py` for the idiom).
+  Digit-adjacent names pin their wire form explicitly with
+  `msgspec.field(name=...)`: `status2xx`, `requestCount24h`.
+- Query parameters carry explicit camelCase `name=` declarations
+  (`fromTimestamp`, `startDate`, `ipAddressNotIn`, ...); shared aliases live
+  in `geometrikks/lib/parameters.py`.
+- Path parameters are URL segments, not fields, and stay snake_case
+  (`{location_id}`, `{job_id}`).
+- WebSocket frame payloads are a separate contract and are not covered by
+  this policy (revisited with the realtime refactor).
+- Data values are exempt: `SettingFieldView.key` deliberately carries Python
+  settings field names like `home_latitude`.
+
+## Error envelope: Litestar native
+
+Errors use Litestar's native HTTP-exception envelope, unchanged:
+
+```json
+{"status_code": 404, "detail": "Not Found"}
+```
+
+- `extra` appears additionally on request-validation errors with the
+  per-field breakdown.
+- The envelope keys are the framework's and stay snake_case; the camelCase
+  policy applies to success payloads only.
+- Domain exceptions (`DomainValidationError`, CrowdSec errors) are translated
+  centrally in `geometrikks/server/exceptions.py` into the same envelope.
+- API-path 404s render this envelope too; non-API 404s (static-asset misses)
+  keep litestar-vite's empty-body behavior.
+
+## Operation IDs
+
+OpenAPI operation IDs use Litestar's default path-derived naming
+(`ApiV1AnalyticsSummaryGetSummary`). Generated TypeScript client method names
+hang off them, so route moves must keep full paths stable or accept a
+client-wide rename.

--- a/docs/api-conventions.md
+++ b/docs/api-conventions.md
@@ -8,12 +8,19 @@ coordinated client regeneration and a changelog migration note.
 ## Versioning
 
 Every REST endpoint lives under `/api/v1`, mounted as a single Litestar
-`Router` in `geometrikks/server/routes.py`. Controllers own only their domain
-segment (`/analytics`, `/crowdsec`, ...). Outside the router:
+`Router` in `geometrikks/server/routes.py`, which stays the one explicit
+registration point. Controllers live in their vertical domain packages
+(`geometrikks/domain/<domain>/controllers*`) and own only their domain
+segment (`/analytics`, `/crowdsec`, ...); the router supplies the version
+prefix. Everything under `/api/v1` requires the session cookie except
+`/api/v1/auth/login` (with `APP_AUTH_DISABLED=true` the auth endpoints are
+not registered at all). Outside the router:
 
 - `/health` and `/health/ready`: unauthenticated probe endpoints.
-- `/ws/live`, `/ws/logs`, `/ws/crowdsec`: WebSocket feeds.
-- `/schema`, `/sw.js`, and the SPA shell.
+- `/ws/live`, `/ws/logs`, `/ws/crowdsec`: WebSocket feeds
+  (`geometrikks/domain/realtime/`), session-authenticated during the
+  handshake.
+- `/schema` (deliberately unauthenticated), `/sw.js`, and the SPA shell.
 
 ## Field casing: camelCase
 
@@ -22,9 +29,10 @@ attributes stay snake_case.
 
 - SQLAlchemy-model responses use Advanced Alchemy DTOs with
   `rename_strategy="camel"`.
-- Bespoke response models are msgspec Structs declared with
-  `rename="camel"` (see `geometrikks/domain/geo/schemas.py` for the idiom).
-  Digit-adjacent names pin their wire form explicitly with
+- Bespoke request and response models are msgspec Structs declared with
+  `rename="camel"` (see `geometrikks/domain/geo/schemas.py` for the idiom);
+  they live in each domain package's `schemas.py`/`dtos.py` or next to their
+  controller. Digit-adjacent names pin their wire form explicitly with
   `msgspec.field(name=...)`: `status2xx`, `requestCount24h`.
 - Query parameters carry explicit camelCase `name=` declarations
   (`fromTimestamp`, `startDate`, `ipAddressNotIn`, ...); shared aliases live

--- a/docs/api-conventions.md
+++ b/docs/api-conventions.md
@@ -42,7 +42,10 @@ attributes stay snake_case.
 - WebSocket frame payloads are a separate contract and are not covered by
   this policy (revisited with the realtime refactor).
 - Data values are exempt: `SettingFieldView.key` deliberately carries Python
-  settings field names like `home_latitude`.
+  settings field names like `home_latitude`, and `/api/v1/logs/tail` records
+  pass raw structlog context keys through as recorded (`request_id`,
+  `status_code`, ...); renaming historical log data would misrepresent it.
+  OpenAPI documents only the stable record fields.
 
 ## Error envelope: Litestar native
 

--- a/geometrikks/config/introspection.py
+++ b/geometrikks/config/introspection.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+
+import msgspec
 from typing import Any, get_args
 
 from pydantic import SecretStr
@@ -43,8 +45,7 @@ _SECTION_TITLES = {
 }
 
 
-@dataclass
-class SettingFieldView:
+class SettingFieldView(msgspec.Struct, rename="camel"):
     key: str
     value: Any
     default: Any
@@ -55,16 +56,14 @@ class SettingFieldView:
     computed_source: str | None = None
 
 
-@dataclass
-class SettingsSectionView:
+class SettingsSectionView(msgspec.Struct, rename="camel"):
     name: str
     title: str
     description: str | None
     fields: list[SettingFieldView]
 
 
-@dataclass
-class SystemSettingsResponse:
+class SystemSettingsResponse(msgspec.Struct, rename="camel"):
     sections: list[SettingsSectionView]
 
 

--- a/geometrikks/domain/analytics/controllers.py
+++ b/geometrikks/domain/analytics/controllers.py
@@ -45,10 +45,10 @@ from geometrikks.domain.analytics.dependencies import (
 from geometrikks.lib.parameters import (
     CityFilter,
     CountryCodeFilter,
-    EndTimestamp,
+    EndDate,
     IpAddressExcludeFilter,
     IpAddressFilter,
-    StartTimestamp,
+    StartDate,
 )
 from geometrikks.lib.validation import validate_ip_addresses
 
@@ -108,11 +108,12 @@ class AnalyticsController(Controller):
     async def get_summary(
         self,
         summary_stats_repo: NamedDependency[SummaryStatsRepository],
-        start_date: StartTimestamp,
-        end_date: EndTimestamp,
+        start_date: StartDate,
+        end_date: EndDate,
         compare_previous: Annotated[
             bool,
             QueryParameter(
+                name="comparePrevious",
                 description="Include comparison with previous period of same length",
             ),
         ] = False,
@@ -232,11 +233,12 @@ class AnalyticsController(Controller):
     async def get_live_summary(
         self,
         live_stats_repo: NamedDependency[LiveStatsRepository],
-        start_date: StartTimestamp,
-        end_date: EndTimestamp,
+        start_date: StartDate,
+        end_date: EndDate,
         compare_previous: Annotated[
             bool,
             QueryParameter(
+                name="comparePrevious",
                 description="Include comparison with previous period of same length",
             ),
         ] = False,
@@ -356,8 +358,8 @@ class AnalyticsController(Controller):
     async def get_cumulative_time_series(
         self,
         summary_stats_repo: NamedDependency[SummaryStatsRepository],
-        start_date: StartTimestamp,
-        end_date: EndTimestamp,
+        start_date: StartDate,
+        end_date: EndDate,
     ) -> CumulativeTimeSeriesResponse:
         """Get cumulative time series data for area charts.
 
@@ -397,8 +399,8 @@ class AnalyticsController(Controller):
         self,
         summary_stats_repo: NamedDependency[SummaryStatsRepository],
         live_stats_repo: NamedDependency[LiveStatsRepository],
-        start_date: StartTimestamp,
-        end_date: EndTimestamp,
+        start_date: StartDate,
+        end_date: EndDate,
         granularity: Annotated[
             Literal["hourly", "daily"] | None,
             QueryParameter(
@@ -460,8 +462,8 @@ class AnalyticsController(Controller):
     async def get_geo_time_series(
         self,
         summary_stats_repo: NamedDependency[SummaryStatsRepository],
-        start_date: StartTimestamp,
-        end_date: EndTimestamp,
+        start_date: StartDate,
+        end_date: EndDate,
         granularity: Annotated[
             Literal["hourly", "daily"] | None,
             QueryParameter(
@@ -494,8 +496,8 @@ class AnalyticsController(Controller):
     async def get_top_urls(
         self,
         summary_stats_repo: NamedDependency[SummaryStatsRepository],
-        start_date: StartTimestamp,
-        end_date: EndTimestamp,
+        start_date: StartDate,
+        end_date: EndDate,
         limit: Annotated[
             int,
             QueryParameter(description="Maximum number of URLs to return", ge=1, le=100),
@@ -522,8 +524,8 @@ class AnalyticsController(Controller):
     async def get_top_user_agents(
         self,
         summary_stats_repo: NamedDependency[SummaryStatsRepository],
-        start_date: StartTimestamp,
-        end_date: EndTimestamp,
+        start_date: StartDate,
+        end_date: EndDate,
         limit: Annotated[
             int,
             QueryParameter(description="Maximum number of user agents to return", ge=1, le=100),
@@ -550,8 +552,8 @@ class AnalyticsController(Controller):
     async def get_top_ips(
         self,
         summary_stats_repo: NamedDependency[SummaryStatsRepository],
-        start_date: StartTimestamp,
-        end_date: EndTimestamp,
+        start_date: StartDate,
+        end_date: EndDate,
         limit: Annotated[
             int,
             QueryParameter(description="Maximum number of IPs", ge=1, le=100),
@@ -574,8 +576,8 @@ class AnalyticsController(Controller):
     async def get_top_countries(
         self,
         summary_stats_repo: NamedDependency[SummaryStatsRepository],
-        start_date: StartTimestamp,
-        end_date: EndTimestamp,
+        start_date: StartDate,
+        end_date: EndDate,
         limit: Annotated[
             int,
             QueryParameter(description="Maximum number of countries", ge=1, le=100),
@@ -598,8 +600,8 @@ class AnalyticsController(Controller):
     async def get_top_cities(
         self,
         summary_stats_repo: NamedDependency[SummaryStatsRepository],
-        start_date: StartTimestamp,
-        end_date: EndTimestamp,
+        start_date: StartDate,
+        end_date: EndDate,
         limit: Annotated[
             int,
             QueryParameter(description="Maximum number of cities", ge=1, le=100),

--- a/geometrikks/domain/analytics/controllers.py
+++ b/geometrikks/domain/analytics/controllers.py
@@ -96,7 +96,7 @@ def _resolve_chart_granularity(
 class AnalyticsController(Controller):
     """Analytics endpoints for dashboard data and time-series charts."""
 
-    path = "/api/v1/analytics"
+    path = "/analytics"
     tags = ["Analytics"]
 
     dependencies = {

--- a/geometrikks/domain/analytics/dtos.py
+++ b/geometrikks/domain/analytics/dtos.py
@@ -1,12 +1,17 @@
-"""DTOs for analytics data transfer."""
+"""Response schemas for the analytics endpoints.
+
+msgspec Structs with camelCase renaming (see geo/schemas.py for the idiom).
+Python attributes stay snake_case; the digit-adjacent status fields pin their
+wire names explicitly because the camel strategy would render status_2xx as
+"status2Xx".
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import msgspec
 
 
-@dataclass
-class TimeSeriesDataPoint:
+class TimeSeriesDataPoint(msgspec.Struct, rename="camel"):
     """A single data point in a time-series response.
 
     Used for charting requests, bandwidth, performance over time.
@@ -16,10 +21,10 @@ class TimeSeriesDataPoint:
     total_requests: int
     total_geo_events: int
     total_bytes_sent: int
-    status_2xx: int
-    status_3xx: int
-    status_4xx: int
-    status_5xx: int
+    status_2xx: int = msgspec.field(name="status2xx")
+    status_3xx: int = msgspec.field(name="status3xx")
+    status_4xx: int = msgspec.field(name="status4xx")
+    status_5xx: int = msgspec.field(name="status5xx")
     error_rate: float
     avg_request_time: float
     p50_request_time: float
@@ -27,8 +32,7 @@ class TimeSeriesDataPoint:
     p99_request_time: float
 
 
-@dataclass
-class PerformanceDataPoint:
+class PerformanceDataPoint(msgspec.Struct, rename="camel"):
     """Performance metrics for a single time point.
 
     Used for response time charts.
@@ -39,8 +43,7 @@ class PerformanceDataPoint:
     max_request_time: float
 
 
-@dataclass
-class BandwidthDataPoint:
+class BandwidthDataPoint(msgspec.Struct, rename="camel"):
     """Bandwidth metrics for a single time point."""
 
     timestamp: str  # ISO format string
@@ -48,8 +51,7 @@ class BandwidthDataPoint:
     avg_bytes_per_request: float
 
 
-@dataclass
-class GeoEventsDataPoint:
+class GeoEventsDataPoint(msgspec.Struct, rename="camel"):
     """Geo events metrics for a single time point."""
 
     timestamp: str  # ISO format string
@@ -59,8 +61,7 @@ class GeoEventsDataPoint:
     unique_cities: int
 
 
-@dataclass
-class TimeSeriesResponse:
+class TimeSeriesResponse(msgspec.Struct, rename="camel"):
     """Response containing time-series data for charts.
 
     ``data`` is deliberately default-less so it is required in OpenAPI and
@@ -73,28 +74,25 @@ class TimeSeriesResponse:
     data: list[TimeSeriesDataPoint]
 
 
-@dataclass
-class PerformanceTimeSeriesResponse:
+class PerformanceTimeSeriesResponse(msgspec.Struct, rename="camel"):
     """Response containing performance time-series data."""
 
     granularity: str
     start_date: str
     end_date: str
-    data: list[PerformanceDataPoint] = field(default_factory=list)
+    data: list[PerformanceDataPoint] = msgspec.field(default_factory=list)
 
 
-@dataclass
-class BandwidthTimeSeriesResponse:
+class BandwidthTimeSeriesResponse(msgspec.Struct, rename="camel"):
     """Response containing bandwidth time-series data."""
 
     granularity: str
     start_date: str
     end_date: str
-    data: list[BandwidthDataPoint] = field(default_factory=list)
+    data: list[BandwidthDataPoint] = msgspec.field(default_factory=list)
 
 
-@dataclass
-class GeoEventsTimeSeriesResponse:
+class GeoEventsTimeSeriesResponse(msgspec.Struct, rename="camel"):
     """Response containing geo events time-series data.
 
     ``data`` is deliberately default-less (see TimeSeriesResponse).
@@ -106,8 +104,7 @@ class GeoEventsTimeSeriesResponse:
     data: list[GeoEventsDataPoint]
 
 
-@dataclass
-class PeriodSummary:
+class PeriodSummary(msgspec.Struct, rename="camel"):
     """Summary statistics for a single period."""
 
     total_requests: int
@@ -116,18 +113,17 @@ class PeriodSummary:
     unique_countries: int
     total_bytes_sent: int
     avg_bytes_per_request: float
-    status_2xx: int
-    status_3xx: int
-    status_4xx: int
-    status_5xx: int
+    status_2xx: int = msgspec.field(name="status2xx")
+    status_3xx: int = msgspec.field(name="status3xx")
+    status_4xx: int = msgspec.field(name="status4xx")
+    status_5xx: int = msgspec.field(name="status5xx")
     avg_request_time: float
     max_request_time: float
     malformed_requests: int
     error_rate: float
 
 
-@dataclass
-class PercentChange:
+class PercentChange(msgspec.Struct, rename="camel"):
     """Percent change between two periods."""
 
     log_records: float | None = None
@@ -139,8 +135,7 @@ class PercentChange:
     malformed_rate: float | None = None
 
 
-@dataclass
-class SummaryResponse:
+class SummaryResponse(msgspec.Struct, rename="camel"):
     """Response containing summary statistics with optional comparison.
 
     Used for dashboard header cards showing key metrics.
@@ -153,30 +148,27 @@ class SummaryResponse:
     percent_changes: PercentChange | None = None
 
 
-@dataclass
-class StatusDistributionPoint:
+class StatusDistributionPoint(msgspec.Struct, rename="camel"):
     """Status code distribution for a time point."""
 
     timestamp: str
-    status_2xx: int
-    status_3xx: int
-    status_4xx: int
-    status_5xx: int
+    status_2xx: int = msgspec.field(name="status2xx")
+    status_3xx: int = msgspec.field(name="status3xx")
+    status_4xx: int = msgspec.field(name="status4xx")
+    status_5xx: int = msgspec.field(name="status5xx")
     total: int
 
 
-@dataclass
-class StatusDistributionResponse:
+class StatusDistributionResponse(msgspec.Struct, rename="camel"):
     """Response containing status code distribution over time."""
 
     granularity: str
     start_date: str
     end_date: str
-    data: list[StatusDistributionPoint] = field(default_factory=list)
+    data: list[StatusDistributionPoint] = msgspec.field(default_factory=list)
 
 
-@dataclass
-class CumulativeDataPoint:
+class CumulativeDataPoint(msgspec.Struct, rename="camel"):
     """Cumulative metrics for a single time point.
 
     Running totals that reset at the start of the selected time range.
@@ -188,18 +180,16 @@ class CumulativeDataPoint:
     cumulative_bytes: int
 
 
-@dataclass
-class CumulativeTimeSeriesResponse:
+class CumulativeTimeSeriesResponse(msgspec.Struct, rename="camel"):
     """Response containing cumulative time-series data for area charts."""
 
     granularity: str  # "hourly" or "daily"
     start_date: str
     end_date: str
-    data: list[CumulativeDataPoint] = field(default_factory=list)
+    data: list[CumulativeDataPoint] = msgspec.field(default_factory=list)
 
 
-@dataclass
-class TopUrlDTO:
+class TopUrlDTO(msgspec.Struct, rename="camel"):
     """A single URL with its aggregate hit metrics."""
 
     url: str
@@ -209,8 +199,7 @@ class TopUrlDTO:
     avg_request_time: float
 
 
-@dataclass
-class TopUrlsResponse:
+class TopUrlsResponse(msgspec.Struct, rename="camel"):
     """Response containing top URLs by hit count.
 
     ``items`` is deliberately default-less: a dataclass default makes it
@@ -222,16 +211,14 @@ class TopUrlsResponse:
     items: list[TopUrlDTO]
 
 
-@dataclass
-class TopUserAgentDTO:
+class TopUserAgentDTO(msgspec.Struct, rename="camel"):
     """A single user agent with its hit count."""
 
     user_agent: str
     hits: int
 
 
-@dataclass
-class TopUserAgentsResponse:
+class TopUserAgentsResponse(msgspec.Struct, rename="camel"):
     """Response containing top user agents by hit count.
 
     ``items`` is deliberately default-less (see TopUrlsResponse).
@@ -242,8 +229,7 @@ class TopUserAgentsResponse:
     items: list[TopUserAgentDTO]
 
 
-@dataclass
-class TopIpDTO:
+class TopIpDTO(msgspec.Struct, rename="camel"):
     """A single IP address with its aggregate hit metrics."""
 
     ip_address: str
@@ -254,8 +240,7 @@ class TopIpDTO:
     city: str | None
 
 
-@dataclass
-class TopIpsResponse:
+class TopIpsResponse(msgspec.Struct, rename="camel"):
     """Response containing top IPs by hit count.
 
     ``items`` is deliberately default-less (see TopUrlsResponse).
@@ -266,8 +251,7 @@ class TopIpsResponse:
     items: list[TopIpDTO]
 
 
-@dataclass
-class TopCountryStatsDTO:
+class TopCountryStatsDTO(msgspec.Struct, rename="camel"):
     """A single country with its aggregate metrics."""
 
     country_code: str
@@ -276,8 +260,7 @@ class TopCountryStatsDTO:
     unique_ips: int
 
 
-@dataclass
-class TopCountriesStatsResponse:
+class TopCountriesStatsResponse(msgspec.Struct, rename="camel"):
     """Response containing top countries by hit count.
 
     ``items`` is deliberately default-less (see TopUrlsResponse).
@@ -288,8 +271,7 @@ class TopCountriesStatsResponse:
     items: list[TopCountryStatsDTO]
 
 
-@dataclass
-class TopCityStatsDTO:
+class TopCityStatsDTO(msgspec.Struct, rename="camel"):
     """A single city with its aggregate metrics."""
 
     city: str
@@ -298,8 +280,7 @@ class TopCityStatsDTO:
     unique_ips: int
 
 
-@dataclass
-class TopCitiesResponse:
+class TopCitiesResponse(msgspec.Struct, rename="camel"):
     """Response containing top cities by hit count.
 
     ``items`` is deliberately default-less (see TopUrlsResponse).

--- a/geometrikks/domain/auth/controllers.py
+++ b/geometrikks/domain/auth/controllers.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 import msgspec
 
 from litestar import Controller, Request, get, post
@@ -19,8 +17,7 @@ logger = get_logger(__name__)
 login_logger = get_logger(LOGIN_LOGGER_NAME)
 
 
-@dataclass
-class LoginPayload:
+class LoginPayload(msgspec.Struct, rename="camel"):
     username: str
     password: str
 

--- a/geometrikks/domain/auth/controllers.py
+++ b/geometrikks/domain/auth/controllers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import msgspec
+
 from litestar import Controller, Request, get, post
 from litestar.exceptions import NotAuthorizedException
 from litestar.status_codes import HTTP_200_OK, HTTP_204_NO_CONTENT
@@ -23,8 +25,7 @@ class LoginPayload:
     password: str
 
 
-@dataclass
-class MeResponse:
+class MeResponse(msgspec.Struct, rename="camel"):
     username: str
 
 

--- a/geometrikks/domain/auth/controllers.py
+++ b/geometrikks/domain/auth/controllers.py
@@ -31,7 +31,7 @@ class MeResponse:
 class AuthController(Controller):
     """Session login/logout. /login is excluded from the auth middleware."""
 
-    path = "/api/v1/auth"
+    path = "/auth"
     tags = ["Auth"]
 
     @post("/login", status_code=HTTP_200_OK, exclude_from_auth=True)

--- a/geometrikks/domain/geo/controllers/events.py
+++ b/geometrikks/domain/geo/controllers/events.py
@@ -140,7 +140,7 @@ class GeoEventController(Controller):
     filters ride the stitched per-IP CAGGs instead.
     """
 
-    path = "/api/v1/geo-events"
+    path = "/geo-events"
     return_dto = GeoEventDTO
     tags = ["Geo Events"]
 

--- a/geometrikks/domain/geo/controllers/events.py
+++ b/geometrikks/domain/geo/controllers/events.py
@@ -32,11 +32,11 @@ from geometrikks.domain.geo.schemas import (
 )
 from geometrikks.domain.geo.services import GeoEventService
 from geometrikks.lib.parameters import (
-    EndTimestamp,
+    ToTimestamp,
     HostnameIn,
     IpAddressIn,
     IpAddressNotIn,
-    StartTimestamp,
+    FromTimestamp,
 )
 from geometrikks.lib.time import ensure_utc
 from geometrikks.lib.validation import validate_ip_addresses
@@ -51,8 +51,8 @@ def _calculate_percent_change(current: float, previous: float) -> float | None:
 
 
 def provide_geo_event_time_window(
-    from_timestamp: Annotated[datetime | None, QueryParameter(required=False)] = None,
-    to_timestamp: Annotated[datetime | None, QueryParameter(required=False)] = None,
+    from_timestamp: Annotated[datetime | None, QueryParameter(name="fromTimestamp", required=False)] = None,
+    to_timestamp: Annotated[datetime | None, QueryParameter(name="toTimestamp", required=False)] = None,
 ) -> list[FilterTypes]:
     """Optional inclusive [from, to] window on the ``timestamp`` column.
 
@@ -180,8 +180,8 @@ class GeoEventController(Controller):
         self,
         geo_event_service: NamedDependency[GeoEventService],
         geo_filters: NamedDependency[SkipValidation[GeoEventFilters]],
-        from_timestamp: StartTimestamp,
-        to_timestamp: EndTimestamp,
+        from_timestamp: FromTimestamp,
+        to_timestamp: ToTimestamp,
         current_page: Annotated[int, QueryParameter(name="currentPage", ge=1, required=False)] = 1,
         page_size: Annotated[int, QueryParameter(name="pageSize", ge=1, le=500, required=False)] = 50,
         order_by: Annotated[
@@ -218,11 +218,11 @@ class GeoEventController(Controller):
         self,
         geo_event_service: NamedDependency[GeoEventService],
         geo_filters: NamedDependency[SkipValidation[GeoEventFilters]],
-        from_timestamp: StartTimestamp,
-        to_timestamp: EndTimestamp,
+        from_timestamp: FromTimestamp,
+        to_timestamp: ToTimestamp,
         compare_previous: Annotated[
             bool,
-            QueryParameter(description="Include comparison with previous period of same length"),
+            QueryParameter(name="comparePrevious", description="Include comparison with previous period of same length"),
         ] = False,
     ) -> GeoLogSummaryResponse:
         """Totals and unique counts for the period, optionally vs the previous one.
@@ -268,8 +268,8 @@ class GeoEventController(Controller):
         self,
         geo_event_service: NamedDependency[GeoEventService],
         geo_filters: NamedDependency[SkipValidation[GeoEventFilters]],
-        from_timestamp: StartTimestamp,
-        to_timestamp: EndTimestamp,
+        from_timestamp: FromTimestamp,
+        to_timestamp: ToTimestamp,
         granularity: Annotated[
             Literal["hourly", "daily"] | None,
             QueryParameter(
@@ -303,8 +303,8 @@ class GeoEventController(Controller):
         self,
         geo_event_service: NamedDependency[GeoEventService],
         geo_filters: NamedDependency[SkipValidation[GeoEventFilters]],
-        from_timestamp: StartTimestamp,
-        to_timestamp: EndTimestamp,
+        from_timestamp: FromTimestamp,
+        to_timestamp: ToTimestamp,
         limit: Annotated[int, QueryParameter(description="Maximum number of IPs", ge=1, le=50)] = 10,
     ) -> TopGeoIpsResponse:
         """Top IPs across all locations for the period."""
@@ -318,8 +318,8 @@ class GeoEventController(Controller):
         self,
         geo_event_service: NamedDependency[GeoEventService],
         geo_filters: NamedDependency[SkipValidation[GeoEventFilters]],
-        from_timestamp: StartTimestamp,
-        to_timestamp: EndTimestamp,
+        from_timestamp: FromTimestamp,
+        to_timestamp: ToTimestamp,
         limit: Annotated[int, QueryParameter(description="Maximum number of countries", ge=1, le=50)] = 10,
     ) -> TopGeoCountriesResponse:
         """Top countries with exact unique-IP counts for the period."""
@@ -333,8 +333,8 @@ class GeoEventController(Controller):
         self,
         geo_event_service: NamedDependency[GeoEventService],
         geo_filters: NamedDependency[SkipValidation[GeoEventFilters]],
-        from_timestamp: StartTimestamp,
-        to_timestamp: EndTimestamp,
+        from_timestamp: FromTimestamp,
+        to_timestamp: ToTimestamp,
         limit: Annotated[int, QueryParameter(description="Maximum number of cities", ge=1, le=50)] = 10,
     ) -> TopGeoCitiesResponse:
         """Top cities (NULL cities excluded) for the period."""

--- a/geometrikks/domain/geo/controllers/locations.py
+++ b/geometrikks/domain/geo/controllers/locations.py
@@ -44,7 +44,7 @@ logger = get_logger(__name__)
 class GeoLocationController(Controller):
     """Geo-location endpoints for managing location data."""
 
-    path = "/api/v1/geo-locations"
+    path = "/geo-locations"
     tags = ["Geo Locations"]
     return_dto = GeoLocationDTO
 

--- a/geometrikks/domain/geo/controllers/locations.py
+++ b/geometrikks/domain/geo/controllers/locations.py
@@ -29,11 +29,11 @@ from geometrikks.domain.geo.dtos import (
 from geometrikks.lib.parameters import (
     CityFilter,
     CountryCodeFilter,
-    EndTimestamp,
+    ToTimestamp,
     HostnameIn,
     IpAddressIn,
     IpAddressNotIn,
-    StartTimestamp,
+    FromTimestamp,
 )
 from geometrikks.lib.time import ensure_utc
 from geometrikks.lib.validation import validate_ip_addresses
@@ -74,8 +74,8 @@ class GeoLocationController(Controller):
     async def get_geojson(
         self,
         geo_location_service: NamedDependency[GeoLocationService],
-        from_timestamp: StartTimestamp,
-        to_timestamp: EndTimestamp,
+        from_timestamp: FromTimestamp,
+        to_timestamp: ToTimestamp,
         country_code: CountryCodeFilter = None,
         city: CityFilter = None,
         ip_address_in: IpAddressIn = None,
@@ -147,8 +147,8 @@ class GeoLocationController(Controller):
     async def get_global_top_ips(
         self,
         geo_location_service: NamedDependency[GeoLocationService],
-        from_timestamp: StartTimestamp,
-        to_timestamp: EndTimestamp,
+        from_timestamp: FromTimestamp,
+        to_timestamp: ToTimestamp,
         limit: Annotated[
             int,
             QueryParameter(description="Maximum number of IPs to return", ge=1, le=20),
@@ -187,8 +187,8 @@ class GeoLocationController(Controller):
         self,
         geo_location_service: NamedDependency[GeoLocationService],
         location_id: Annotated[int, PathParameter()],
-        from_timestamp: StartTimestamp,
-        to_timestamp: EndTimestamp,
+        from_timestamp: FromTimestamp,
+        to_timestamp: ToTimestamp,
         limit: Annotated[
             int,
             QueryParameter(description="Maximum number of IPs to return", ge=1, le=20),
@@ -214,8 +214,8 @@ class GeoLocationController(Controller):
     async def get_top_countries(
         self,
         geo_location_service: NamedDependency[GeoLocationService],
-        from_timestamp: StartTimestamp,
-        to_timestamp: EndTimestamp,
+        from_timestamp: FromTimestamp,
+        to_timestamp: ToTimestamp,
         limit: Annotated[
             int,
             QueryParameter(description="Maximum number of countries to return", ge=1, le=50),

--- a/geometrikks/domain/geo/dtos.py
+++ b/geometrikks/domain/geo/dtos.py
@@ -1,8 +1,9 @@
 """DTOs for geo-location and geo-event data transfer."""
 
 from __future__ import annotations
-from dataclasses import dataclass, field
 from datetime import datetime
+
+import msgspec
 
 from advanced_alchemy.extensions.litestar import SQLAlchemyDTO, SQLAlchemyDTOConfig
 from geometrikks.domain.geo.models import GeoEvent, GeoLocation
@@ -23,8 +24,7 @@ class GeoLocationDTO(SQLAlchemyDTO[GeoLocation]):
     )
 
 
-@dataclass
-class EmbeddedLocationDTO:
+class EmbeddedLocationDTO(msgspec.Struct, rename="camel"):
     """Lightweight location data for embedding in other DTOs."""
 
     id: int
@@ -35,8 +35,7 @@ class EmbeddedLocationDTO:
     country_name: str | None = None
 
 
-@dataclass
-class TopIPDTO:
+class TopIPDTO(msgspec.Struct, rename="camel"):
     """Top IP address with event count and optional location."""
 
     ip_address: str
@@ -44,8 +43,7 @@ class TopIPDTO:
     location: EmbeddedLocationDTO | None = None  # Optional - used for global top IPs
 
 
-@dataclass
-class GeoJSONPointGeometry:
+class GeoJSONPointGeometry(msgspec.Struct, rename="camel"):
     """GeoJSON Point geometry.
 
     Fields are deliberately default-less: dataclass defaults make them
@@ -57,8 +55,7 @@ class GeoJSONPointGeometry:
     coordinates: tuple[float, float]
 
 
-@dataclass
-class GeoJSONFeatureProperties:
+class GeoJSONFeatureProperties(msgspec.Struct, rename="camel"):
     """Properties for a GeoJSON feature representing a location with event count."""
 
     id: int
@@ -72,19 +69,17 @@ class GeoJSONFeatureProperties:
     postal_code: str | None
     timezone: str | None
     event_count: int
-    top_ips: list[TopIPDTO] = field(default_factory=list)
+    top_ips: list[TopIPDTO] = msgspec.field(default_factory=list)
 
 
-@dataclass
-class GeoJSONFeature:
+class GeoJSONFeature(msgspec.Struct, rename="camel"):
     """GeoJSON Feature representing a location."""
 
     type: str
     geometry: GeoJSONPointGeometry
     properties: GeoJSONFeatureProperties
 
-@dataclass
-class GeoJSONFeatureStats:
+class GeoJSONFeatureStats(msgspec.Struct, rename="camel"):
     """Statistics for GeoJSONFeatureCollection."""
 
     events: int
@@ -92,8 +87,7 @@ class GeoJSONFeatureStats:
     cities: int
     locations: int
 
-@dataclass
-class GeoJSONFeatureCollection:
+class GeoJSONFeatureCollection(msgspec.Struct, rename="camel"):
     """GeoJSON FeatureCollection for locations with event counts."""
 
     type: str
@@ -101,23 +95,20 @@ class GeoJSONFeatureCollection:
     stats: GeoJSONFeatureStats
 
 
-@dataclass
-class LocationTopIPsResponse:
+class LocationTopIPsResponse(msgspec.Struct, rename="camel"):
     """Response for location top IPs endpoint."""
 
     location_id: int
-    top_ips: list[TopIPDTO] = field(default_factory=list)
+    top_ips: list[TopIPDTO] = msgspec.field(default_factory=list)
 
 
-@dataclass
-class GlobalTopIPsResponse:
+class GlobalTopIPsResponse(msgspec.Struct, rename="camel"):
     """Response for global top IPs endpoint."""
 
-    top_ips: list[TopIPDTO] = field(default_factory=list)
+    top_ips: list[TopIPDTO] = msgspec.field(default_factory=list)
 
 
-@dataclass
-class TopCountryDTO:
+class TopCountryDTO(msgspec.Struct, rename="camel"):
     """Top country with event count."""
 
     country_code: str
@@ -125,9 +116,8 @@ class TopCountryDTO:
     event_count: int
 
 
-@dataclass
-class TopCountriesResponse:
+class TopCountriesResponse(msgspec.Struct, rename="camel"):
     """Response for top countries endpoint."""
 
-    top_countries: list[TopCountryDTO] = field(default_factory=list)
+    top_countries: list[TopCountryDTO] = msgspec.field(default_factory=list)
 

--- a/geometrikks/domain/logs/controllers/access_log_debug.py
+++ b/geometrikks/domain/logs/controllers/access_log_debug.py
@@ -17,8 +17,8 @@ from geometrikks.lib.validation import validate_ip_addresses
 
 
 def provide_debug_time_window(
-    from_timestamp: Annotated[datetime | None, QueryParameter(required=False)] = None,
-    to_timestamp: Annotated[datetime | None, QueryParameter(required=False)] = None,
+    from_timestamp: Annotated[datetime | None, QueryParameter(name="fromTimestamp", required=False)] = None,
+    to_timestamp: Annotated[datetime | None, QueryParameter(name="toTimestamp", required=False)] = None,
 ) -> list[FilterTypes]:
     """Optional inclusive [from, to] window on ``created_at`` (ingest time).
 
@@ -116,8 +116,8 @@ class AccessLogDebugController(Controller):
     async def get_access_log_debug_stats(
         self,
         access_log_debug_service: NamedDependency[AccessLogDebugService],
-        from_timestamp: Annotated[datetime | None, QueryParameter(required=False)] = None,
-        to_timestamp: Annotated[datetime | None, QueryParameter(required=False)] = None,
+        from_timestamp: Annotated[datetime | None, QueryParameter(name="fromTimestamp", required=False)] = None,
+        to_timestamp: Annotated[datetime | None, QueryParameter(name="toTimestamp", required=False)] = None,
     ) -> AccessLogDebugStats:
         """Totals, malformed count, and top parse error within the range."""
         return await access_log_debug_service.get_stats(

--- a/geometrikks/domain/logs/controllers/access_log_debug.py
+++ b/geometrikks/domain/logs/controllers/access_log_debug.py
@@ -51,7 +51,7 @@ class AccessLogDebugController(Controller):
     access-log context, filtering, search, sorting, and pagination.
     """
 
-    path = "/api/v1/access-log-debug"
+    path = "/access-log-debug"
     tags = ["Access Log Debug"]
 
     dependencies = create_service_dependencies(

--- a/geometrikks/domain/logs/controllers/access_logs.py
+++ b/geometrikks/domain/logs/controllers/access_logs.py
@@ -110,7 +110,7 @@ class AccessLogController(Controller):
     Handles read operations for access logs with filtering, search, sorting,
     and pagination.
     """
-    path = "/api/v1/access-logs"
+    path = "/access-logs"
     return_dto = AccessLogDTO
     tags = ["Access Logs"]
 

--- a/geometrikks/domain/logs/controllers/access_logs.py
+++ b/geometrikks/domain/logs/controllers/access_logs.py
@@ -27,8 +27,8 @@ from geometrikks.lib.validation import validate_ip_addresses
 
 
 def provide_access_log_time_window(
-    from_timestamp: Annotated[datetime | None, QueryParameter(required=False)] = None,
-    to_timestamp: Annotated[datetime | None, QueryParameter(required=False)] = None,
+    from_timestamp: Annotated[datetime | None, QueryParameter(name="fromTimestamp", required=False)] = None,
+    to_timestamp: Annotated[datetime | None, QueryParameter(name="toTimestamp", required=False)] = None,
 ) -> list[FilterTypes]:
     """Optional inclusive [from, to] window on the ``timestamp`` column.
 

--- a/geometrikks/domain/logs/schemas.py
+++ b/geometrikks/domain/logs/schemas.py
@@ -1,14 +1,12 @@
 """Plain schemas for access-log query results - pure data, no ORM dependencies."""
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import datetime
 
 import msgspec
 
 
-@dataclass
-class CountryFacet:
+class CountryFacet(msgspec.Struct, rename="camel"):
     """One country present in the access-log data."""
 
     code: str
@@ -17,8 +15,7 @@ class CountryFacet:
     """Display name, e.g. ``Norway`` (falls back to the code)."""
 
 
-@dataclass
-class AccessLogFacets:
+class AccessLogFacets(msgspec.Struct, rename="camel"):
     """Distinct filterable values present in the access-log data."""
 
     countries: list[CountryFacet]

--- a/geometrikks/domain/security/controllers.py
+++ b/geometrikks/domain/security/controllers.py
@@ -8,9 +8,10 @@ key) the data endpoints return 404 and the frontend hides the page.
 from __future__ import annotations
 
 import re
+
+import msgspec
 from datetime import datetime
 from collections import Counter
-from dataclasses import dataclass
 from typing import Annotated
 
 from advanced_alchemy.extensions.litestar import filters
@@ -49,15 +50,13 @@ GO_DURATION_RE = re.compile(r"^(\d+h)?(\d+m)?(\d+s)?$")
 logger = get_logger(__name__)
 
 
-@dataclass
-class CrowdSecStatusResponse:
+class CrowdSecStatusResponse(msgspec.Struct, rename="camel"):
     enabled: bool
     write_enabled: bool
     lapi_reachable: bool
 
 
-@dataclass
-class DecisionView:
+class DecisionView(msgspec.Struct, rename="camel"):
     id: int | None
     ip: str  # Decision value; a CIDR/country/AS number for non-Ip scopes
     type: str
@@ -69,30 +68,26 @@ class DecisionView:
     country_code: str | None
     country_name: str | None
     city: str | None
-    request_count_24h: int | None
+    request_count_24h: int | None = msgspec.field(name="requestCount24h")
 
 
-@dataclass
-class OriginCount:
+class OriginCount(msgspec.Struct, rename="camel"):
     origin: str
     count: int
 
 
-@dataclass
-class ScenarioCount:
+class ScenarioCount(msgspec.Struct, rename="camel"):
     scenario: str
     count: int
 
 
-@dataclass
-class CrowdSecStatsResponse:
+class CrowdSecStatsResponse(msgspec.Struct, rename="camel"):
     total: int
     by_origin: list[OriginCount]
     top_scenarios: list[ScenarioCount]
 
 
-@dataclass
-class AlertView:
+class AlertView(msgspec.Struct, rename="camel"):
     id: int | None
     scenario: str
     message: str
@@ -106,20 +101,17 @@ class AlertView:
     decision_count: int
 
 
-@dataclass
-class BanRequest:
+class BanRequest(msgspec.Struct, rename="camel"):
     ip: str
     duration: str | None = None
     reason: str = "manual ban from GeoMetrikks"
 
 
-@dataclass
-class UnbanRequest:
+class UnbanRequest(msgspec.Struct, rename="camel"):
     ip: str
 
 
-@dataclass
-class UnbanResponse:
+class UnbanResponse(msgspec.Struct, rename="camel"):
     deleted: int
 
 
@@ -273,8 +265,8 @@ class CrowdSecController(Controller):
         self,
         crowdsec: NamedDependency[CrowdSecService | None],
         enrichment_repo: NamedDependency[SecurityEnrichmentRepository],
-        from_timestamp: Annotated[datetime | None, QueryParameter(required=False)] = None,
-        to_timestamp: Annotated[datetime | None, QueryParameter(required=False)] = None,
+        from_timestamp: Annotated[datetime | None, QueryParameter(name="fromTimestamp", required=False)] = None,
+        to_timestamp: Annotated[datetime | None, QueryParameter(name="toTimestamp", required=False)] = None,
     ) -> list[IpLocation]:
         """Coordinates of banned IPs that appear in this server's own traffic.
 

--- a/geometrikks/domain/security/controllers.py
+++ b/geometrikks/domain/security/controllers.py
@@ -174,7 +174,7 @@ def _actor(request: Request) -> str:
 class CrowdSecController(Controller):
     """CrowdSec decision views and ban statistics."""
 
-    path = "/api/v1/crowdsec"
+    path = "/crowdsec"
     tags = ["CrowdSec"]
     dependencies = {
         "crowdsec": Provide(provide_crowdsec_service, sync_to_thread=False),

--- a/geometrikks/domain/security/schemas.py
+++ b/geometrikks/domain/security/schemas.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import msgspec
+
 
 @dataclass
 class IpEnrichment:
@@ -14,8 +16,7 @@ class IpEnrichment:
     request_count_24h: int
 
 
-@dataclass
-class IpLocation:
+class IpLocation(msgspec.Struct, rename="camel"):
     """Latest known coordinates for one IP, for the map's banned overlay."""
 
     ip: str

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -10,7 +10,7 @@ format this payload has always used on the wire.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+import msgspec
 from datetime import datetime, timezone
 from typing import Literal
 
@@ -28,8 +28,7 @@ from geometrikks.services.ingestion import LogIngestionService
 from geometrikks.domain.system.dependencies import provide_ingestion_service as pis
 
 
-@dataclass
-class IngestionHealth:
+class IngestionHealth(msgspec.Struct, rename="camel"):
     running: bool
     parsed_lines: int
     pending_records: int
@@ -37,25 +36,21 @@ class IngestionHealth:
     last_record_at: str | None
 
 
-@dataclass
-class DatabaseHealth:
+class DatabaseHealth(msgspec.Struct, rename="camel"):
     reachable: bool
 
 
-@dataclass
-class GeoIPHealth:
+class GeoIPHealth(msgspec.Struct, rename="camel"):
     available: bool
     db_build_date: str | None
 
 
-@dataclass
-class CrowdSecHealth:
+class CrowdSecHealth(msgspec.Struct, rename="camel"):
     enabled: bool
     lapi_reachable: bool | None
 
 
-@dataclass
-class HealthResponse:
+class HealthResponse(msgspec.Struct, rename="camel"):
     status: Literal["healthy", "degraded"]
     started_at: str | None
     ingestion: IngestionHealth
@@ -65,8 +60,7 @@ class HealthResponse:
     timestamp: str
 
 
-@dataclass
-class ReadinessResponse:
+class ReadinessResponse(msgspec.Struct, rename="camel"):
     ready: bool
 
 

--- a/geometrikks/domain/system/controllers/logs.py
+++ b/geometrikks/domain/system/controllers/logs.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import msgspec
 from datetime import datetime
 from typing import Annotated, Literal
 
@@ -23,8 +23,7 @@ from geometrikks.services.logfiles import (
 MAX_TAIL_LINES = 2000
 
 
-@dataclass
-class LogFileView:
+class LogFileView(msgspec.Struct, rename="camel"):
     name: str
     kind: LogFileKind
     size_bytes: int
@@ -32,20 +31,17 @@ class LogFileView:
     available: bool
 
 
-@dataclass
-class LogFilesResponse:
+class LogFilesResponse(msgspec.Struct, rename="camel"):
     files: list[LogFileView]
 
 
-@dataclass
-class LogTailResponse:
+class LogTailResponse(msgspec.Struct, rename="camel"):
     # LogTailRecord is a TypedDict: app-log records keep their extra
     # structlog context keys on the wire; the schema documents the stable ones.
     records: list[LogTailRecord]
 
 
-@dataclass
-class LogRotateResponse:
+class LogRotateResponse(msgspec.Struct, rename="camel"):
     rotated: list[str]
 
 

--- a/geometrikks/domain/system/controllers/logs.py
+++ b/geometrikks/domain/system/controllers/logs.py
@@ -52,7 +52,7 @@ class LogRotateResponse:
 class LogsController(Controller):
     """Access to the application's own log files: tail, list, download, rotate."""
 
-    path = "/api/v1/logs"
+    path = "/logs"
     tags = ["Logs"]
 
     @get("/tail", sync_to_thread=True)

--- a/geometrikks/domain/system/controllers/settings.py
+++ b/geometrikks/domain/system/controllers/settings.py
@@ -7,7 +7,7 @@ exposed; add new fields consciously.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import msgspec
 
 from litestar import Request, get
 from litestar.di import NamedDependency
@@ -18,38 +18,33 @@ from geometrikks.server import runtime
 from geometrikks.services.geoip.home import HomeLocation, HomeLocationSource
 
 
-@dataclass
-class LogparserSettingsView:
+class LogparserSettingsView(msgspec.Struct, rename="camel"):
     log_paths: list[str]
     send_logs: bool
     store_debug_lines: bool
 
 
-@dataclass
-class AnalyticsSettingsView:
+class AnalyticsSettingsView(msgspec.Struct, rename="camel"):
     raw_retention_days: int
     debug_retention_days: int
     hourly_retention_days: int
     compression_after_days: int
 
 
-@dataclass
-class MapSettingsView:
+class MapSettingsView(msgspec.Struct, rename="camel"):
     home_latitude: float | None
     home_longitude: float | None
     home_source: HomeLocationSource | None
 
 
-@dataclass
-class RuntimeSettingsView:
+class RuntimeSettingsView(msgspec.Struct, rename="camel"):
     """Non-sensitive information about the executing application image."""
 
     container: bool
     image_tag: str | None
 
 
-@dataclass
-class SafeSettingsResponse:
+class SafeSettingsResponse(msgspec.Struct, rename="camel"):
     name: str
     version: str
     environment: str

--- a/geometrikks/domain/system/controllers/settings.py
+++ b/geometrikks/domain/system/controllers/settings.py
@@ -59,7 +59,7 @@ class SafeSettingsResponse:
     map: MapSettingsView
 
 
-@get("/api/v1/settings", tags=["Settings"])
+@get("/settings", tags=["Settings"])
 async def read_settings(
     request: Request, settings: NamedDependency[SkipValidation[Settings]]
 ) -> SafeSettingsResponse:

--- a/geometrikks/domain/system/controllers/stats.py
+++ b/geometrikks/domain/system/controllers/stats.py
@@ -21,7 +21,7 @@ class IngestionStatsResponse:
 
 
 @get(
-    "/api/v1/stats",
+    "/stats",
     tags=["Analytics"],
     dependencies={"ingestion_service": Provide(pis, sync_to_thread=False)},
 )

--- a/geometrikks/domain/system/controllers/stats.py
+++ b/geometrikks/domain/system/controllers/stats.py
@@ -1,7 +1,7 @@
 """Stats API endpoint for log parser statistics."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+import msgspec
 
 from litestar import get
 from litestar.di import NamedDependency, Provide
@@ -10,8 +10,7 @@ from geometrikks.services.ingestion import LogIngestionService
 from geometrikks.domain.system.dependencies import provide_ingestion_service as pis
 
 
-@dataclass
-class IngestionStatsResponse:
+class IngestionStatsResponse(msgspec.Struct, rename="camel"):
     total_parsed_lines: int
     total_skipped_lines: int
     total_pending_records: int

--- a/geometrikks/domain/system/controllers/system.py
+++ b/geometrikks/domain/system/controllers/system.py
@@ -7,7 +7,8 @@ is the only user, so no extra guards are needed here.
 from __future__ import annotations
 
 import platform
-from dataclasses import dataclass
+
+import msgspec
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, version as dist_version
 from typing import TYPE_CHECKING
@@ -36,8 +37,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-@dataclass
-class SchedulerJobView:
+class SchedulerJobView(msgspec.Struct, rename="camel"):
     id: str
     name: str
     trigger: str
@@ -49,8 +49,7 @@ class SchedulerJobView:
     last_error: str | None
 
 
-@dataclass
-class SchedulerJobsResponse:
+class SchedulerJobsResponse(msgspec.Struct, rename="camel"):
     scheduler_enabled: bool
     scheduler_running: bool
     jobs: list[SchedulerJobView]
@@ -59,8 +58,7 @@ class SchedulerJobsResponse:
 REPO_URL = "https://github.com/GilbN/geometrikks"
 
 
-@dataclass
-class AboutAppView:
+class AboutAppView(msgspec.Struct, rename="camel"):
     name: str
     version: str
     environment: str
@@ -69,28 +67,24 @@ class AboutAppView:
     started_at: datetime | None
 
 
-@dataclass
-class RuntimeVersionsView:
+class RuntimeVersionsView(msgspec.Struct, rename="camel"):
     python_version: str
     litestar_version: str | None
     apscheduler_version: str | None
 
 
-@dataclass
-class DatabaseVersionsView:
+class DatabaseVersionsView(msgspec.Struct, rename="camel"):
     postgres_version: str | None
     timescaledb_version: str | None
     postgis_version: str | None
 
 
-@dataclass
-class AboutLinksView:
+class AboutLinksView(msgspec.Struct, rename="camel"):
     repository: str
     issues: str
 
 
-@dataclass
-class AboutResponse:
+class AboutResponse(msgspec.Struct, rename="camel"):
     app: AboutAppView
     runtime: RuntimeVersionsView
     database: DatabaseVersionsView
@@ -134,8 +128,7 @@ async def _database_versions(app: Litestar) -> DatabaseVersionsView:
         )
 
 
-@dataclass
-class HypertableStatsView:
+class HypertableStatsView(msgspec.Struct, rename="camel"):
     name: str
     approx_rows: int | None
     total_bytes: int | None
@@ -145,8 +138,7 @@ class HypertableStatsView:
     after_compression_bytes: int | None
 
 
-@dataclass
-class DatabaseInfoResponse:
+class DatabaseInfoResponse(msgspec.Struct, rename="camel"):
     reachable: bool
     size_bytes: int | None
     postgres_version: str | None

--- a/geometrikks/domain/system/controllers/system.py
+++ b/geometrikks/domain/system/controllers/system.py
@@ -258,7 +258,7 @@ def _computed_settings_overlay(
 class SystemController(Controller):
     """Settings overview and scheduler administration."""
 
-    path = "/api/v1/system"
+    path = "/system"
     tags = ["System"]
 
     @get("/settings")

--- a/geometrikks/lib/parameters.py
+++ b/geometrikks/lib/parameters.py
@@ -1,9 +1,8 @@
 """Shared query-parameter declarations reused across API controllers.
 
-These are ``Annotated`` aliases: unless a declaration carries an explicit
-``name=``, the wire-level query-parameter name still comes from the handler
-argument name, so reusing an alias across handlers never changes the wire
-contract.
+These are ``Annotated`` aliases. Every alias carries an explicit camelCase
+``name=`` (the public API casing policy); handler argument names stay
+snake_case Python.
 """
 
 from __future__ import annotations
@@ -14,17 +13,38 @@ from typing import Annotated
 from litestar.openapi.spec import Example
 from litestar.params import QueryParameter
 
-StartTimestamp = Annotated[
+FromTimestamp = Annotated[
     datetime,
     QueryParameter(
+        name="fromTimestamp",
         description="Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
         examples=[Example(value="2024-01-01T00:00:00Z")],
     ),
 ]
 
-EndTimestamp = Annotated[
+ToTimestamp = Annotated[
     datetime,
     QueryParameter(
+        name="toTimestamp",
+        description="End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
+        examples=[Example(value="2024-12-31T23:59:59Z")],
+    ),
+]
+
+# The analytics endpoints keep their own wire names for the same window.
+StartDate = Annotated[
+    datetime,
+    QueryParameter(
+        name="startDate",
+        description="Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
+        examples=[Example(value="2024-01-01T00:00:00Z")],
+    ),
+]
+
+EndDate = Annotated[
+    datetime,
+    QueryParameter(
+        name="endDate",
         description="End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
         examples=[Example(value="2024-12-31T23:59:59Z")],
     ),
@@ -32,7 +52,7 @@ EndTimestamp = Annotated[
 
 CountryCodeFilter = Annotated[
     list[str] | None,
-    QueryParameter(description="Filter to these ISO country codes (repeatable)", required=False),
+    QueryParameter(name="countryCode", description="Filter to these ISO country codes (repeatable)", required=False),
 ]
 
 CityFilter = Annotated[
@@ -42,12 +62,12 @@ CityFilter = Annotated[
 
 IpAddressFilter = Annotated[
     list[str] | None,
-    QueryParameter(description="Filter to these client IPs (repeatable)", required=False),
+    QueryParameter(name="ipAddress", description="Filter to these client IPs (repeatable)", required=False),
 ]
 
 IpAddressExcludeFilter = Annotated[
     list[str] | None,
-    QueryParameter(description="Exclude these client IPs (repeatable)", required=False),
+    QueryParameter(name="ipAddressNotIn", description="Exclude these client IPs (repeatable)", required=False),
 ]
 
 # camelCase-named variants used by the geo endpoints.

--- a/geometrikks/lib/utils.py
+++ b/geometrikks/lib/utils.py
@@ -4,7 +4,9 @@ import asyncio
 from functools import wraps
 from pathlib import Path
 from typing import ParamSpec, Callable
-from dataclasses import dataclass
+
+
+import msgspec
 
 import aiofiles.os
 import aiofiles
@@ -18,8 +20,7 @@ logger = get_logger(__name__)
 
 P = ParamSpec("P")
 
-@dataclass
-class GeoIPInfoView:
+class GeoIPInfoView(msgspec.Struct, rename="camel"):
     available: bool
     db_path: str
     build_date: datetime | None

--- a/geometrikks/server/exceptions.py
+++ b/geometrikks/server/exceptions.py
@@ -34,6 +34,11 @@ def handle_not_found(request: Request, exc: NotFoundException) -> Response:
     is present, so this one owns all 404 rendering. Non-API paths keep the
     plugin's empty-body behavior for static-asset misses; API paths get the
     same native envelope as every other error.
+
+    The match is deliberately the whole /api/ namespace, not just /api/v1/:
+    it mirrors the auth boundary (NON_API_PATTERN in server/auth.py), which
+    reserves everything under /api/ for the REST API. A request to an unknown
+    or unversioned /api/ path comes from an API consumer and gets JSON.
     """
     if request.scope["path"].startswith("/api/"):
         return Response(

--- a/geometrikks/server/exceptions.py
+++ b/geometrikks/server/exceptions.py
@@ -2,8 +2,10 @@
 from __future__ import annotations
 
 from litestar import MediaType, Request, Response
+from litestar.exceptions import NotFoundException
 from litestar.status_codes import (
     HTTP_400_BAD_REQUEST,
+    HTTP_404_NOT_FOUND,
     HTTP_500_INTERNAL_SERVER_ERROR,
     HTTP_502_BAD_GATEWAY,
 )
@@ -23,6 +25,23 @@ def handle_domain_validation_error(request: Request, exc: DomainValidationError)
         status_code=HTTP_400_BAD_REQUEST,
         content={"status_code": HTTP_400_BAD_REQUEST, "detail": exc.detail},
     )
+
+
+def handle_not_found(request: Request, exc: NotFoundException) -> Response:
+    """404: native JSON envelope for API paths, empty body elsewhere.
+
+    litestar-vite only registers its own NotFoundException handler when none
+    is present, so this one owns all 404 rendering. Non-API paths keep the
+    plugin's empty-body behavior for static-asset misses; API paths get the
+    same native envelope as every other error.
+    """
+    if request.scope["path"].startswith("/api/"):
+        return Response(
+            media_type=MediaType.JSON,
+            status_code=HTTP_404_NOT_FOUND,
+            content={"status_code": HTTP_404_NOT_FOUND, "detail": exc.detail},
+        )
+    return Response(status_code=HTTP_404_NOT_FOUND, content=b"")
 
 
 def handle_crowdsec_unavailable(request: Request, exc: Exception) -> Response:
@@ -57,4 +76,5 @@ CROWDSEC_EXCEPTION_HANDLERS: ExceptionHandlersMap = {
 EXCEPTION_HANDLERS: ExceptionHandlersMap = {
     **CROWDSEC_EXCEPTION_HANDLERS,
     DomainValidationError: handle_domain_validation_error,
+    NotFoundException: handle_not_found,
 }

--- a/geometrikks/server/routes.py
+++ b/geometrikks/server/routes.py
@@ -1,7 +1,7 @@
 """Central route registration."""
 from pathlib import Path
 
-from litestar import get
+from litestar import Router, get
 from litestar.datastructures import ResponseHeader
 from litestar.di import NamedDependency
 from litestar.exceptions import NotFoundException
@@ -44,6 +44,19 @@ def service_worker(settings: NamedDependency[SkipValidation[Settings]]) -> File:
     return File(path=sw_path, media_type="text/javascript")
 
 
+API_V1_PREFIX = "/api/v1"
+
+
+def create_api_v1_router(handlers: list[ControllerRouterHandler]) -> Router:
+    """Mount handlers under the versioned API prefix.
+
+    Controllers own only their domain segment (``/crowdsec``, ``/analytics``,
+    ...); this router supplies the ``/api/v1`` scope. Tests that mount a
+    single controller use this too, so it keeps its production URL.
+    """
+    return Router(path=API_V1_PREFIX, route_handlers=handlers)
+
+
 def get_route_handlers(*, include_auth: bool = True) -> list[ControllerRouterHandler]:
     """Get all route handlers for the application.
 
@@ -53,7 +66,7 @@ def get_route_handlers(*, include_auth: bool = True) -> list[ControllerRouterHan
             handlers would crash on ``app.state.auth_state`` / ``request.user``.
     """
 
-    handlers: list[ControllerRouterHandler] = [
+    api_handlers: list[ControllerRouterHandler] = [
         GeoEventController,
         GeoLocationController,
         AccessLogController,
@@ -62,16 +75,20 @@ def get_route_handlers(*, include_auth: bool = True) -> list[ControllerRouterHan
         CrowdSecController,
         LogsController,
         SystemController,
+        read_settings,
+        stats,
+    ]
+    if include_auth:
+        api_handlers.append(AuthController)
+
+    return [
+        create_api_v1_router(api_handlers),
+        # The WebSocket feeds and probe endpoints live outside /api/v1: /ws/*
+        # by contract, /health and /health/ready for unauthenticated probes.
         live_feed,
         crowdsec_feed,
         logs_feed,
-        read_settings,
-        stats,
         health,
         health_ready,
         service_worker,
     ]
-
-    if include_auth:
-        handlers.append(AuthController)
-    return handlers

--- a/resources/components/analytics/bytes-chart.tsx
+++ b/resources/components/analytics/bytes-chart.tsx
@@ -12,7 +12,7 @@ import { useTimeSeries } from "@/lib/queries"
 import { formatBucketTick } from "./chart-utils"
 
 const chartConfig = {
-  total_bytes_sent: { label: "Bytes sent", color: "var(--chart-2)" },
+  totalBytesSent: { label: "Bytes sent", color: "var(--chart-2)" },
 } satisfies ChartConfig
 
 export function BytesChart() {
@@ -50,11 +50,11 @@ export function BytesChart() {
                 }
               />
               <Area
-                dataKey="total_bytes_sent"
+                dataKey="totalBytesSent"
                 type="monotone"
-                fill="var(--color-total_bytes_sent)"
+                fill="var(--color-totalBytesSent)"
                 fillOpacity={0.2}
-                stroke="var(--color-total_bytes_sent)"
+                stroke="var(--color-totalBytesSent)"
                 strokeWidth={2}
               />
             </AreaChart>

--- a/resources/components/analytics/latency-chart.tsx
+++ b/resources/components/analytics/latency-chart.tsx
@@ -14,10 +14,10 @@ import { useTimeSeries } from "@/lib/queries"
 import { formatBucketTick } from "./chart-utils"
 
 const chartConfig = {
-  avg_request_time: { label: "avg", color: "var(--chart-1)" },
-  p50_request_time: { label: "p50", color: "var(--chart-2)" },
-  p95_request_time: { label: "p95", color: "var(--chart-3)" },
-  p99_request_time: { label: "p99", color: "var(--chart-4)" },
+  avgRequestTime: { label: "avg", color: "var(--chart-1)" },
+  p50RequestTime: { label: "p50", color: "var(--chart-2)" },
+  p95RequestTime: { label: "p95", color: "var(--chart-3)" },
+  p99RequestTime: { label: "p99", color: "var(--chart-4)" },
 } satisfies ChartConfig
 
 const SERIES = Object.keys(chartConfig) as (keyof typeof chartConfig)[]

--- a/resources/components/analytics/requests-chart.tsx
+++ b/resources/components/analytics/requests-chart.tsx
@@ -12,7 +12,7 @@ import { useTimeSeries } from "@/lib/queries"
 import { formatBucketTick } from "./chart-utils"
 
 const chartConfig = {
-  total_requests: { label: "Requests", color: "var(--chart-1)" },
+  totalRequests: { label: "Requests", color: "var(--chart-1)" },
 } satisfies ChartConfig
 
 export function RequestsChart() {
@@ -44,11 +44,11 @@ export function RequestsChart() {
               />
               <ChartTooltip content={<ChartTooltipContent />} />
               <Area
-                dataKey="total_requests"
+                dataKey="totalRequests"
                 type="monotone"
-                fill="var(--color-total_requests)"
+                fill="var(--color-totalRequests)"
                 fillOpacity={0.2}
-                stroke="var(--color-total_requests)"
+                stroke="var(--color-totalRequests)"
                 strokeWidth={2}
               />
             </AreaChart>

--- a/resources/components/analytics/status-chart.tsx
+++ b/resources/components/analytics/status-chart.tsx
@@ -16,10 +16,10 @@ import { formatBucketTick } from "./chart-utils"
 // Slot order matches the stack order: adjacent-pair CVD separation of the
 // palette is only guaranteed for slots used in sequence.
 const chartConfig = {
-  status_2xx: { label: "2xx", color: "var(--chart-1)" },
-  status_3xx: { label: "3xx", color: "var(--chart-2)" },
-  status_4xx: { label: "4xx", color: "var(--chart-3)" },
-  status_5xx: { label: "5xx", color: "var(--chart-4)" },
+  status2xx: { label: "2xx", color: "var(--chart-1)" },
+  status3xx: { label: "3xx", color: "var(--chart-2)" },
+  status4xx: { label: "4xx", color: "var(--chart-3)" },
+  status5xx: { label: "5xx", color: "var(--chart-4)" },
 } satisfies ChartConfig
 
 export function StatusChart() {
@@ -52,10 +52,10 @@ export function StatusChart() {
               <ChartTooltip content={<ChartTooltipContent />} />
               <ChartLegend content={<ChartLegendContent />} />
               {/* stroke = card surface: the 2px spacer between stacked segments */}
-              <Bar dataKey="status_2xx" stackId="s" fill="var(--color-status_2xx)" stroke="var(--card)" strokeWidth={1} />
-              <Bar dataKey="status_3xx" stackId="s" fill="var(--color-status_3xx)" stroke="var(--card)" strokeWidth={1} />
-              <Bar dataKey="status_4xx" stackId="s" fill="var(--color-status_4xx)" stroke="var(--card)" strokeWidth={1} />
-              <Bar dataKey="status_5xx" stackId="s" fill="var(--color-status_5xx)" stroke="var(--card)" strokeWidth={1} radius={[2, 2, 0, 0]} />
+              <Bar dataKey="status2xx" stackId="s" fill="var(--color-status2xx)" stroke="var(--card)" strokeWidth={1} />
+              <Bar dataKey="status3xx" stackId="s" fill="var(--color-status3xx)" stroke="var(--card)" strokeWidth={1} />
+              <Bar dataKey="status4xx" stackId="s" fill="var(--color-status4xx)" stroke="var(--card)" strokeWidth={1} />
+              <Bar dataKey="status5xx" stackId="s" fill="var(--color-status5xx)" stroke="var(--card)" strokeWidth={1} radius={[2, 2, 0, 0]} />
             </BarChart>
           </ChartContainer>
         )}

--- a/resources/components/analytics/top-countries-cities.tsx
+++ b/resources/components/analytics/top-countries-cities.tsx
@@ -45,10 +45,10 @@ export function TopCountriesCities() {
                   </TableHeader>
                   <TableBody>
                     {countryItems.map((row) => (
-                      <TableRow key={row.country_code}>
-                        <TableCell>{row.country_name ?? row.country_code}</TableCell>
+                      <TableRow key={row.countryCode}>
+                        <TableCell>{row.countryName ?? row.countryCode}</TableCell>
                         <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
-                        <TableCell className="text-right tabular-nums">{formatNumber(row.unique_ips)}</TableCell>
+                        <TableCell className="text-right tabular-nums">{formatNumber(row.uniqueIps)}</TableCell>
                       </TableRow>
                     ))}
                   </TableBody>
@@ -72,10 +72,10 @@ export function TopCountriesCities() {
                   </TableHeader>
                   <TableBody>
                     {cityItems.map((row, index) => (
-                      <TableRow key={`${row.city}-${row.country_code}-${index}`}>
+                      <TableRow key={`${row.city}-${row.countryCode}-${index}`}>
                         <TableCell>{row.city}</TableCell>
                         <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
-                        <TableCell className="text-right tabular-nums">{formatNumber(row.unique_ips)}</TableCell>
+                        <TableCell className="text-right tabular-nums">{formatNumber(row.uniqueIps)}</TableCell>
                       </TableRow>
                     ))}
                   </TableBody>

--- a/resources/components/analytics/top-ips-table.tsx
+++ b/resources/components/analytics/top-ips-table.tsx
@@ -42,16 +42,16 @@ export function TopIpsTable() {
               </TableHeader>
               <TableBody>
                 {pageItems.map((row) => (
-                  <TableRow key={row.ip_address}>
+                  <TableRow key={row.ipAddress}>
                     <TableCell className="font-mono text-xs">
-                      {row.ip_address}
-                      <IpBanControls ip={row.ip_address} />
+                      {row.ipAddress}
+                      <IpBanControls ip={row.ipAddress} />
                     </TableCell>
-                    <TableCell>{row.country_code ?? "-"}</TableCell>
+                    <TableCell>{row.countryCode ?? "-"}</TableCell>
                     <TableCell>{row.city ?? "-"}</TableCell>
                     <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
-                    <TableCell className="text-right tabular-nums">{formatNumber(row.error_hits)}</TableCell>
-                    <TableCell className="text-right tabular-nums">{formatBytes(row.total_bytes)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatNumber(row.errorHits)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatBytes(row.totalBytes)}</TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/resources/components/analytics/top-urls-table.tsx
+++ b/resources/components/analytics/top-urls-table.tsx
@@ -41,9 +41,9 @@ export function TopUrlsTable() {
                   <TableRow key={row.url}>
                     <TableCell className="font-mono text-xs max-w-[420px] truncate">{row.url}</TableCell>
                     <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
-                    <TableCell className="text-right tabular-nums">{formatNumber(row.error_hits)}</TableCell>
-                    <TableCell className="text-right tabular-nums">{formatBytes(row.total_bytes)}</TableCell>
-                    <TableCell className="text-right tabular-nums">{formatDuration(row.avg_request_time * 1000)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatNumber(row.errorHits)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatBytes(row.totalBytes)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatDuration(row.avgRequestTime * 1000)}</TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/resources/components/analytics/top-user-agents-table.tsx
+++ b/resources/components/analytics/top-user-agents-table.tsx
@@ -35,8 +35,8 @@ export function TopUserAgentsTable() {
               </TableHeader>
               <TableBody>
                 {pageItems.map((row) => (
-                  <TableRow key={row.user_agent}>
-                    <TableCell className="font-mono text-xs max-w-[640px] truncate">{row.user_agent}</TableCell>
+                  <TableRow key={row.userAgent}>
+                    <TableCell className="font-mono text-xs max-w-[640px] truncate">{row.userAgent}</TableCell>
                     <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
                   </TableRow>
                 ))}

--- a/resources/components/app-sidebar.tsx
+++ b/resources/components/app-sidebar.tsx
@@ -474,7 +474,7 @@ function RuntimeMetadata({ collapsed }: { collapsed: boolean }) {
 
   if (collapsed || !settings) return null
 
-  const imageTag = settings.runtime.image_tag
+  const imageTag = settings.runtime.imageTag
   const runtimeLabel = imageTag
     ? `Container image ${imageTag}`
     : "Running in a container"
@@ -517,7 +517,7 @@ export function AppSidebar() {
     retry: 1,
   })
   const crowdsecDown =
-    health?.crowdsec?.enabled === true && health.crowdsec.lapi_reachable === false
+    health?.crowdsec?.enabled === true && health.crowdsec.lapiReachable === false
 
   // The mobile sidebar is a full-height sheet; leaving it open after a nav
   // tap would cover the page the user just navigated to.

--- a/resources/components/crowdsec/ip-ban-controls.tsx
+++ b/resources/components/crowdsec/ip-ban-controls.tsx
@@ -31,7 +31,7 @@ export function IpBanAction({ ip, banned }: { ip: string; banned: boolean }) {
   const ban = useBanIp()
   const unban = useUnbanIp()
   const isPending = ban.isPending || unban.isPending
-  if (!status?.write_enabled) return null
+  if (!status?.writeEnabled) return null
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>

--- a/resources/components/dashboard/summary.tsx
+++ b/resources/components/dashboard/summary.tsx
@@ -63,7 +63,7 @@ export function Summary() {
             <h1 className="text-2xl font-semibold tracking-tight">Summary</h1>
 
             {summary && (
-              <DateTimeRange start={summary.start_date} end={summary.end_date} />
+              <DateTimeRange start={summary.startDate} end={summary.endDate} />
             )}
           </div>
           <p className="text-sm text-muted-foreground">
@@ -118,38 +118,38 @@ export function Summary() {
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
               <StatCard
                 title="Access Log Records"
-                value={formatNumber(summary.current_period.total_requests)}
+                value={formatNumber(summary.currentPeriod.totalRequests)}
                 subtitle={`Last ${rangeLabel}`}
                 icon={Activity}
                 trend={{
-                  value: summary.percent_changes?.log_records ?? null,
-                  positive: (summary.percent_changes?.log_records ?? 0) >= 0,
+                  value: summary.percentChanges?.logRecords ?? null,
+                  positive: (summary.percentChanges?.logRecords ?? 0) >= 0,
                 }}
               />
               <StatCard
                 title="Geo Event Records"
-                value={formatNumber(summary.current_period.total_geo_events)}
+                value={formatNumber(summary.currentPeriod.totalGeoEvents)}
                 subtitle={`Last ${rangeLabel}`}
                 icon={FileText}
                 trend={{
-                  value: summary.percent_changes?.geo_records ?? null,
-                  positive: (summary.percent_changes?.geo_records ?? 0) >= 0,
+                  value: summary.percentChanges?.geoRecords ?? null,
+                  positive: (summary.percentChanges?.geoRecords ?? 0) >= 0,
                 }}
               />
               <StatCard
                 title="Unique Countries"
-                value={formatNumber(summary.current_period.unique_countries)}
+                value={formatNumber(summary.currentPeriod.uniqueCountries)}
                 subtitle="Active locations"
                 icon={Globe2}
               />
               <StatCard
                 title="Malformed Requests"
-                value={formatNumber(summary.current_period.malformed_requests)}
+                value={formatNumber(summary.currentPeriod.malformedRequests)}
                 subtitle={`Last ${rangeLabel}`}
                 icon={AlertTriangle}
                 trend={{
-                  value: summary.percent_changes?.malformed_rate ?? null,
-                  positive: (summary.percent_changes?.malformed_rate ?? 0) < 0,
+                  value: summary.percentChanges?.malformedRate ?? null,
+                  positive: (summary.percentChanges?.malformedRate ?? 0) < 0,
                 }}
               />
             </div>
@@ -159,49 +159,49 @@ export function Summary() {
             <div className="grid gap-4 grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
               <StatCard
                 title="Success (2xx)"
-                value={`${calcPercent(summary.current_period.status_2xx, summary.current_period.total_requests)}%`}
-                subtitle={`${formatNumber(summary.current_period.status_2xx)} requests`}
+                value={`${calcPercent(summary.currentPeriod.status2xx, summary.currentPeriod.totalRequests)}%`}
+                subtitle={`${formatNumber(summary.currentPeriod.status2xx)} requests`}
                 icon={CheckCircle2}
                 iconClassName="text-emerald-500/70"
                 valueClassName="text-emerald-500"
               />
               <StatCard
                 title="Redirects (3xx)"
-                value={formatNumber(summary.current_period.status_3xx)}
-                subtitle={`${calcPercent(summary.current_period.status_3xx, summary.current_period.total_requests)}% of requests`}
+                value={formatNumber(summary.currentPeriod.status3xx)}
+                subtitle={`${calcPercent(summary.currentPeriod.status3xx, summary.currentPeriod.totalRequests)}% of requests`}
                 icon={CornerUpRight}
                 iconClassName="text-blue-500/70"
                 valueClassName="text-blue-500"
               />
               <StatCard
                 title="Client Errors (4xx)"
-                value={formatNumber(summary.current_period.status_4xx)}
-                subtitle={`${calcPercent(summary.current_period.status_4xx, summary.current_period.total_requests)}% of requests`}
+                value={formatNumber(summary.currentPeriod.status4xx)}
+                subtitle={`${calcPercent(summary.currentPeriod.status4xx, summary.currentPeriod.totalRequests)}% of requests`}
                 icon={AlertCircle}
                 iconClassName="text-amber-500/70"
                 valueClassName="text-amber-500"
               />
               <StatCard
                 title="Server Errors (5xx)"
-                value={formatNumber(summary.current_period.status_5xx)}
-                subtitle={`${calcPercent(summary.current_period.status_5xx, summary.current_period.total_requests)}% of requests`}
+                value={formatNumber(summary.currentPeriod.status5xx)}
+                subtitle={`${calcPercent(summary.currentPeriod.status5xx, summary.currentPeriod.totalRequests)}% of requests`}
                 icon={XCircle}
                 iconClassName="text-red-500/70"
                 valueClassName="text-red-500"
               />
               <StatCard
                 title="Unique IPs"
-                value={formatNumber(summary.current_period.unique_ips)}
+                value={formatNumber(summary.currentPeriod.uniqueIps)}
                 subtitle={
-                  summary.percent_changes?.unique_ips !== null ? (
+                  summary.percentChanges?.uniqueIps !== null ? (
                     <span
                       className={cn(
-                        (summary.percent_changes?.unique_ips ?? 0) >= 0
+                        (summary.percentChanges?.uniqueIps ?? 0) >= 0
                           ? "text-emerald-500"
                           : "text-red-500"
                       )}
                     >
-                      {formatPercent(summary.percent_changes?.unique_ips)} vs last {rangeLabel}
+                      {formatPercent(summary.percentChanges?.uniqueIps)} vs last {rangeLabel}
                     </span>
                   ) : (
                     "Active visitors"
@@ -218,17 +218,17 @@ export function Summary() {
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
               <StatCard
                 title="Avg Request Time"
-                value={formatDuration(summary.current_period.avg_request_time)}
+                value={formatDuration(summary.currentPeriod.avgRequestTime)}
                 subtitle={
-                  summary.percent_changes?.avg_request_time !== null ? (
+                  summary.percentChanges?.avgRequestTime !== null ? (
                     <span
                       className={cn(
-                        (summary.percent_changes?.avg_request_time ?? 0) <= 0
+                        (summary.percentChanges?.avgRequestTime ?? 0) <= 0
                           ? "text-emerald-500"
                           : "text-red-500"
                       )}
                     >
-                      {formatPercent(summary.percent_changes?.avg_request_time)} vs last {rangeLabel}
+                      {formatPercent(summary.percentChanges?.avgRequestTime)} vs last {rangeLabel}
                     </span>
                   ) : (
                     "Response time"
@@ -239,7 +239,7 @@ export function Summary() {
               />
               <StatCard
                 title="Max Request Time"
-                value={formatDuration(summary.current_period.max_request_time)}
+                value={formatDuration(summary.currentPeriod.maxRequestTime)}
                 subtitle="Peak latency"
                 icon={Zap}
                 iconClassName="text-amber-500/70"
@@ -247,17 +247,17 @@ export function Summary() {
               />
               <StatCard
                 title="Total Bandwidth"
-                value={formatBytes(summary.current_period.total_bytes_sent)}
+                value={formatBytes(summary.currentPeriod.totalBytesSent)}
                 subtitle={
-                  summary.percent_changes?.bytes_sent !== null ? (
+                  summary.percentChanges?.bytesSent !== null ? (
                     <span
                       className={cn(
-                        (summary.percent_changes?.bytes_sent ?? 0) >= 0
+                        (summary.percentChanges?.bytesSent ?? 0) >= 0
                           ? "text-emerald-500"
                           : "text-red-500"
                       )}
                     >
-                      {formatPercent(summary.percent_changes?.bytes_sent)} vs last {rangeLabel}
+                      {formatPercent(summary.percentChanges?.bytesSent)} vs last {rangeLabel}
                     </span>
                   ) : (
                     "Data transferred"
@@ -268,7 +268,7 @@ export function Summary() {
               />
               <StatCard
                 title="Avg Request Size"
-                value={formatBytes(summary.current_period.avg_bytes_per_request)}
+                value={formatBytes(summary.currentPeriod.avgBytesPerRequest)}
                 subtitle="Per request"
                 icon={ArrowRightLeft}
               />

--- a/resources/components/geo-logs/geo-logs-map.tsx
+++ b/resources/components/geo-logs/geo-logs-map.tsx
@@ -148,7 +148,7 @@ export default function GeoLogsMap() {
                 clusterRadius={50}
                 clusterProperties={{
                   // Sum event_count for all points in the cluster
-                  sum_event_count: ["+", ["get", "event_count"]],
+                  sum_event_count: ["+", ["get", "eventCount"]],
                 }}
               >
                 <Layer {...clusterLayer} />

--- a/resources/components/map/GeoMap.tsx
+++ b/resources/components/map/GeoMap.tsx
@@ -108,8 +108,8 @@ function GeoMapInner({
   const { data: globalTopIPs, isLoading: isLoadingTopIPs } = useGlobalTopIPs()
   const { data: runtimeSettings } = useRuntimeSettings()
   const homeDestination = useMemo<[number, number] | null>(() => {
-    const latitude = runtimeSettings?.map.home_latitude
-    const longitude = runtimeSettings?.map.home_longitude
+    const latitude = runtimeSettings?.map.homeLatitude
+    const longitude = runtimeSettings?.map.homeLongitude
     return typeof latitude === "number" && typeof longitude === "number"
       ? [longitude, latitude]
       : null
@@ -143,7 +143,7 @@ function GeoMapInner({
         properties: {
           ip: loc.ip,
           city: loc.city,
-          country_code: loc.country_code,
+          countryCode: loc.countryCode,
         },
       })),
     }),
@@ -206,12 +206,12 @@ function GeoMapInner({
       const countryLabels: Record<string, string> = {}
       const cities = new Set<string>()
       for (const f of geojson.features) {
-        const code = f.properties.country_code
+        const code = f.properties.countryCode
         if (code) {
           // Display "<name> (<code>)" but keep the code as the option value,
           // since the value feeds useGeoJSON({ countryCodes }).
-          countryLabels[code] = f.properties.country_name
-            ? `${f.properties.country_name} (${code})`
+          countryLabels[code] = f.properties.countryName
+            ? `${f.properties.countryName} (${code})`
             : code
         }
         if (f.properties.city) cities.add(f.properties.city)
@@ -465,7 +465,7 @@ function GeoMapInner({
             clusterRadius={50}
             clusterProperties={{
               // Sum event_count for all points in the cluster
-              sum_event_count: ["+", ["get", "event_count"]],
+              sum_event_count: ["+", ["get", "eventCount"]],
             }}
           >
             {/* Heatmap layer */}
@@ -564,7 +564,7 @@ function GeoMapInner({
         onGoHome={goToHome}
         isLoading={isLoading}
         featureStats={geojson?.stats ?? { events: 0, countries: 0, cities: 0, locations: 0 }}
-        topIPs={globalTopIPs?.top_ips ?? []}
+        topIPs={globalTopIPs?.topIps ?? []}
         onFlyToLocation={flyToLocation}
         countryOptions={filterOptions.countries}
         countryLabels={filterOptions.countryLabels}

--- a/resources/components/map/IpBanControls.tsx
+++ b/resources/components/map/IpBanControls.tsx
@@ -38,7 +38,7 @@ export function IpBanControls({
   const banned = bannedIps?.has(ip) ?? initialBanned
   const isPending = ban.isPending || unban.isPending
 
-  if (!banned && !status?.write_enabled) return null
+  if (!banned && !status?.writeEnabled) return null
 
   const isFooter = variant === "footer"
   const Wrapper = isFooter ? "div" : "span"
@@ -73,7 +73,7 @@ export function IpBanControls({
           banned
         </span>
       )}
-      {status?.write_enabled && (
+      {status?.writeEnabled && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button

--- a/resources/components/map/MapControls.tsx
+++ b/resources/components/map/MapControls.tsx
@@ -402,14 +402,14 @@ export function MapControls({
           <div className="flex flex-col gap-1">
             {topIPs.map((ip) => (
               <button
-                key={ip.ip_address}
+                key={ip.ipAddress}
                 onClick={() => ip.location && onFlyToLocation?.(ip.location.latitude, ip.location.longitude)}
                 disabled={!ip.location}
                 className="flex items-center justify-between text-[10px] hover:bg-foreground/[0.07] rounded px-1 py-0.5 -mx-1 cursor-pointer disabled:cursor-default disabled:opacity-50 text-left"
               >
-                <div className="font-mono truncate"><Badge variant="secondary" className="text-[10px] h-5 min-w-5 py-0 font-mono tabular-nums">{formatNumber(ip.event_count)}</Badge> {ip.ip_address}</div>
+                <div className="font-mono truncate"><Badge variant="secondary" className="text-[10px] h-5 min-w-5 py-0 font-mono tabular-nums">{formatNumber(ip.eventCount)}</Badge> {ip.ipAddress}</div>
                 <span className="text-muted-foreground ml-2 shrink-0">
-                  {ip.location?.city ?? ip.location?.country_code ?? ""}
+                  {ip.location?.city ?? ip.location?.countryCode ?? ""}
                 </span>
               </button>
             ))}

--- a/resources/components/map/MapPopup.tsx
+++ b/resources/components/map/MapPopup.tsx
@@ -53,25 +53,25 @@ export function MapPopup({
   const {
     id: locationId,
     city,
-    country_name,
-    country_code,
+    countryName,
+    countryCode,
     state,
-    event_count,
-    last_hit,
+    eventCount,
+    lastHit,
     geohash,
   } = properties
 
   // Fetch top IPs on-demand when popup opens
   const { data: topIPsData, isLoading: isLoadingTopIPs } = useLocationTopIPs(locationId)
-  const top_ips = topIPsData?.top_ips ?? []
+  const top_ips = topIPsData?.topIps ?? []
 
   // Format last hit date
-  const formattedLastHit = last_hit
-    ? new Date(last_hit).toLocaleString()
+  const formattedLastHit = lastHit
+    ? new Date(lastHit).toLocaleString()
     : "Unknown"
 
   // Build location string
-  const locationParts = [city, state, country_name].filter(Boolean)
+  const locationParts = [city, state, countryName].filter(Boolean)
   const locationString = locationParts.join(", ") || "Unknown Location"
 
   return (
@@ -156,18 +156,18 @@ export function MapPopup({
               fontWeight: 500,
             }}
           >
-            {formatNumber(event_count)}
+            {formatNumber(eventCount)}
           </span>
         </div>
 
         {/* Country */}
-        {country_code && (
+        {countryCode && (
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", fontSize: "12px", marginBottom: "6px" }}>
             <span style={{ color: "var(--popup-muted)", display: "flex", alignItems: "center", gap: "4px" }}>
               <Globe style={{ width: 12, height: 12 }} />
               Country
             </span>
-            <span style={{ fontWeight: 500 }}>{country_code}</span>
+            <span style={{ fontWeight: 500 }}>{countryCode}</span>
           </div>
         )}
 
@@ -235,17 +235,17 @@ export function MapPopup({
                       fontFamily: "monospace",
                     }}
                   >
-                    1. {top_ips[0].ip_address}
+                    1. {top_ips[0].ipAddress}
                   </code>
                   <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}>
-                    <IpBanControls ip={top_ips[0].ip_address} />
+                    <IpBanControls ip={top_ips[0].ipAddress} />
                     <span
                       style={{
                         fontSize: "10px",
                         color: "var(--popup-muted)",
                       }}
                     >
-                      {formatNumber(top_ips[0].event_count)}
+                      {formatNumber(top_ips[0].eventCount)}
                     </span>
                   </span>
                 </div>
@@ -256,7 +256,7 @@ export function MapPopup({
                       <div style={{ display: "flex", flexDirection: "column", gap: "4px", marginTop: "4px" }}>
                         {top_ips.slice(1).map((ip, index) => (
                           <div
-                            key={ip.ip_address}
+                            key={ip.ipAddress}
                             style={{
                               display: "flex",
                               justifyContent: "space-between",
@@ -273,17 +273,17 @@ export function MapPopup({
                                 fontFamily: "monospace",
                               }}
                             >
-                              {index + 2}. {ip.ip_address}
+                              {index + 2}. {ip.ipAddress}
                             </code>
                             <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}>
-                              <IpBanControls ip={ip.ip_address} />
+                              <IpBanControls ip={ip.ipAddress} />
                               <span
                                 style={{
                                   fontSize: "10px",
                                   color: "var(--popup-muted)",
                                 }}
                               >
-                                {formatNumber(ip.event_count)}
+                                {formatNumber(ip.eventCount)}
                               </span>
                             </span>
                           </div>

--- a/resources/components/map/layers.ts
+++ b/resources/components/map/layers.ts
@@ -12,11 +12,11 @@ export const heatmapLayer: LayerSpecification = {
   source: "geo-data",
   maxzoom: 15,
   paint: {
-    // Increase weight based on event_count property - more aggressive curve
+    // Increase weight based on eventCount property - more aggressive curve
     "heatmap-weight": [
       "interpolate",
       ["exponential", 1.5],
-      ["get", "event_count"],
+      ["get", "eventCount"],
       0, 0,
       1, 0.1,
       10, 0.4,
@@ -146,7 +146,7 @@ export const clusterCountLayer: LayerSpecification = {
   },
 }
 
-// Unclustered point layer - color based on event_count (green -> yellow -> red)
+// Unclustered point layer - color based on eventCount (green -> yellow -> red)
 // More transparent fill with strong colored stroke
 export const unclusteredPointLayer: LayerSpecification = {
   id: "unclustered-point",
@@ -154,11 +154,11 @@ export const unclusteredPointLayer: LayerSpecification = {
   source: "geo-data",
   filter: ["!", ["has", "point_count"]],
   paint: {
-    // Size based on event_count
+    // Size based on eventCount
     "circle-radius": [
       "interpolate",
       ["linear"],
-      ["get", "event_count"],
+      ["get", "eventCount"],
       1, 6,
       10, 8,
       100, 12,
@@ -168,7 +168,7 @@ export const unclusteredPointLayer: LayerSpecification = {
     "circle-color": [
       "interpolate",
       ["linear"],
-      ["get", "event_count"],
+      ["get", "eventCount"],
       1, "rgba(34, 197, 94, 0.35)",      // Green (low)
       10, "rgba(132, 204, 22, 0.35)",    // Lime
       50, "rgba(234, 179, 8, 0.4)",      // Yellow
@@ -181,7 +181,7 @@ export const unclusteredPointLayer: LayerSpecification = {
     "circle-stroke-color": [
       "interpolate",
       ["linear"],
-      ["get", "event_count"],
+      ["get", "eventCount"],
       1, "rgba(34, 197, 94, 0.9)",       // Green (low)
       10, "rgba(132, 204, 22, 0.9)",     // Lime
       50, "rgba(234, 179, 8, 0.9)",      // Yellow
@@ -192,7 +192,7 @@ export const unclusteredPointLayer: LayerSpecification = {
   },
 }
 
-// Unclustered point label - shows event_count with K/M abbreviation
+// Unclustered point label - shows eventCount with K/M abbreviation
 export const unclusteredPointLabelLayer: LayerSpecification = {
   id: "unclustered-point-label",
   type: "symbol",
@@ -201,11 +201,11 @@ export const unclusteredPointLabelLayer: LayerSpecification = {
   layout: {
     "text-field": [
       "case",
-      [">=", ["get", "event_count"], 1000000],
-      ["concat", ["to-string", ["floor", ["/", ["get", "event_count"], 1000000]]], "M+"],
-      [">=", ["get", "event_count"], 1000],
-      ["concat", ["to-string", ["floor", ["/", ["get", "event_count"], 1000]]], "K+"],
-      ["to-string", ["get", "event_count"]]
+      [">=", ["get", "eventCount"], 1000000],
+      ["concat", ["to-string", ["floor", ["/", ["get", "eventCount"], 1000000]]], "M+"],
+      [">=", ["get", "eventCount"], 1000],
+      ["concat", ["to-string", ["floor", ["/", ["get", "eventCount"], 1000]]], "K+"],
+      ["to-string", ["get", "eventCount"]]
     ],
     "text-font": ["Open Sans Bold", "Arial Unicode MS Bold"],
     "text-size": 10,

--- a/resources/components/security/alerts-table.tsx
+++ b/resources/components/security/alerts-table.tsx
@@ -72,7 +72,7 @@ export function AlertsTable() {
                 : alerts?.map((alert) => (
                     <TableRow key={alert.id}>
                       <TableCell className="whitespace-nowrap text-muted-foreground">
-                        {new Date(alert.created_at).toLocaleString()}
+                        {new Date(alert.createdAt).toLocaleString()}
                       </TableCell>
                       <TableCell
                         className="max-w-[240px] truncate font-mono text-xs"
@@ -85,17 +85,17 @@ export function AlertsTable() {
                         {alert.scope === "Ip" && <IpBanControls ip={alert.value} />}
                       </TableCell>
                       <TableCell>{alert.country ?? "-"}</TableCell>
-                      <TableCell className="max-w-[160px] truncate" title={alert.as_name ?? undefined}>
-                        {alert.as_name ?? "-"}
+                      <TableCell className="max-w-[160px] truncate" title={alert.asName ?? undefined}>
+                        {alert.asName ?? "-"}
                       </TableCell>
                       <TableCell className="text-muted-foreground">
-                        {alert.machine_id ?? "-"}
+                        {alert.machineId ?? "-"}
                       </TableCell>
                       <TableCell className="text-right tabular-nums">
-                        {alert.events_count}
+                        {alert.eventsCount}
                       </TableCell>
                       <TableCell className="text-right tabular-nums">
-                        {alert.decision_count}
+                        {alert.decisionCount}
                       </TableCell>
                     </TableRow>
                   ))}

--- a/resources/components/security/alerts-table.tsx
+++ b/resources/components/security/alerts-table.tsx
@@ -1,6 +1,6 @@
 /**
  * Alert history: which scenarios fired, against whom, and what they decided.
- * Machine credentials required (the card only renders when write_enabled).
+ * Machine credentials required (the card only renders when writeEnabled).
  */
 import { useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"

--- a/resources/components/security/crowdsec-unreachable-banner.tsx
+++ b/resources/components/security/crowdsec-unreachable-banner.tsx
@@ -8,7 +8,7 @@ import { useCrowdsecStatus } from "@/lib/queries"
 
 export function CrowdsecUnreachableBanner() {
   const { data: status } = useCrowdsecStatus()
-  if (!status?.enabled || status.lapi_reachable) return null
+  if (!status?.enabled || status.lapiReachable) return null
   return (
     <div role="alert" className="flex items-center gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
       <AlertTriangle className="h-4 w-4 shrink-0" />

--- a/resources/components/security/decisions-table.tsx
+++ b/resources/components/security/decisions-table.tsx
@@ -53,14 +53,14 @@ export function DecisionsTable() {
 
   const total = data?.total ?? 0
   const pageCount = Math.max(1, Math.ceil(total / pageSize))
-  const colCount = status?.write_enabled ? 8 : 7
+  const colCount = status?.writeEnabled ? 8 : 7
 
   return (
     <Card className="py-4">
       <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-2 pb-2">
         <CardTitle className="text-base">Active decisions</CardTitle>
         <div className="flex flex-wrap items-center gap-2">
-          {status?.write_enabled && <BanIpDialog />}
+          {status?.writeEnabled && <BanIpDialog />}
           <Tabs
             value={scope}
             onValueChange={(value) => {
@@ -90,7 +90,7 @@ export function DecisionsTable() {
                 <TableHead>Scenario</TableHead>
                 <TableHead>Expires in</TableHead>
                 <TableHead className="text-right">Seen 24h</TableHead>
-                {status?.write_enabled && <TableHead className="w-10" />}
+                {status?.writeEnabled && <TableHead className="w-10" />}
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -117,7 +117,7 @@ export function DecisionsTable() {
                           </Badge>
                         )}
                       </TableCell>
-                      <TableCell>{d.country_name ?? d.country_code ?? "-"}</TableCell>
+                      <TableCell>{d.countryName ?? d.countryCode ?? "-"}</TableCell>
                       <TableCell>{d.city ?? "-"}</TableCell>
                       <TableCell>
                         <Badge variant="secondary">{d.origin}</Badge>
@@ -134,12 +134,12 @@ export function DecisionsTable() {
                       <TableCell
                         className={cn(
                           "text-right tabular-nums",
-                          (d.request_count_24h ?? 0) > 0 && "font-semibold text-amber-500",
+                          (d.requestCount24h ?? 0) > 0 && "font-semibold text-amber-500",
                         )}
                       >
-                        {d.request_count_24h ?? "-"}
+                        {d.requestCount24h ?? "-"}
                       </TableCell>
-                      {status?.write_enabled && (
+                      {status?.writeEnabled && (
                         <TableCell>
                           {d.scope === "Ip" && (
                             <Button

--- a/resources/components/security/security-stat-cards.tsx
+++ b/resources/components/security/security-stat-cards.tsx
@@ -27,12 +27,12 @@ export function SecurityStatCards() {
   }
 
   const localCount = stats
-    ? stats.by_origin
+    ? stats.byOrigin
         .filter((o) => LOCAL_ORIGINS.has(o.origin))
         .reduce((sum, o) => sum + o.count, 0)
     : null
   const crowdCount = stats && localCount !== null ? stats.total - localCount : null
-  const topScenario = stats?.top_scenarios[0]
+  const topScenario = stats?.topScenarios[0]
 
   return (
     <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
@@ -66,11 +66,11 @@ export function SecurityStatCards() {
       />
       <StatCard
         title="LAPI"
-        value={status.lapi_reachable ? "Connected" : "Unreachable"}
-        valueClassName={status.lapi_reachable ? "text-emerald-500" : "text-red-500"}
-        subtitle={status.write_enabled ? "ban/unban enabled" : "read-only (no machine credentials)"}
+        value={status.lapiReachable ? "Connected" : "Unreachable"}
+        valueClassName={status.lapiReachable ? "text-emerald-500" : "text-red-500"}
+        subtitle={status.writeEnabled ? "ban/unban enabled" : "read-only (no machine credentials)"}
         icon={ShieldCheck}
-        iconClassName={status.lapi_reachable ? "text-emerald-500" : "text-red-500"}
+        iconClassName={status.lapiReachable ? "text-emerald-500" : "text-red-500"}
       />
     </div>
   )

--- a/resources/components/settings/about-page.tsx
+++ b/resources/components/settings/about-page.tsx
@@ -86,8 +86,8 @@ export function AboutPage() {
     )
   }
 
-  const geoip = geoipFreshness(data.geoip.available, data.geoip.age_days)
-  const dbReachable = data.database.postgres_version !== null
+  const geoip = geoipFreshness(data.geoip.available, data.geoip.ageDays)
+  const dbReachable = data.database.postgresVersion !== null
 
   return (
     <div className="grid gap-4 md:grid-cols-2">
@@ -108,7 +108,7 @@ export function AboutPage() {
                 </Badge>
                 {data.app.container ? (
                   <Badge variant="secondary">
-                    container{data.app.image_tag ? `: ${data.app.image_tag}` : ""}
+                    container{data.app.imageTag ? `: ${data.app.imageTag}` : ""}
                   </Badge>
                 ) : (
                   <Badge variant="outline" className="text-muted-foreground">
@@ -121,7 +121,7 @@ export function AboutPage() {
           <div className="flex items-center gap-2 text-sm">
             <StatusLed tone="emerald" pulse />
             <span className="text-muted-foreground">up</span>
-            <span className="font-medium">{formatUptime(data.app.started_at)}</span>
+            <span className="font-medium">{formatUptime(data.app.startedAt)}</span>
           </div>
         </CardContent>
       </Card>
@@ -134,12 +134,12 @@ export function AboutPage() {
           </div>
         </CardHeader>
         <CardContent>
-          <Row label="Python" value={<MonoChip>{data.runtime.python_version}</MonoChip>} />
+          <Row label="Python" value={<MonoChip>{data.runtime.pythonVersion}</MonoChip>} />
           <Row
             label="Litestar"
             value={
-              data.runtime.litestar_version ? (
-                <MonoChip>{data.runtime.litestar_version}</MonoChip>
+              data.runtime.litestarVersion ? (
+                <MonoChip>{data.runtime.litestarVersion}</MonoChip>
               ) : (
                 "unknown"
               )
@@ -148,8 +148,8 @@ export function AboutPage() {
           <Row
             label="APScheduler"
             value={
-              data.runtime.apscheduler_version ? (
-                <MonoChip>{data.runtime.apscheduler_version}</MonoChip>
+              data.runtime.apschedulerVersion ? (
+                <MonoChip>{data.runtime.apschedulerVersion}</MonoChip>
               ) : (
                 "unknown"
               )
@@ -175,8 +175,8 @@ export function AboutPage() {
           <Row
             label="PostgreSQL"
             value={
-              data.database.postgres_version ? (
-                <MonoChip>{data.database.postgres_version}</MonoChip>
+              data.database.postgresVersion ? (
+                <MonoChip>{data.database.postgresVersion}</MonoChip>
               ) : (
                 <span className="text-muted-foreground">unavailable</span>
               )
@@ -185,8 +185,8 @@ export function AboutPage() {
           <Row
             label="TimescaleDB"
             value={
-              data.database.timescaledb_version ? (
-                <MonoChip>{data.database.timescaledb_version}</MonoChip>
+              data.database.timescaledbVersion ? (
+                <MonoChip>{data.database.timescaledbVersion}</MonoChip>
               ) : (
                 <span className="text-muted-foreground">unavailable</span>
               )
@@ -195,8 +195,8 @@ export function AboutPage() {
           <Row
             label="PostGIS"
             value={
-              data.database.postgis_version ? (
-                <MonoChip>{data.database.postgis_version}</MonoChip>
+              data.database.postgisVersion ? (
+                <MonoChip>{data.database.postgisVersion}</MonoChip>
               ) : (
                 <span className="text-muted-foreground">unavailable</span>
               )
@@ -224,22 +224,22 @@ export function AboutPage() {
               <Row
                 label="Build date"
                 value={
-                  data.geoip.build_date
-                    ? new Date(data.geoip.build_date).toLocaleDateString()
+                  data.geoip.buildDate
+                    ? new Date(data.geoip.buildDate).toLocaleDateString()
                     : "unknown"
                 }
               />
               <Row
                 label="Age"
                 value={
-                  data.geoip.age_days !== null && data.geoip.age_days !== undefined
-                    ? `${data.geoip.age_days} days`
+                  data.geoip.ageDays !== null && data.geoip.ageDays !== undefined
+                    ? `${data.geoip.ageDays} days`
                     : "unknown"
                 }
               />
             </div>
             <div>
-              <Row label="Path" value={<MonoChip>{data.geoip.db_path}</MonoChip>} />
+              <Row label="Path" value={<MonoChip>{data.geoip.dbPath}</MonoChip>} />
             </div>
           </div>
         </CardContent>

--- a/resources/components/settings/environment-overview.tsx
+++ b/resources/components/settings/environment-overview.tsx
@@ -61,7 +61,7 @@ function isOverridden(field: SettingFieldView): boolean {
 }
 
 function ValueBlock({ field }: { field: SettingFieldView }) {
-  if (field.is_secret) {
+  if (field.isSecret) {
     const isSet = field.value !== null && field.value !== undefined
     return (
       <span className="inline-flex items-center gap-1.5">
@@ -82,13 +82,13 @@ function ValueBlock({ field }: { field: SettingFieldView }) {
     )
   }
   const hasValue = field.value !== null && field.value !== undefined
-  const hasComputed = field.computed_value !== null && field.computed_value !== undefined
+  const hasComputed = field.computedValue !== null && field.computedValue !== undefined
   if (!hasValue && hasComputed) {
-    const label = computedLabel[field.computed_source ?? ""] ?? "computed"
+    const label = computedLabel[field.computedSource ?? ""] ?? "computed"
     return (
       <span className="inline-flex items-baseline gap-1.5">
         <code className="font-mono text-xs break-all font-medium text-foreground">
-          {formatValue(field.computed_value)}
+          {formatValue(field.computedValue)}
         </code>
         <Badge
           variant="outline"
@@ -128,12 +128,12 @@ function FieldRow({ field }: { field: SettingFieldView }) {
       <div className="flex shrink-0 flex-col items-start gap-1 sm:items-end sm:text-right">
         <ValueBlock field={field} />
         <div className="flex items-center gap-2">
-          {overridden && !field.is_secret && (
+          {overridden && !field.isSecret && (
             <span className="text-[11px] text-muted-foreground">
               default: <code className="font-mono">{formatValue(field.default)}</code>
             </span>
           )}
-          {field.env_var && <MonoChip>{field.env_var}</MonoChip>}
+          {field.envVar && <MonoChip>{field.envVar}</MonoChip>}
         </div>
       </div>
     </div>
@@ -211,7 +211,7 @@ export function EnvironmentOverview() {
           (!overriddenOnly || isOverridden(f)) &&
           (!q ||
             f.key.toLowerCase().includes(q) ||
-            (f.env_var ?? "").toLowerCase().includes(q) ||
+            (f.envVar ?? "").toLowerCase().includes(q) ||
             section.title.toLowerCase().includes(q) ||
             (f.description ?? "").toLowerCase().includes(q)),
       ),
@@ -250,7 +250,7 @@ export function EnvironmentOverview() {
           <StatusLed tone="cyan" />
           {totalOverridden} of{" "}
           {data.sections.reduce(
-            (n, s) => n + s.fields.filter((f) => f.env_var).length,
+            (n, s) => n + s.fields.filter((f) => f.envVar).length,
             0,
           )}{" "}
           settings

--- a/resources/components/settings/logs-overview.tsx
+++ b/resources/components/settings/logs-overview.tsx
@@ -376,9 +376,9 @@ export function LogsOverview() {
                         <div className="min-w-0">
                           <div className="truncate font-mono text-xs">{f.name}</div>
                           <div className="text-xs text-muted-foreground">
-                            {formatSize(f.size_bytes)}
+                            {formatSize(f.sizeBytes)}
                             {" · "}
-                            {f.modified_at ? new Date(f.modified_at).toLocaleString() : "unknown"}
+                            {f.modifiedAt ? new Date(f.modifiedAt).toLocaleString() : "unknown"}
                             {!f.available ? " · not readable" : ""}
                           </div>
                         </div>

--- a/resources/components/settings/scheduler-overview.tsx
+++ b/resources/components/settings/scheduler-overview.tsx
@@ -59,8 +59,8 @@ function useTicker(active: boolean): void {
 }
 
 function DurationCell({ job }: { job: SchedulerJobView }) {
-  if (job.running && job.last_run_time) {
-    const elapsed = (Date.now() - new Date(job.last_run_time).getTime()) / 1000
+  if (job.running && job.lastRunTime) {
+    const elapsed = (Date.now() - new Date(job.lastRunTime).getTime()) / 1000
     return (
       <span className="inline-flex items-center gap-1.5 text-sm text-geo-cyan tabular-nums">
         <Timer className="h-3.5 w-3.5" />
@@ -68,13 +68,13 @@ function DurationCell({ job }: { job: SchedulerJobView }) {
       </span>
     )
   }
-  if (job.last_duration_seconds === null || job.last_duration_seconds === undefined) {
+  if (job.lastDurationSeconds === null || job.lastDurationSeconds === undefined) {
     return <span className="text-sm text-muted-foreground">-</span>
   }
   return (
     <span className="inline-flex items-center gap-1.5 text-sm tabular-nums">
       <Timer className="h-3.5 w-3.5 text-muted-foreground" />
-      {formatDuration(job.last_duration_seconds)}
+      {formatDuration(job.lastDurationSeconds)}
     </span>
   )
 }
@@ -88,7 +88,7 @@ function StatusCell({ job }: { job: SchedulerJobView }) {
       </span>
     )
   }
-  if (!job.next_run_time) {
+  if (!job.nextRunTime) {
     return (
       <span className="inline-flex items-center gap-2 text-sm text-amber-600 dark:text-amber-400">
         <StatusLed tone="amber" />
@@ -111,22 +111,22 @@ const statusBadgeClasses: Record<string, string> = {
 }
 
 function LastRunCell({ job }: { job: SchedulerJobView }) {
-  if (!job.last_run_time) {
+  if (!job.lastRunTime) {
     return <span className="text-sm text-muted-foreground">not since startup</span>
   }
-  const badge = job.last_status ? (
-    <Badge variant="outline" className={cn("gap-1", statusBadgeClasses[job.last_status])}>
-      {job.last_status}
+  const badge = job.lastStatus ? (
+    <Badge variant="outline" className={cn("gap-1", statusBadgeClasses[job.lastStatus])}>
+      {job.lastStatus}
     </Badge>
   ) : null
   return (
     <div className="space-y-1">
-      <div className="text-sm">{relativeTime(job.last_run_time)}</div>
-      {job.last_status === "error" ? (
+      <div className="text-sm">{relativeTime(job.lastRunTime)}</div>
+      {job.lastStatus === "error" ? (
         <Tooltip>
           <TooltipTrigger asChild>{badge ?? <span />}</TooltipTrigger>
           <TooltipContent className="max-w-sm break-all">
-            {job.last_error ?? "unknown error"}
+            {job.lastError ?? "unknown error"}
           </TooltipContent>
         </Tooltip>
       ) : (
@@ -150,7 +150,7 @@ export function SchedulerOverview() {
     return <Skeleton className="h-64 w-full" />
   }
 
-  if (!data.scheduler_enabled) {
+  if (!data.schedulerEnabled) {
     return (
       <Card>
         <CardHeader>
@@ -189,7 +189,7 @@ export function SchedulerOverview() {
             <CardTitle className="text-base">
               <span className="inline-flex items-center gap-2">
                 <StatusLed
-                  tone={data.scheduler_running ? "emerald" : "red"}
+                  tone={data.schedulerRunning ? "emerald" : "red"}
                   pulse={runningCount > 0}
                 />
                 Scheduled tasks
@@ -197,7 +197,7 @@ export function SchedulerOverview() {
             </CardTitle>
             <CardDescription>
               {data.jobs.length} background jobs, scheduler{" "}
-              {data.scheduler_running ? "running" : "stopped"}. Last-run info resets on app
+              {data.schedulerRunning ? "running" : "stopped"}. Last-run info resets on app
               restart.
             </CardDescription>
           </div>
@@ -234,10 +234,10 @@ export function SchedulerOverview() {
                   <DurationCell job={job} />
                 </TableCell>
                 <TableCell className="align-top text-sm">
-                  {job.next_run_time ? (
+                  {job.nextRunTime ? (
                     <span className="inline-flex items-center gap-1.5">
                       <CalendarClock className="h-3.5 w-3.5 text-muted-foreground" />
-                      {relativeTime(job.next_run_time)}
+                      {relativeTime(job.nextRunTime)}
                     </span>
                   ) : (
                     <span className="text-muted-foreground">paused</span>

--- a/resources/components/settings/status-logic.test.ts
+++ b/resources/components/settings/status-logic.test.ts
@@ -28,17 +28,17 @@ import {
 function makeHealth(overrides: Partial<HealthResponse> = {}): HealthResponse {
   return {
     status: "healthy",
-    started_at: "2026-07-31T07:00:00+00:00",
+    startedAt: "2026-07-31T07:00:00+00:00",
     ingestion: {
       running: true,
-      parsed_lines: 10,
-      pending_records: 0,
-      missing_files: [],
-      last_record_at: "2026-07-31T09:59:00+00:00",
+      parsedLines: 10,
+      pendingRecords: 0,
+      missingFiles: [],
+      lastRecordAt: "2026-07-31T09:59:00+00:00",
     },
     database: { reachable: true },
-    geoip: { available: true, db_build_date: "2026-07-28T00:00:00+00:00" },
-    crowdsec: { enabled: true, lapi_reachable: true },
+    geoip: { available: true, dbBuildDate: "2026-07-28T00:00:00+00:00" },
+    crowdsec: { enabled: true, lapiReachable: true },
     timestamp: "2026-07-31T10:00:00+00:00",
     ...overrides,
   }
@@ -71,10 +71,10 @@ describe("ingestionState", () => {
       makeHealth({
         ingestion: {
           running: false,
-          parsed_lines: 0,
-          pending_records: 0,
-          missing_files: [],
-          last_record_at: null,
+          parsedLines: 0,
+          pendingRecords: 0,
+          missingFiles: [],
+          lastRecordAt: null,
         },
       }),
       false,
@@ -88,10 +88,10 @@ describe("ingestionState", () => {
       makeHealth({
         ingestion: {
           running: true,
-          parsed_lines: 10,
-          pending_records: 0,
-          missing_files: ["nginx_logs/access.log"],
-          last_record_at: null,
+          parsedLines: 10,
+          pendingRecords: 0,
+          missingFiles: ["nginx_logs/access.log"],
+          lastRecordAt: null,
         },
       }),
       false,
@@ -115,7 +115,7 @@ describe("databaseState / geoipState", () => {
     expect(databaseState(makeHealth())).toMatchObject({ tone: "emerald", label: "Reachable" })
   })
   it("geoip missing is amber", () => {
-    expect(geoipState(makeHealth({ geoip: { available: false, db_build_date: null } }))).toMatchObject({
+    expect(geoipState(makeHealth({ geoip: { available: false, dbBuildDate: null } }))).toMatchObject({
       tone: "amber",
       label: "Missing",
     })
@@ -124,7 +124,7 @@ describe("databaseState / geoipState", () => {
 })
 
 describe("crowdsecState", () => {
-  const enabled: CrowdSecStatusResponse = { enabled: true, write_enabled: true, lapi_reachable: true }
+  const enabled: CrowdSecStatusResponse = { enabled: true, writeEnabled: true, lapiReachable: true }
   it("disabled integration is muted Disabled", () => {
     expect(crowdsecState({ ...enabled, enabled: false }, false)).toMatchObject({
       tone: "muted",
@@ -133,7 +133,7 @@ describe("crowdsecState", () => {
   })
   it("reachable LAPI is emerald, unreachable is red", () => {
     expect(crowdsecState(enabled, false)).toMatchObject({ tone: "emerald", label: "LAPI reachable" })
-    expect(crowdsecState({ ...enabled, lapi_reachable: false }, false)).toMatchObject({
+    expect(crowdsecState({ ...enabled, lapiReachable: false }, false)).toMatchObject({
       tone: "red",
       label: "LAPI unreachable",
     })
@@ -145,8 +145,8 @@ describe("crowdsecState", () => {
 
 describe("nginxLogFiles", () => {
   const files: LogFileView[] = [
-    { name: "geometrikks.log", kind: "app", size_bytes: 10, modified_at: null, available: true },
-    { name: "access.log", kind: "nginx", size_bytes: 20, modified_at: null, available: false },
+    { name: "geometrikks.log", kind: "app", sizeBytes: 10, modifiedAt: null, available: true },
+    { name: "access.log", kind: "nginx", sizeBytes: 20, modifiedAt: null, available: false },
   ]
   it("keeps only nginx entries and tolerates undefined", () => {
     expect(nginxLogFiles(files).map((f) => f.name)).toEqual(["access.log"])
@@ -176,10 +176,10 @@ describe("formatApproxRows", () => {
 describe("compressionSummary", () => {
   const table = (before: number | null, after: number | null): HypertableStatsView => ({
     name: "t",
-    approx_rows: 1,
-    total_bytes: 1,
-    before_compression_bytes: before,
-    after_compression_bytes: after,
+    approxRows: 1,
+    totalBytes: 1,
+    beforeCompressionBytes: before,
+    afterCompressionBytes: after,
   })
   it("aggregates ratio across tables with compression stats", () => {
     const result = compressionSummary([
@@ -240,19 +240,19 @@ describe("schedulerJobState", () => {
     id: "j",
     name: "Job",
     trigger: "interval",
-    next_run_time: null,
-    last_run_time: null,
-    last_status: null,
-    last_error: null,
-    last_duration_seconds: null,
+    nextRunTime: null,
+    lastRunTime: null,
+    lastStatus: null,
+    lastError: null,
+    lastDurationSeconds: null,
     running: false,
     ...over,
   })
   it("maps states to tones", () => {
     expect(schedulerJobState(job({ running: true })).tone).toBe("cyan")
-    expect(schedulerJobState(job({ last_status: "error" })).tone).toBe("red")
-    expect(schedulerJobState(job({ last_status: "missed" })).tone).toBe("amber")
-    expect(schedulerJobState(job({ last_status: "success" })).tone).toBe("emerald")
+    expect(schedulerJobState(job({ lastStatus: "error" })).tone).toBe("red")
+    expect(schedulerJobState(job({ lastStatus: "missed" })).tone).toBe("amber")
+    expect(schedulerJobState(job({ lastStatus: "success" })).tone).toBe("emerald")
     expect(schedulerJobState(job({})).tone).toBe("muted")
   })
 })

--- a/resources/components/settings/status-logic.ts
+++ b/resources/components/settings/status-logic.ts
@@ -36,7 +36,7 @@ export function ingestionState(health: HealthResponse | undefined, isError: bool
       detail: "No log files are being tailed. Check the Logs tab for ingestion errors.",
     }
   }
-  if ((health.ingestion.missing_files ?? []).length > 0) {
+  if ((health.ingestion.missingFiles ?? []).length > 0) {
     return {
       tone: "amber",
       label: "Running, log file missing",
@@ -71,7 +71,7 @@ export function crowdsecState(
   if (isError) return { tone: "muted", label: "Unavailable" }
   if (!status) return { tone: "muted", label: "Unknown" }
   if (!status.enabled) return { tone: "muted", label: "Disabled" }
-  return status.lapi_reachable
+  return status.lapiReachable
     ? { tone: "emerald", label: "LAPI reachable" }
     : {
         tone: "red",
@@ -107,9 +107,9 @@ export function compressionSummary(
   let before = 0
   let after = 0
   for (const t of hypertables ?? []) {
-    if (t.before_compression_bytes !== null && t.after_compression_bytes !== null) {
-      before += t.before_compression_bytes
-      after += t.after_compression_bytes
+    if (t.beforeCompressionBytes !== null && t.afterCompressionBytes !== null) {
+      before += t.beforeCompressionBytes
+      after += t.afterCompressionBytes
     }
   }
   if (before === 0 || after === 0) return null
@@ -173,11 +173,11 @@ export function lastEventState(
 
 export function schedulerJobState(job: SchedulerJobView): CardState {
   if (job.running) return { tone: "cyan", label: "Running" }
-  if (job.last_status === "error") {
-    return { tone: "red", label: "Last run failed", detail: job.last_error ?? undefined }
+  if (job.lastStatus === "error") {
+    return { tone: "red", label: "Last run failed", detail: job.lastError ?? undefined }
   }
-  if (job.last_status === "missed") return { tone: "amber", label: "Missed last run" }
-  if (job.last_status === "success") return { tone: "emerald", label: "OK" }
+  if (job.lastStatus === "missed") return { tone: "amber", label: "Missed last run" }
+  if (job.lastStatus === "success") return { tone: "emerald", label: "OK" }
   return { tone: "muted", label: "Not run yet" }
 }
 

--- a/resources/components/settings/status-overview.tsx
+++ b/resources/components/settings/status-overview.tsx
@@ -86,7 +86,7 @@ export function StatusOverview() {
   const now = Date.now()
   const overall = overallState(health, healthError)
   const nginx = nginxLogFiles(files)
-  const uptime = formatUptime(health?.started_at, now)
+  const uptime = formatUptime(health?.startedAt, now)
   const geoipRefreshJob = jobs?.find((j) => j.id === "geoip-refresh")
   const recentErrors = filterErrorRecords(logRecords, 5)
 
@@ -140,11 +140,11 @@ export function StatusOverview() {
               <p className="text-xs text-muted-foreground">Statistics unavailable.</p>
             ) : (
               <div className="grid grid-cols-2 gap-x-6 gap-y-1">
-                <Counter label="Parsed lines" value={stats?.total_parsed_lines} />
-                <Counter label="Processed" value={stats?.total_processed} />
-                <Counter label="Skipped lines" value={stats?.total_skipped_lines} />
-                <Counter label="Ignored lines" value={stats?.total_ignored_lines} />
-                <Counter label="Pending records" value={stats?.total_pending_records} />
+                <Counter label="Parsed lines" value={stats?.totalParsedLines} />
+                <Counter label="Processed" value={stats?.totalProcessed} />
+                <Counter label="Skipped lines" value={stats?.totalSkippedLines} />
+                <Counter label="Ignored lines" value={stats?.totalIgnoredLines} />
+                <Counter label="Pending records" value={stats?.totalPendingRecords} />
               </div>
             )}
             {health && (
@@ -152,7 +152,7 @@ export function StatusOverview() {
                 <span className="text-muted-foreground">Last event</span>
                 {(() => {
                   const state = lastEventState(
-                    health.ingestion.last_record_at,
+                    health.ingestion.lastRecordAt,
                     health.ingestion.running,
                     now,
                   )
@@ -180,8 +180,8 @@ export function StatusOverview() {
                   <MonoChip>{f.name}</MonoChip>
                   {f.available ? (
                     <span className="ml-auto text-muted-foreground tabular-nums">
-                      {formatSize(f.size_bytes)}
-                      {f.modified_at && ` · ${new Date(f.modified_at).toLocaleString()}`}
+                      {formatSize(f.sizeBytes)}
+                      {f.modifiedAt && ` · ${new Date(f.modifiedAt).toLocaleString()}`}
                     </span>
                   ) : (
                     <span className="ml-auto text-red-500">missing</span>
@@ -208,17 +208,17 @@ export function StatusOverview() {
               <>
                 <div className="space-y-1 text-xs text-muted-foreground">
                   <p>
-                    {dbInfo.size_bytes !== null && (
+                    {dbInfo.sizeBytes !== null && (
                       <span className="font-medium text-foreground">
-                        {formatSize(dbInfo.size_bytes)}
+                        {formatSize(dbInfo.sizeBytes)}
                       </span>
                     )}{" "}
-                    total · PostgreSQL {dbInfo.postgres_version?.split(" ")[0]} · TimescaleDB{" "}
-                    {dbInfo.timescaledb_version}
+                    total · PostgreSQL {dbInfo.postgresVersion?.split(" ")[0]} · TimescaleDB{" "}
+                    {dbInfo.timescaledbVersion}
                   </p>
                   <p>
-                    Raw events kept {dbInfo.retention_days} days, debug lines{" "}
-                    {dbInfo.debug_retention_days} days
+                    Raw events kept {dbInfo.retentionDays} days, debug lines{" "}
+                    {dbInfo.debugRetentionDays} days
                   </p>
                   {compressionSummary(dbInfo.hypertables) && (
                     <p>Compression {compressionSummary(dbInfo.hypertables)}</p>
@@ -230,8 +230,8 @@ export function StatusOverview() {
                     <div key={t.name} className="flex items-center gap-2 text-xs">
                       <MonoChip>{t.name}</MonoChip>
                       <span className="ml-auto text-muted-foreground tabular-nums">
-                        ~{formatApproxRows(t.approx_rows)} rows
-                        {t.total_bytes !== null && ` · ${formatSize(t.total_bytes)}`}
+                        ~{formatApproxRows(t.approxRows)} rows
+                        {t.totalBytes !== null && ` · ${formatSize(t.totalBytes)}`}
                       </span>
                     </div>
                   ))}
@@ -254,11 +254,11 @@ export function StatusOverview() {
           <CardContent className="space-y-2">
             <StateLine state={geoipState(health)} />
             <div className="space-y-1 text-xs text-muted-foreground">
-              {health?.geoip.db_build_date && (
-                <p>Database built {relativeTime(health.geoip.db_build_date, now)}</p>
+              {health?.geoip.dbBuildDate && (
+                <p>Database built {relativeTime(health.geoip.dbBuildDate, now)}</p>
               )}
-              {geoipRefreshJob?.next_run_time && (
-                <p>Next refresh {relativeTime(geoipRefreshJob.next_run_time, now)}</p>
+              {geoipRefreshJob?.nextRunTime && (
+                <p>Next refresh {relativeTime(geoipRefreshJob.nextRunTime, now)}</p>
               )}
             </div>
           </CardContent>
@@ -279,7 +279,7 @@ export function StatusOverview() {
             <div className="flex items-center gap-2">
               {crowdsec?.enabled && (
                 <Badge variant="outline">
-                  {crowdsec.write_enabled ? "write enabled" : "read only"}
+                  {crowdsec.writeEnabled ? "write enabled" : "read only"}
                 </Badge>
               )}
               {crowdsecStats && (
@@ -320,8 +320,8 @@ export function StatusOverview() {
                   <span className="ml-auto text-muted-foreground">
                     {job.running
                       ? "running"
-                      : job.next_run_time
-                        ? `next ${relativeTime(job.next_run_time, now)}`
+                      : job.nextRunTime
+                        ? `next ${relativeTime(job.nextRunTime, now)}`
                         : state.label}
                   </span>
                 </div>

--- a/resources/generated/api/schemas.gen.ts
+++ b/resources/generated/api/schemas.gen.ts
@@ -8,7 +8,7 @@ export const AboutAppViewSchema = {
     environment: {
       type: "string",
     },
-    image_tag: {
+    imageTag: {
       oneOf: [
         {
           type: "string",
@@ -21,7 +21,7 @@ export const AboutAppViewSchema = {
     name: {
       type: "string",
     },
-    started_at: {
+    startedAt: {
       oneOf: [
         {
           format: "date-time",
@@ -39,9 +39,9 @@ export const AboutAppViewSchema = {
   required: [
     "container",
     "environment",
-    "image_tag",
+    "imageTag",
     "name",
-    "started_at",
+    "startedAt",
     "version",
   ],
   title: "AboutAppView",
@@ -279,7 +279,7 @@ export const AccessLogFacetsSchema = {
 
 export const AlertViewSchema = {
   properties: {
-    as_name: {
+    asName: {
       oneOf: [
         {
           type: "string",
@@ -299,13 +299,13 @@ export const AlertViewSchema = {
         },
       ],
     },
-    created_at: {
+    createdAt: {
       type: "string",
     },
-    decision_count: {
+    decisionCount: {
       type: "integer",
     },
-    events_count: {
+    eventsCount: {
       type: "integer",
     },
     id: {
@@ -318,7 +318,7 @@ export const AlertViewSchema = {
         },
       ],
     },
-    machine_id: {
+    machineId: {
       oneOf: [
         {
           type: "string",
@@ -342,13 +342,13 @@ export const AlertViewSchema = {
     },
   },
   required: [
-    "as_name",
+    "asName",
     "country",
-    "created_at",
-    "decision_count",
-    "events_count",
+    "createdAt",
+    "decisionCount",
+    "eventsCount",
     "id",
-    "machine_id",
+    "machineId",
     "message",
     "scenario",
     "scope",
@@ -360,24 +360,24 @@ export const AlertViewSchema = {
 
 export const AnalyticsSettingsViewSchema = {
   properties: {
-    compression_after_days: {
+    compressionAfterDays: {
       type: "integer",
     },
-    debug_retention_days: {
+    debugRetentionDays: {
       type: "integer",
     },
-    hourly_retention_days: {
+    hourlyRetentionDays: {
       type: "integer",
     },
-    raw_retention_days: {
+    rawRetentionDays: {
       type: "integer",
     },
   },
   required: [
-    "compression_after_days",
-    "debug_retention_days",
-    "hourly_retention_days",
-    "raw_retention_days",
+    "compressionAfterDays",
+    "debugRetentionDays",
+    "hourlyRetentionDays",
+    "rawRetentionDays",
   ],
   title: "AnalyticsSettingsView",
   type: "object",
@@ -427,7 +427,7 @@ export const CrowdSecHealthSchema = {
     enabled: {
       type: "boolean",
     },
-    lapi_reachable: {
+    lapiReachable: {
       oneOf: [
         {
           type: "boolean",
@@ -438,20 +438,20 @@ export const CrowdSecHealthSchema = {
       ],
     },
   },
-  required: ["enabled", "lapi_reachable"],
+  required: ["enabled", "lapiReachable"],
   title: "CrowdSecHealth",
   type: "object",
 } as const;
 
 export const CrowdSecStatsResponseSchema = {
   properties: {
-    by_origin: {
+    byOrigin: {
       items: {
         $ref: "#/components/schemas/OriginCount",
       },
       type: "array",
     },
-    top_scenarios: {
+    topScenarios: {
       items: {
         $ref: "#/components/schemas/ScenarioCount",
       },
@@ -461,7 +461,7 @@ export const CrowdSecStatsResponseSchema = {
       type: "integer",
     },
   },
-  required: ["by_origin", "top_scenarios", "total"],
+  required: ["byOrigin", "topScenarios", "total"],
   title: "CrowdSecStatsResponse",
   type: "object",
 } as const;
@@ -471,27 +471,27 @@ export const CrowdSecStatusResponseSchema = {
     enabled: {
       type: "boolean",
     },
-    lapi_reachable: {
+    lapiReachable: {
       type: "boolean",
     },
-    write_enabled: {
+    writeEnabled: {
       type: "boolean",
     },
   },
-  required: ["enabled", "lapi_reachable", "write_enabled"],
+  required: ["enabled", "lapiReachable", "writeEnabled"],
   title: "CrowdSecStatusResponse",
   type: "object",
 } as const;
 
 export const CumulativeDataPointSchema = {
   properties: {
-    cumulative_access_logs: {
+    cumulativeAccessLogs: {
       type: "integer",
     },
-    cumulative_bytes: {
+    cumulativeBytes: {
       type: "integer",
     },
-    cumulative_geo_events: {
+    cumulativeGeoEvents: {
       type: "integer",
     },
     timestamp: {
@@ -499,9 +499,9 @@ export const CumulativeDataPointSchema = {
     },
   },
   required: [
-    "cumulative_access_logs",
-    "cumulative_bytes",
-    "cumulative_geo_events",
+    "cumulativeAccessLogs",
+    "cumulativeBytes",
+    "cumulativeGeoEvents",
     "timestamp",
   ],
   title: "CumulativeDataPoint",
@@ -516,17 +516,17 @@ export const CumulativeTimeSeriesResponseSchema = {
       },
       type: "array",
     },
-    end_date: {
+    endDate: {
       type: "string",
     },
     granularity: {
       type: "string",
     },
-    start_date: {
+    startDate: {
       type: "string",
     },
   },
-  required: ["end_date", "granularity", "start_date"],
+  required: ["endDate", "granularity", "startDate"],
   title: "CumulativeTimeSeriesResponse",
   type: "object",
 } as const;
@@ -544,7 +544,7 @@ export const DatabaseHealthSchema = {
 
 export const DatabaseInfoResponseSchema = {
   properties: {
-    debug_retention_days: {
+    debugRetentionDays: {
       type: "integer",
     },
     hypertables: {
@@ -553,7 +553,7 @@ export const DatabaseInfoResponseSchema = {
       },
       type: "array",
     },
-    postgres_version: {
+    postgresVersion: {
       oneOf: [
         {
           type: "string",
@@ -566,10 +566,10 @@ export const DatabaseInfoResponseSchema = {
     reachable: {
       type: "boolean",
     },
-    retention_days: {
+    retentionDays: {
       type: "integer",
     },
-    size_bytes: {
+    sizeBytes: {
       oneOf: [
         {
           type: "integer",
@@ -579,7 +579,7 @@ export const DatabaseInfoResponseSchema = {
         },
       ],
     },
-    timescaledb_version: {
+    timescaledbVersion: {
       oneOf: [
         {
           type: "string",
@@ -591,13 +591,13 @@ export const DatabaseInfoResponseSchema = {
     },
   },
   required: [
-    "debug_retention_days",
+    "debugRetentionDays",
     "hypertables",
-    "postgres_version",
+    "postgresVersion",
     "reachable",
-    "retention_days",
-    "size_bytes",
-    "timescaledb_version",
+    "retentionDays",
+    "sizeBytes",
+    "timescaledbVersion",
   ],
   title: "DatabaseInfoResponse",
   type: "object",
@@ -605,7 +605,7 @@ export const DatabaseInfoResponseSchema = {
 
 export const DatabaseVersionsViewSchema = {
   properties: {
-    postgis_version: {
+    postgisVersion: {
       oneOf: [
         {
           type: "string",
@@ -615,7 +615,7 @@ export const DatabaseVersionsViewSchema = {
         },
       ],
     },
-    postgres_version: {
+    postgresVersion: {
       oneOf: [
         {
           type: "string",
@@ -625,7 +625,7 @@ export const DatabaseVersionsViewSchema = {
         },
       ],
     },
-    timescaledb_version: {
+    timescaledbVersion: {
       oneOf: [
         {
           type: "string",
@@ -636,7 +636,7 @@ export const DatabaseVersionsViewSchema = {
       ],
     },
   },
-  required: ["postgis_version", "postgres_version", "timescaledb_version"],
+  required: ["postgisVersion", "postgresVersion", "timescaledbVersion"],
   title: "DatabaseVersionsView",
   type: "object",
 } as const;
@@ -653,7 +653,7 @@ export const DecisionViewSchema = {
         },
       ],
     },
-    country_code: {
+    countryCode: {
       oneOf: [
         {
           type: "string",
@@ -663,7 +663,7 @@ export const DecisionViewSchema = {
         },
       ],
     },
-    country_name: {
+    countryName: {
       oneOf: [
         {
           type: "string",
@@ -692,7 +692,7 @@ export const DecisionViewSchema = {
     origin: {
       type: "string",
     },
-    request_count_24h: {
+    requestCount24h: {
       oneOf: [
         {
           type: "integer",
@@ -714,13 +714,13 @@ export const DecisionViewSchema = {
   },
   required: [
     "city",
-    "country_code",
-    "country_name",
+    "countryCode",
+    "countryName",
     "duration",
     "id",
     "ip",
     "origin",
-    "request_count_24h",
+    "requestCount24h",
     "scenario",
     "scope",
     "type",
@@ -741,7 +741,7 @@ export const EmbeddedLocationDTOSchema = {
         },
       ],
     },
-    country_code: {
+    countryCode: {
       oneOf: [
         {
           type: "string",
@@ -751,7 +751,7 @@ export const EmbeddedLocationDTOSchema = {
         },
       ],
     },
-    country_name: {
+    countryName: {
       oneOf: [
         {
           type: "string",
@@ -821,25 +821,25 @@ export const GeoEventsDataPointSchema = {
     timestamp: {
       type: "string",
     },
-    total_geo_events: {
+    totalGeoEvents: {
       type: "integer",
     },
-    unique_cities: {
+    uniqueCities: {
       type: "integer",
     },
-    unique_countries: {
+    uniqueCountries: {
       type: "integer",
     },
-    unique_ips: {
+    uniqueIps: {
       type: "integer",
     },
   },
   required: [
     "timestamp",
-    "total_geo_events",
-    "unique_cities",
-    "unique_countries",
-    "unique_ips",
+    "totalGeoEvents",
+    "uniqueCities",
+    "uniqueCountries",
+    "uniqueIps",
   ],
   title: "GeoEventsDataPoint",
   type: "object",
@@ -853,17 +853,17 @@ export const GeoEventsTimeSeriesResponseSchema = {
       },
       type: "array",
     },
-    end_date: {
+    endDate: {
       type: "string",
     },
     granularity: {
       type: "string",
     },
-    start_date: {
+    startDate: {
       type: "string",
     },
   },
-  required: ["data", "end_date", "granularity", "start_date"],
+  required: ["data", "endDate", "granularity", "startDate"],
   title: "GeoEventsTimeSeriesResponse",
   type: "object",
 } as const;
@@ -873,7 +873,7 @@ export const GeoIPHealthSchema = {
     available: {
       type: "boolean",
     },
-    db_build_date: {
+    dbBuildDate: {
       oneOf: [
         {
           type: "string",
@@ -884,14 +884,14 @@ export const GeoIPHealthSchema = {
       ],
     },
   },
-  required: ["available", "db_build_date"],
+  required: ["available", "dbBuildDate"],
   title: "GeoIPHealth",
   type: "object",
 } as const;
 
 export const GeoIPInfoViewSchema = {
   properties: {
-    age_days: {
+    ageDays: {
       oneOf: [
         {
           type: "integer",
@@ -904,7 +904,7 @@ export const GeoIPInfoViewSchema = {
     available: {
       type: "boolean",
     },
-    build_date: {
+    buildDate: {
       oneOf: [
         {
           format: "date-time",
@@ -915,11 +915,11 @@ export const GeoIPInfoViewSchema = {
         },
       ],
     },
-    db_path: {
+    dbPath: {
       type: "string",
     },
   },
-  required: ["age_days", "available", "build_date", "db_path"],
+  required: ["ageDays", "available", "buildDate", "dbPath"],
   title: "GeoIPInfoView",
   type: "object",
 } as const;
@@ -973,13 +973,13 @@ export const GeoJSONFeaturePropertiesSchema = {
         },
       ],
     },
-    country_code: {
+    countryCode: {
       type: "string",
     },
-    country_name: {
+    countryName: {
       type: "string",
     },
-    event_count: {
+    eventCount: {
       type: "integer",
     },
     geohash: {
@@ -988,7 +988,7 @@ export const GeoJSONFeaturePropertiesSchema = {
     id: {
       type: "integer",
     },
-    last_hit: {
+    lastHit: {
       oneOf: [
         {
           format: "date-time",
@@ -999,7 +999,7 @@ export const GeoJSONFeaturePropertiesSchema = {
         },
       ],
     },
-    postal_code: {
+    postalCode: {
       oneOf: [
         {
           type: "string",
@@ -1019,7 +1019,7 @@ export const GeoJSONFeaturePropertiesSchema = {
         },
       ],
     },
-    state_code: {
+    stateCode: {
       oneOf: [
         {
           type: "string",
@@ -1039,7 +1039,7 @@ export const GeoJSONFeaturePropertiesSchema = {
         },
       ],
     },
-    top_ips: {
+    topIps: {
       items: {
         $ref: "#/components/schemas/TopIPDTO",
       },
@@ -1048,15 +1048,15 @@ export const GeoJSONFeaturePropertiesSchema = {
   },
   required: [
     "city",
-    "country_code",
-    "country_name",
-    "event_count",
+    "countryCode",
+    "countryName",
+    "eventCount",
     "geohash",
     "id",
-    "last_hit",
-    "postal_code",
+    "lastHit",
+    "postalCode",
     "state",
-    "state_code",
+    "stateCode",
     "timezone",
   ],
   title: "GeoJSONFeatureProperties",
@@ -1359,7 +1359,7 @@ export const GeoLogTimeSeriesResponseSchema = {
 
 export const GlobalTopIPsResponseSchema = {
   properties: {
-    top_ips: {
+    topIps: {
       items: {
         $ref: "#/components/schemas/TopIPDTO",
       },
@@ -1385,7 +1385,7 @@ export const HealthResponseSchema = {
     ingestion: {
       $ref: "#/components/schemas/IngestionHealth",
     },
-    started_at: {
+    startedAt: {
       oneOf: [
         {
           type: "string",
@@ -1408,7 +1408,7 @@ export const HealthResponseSchema = {
     "database",
     "geoip",
     "ingestion",
-    "started_at",
+    "startedAt",
     "status",
     "timestamp",
   ],
@@ -1418,7 +1418,7 @@ export const HealthResponseSchema = {
 
 export const HypertableStatsViewSchema = {
   properties: {
-    after_compression_bytes: {
+    afterCompressionBytes: {
       oneOf: [
         {
           type: "integer",
@@ -1428,7 +1428,7 @@ export const HypertableStatsViewSchema = {
         },
       ],
     },
-    approx_rows: {
+    approxRows: {
       oneOf: [
         {
           type: "integer",
@@ -1438,7 +1438,7 @@ export const HypertableStatsViewSchema = {
         },
       ],
     },
-    before_compression_bytes: {
+    beforeCompressionBytes: {
       oneOf: [
         {
           type: "integer",
@@ -1451,7 +1451,7 @@ export const HypertableStatsViewSchema = {
     name: {
       type: "string",
     },
-    total_bytes: {
+    totalBytes: {
       oneOf: [
         {
           type: "integer",
@@ -1463,11 +1463,11 @@ export const HypertableStatsViewSchema = {
     },
   },
   required: [
-    "after_compression_bytes",
-    "approx_rows",
-    "before_compression_bytes",
+    "afterCompressionBytes",
+    "approxRows",
+    "beforeCompressionBytes",
     "name",
-    "total_bytes",
+    "totalBytes",
   ],
   title: "HypertableStatsView",
   type: "object",
@@ -1475,7 +1475,7 @@ export const HypertableStatsViewSchema = {
 
 export const IngestionHealthSchema = {
   properties: {
-    last_record_at: {
+    lastRecordAt: {
       oneOf: [
         {
           type: "string",
@@ -1485,16 +1485,16 @@ export const IngestionHealthSchema = {
         },
       ],
     },
-    missing_files: {
+    missingFiles: {
       items: {
         type: "string",
       },
       type: "array",
     },
-    parsed_lines: {
+    parsedLines: {
       type: "integer",
     },
-    pending_records: {
+    pendingRecords: {
       type: "integer",
     },
     running: {
@@ -1502,10 +1502,10 @@ export const IngestionHealthSchema = {
     },
   },
   required: [
-    "last_record_at",
-    "missing_files",
-    "parsed_lines",
-    "pending_records",
+    "lastRecordAt",
+    "missingFiles",
+    "parsedLines",
+    "pendingRecords",
     "running",
   ],
   title: "IngestionHealth",
@@ -1514,32 +1514,32 @@ export const IngestionHealthSchema = {
 
 export const IngestionStatsResponseSchema = {
   properties: {
-    is_running: {
+    isRunning: {
       type: "boolean",
     },
-    total_ignored_lines: {
+    totalIgnoredLines: {
       type: "integer",
     },
-    total_parsed_lines: {
+    totalParsedLines: {
       type: "integer",
     },
-    total_pending_records: {
+    totalPendingRecords: {
       type: "integer",
     },
-    total_processed: {
+    totalProcessed: {
       type: "integer",
     },
-    total_skipped_lines: {
+    totalSkippedLines: {
       type: "integer",
     },
   },
   required: [
-    "is_running",
-    "total_ignored_lines",
-    "total_parsed_lines",
-    "total_pending_records",
-    "total_processed",
-    "total_skipped_lines",
+    "isRunning",
+    "totalIgnoredLines",
+    "totalParsedLines",
+    "totalPendingRecords",
+    "totalProcessed",
+    "totalSkippedLines",
   ],
   title: "IngestionStatsResponse",
   type: "object",
@@ -1557,7 +1557,7 @@ export const IpLocationSchema = {
         },
       ],
     },
-    country_code: {
+    countryCode: {
       oneOf: [
         {
           type: "string",
@@ -1577,7 +1577,7 @@ export const IpLocationSchema = {
       type: "number",
     },
   },
-  required: ["city", "country_code", "ip", "latitude", "longitude"],
+  required: ["city", "countryCode", "ip", "latitude", "longitude"],
   title: "IpLocation",
   type: "object",
 } as const;
@@ -1955,17 +1955,17 @@ export const ListGeoLocationsGeoLocationResponseBodySchema = {
 
 export const LocationTopIPsResponseSchema = {
   properties: {
-    location_id: {
+    locationId: {
       type: "integer",
     },
-    top_ips: {
+    topIps: {
       items: {
         $ref: "#/components/schemas/TopIPDTO",
       },
       type: "array",
     },
   },
-  required: ["location_id"],
+  required: ["locationId"],
   title: "LocationTopIPsResponse",
   type: "object",
 } as const;
@@ -1979,7 +1979,7 @@ export const LogFileViewSchema = {
       enum: ["app", "login", "nginx"],
       type: "string",
     },
-    modified_at: {
+    modifiedAt: {
       oneOf: [
         {
           format: "date-time",
@@ -1993,11 +1993,11 @@ export const LogFileViewSchema = {
     name: {
       type: "string",
     },
-    size_bytes: {
+    sizeBytes: {
       type: "integer",
     },
   },
-  required: ["available", "kind", "modified_at", "name", "size_bytes"],
+  required: ["available", "kind", "modifiedAt", "name", "sizeBytes"],
   title: "LogFileView",
   type: "object",
 } as const;
@@ -2089,27 +2089,27 @@ export const LoginPayloadSchema = {
 
 export const LogparserSettingsViewSchema = {
   properties: {
-    log_paths: {
+    logPaths: {
       items: {
         type: "string",
       },
       type: "array",
     },
-    send_logs: {
+    sendLogs: {
       type: "boolean",
     },
-    store_debug_lines: {
+    storeDebugLines: {
       type: "boolean",
     },
   },
-  required: ["log_paths", "send_logs", "store_debug_lines"],
+  required: ["logPaths", "sendLogs", "storeDebugLines"],
   title: "LogparserSettingsView",
   type: "object",
 } as const;
 
 export const MapSettingsViewSchema = {
   properties: {
-    home_latitude: {
+    homeLatitude: {
       oneOf: [
         {
           type: "number",
@@ -2119,7 +2119,7 @@ export const MapSettingsViewSchema = {
         },
       ],
     },
-    home_longitude: {
+    homeLongitude: {
       oneOf: [
         {
           type: "number",
@@ -2129,12 +2129,12 @@ export const MapSettingsViewSchema = {
         },
       ],
     },
-    home_source: {
+    homeSource: {
       enum: ["configured", "external_ip", null],
       type: ["null", "string"],
     },
   },
-  required: ["home_latitude", "home_longitude", "home_source"],
+  required: ["homeLatitude", "homeLongitude", "homeSource"],
   title: "MapSettingsView",
   type: "object",
 } as const;
@@ -2180,7 +2180,7 @@ export const ParseErrorCountSchema = {
 
 export const PercentChangeSchema = {
   properties: {
-    avg_request_time: {
+    avgRequestTime: {
       oneOf: [
         {
           type: "number",
@@ -2190,7 +2190,7 @@ export const PercentChangeSchema = {
         },
       ],
     },
-    bytes_sent: {
+    bytesSent: {
       oneOf: [
         {
           type: "number",
@@ -2200,7 +2200,7 @@ export const PercentChangeSchema = {
         },
       ],
     },
-    error_rate: {
+    errorRate: {
       oneOf: [
         {
           type: "number",
@@ -2210,7 +2210,7 @@ export const PercentChangeSchema = {
         },
       ],
     },
-    geo_records: {
+    geoRecords: {
       oneOf: [
         {
           type: "number",
@@ -2220,7 +2220,7 @@ export const PercentChangeSchema = {
         },
       ],
     },
-    log_records: {
+    logRecords: {
       oneOf: [
         {
           type: "number",
@@ -2230,7 +2230,7 @@ export const PercentChangeSchema = {
         },
       ],
     },
-    malformed_rate: {
+    malformedRate: {
       oneOf: [
         {
           type: "number",
@@ -2240,7 +2240,7 @@ export const PercentChangeSchema = {
         },
       ],
     },
-    unique_ips: {
+    uniqueIps: {
       oneOf: [
         {
           type: "number",
@@ -2258,64 +2258,64 @@ export const PercentChangeSchema = {
 
 export const PeriodSummarySchema = {
   properties: {
-    avg_bytes_per_request: {
+    avgBytesPerRequest: {
       type: "number",
     },
-    avg_request_time: {
+    avgRequestTime: {
       type: "number",
     },
-    error_rate: {
+    errorRate: {
       type: "number",
     },
-    malformed_requests: {
+    malformedRequests: {
       type: "integer",
     },
-    max_request_time: {
+    maxRequestTime: {
       type: "number",
     },
-    status_2xx: {
+    status2xx: {
       type: "integer",
     },
-    status_3xx: {
+    status3xx: {
       type: "integer",
     },
-    status_4xx: {
+    status4xx: {
       type: "integer",
     },
-    status_5xx: {
+    status5xx: {
       type: "integer",
     },
-    total_bytes_sent: {
+    totalBytesSent: {
       type: "integer",
     },
-    total_geo_events: {
+    totalGeoEvents: {
       type: "integer",
     },
-    total_requests: {
+    totalRequests: {
       type: "integer",
     },
-    unique_countries: {
+    uniqueCountries: {
       type: "integer",
     },
-    unique_ips: {
+    uniqueIps: {
       type: "integer",
     },
   },
   required: [
-    "avg_bytes_per_request",
-    "avg_request_time",
-    "error_rate",
-    "malformed_requests",
-    "max_request_time",
-    "status_2xx",
-    "status_3xx",
-    "status_4xx",
-    "status_5xx",
-    "total_bytes_sent",
-    "total_geo_events",
-    "total_requests",
-    "unique_countries",
-    "unique_ips",
+    "avgBytesPerRequest",
+    "avgRequestTime",
+    "errorRate",
+    "malformedRequests",
+    "maxRequestTime",
+    "status2xx",
+    "status3xx",
+    "status4xx",
+    "status5xx",
+    "totalBytesSent",
+    "totalGeoEvents",
+    "totalRequests",
+    "uniqueCountries",
+    "uniqueIps",
   ],
   title: "PeriodSummary",
   type: "object",
@@ -2337,7 +2337,7 @@ export const RuntimeSettingsViewSchema = {
     container: {
       type: "boolean",
     },
-    image_tag: {
+    imageTag: {
       oneOf: [
         {
           type: "string",
@@ -2348,14 +2348,14 @@ export const RuntimeSettingsViewSchema = {
       ],
     },
   },
-  required: ["container", "image_tag"],
+  required: ["container", "imageTag"],
   title: "RuntimeSettingsView",
   type: "object",
 } as const;
 
 export const RuntimeVersionsViewSchema = {
   properties: {
-    apscheduler_version: {
+    apschedulerVersion: {
       oneOf: [
         {
           type: "string",
@@ -2365,7 +2365,7 @@ export const RuntimeVersionsViewSchema = {
         },
       ],
     },
-    litestar_version: {
+    litestarVersion: {
       oneOf: [
         {
           type: "string",
@@ -2375,11 +2375,11 @@ export const RuntimeVersionsViewSchema = {
         },
       ],
     },
-    python_version: {
+    pythonVersion: {
       type: "string",
     },
   },
-  required: ["apscheduler_version", "litestar_version", "python_version"],
+  required: ["apschedulerVersion", "litestarVersion", "pythonVersion"],
   title: "RuntimeVersionsView",
   type: "object",
 } as const;
@@ -2440,7 +2440,7 @@ export const SchedulerJobViewSchema = {
     id: {
       type: "string",
     },
-    last_duration_seconds: {
+    lastDurationSeconds: {
       oneOf: [
         {
           type: "number",
@@ -2450,7 +2450,7 @@ export const SchedulerJobViewSchema = {
         },
       ],
     },
-    last_error: {
+    lastError: {
       oneOf: [
         {
           type: "string",
@@ -2460,7 +2460,7 @@ export const SchedulerJobViewSchema = {
         },
       ],
     },
-    last_run_time: {
+    lastRunTime: {
       oneOf: [
         {
           format: "date-time",
@@ -2471,14 +2471,14 @@ export const SchedulerJobViewSchema = {
         },
       ],
     },
-    last_status: {
+    lastStatus: {
       enum: ["success", "error", "missed", null],
       type: ["null", "string"],
     },
     name: {
       type: "string",
     },
-    next_run_time: {
+    nextRunTime: {
       oneOf: [
         {
           format: "date-time",
@@ -2498,12 +2498,12 @@ export const SchedulerJobViewSchema = {
   },
   required: [
     "id",
-    "last_duration_seconds",
-    "last_error",
-    "last_run_time",
-    "last_status",
+    "lastDurationSeconds",
+    "lastError",
+    "lastRunTime",
+    "lastStatus",
     "name",
-    "next_run_time",
+    "nextRunTime",
     "running",
     "trigger",
   ],
@@ -2519,21 +2519,21 @@ export const SchedulerJobsResponseSchema = {
       },
       type: "array",
     },
-    scheduler_enabled: {
+    schedulerEnabled: {
       type: "boolean",
     },
-    scheduler_running: {
+    schedulerRunning: {
       type: "boolean",
     },
   },
-  required: ["jobs", "scheduler_enabled", "scheduler_running"],
+  required: ["jobs", "schedulerEnabled", "schedulerRunning"],
   title: "SchedulerJobsResponse",
   type: "object",
 } as const;
 
 export const SettingFieldViewSchema = {
   properties: {
-    computed_source: {
+    computedSource: {
       oneOf: [
         {
           type: "string",
@@ -2543,7 +2543,7 @@ export const SettingFieldViewSchema = {
         },
       ],
     },
-    computed_value: {},
+    computedValue: {},
     default: {},
     description: {
       oneOf: [
@@ -2555,7 +2555,7 @@ export const SettingFieldViewSchema = {
         },
       ],
     },
-    env_var: {
+    envVar: {
       oneOf: [
         {
           type: "string",
@@ -2565,7 +2565,7 @@ export const SettingFieldViewSchema = {
         },
       ],
     },
-    is_secret: {
+    isSecret: {
       type: "boolean",
     },
     key: {
@@ -2573,7 +2573,7 @@ export const SettingFieldViewSchema = {
     },
     value: {},
   },
-  required: ["default", "description", "env_var", "is_secret", "key", "value"],
+  required: ["default", "description", "envVar", "isSecret", "key", "value"],
   title: "SettingFieldView",
   type: "object",
 } as const;
@@ -2610,13 +2610,13 @@ export const SettingsSectionViewSchema = {
 
 export const SummaryResponseSchema = {
   properties: {
-    current_period: {
+    currentPeriod: {
       $ref: "#/components/schemas/PeriodSummary",
     },
-    end_date: {
+    endDate: {
       type: "string",
     },
-    percent_changes: {
+    percentChanges: {
       oneOf: [
         {
           $ref: "#/components/schemas/PercentChange",
@@ -2626,7 +2626,7 @@ export const SummaryResponseSchema = {
         },
       ],
     },
-    previous_period: {
+    previousPeriod: {
       oneOf: [
         {
           $ref: "#/components/schemas/PeriodSummary",
@@ -2636,11 +2636,11 @@ export const SummaryResponseSchema = {
         },
       ],
     },
-    start_date: {
+    startDate: {
       type: "string",
     },
   },
-  required: ["current_period", "end_date", "start_date"],
+  required: ["currentPeriod", "endDate", "startDate"],
   title: "SummaryResponse",
   type: "object",
 } as const;
@@ -2661,60 +2661,60 @@ export const SystemSettingsResponseSchema = {
 
 export const TimeSeriesDataPointSchema = {
   properties: {
-    avg_request_time: {
+    avgRequestTime: {
       type: "number",
     },
-    error_rate: {
+    errorRate: {
       type: "number",
     },
-    p50_request_time: {
+    p50RequestTime: {
       type: "number",
     },
-    p95_request_time: {
+    p95RequestTime: {
       type: "number",
     },
-    p99_request_time: {
+    p99RequestTime: {
       type: "number",
     },
-    status_2xx: {
+    status2xx: {
       type: "integer",
     },
-    status_3xx: {
+    status3xx: {
       type: "integer",
     },
-    status_4xx: {
+    status4xx: {
       type: "integer",
     },
-    status_5xx: {
+    status5xx: {
       type: "integer",
     },
     timestamp: {
       type: "string",
     },
-    total_bytes_sent: {
+    totalBytesSent: {
       type: "integer",
     },
-    total_geo_events: {
+    totalGeoEvents: {
       type: "integer",
     },
-    total_requests: {
+    totalRequests: {
       type: "integer",
     },
   },
   required: [
-    "avg_request_time",
-    "error_rate",
-    "p50_request_time",
-    "p95_request_time",
-    "p99_request_time",
-    "status_2xx",
-    "status_3xx",
-    "status_4xx",
-    "status_5xx",
+    "avgRequestTime",
+    "errorRate",
+    "p50RequestTime",
+    "p95RequestTime",
+    "p99RequestTime",
+    "status2xx",
+    "status3xx",
+    "status4xx",
+    "status5xx",
     "timestamp",
-    "total_bytes_sent",
-    "total_geo_events",
-    "total_requests",
+    "totalBytesSent",
+    "totalGeoEvents",
+    "totalRequests",
   ],
   title: "TimeSeriesDataPoint",
   type: "object",
@@ -2728,24 +2728,24 @@ export const TimeSeriesResponseSchema = {
       },
       type: "array",
     },
-    end_date: {
+    endDate: {
       type: "string",
     },
     granularity: {
       type: "string",
     },
-    start_date: {
+    startDate: {
       type: "string",
     },
   },
-  required: ["data", "end_date", "granularity", "start_date"],
+  required: ["data", "endDate", "granularity", "startDate"],
   title: "TimeSeriesResponse",
   type: "object",
 } as const;
 
 export const TopCitiesResponseSchema = {
   properties: {
-    end_date: {
+    endDate: {
       type: "string",
     },
     items: {
@@ -2754,11 +2754,11 @@ export const TopCitiesResponseSchema = {
       },
       type: "array",
     },
-    start_date: {
+    startDate: {
       type: "string",
     },
   },
-  required: ["end_date", "items", "start_date"],
+  required: ["endDate", "items", "startDate"],
   title: "TopCitiesResponse",
   type: "object",
 } as const;
@@ -2768,7 +2768,7 @@ export const TopCityStatsDTOSchema = {
     city: {
       type: "string",
     },
-    country_code: {
+    countryCode: {
       oneOf: [
         {
           type: "string",
@@ -2781,18 +2781,18 @@ export const TopCityStatsDTOSchema = {
     hits: {
       type: "integer",
     },
-    unique_ips: {
+    uniqueIps: {
       type: "integer",
     },
   },
-  required: ["city", "country_code", "hits", "unique_ips"],
+  required: ["city", "countryCode", "hits", "uniqueIps"],
   title: "TopCityStatsDTO",
   type: "object",
 } as const;
 
 export const TopCountriesResponseSchema = {
   properties: {
-    top_countries: {
+    topCountries: {
       items: {
         $ref: "#/components/schemas/TopCountryDTO",
       },
@@ -2806,7 +2806,7 @@ export const TopCountriesResponseSchema = {
 
 export const TopCountriesStatsResponseSchema = {
   properties: {
-    end_date: {
+    endDate: {
       type: "string",
     },
     items: {
@@ -2815,21 +2815,21 @@ export const TopCountriesStatsResponseSchema = {
       },
       type: "array",
     },
-    start_date: {
+    startDate: {
       type: "string",
     },
   },
-  required: ["end_date", "items", "start_date"],
+  required: ["endDate", "items", "startDate"],
   title: "TopCountriesStatsResponse",
   type: "object",
 } as const;
 
 export const TopCountryDTOSchema = {
   properties: {
-    country_code: {
+    countryCode: {
       type: "string",
     },
-    country_name: {
+    countryName: {
       oneOf: [
         {
           type: "string",
@@ -2839,21 +2839,21 @@ export const TopCountryDTOSchema = {
         },
       ],
     },
-    event_count: {
+    eventCount: {
       type: "integer",
     },
   },
-  required: ["country_code", "country_name", "event_count"],
+  required: ["countryCode", "countryName", "eventCount"],
   title: "TopCountryDTO",
   type: "object",
 } as const;
 
 export const TopCountryStatsDTOSchema = {
   properties: {
-    country_code: {
+    countryCode: {
       type: "string",
     },
-    country_name: {
+    countryName: {
       oneOf: [
         {
           type: "string",
@@ -2866,11 +2866,11 @@ export const TopCountryStatsDTOSchema = {
     hits: {
       type: "integer",
     },
-    unique_ips: {
+    uniqueIps: {
       type: "integer",
     },
   },
-  required: ["country_code", "country_name", "hits", "unique_ips"],
+  required: ["countryCode", "countryName", "hits", "uniqueIps"],
   title: "TopCountryStatsDTO",
   type: "object",
 } as const;
@@ -3007,10 +3007,10 @@ export const TopGeoIpsResponseSchema = {
 
 export const TopIPDTOSchema = {
   properties: {
-    event_count: {
+    eventCount: {
       type: "integer",
     },
-    ip_address: {
+    ipAddress: {
       type: "string",
     },
     location: {
@@ -3024,7 +3024,7 @@ export const TopIPDTOSchema = {
       ],
     },
   },
-  required: ["event_count", "ip_address"],
+  required: ["eventCount", "ipAddress"],
   title: "TopIPDTO",
   type: "object",
 } as const;
@@ -3041,7 +3041,7 @@ export const TopIpDTOSchema = {
         },
       ],
     },
-    country_code: {
+    countryCode: {
       oneOf: [
         {
           type: "string",
@@ -3051,26 +3051,26 @@ export const TopIpDTOSchema = {
         },
       ],
     },
-    error_hits: {
+    errorHits: {
       type: "integer",
     },
     hits: {
       type: "integer",
     },
-    ip_address: {
+    ipAddress: {
       type: "string",
     },
-    total_bytes: {
+    totalBytes: {
       type: "integer",
     },
   },
   required: [
     "city",
-    "country_code",
-    "error_hits",
+    "countryCode",
+    "errorHits",
     "hits",
-    "ip_address",
-    "total_bytes",
+    "ipAddress",
+    "totalBytes",
   ],
   title: "TopIpDTO",
   type: "object",
@@ -3078,7 +3078,7 @@ export const TopIpDTOSchema = {
 
 export const TopIpsResponseSchema = {
   properties: {
-    end_date: {
+    endDate: {
       type: "string",
     },
     items: {
@@ -3087,41 +3087,41 @@ export const TopIpsResponseSchema = {
       },
       type: "array",
     },
-    start_date: {
+    startDate: {
       type: "string",
     },
   },
-  required: ["end_date", "items", "start_date"],
+  required: ["endDate", "items", "startDate"],
   title: "TopIpsResponse",
   type: "object",
 } as const;
 
 export const TopUrlDTOSchema = {
   properties: {
-    avg_request_time: {
+    avgRequestTime: {
       type: "number",
     },
-    error_hits: {
+    errorHits: {
       type: "integer",
     },
     hits: {
       type: "integer",
     },
-    total_bytes: {
+    totalBytes: {
       type: "integer",
     },
     url: {
       type: "string",
     },
   },
-  required: ["avg_request_time", "error_hits", "hits", "total_bytes", "url"],
+  required: ["avgRequestTime", "errorHits", "hits", "totalBytes", "url"],
   title: "TopUrlDTO",
   type: "object",
 } as const;
 
 export const TopUrlsResponseSchema = {
   properties: {
-    end_date: {
+    endDate: {
       type: "string",
     },
     items: {
@@ -3130,11 +3130,11 @@ export const TopUrlsResponseSchema = {
       },
       type: "array",
     },
-    start_date: {
+    startDate: {
       type: "string",
     },
   },
-  required: ["end_date", "items", "start_date"],
+  required: ["endDate", "items", "startDate"],
   title: "TopUrlsResponse",
   type: "object",
 } as const;
@@ -3144,18 +3144,18 @@ export const TopUserAgentDTOSchema = {
     hits: {
       type: "integer",
     },
-    user_agent: {
+    userAgent: {
       type: "string",
     },
   },
-  required: ["hits", "user_agent"],
+  required: ["hits", "userAgent"],
   title: "TopUserAgentDTO",
   type: "object",
 } as const;
 
 export const TopUserAgentsResponseSchema = {
   properties: {
-    end_date: {
+    endDate: {
       type: "string",
     },
     items: {
@@ -3164,11 +3164,11 @@ export const TopUserAgentsResponseSchema = {
       },
       type: "array",
     },
-    start_date: {
+    startDate: {
       type: "string",
     },
   },
-  required: ["end_date", "items", "start_date"],
+  required: ["endDate", "items", "startDate"],
   title: "TopUserAgentsResponse",
   type: "object",
 } as const;

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -10,9 +10,9 @@ export type ClientOptions = {
 export type AboutAppView = {
   container: boolean;
   environment: string;
-  image_tag: string | null;
+  imageTag: string | null;
   name: string;
-  started_at: string | null;
+  startedAt: string | null;
   version: string;
 };
 
@@ -79,13 +79,13 @@ export type AccessLogFacets = {
  * AlertView
  */
 export type AlertView = {
-  as_name: string | null;
+  asName: string | null;
   country: string | null;
-  created_at: string;
-  decision_count: number;
-  events_count: number;
+  createdAt: string;
+  decisionCount: number;
+  eventsCount: number;
   id: number | null;
-  machine_id: string | null;
+  machineId: string | null;
   message: string;
   scenario: string;
   scope: string;
@@ -96,10 +96,10 @@ export type AlertView = {
  * AnalyticsSettingsView
  */
 export type AnalyticsSettingsView = {
-  compression_after_days: number;
-  debug_retention_days: number;
-  hourly_retention_days: number;
-  raw_retention_days: number;
+  compressionAfterDays: number;
+  debugRetentionDays: number;
+  hourlyRetentionDays: number;
+  rawRetentionDays: number;
 };
 
 /**
@@ -124,15 +124,15 @@ export type CountryFacet = {
  */
 export type CrowdSecHealth = {
   enabled: boolean;
-  lapi_reachable: boolean | null;
+  lapiReachable: boolean | null;
 };
 
 /**
  * CrowdSecStatsResponse
  */
 export type CrowdSecStatsResponse = {
-  by_origin: Array<OriginCount>;
-  top_scenarios: Array<ScenarioCount>;
+  byOrigin: Array<OriginCount>;
+  topScenarios: Array<ScenarioCount>;
   total: number;
 };
 
@@ -141,17 +141,17 @@ export type CrowdSecStatsResponse = {
  */
 export type CrowdSecStatusResponse = {
   enabled: boolean;
-  lapi_reachable: boolean;
-  write_enabled: boolean;
+  lapiReachable: boolean;
+  writeEnabled: boolean;
 };
 
 /**
  * CumulativeDataPoint
  */
 export type CumulativeDataPoint = {
-  cumulative_access_logs: number;
-  cumulative_bytes: number;
-  cumulative_geo_events: number;
+  cumulativeAccessLogs: number;
+  cumulativeBytes: number;
+  cumulativeGeoEvents: number;
   timestamp: string;
 };
 
@@ -160,9 +160,9 @@ export type CumulativeDataPoint = {
  */
 export type CumulativeTimeSeriesResponse = {
   data?: Array<CumulativeDataPoint>;
-  end_date: string;
+  endDate: string;
   granularity: string;
-  start_date: string;
+  startDate: string;
 };
 
 /**
@@ -176,22 +176,22 @@ export type DatabaseHealth = {
  * DatabaseInfoResponse
  */
 export type DatabaseInfoResponse = {
-  debug_retention_days: number;
+  debugRetentionDays: number;
   hypertables: Array<HypertableStatsView>;
-  postgres_version: string | null;
+  postgresVersion: string | null;
   reachable: boolean;
-  retention_days: number;
-  size_bytes: number | null;
-  timescaledb_version: string | null;
+  retentionDays: number;
+  sizeBytes: number | null;
+  timescaledbVersion: string | null;
 };
 
 /**
  * DatabaseVersionsView
  */
 export type DatabaseVersionsView = {
-  postgis_version: string | null;
-  postgres_version: string | null;
-  timescaledb_version: string | null;
+  postgisVersion: string | null;
+  postgresVersion: string | null;
+  timescaledbVersion: string | null;
 };
 
 /**
@@ -199,13 +199,13 @@ export type DatabaseVersionsView = {
  */
 export type DecisionView = {
   city: string | null;
-  country_code: string | null;
-  country_name: string | null;
+  countryCode: string | null;
+  countryName: string | null;
   duration: string;
   id: number | null;
   ip: string;
   origin: string;
-  request_count_24h: number | null;
+  requestCount24h: number | null;
   scenario: string;
   scope: string;
   type: string;
@@ -216,8 +216,8 @@ export type DecisionView = {
  */
 export type EmbeddedLocationDto = {
   city?: string | null;
-  country_code?: string | null;
-  country_name?: string | null;
+  countryCode?: string | null;
+  countryName?: string | null;
   id: number;
   latitude: number;
   longitude: number;
@@ -245,10 +245,10 @@ export type GeoEventFacets = {
  */
 export type GeoEventsDataPoint = {
   timestamp: string;
-  total_geo_events: number;
-  unique_cities: number;
-  unique_countries: number;
-  unique_ips: number;
+  totalGeoEvents: number;
+  uniqueCities: number;
+  uniqueCountries: number;
+  uniqueIps: number;
 };
 
 /**
@@ -256,9 +256,9 @@ export type GeoEventsDataPoint = {
  */
 export type GeoEventsTimeSeriesResponse = {
   data: Array<GeoEventsDataPoint>;
-  end_date: string;
+  endDate: string;
   granularity: string;
-  start_date: string;
+  startDate: string;
 };
 
 /**
@@ -266,17 +266,17 @@ export type GeoEventsTimeSeriesResponse = {
  */
 export type GeoIpHealth = {
   available: boolean;
-  db_build_date: string | null;
+  dbBuildDate: string | null;
 };
 
 /**
  * GeoIPInfoView
  */
 export type GeoIpInfoView = {
-  age_days: number | null;
+  ageDays: number | null;
   available: boolean;
-  build_date: string | null;
-  db_path: string;
+  buildDate: string | null;
+  dbPath: string;
 };
 
 /**
@@ -302,17 +302,17 @@ export type GeoJsonFeatureCollection = {
  */
 export type GeoJsonFeatureProperties = {
   city: string | null;
-  country_code: string;
-  country_name: string;
-  event_count: number;
+  countryCode: string;
+  countryName: string;
+  eventCount: number;
   geohash: string;
   id: number;
-  last_hit: string | null;
-  postal_code: string | null;
+  lastHit: string | null;
+  postalCode: string | null;
   state: string | null;
-  state_code: string | null;
+  stateCode: string | null;
   timezone: string | null;
-  top_ips?: Array<TopIpdto>;
+  topIps?: Array<TopIpdto>;
 };
 
 /**
@@ -406,7 +406,7 @@ export type GeoLogTimeSeriesResponse = {
  * GlobalTopIPsResponse
  */
 export type GlobalTopIpsResponse = {
-  top_ips?: Array<TopIpdto>;
+  topIps?: Array<TopIpdto>;
 };
 
 /**
@@ -417,7 +417,7 @@ export type HealthResponse = {
   database: DatabaseHealth;
   geoip: GeoIpHealth;
   ingestion: IngestionHealth;
-  started_at: string | null;
+  startedAt: string | null;
   status: "healthy" | "degraded";
   timestamp: string;
 };
@@ -426,21 +426,21 @@ export type HealthResponse = {
  * HypertableStatsView
  */
 export type HypertableStatsView = {
-  after_compression_bytes: number | null;
-  approx_rows: number | null;
-  before_compression_bytes: number | null;
+  afterCompressionBytes: number | null;
+  approxRows: number | null;
+  beforeCompressionBytes: number | null;
   name: string;
-  total_bytes: number | null;
+  totalBytes: number | null;
 };
 
 /**
  * IngestionHealth
  */
 export type IngestionHealth = {
-  last_record_at: string | null;
-  missing_files: Array<string>;
-  parsed_lines: number;
-  pending_records: number;
+  lastRecordAt: string | null;
+  missingFiles: Array<string>;
+  parsedLines: number;
+  pendingRecords: number;
   running: boolean;
 };
 
@@ -448,12 +448,12 @@ export type IngestionHealth = {
  * IngestionStatsResponse
  */
 export type IngestionStatsResponse = {
-  is_running: boolean;
-  total_ignored_lines: number;
-  total_parsed_lines: number;
-  total_pending_records: number;
-  total_processed: number;
-  total_skipped_lines: number;
+  isRunning: boolean;
+  totalIgnoredLines: number;
+  totalParsedLines: number;
+  totalPendingRecords: number;
+  totalProcessed: number;
+  totalSkippedLines: number;
 };
 
 /**
@@ -461,7 +461,7 @@ export type IngestionStatsResponse = {
  */
 export type IpLocation = {
   city: string | null;
-  country_code: string | null;
+  countryCode: string | null;
   ip: string;
   latitude: number;
   longitude: number;
@@ -548,8 +548,8 @@ export type ListGeoLocationsGeoLocationResponseBody = {
  * LocationTopIPsResponse
  */
 export type LocationTopIpsResponse = {
-  location_id: number;
-  top_ips?: Array<TopIpdto>;
+  locationId: number;
+  topIps?: Array<TopIpdto>;
 };
 
 /**
@@ -558,9 +558,9 @@ export type LocationTopIpsResponse = {
 export type LogFileView = {
   available: boolean;
   kind: "app" | "login" | "nginx";
-  modified_at: string | null;
+  modifiedAt: string | null;
   name: string;
-  size_bytes: number;
+  sizeBytes: number;
 };
 
 /**
@@ -609,18 +609,18 @@ export type LoginPayload = {
  * LogparserSettingsView
  */
 export type LogparserSettingsView = {
-  log_paths: Array<string>;
-  send_logs: boolean;
-  store_debug_lines: boolean;
+  logPaths: Array<string>;
+  sendLogs: boolean;
+  storeDebugLines: boolean;
 };
 
 /**
  * MapSettingsView
  */
 export type MapSettingsView = {
-  home_latitude: number | null;
-  home_longitude: number | null;
-  home_source: "configured" | "external_ip" | null;
+  homeLatitude: number | null;
+  homeLongitude: number | null;
+  homeSource: "configured" | "external_ip" | null;
 };
 
 /**
@@ -650,33 +650,33 @@ export type ParseErrorCount = {
  * PercentChange
  */
 export type PercentChange = {
-  avg_request_time?: number | null;
-  bytes_sent?: number | null;
-  error_rate?: number | null;
-  geo_records?: number | null;
-  log_records?: number | null;
-  malformed_rate?: number | null;
-  unique_ips?: number | null;
+  avgRequestTime?: number | null;
+  bytesSent?: number | null;
+  errorRate?: number | null;
+  geoRecords?: number | null;
+  logRecords?: number | null;
+  malformedRate?: number | null;
+  uniqueIps?: number | null;
 };
 
 /**
  * PeriodSummary
  */
 export type PeriodSummary = {
-  avg_bytes_per_request: number;
-  avg_request_time: number;
-  error_rate: number;
-  malformed_requests: number;
-  max_request_time: number;
-  status_2xx: number;
-  status_3xx: number;
-  status_4xx: number;
-  status_5xx: number;
-  total_bytes_sent: number;
-  total_geo_events: number;
-  total_requests: number;
-  unique_countries: number;
-  unique_ips: number;
+  avgBytesPerRequest: number;
+  avgRequestTime: number;
+  errorRate: number;
+  malformedRequests: number;
+  maxRequestTime: number;
+  status2xx: number;
+  status3xx: number;
+  status4xx: number;
+  status5xx: number;
+  totalBytesSent: number;
+  totalGeoEvents: number;
+  totalRequests: number;
+  uniqueCountries: number;
+  uniqueIps: number;
 };
 
 /**
@@ -691,16 +691,16 @@ export type ReadinessResponse = {
  */
 export type RuntimeSettingsView = {
   container: boolean;
-  image_tag: string | null;
+  imageTag: string | null;
 };
 
 /**
  * RuntimeVersionsView
  */
 export type RuntimeVersionsView = {
-  apscheduler_version: string | null;
-  litestar_version: string | null;
-  python_version: string;
+  apschedulerVersion: string | null;
+  litestarVersion: string | null;
+  pythonVersion: string;
 };
 
 /**
@@ -729,12 +729,12 @@ export type ScenarioCount = {
  */
 export type SchedulerJobView = {
   id: string;
-  last_duration_seconds: number | null;
-  last_error: string | null;
-  last_run_time: string | null;
-  last_status: "success" | "error" | "missed" | null;
+  lastDurationSeconds: number | null;
+  lastError: string | null;
+  lastRunTime: string | null;
+  lastStatus: "success" | "error" | "missed" | null;
   name: string;
-  next_run_time: string | null;
+  nextRunTime: string | null;
   running: boolean;
   trigger: string;
 };
@@ -744,20 +744,20 @@ export type SchedulerJobView = {
  */
 export type SchedulerJobsResponse = {
   jobs: Array<SchedulerJobView>;
-  scheduler_enabled: boolean;
-  scheduler_running: boolean;
+  schedulerEnabled: boolean;
+  schedulerRunning: boolean;
 };
 
 /**
  * SettingFieldView
  */
 export type SettingFieldView = {
-  computed_source?: string | null;
-  computed_value?: unknown;
+  computedSource?: string | null;
+  computedValue?: unknown;
   default: unknown;
   description: string | null;
-  env_var: string | null;
-  is_secret: boolean;
+  envVar: string | null;
+  isSecret: boolean;
   key: string;
   value: unknown;
 };
@@ -776,11 +776,11 @@ export type SettingsSectionView = {
  * SummaryResponse
  */
 export type SummaryResponse = {
-  current_period: PeriodSummary;
-  end_date: string;
-  percent_changes?: PercentChange | null;
-  previous_period?: PeriodSummary | null;
-  start_date: string;
+  currentPeriod: PeriodSummary;
+  endDate: string;
+  percentChanges?: PercentChange | null;
+  previousPeriod?: PeriodSummary | null;
+  startDate: string;
 };
 
 /**
@@ -794,19 +794,19 @@ export type SystemSettingsResponse = {
  * TimeSeriesDataPoint
  */
 export type TimeSeriesDataPoint = {
-  avg_request_time: number;
-  error_rate: number;
-  p50_request_time: number;
-  p95_request_time: number;
-  p99_request_time: number;
-  status_2xx: number;
-  status_3xx: number;
-  status_4xx: number;
-  status_5xx: number;
+  avgRequestTime: number;
+  errorRate: number;
+  p50RequestTime: number;
+  p95RequestTime: number;
+  p99RequestTime: number;
+  status2xx: number;
+  status3xx: number;
+  status4xx: number;
+  status5xx: number;
   timestamp: string;
-  total_bytes_sent: number;
-  total_geo_events: number;
-  total_requests: number;
+  totalBytesSent: number;
+  totalGeoEvents: number;
+  totalRequests: number;
 };
 
 /**
@@ -814,18 +814,18 @@ export type TimeSeriesDataPoint = {
  */
 export type TimeSeriesResponse = {
   data: Array<TimeSeriesDataPoint>;
-  end_date: string;
+  endDate: string;
   granularity: string;
-  start_date: string;
+  startDate: string;
 };
 
 /**
  * TopCitiesResponse
  */
 export type TopCitiesResponse = {
-  end_date: string;
+  endDate: string;
   items: Array<TopCityStatsDto>;
-  start_date: string;
+  startDate: string;
 };
 
 /**
@@ -833,44 +833,44 @@ export type TopCitiesResponse = {
  */
 export type TopCityStatsDto = {
   city: string;
-  country_code: string | null;
+  countryCode: string | null;
   hits: number;
-  unique_ips: number;
+  uniqueIps: number;
 };
 
 /**
  * TopCountriesResponse
  */
 export type TopCountriesResponse = {
-  top_countries?: Array<TopCountryDto>;
+  topCountries?: Array<TopCountryDto>;
 };
 
 /**
  * TopCountriesStatsResponse
  */
 export type TopCountriesStatsResponse = {
-  end_date: string;
+  endDate: string;
   items: Array<TopCountryStatsDto>;
-  start_date: string;
+  startDate: string;
 };
 
 /**
  * TopCountryDTO
  */
 export type TopCountryDto = {
-  country_code: string;
-  country_name: string | null;
-  event_count: number;
+  countryCode: string;
+  countryName: string | null;
+  eventCount: number;
 };
 
 /**
  * TopCountryStatsDTO
  */
 export type TopCountryStatsDto = {
-  country_code: string;
-  country_name: string | null;
+  countryCode: string;
+  countryName: string | null;
   hits: number;
-  unique_ips: number;
+  uniqueIps: number;
 };
 
 /**
@@ -928,8 +928,8 @@ export type TopGeoIpsResponse = {
  * TopIPDTO
  */
 export type TopIpdto = {
-  event_count: number;
-  ip_address: string;
+  eventCount: number;
+  ipAddress: string;
   location?: EmbeddedLocationDto | null;
 };
 
@@ -938,30 +938,30 @@ export type TopIpdto = {
  */
 export type TopIpDto = {
   city: string | null;
-  country_code: string | null;
-  error_hits: number;
+  countryCode: string | null;
+  errorHits: number;
   hits: number;
-  ip_address: string;
-  total_bytes: number;
+  ipAddress: string;
+  totalBytes: number;
 };
 
 /**
  * TopIpsResponse
  */
 export type TopIpsResponse = {
-  end_date: string;
+  endDate: string;
   items: Array<TopIpDto>;
-  start_date: string;
+  startDate: string;
 };
 
 /**
  * TopUrlDTO
  */
 export type TopUrlDto = {
-  avg_request_time: number;
-  error_hits: number;
+  avgRequestTime: number;
+  errorHits: number;
   hits: number;
-  total_bytes: number;
+  totalBytes: number;
   url: string;
 };
 
@@ -969,9 +969,9 @@ export type TopUrlDto = {
  * TopUrlsResponse
  */
 export type TopUrlsResponse = {
-  end_date: string;
+  endDate: string;
   items: Array<TopUrlDto>;
-  start_date: string;
+  startDate: string;
 };
 
 /**
@@ -979,16 +979,16 @@ export type TopUrlsResponse = {
  */
 export type TopUserAgentDto = {
   hits: number;
-  user_agent: string;
+  userAgent: string;
 };
 
 /**
  * TopUserAgentsResponse
  */
 export type TopUserAgentsResponse = {
-  end_date: string;
+  endDate: string;
   items: Array<TopUserAgentDto>;
-  start_date: string;
+  startDate: string;
 };
 
 /**
@@ -1019,8 +1019,8 @@ export type ApiV1AccessLogDebugListAccessLogDebugData = {
     searchIgnoreCase?: boolean | null;
     currentPage?: number;
     pageSize?: number;
-    from_timestamp?: string | null;
-    to_timestamp?: string | null;
+    fromTimestamp?: string | null;
+    toTimestamp?: string | null;
     ipAddressIn?: Array<string> | null;
     countryCodeIn?: Array<string> | null;
     cityIn?: Array<string> | null;
@@ -1078,8 +1078,8 @@ export type ApiV1AccessLogDebugStatsGetAccessLogDebugStatsData = {
   body?: never;
   path?: never;
   query?: {
-    from_timestamp?: string | null;
-    to_timestamp?: string | null;
+    fromTimestamp?: string | null;
+    toTimestamp?: string | null;
   };
   url: "/api/v1/access-log-debug/stats";
 };
@@ -1135,8 +1135,8 @@ export type ApiV1AccessLogsListAccessLogsData = {
      * Field to search
      */
     sortOrder?: "asc" | "desc" | null;
-    from_timestamp?: string | null;
-    to_timestamp?: string | null;
+    fromTimestamp?: string | null;
+    toTimestamp?: string | null;
     methodIn?: Array<string> | null;
     ipAddressIn?: Array<string> | null;
     cityIn?: Array<string> | null;
@@ -1216,11 +1216,11 @@ export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    start_date: string;
+    startDate: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    end_date: string;
+    endDate: string;
     /**
      * Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available.
      */
@@ -1265,15 +1265,15 @@ export type ApiV1AnalyticsLiveSummaryGetLiveSummaryData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    start_date: string;
+    startDate: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    end_date: string;
+    endDate: string;
     /**
      * Include comparison with previous period of same length
      */
-    compare_previous?: boolean;
+    comparePrevious?: boolean;
   };
   url: "/api/v1/analytics/live-summary";
 };
@@ -1314,15 +1314,15 @@ export type ApiV1AnalyticsSummaryGetSummaryData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    start_date: string;
+    startDate: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    end_date: string;
+    endDate: string;
     /**
      * Include comparison with previous period of same length
      */
-    compare_previous?: boolean;
+    comparePrevious?: boolean;
   };
   url: "/api/v1/analytics/summary";
 };
@@ -1363,11 +1363,11 @@ export type ApiV1AnalyticsTimeSeriesGetTimeSeriesData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    start_date: string;
+    startDate: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    end_date: string;
+    endDate: string;
     /**
      * Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available.
      */
@@ -1375,7 +1375,7 @@ export type ApiV1AnalyticsTimeSeriesGetTimeSeriesData = {
     /**
      * Filter to these ISO country codes (repeatable)
      */
-    country_code?: Array<string> | null;
+    countryCode?: Array<string> | null;
     /**
      * Filter to these city names (repeatable)
      */
@@ -1383,11 +1383,11 @@ export type ApiV1AnalyticsTimeSeriesGetTimeSeriesData = {
     /**
      * Filter to these client IPs (repeatable)
      */
-    ip_address?: Array<string> | null;
+    ipAddress?: Array<string> | null;
     /**
      * Exclude these client IPs (repeatable)
      */
-    ip_address_not_in?: Array<string> | null;
+    ipAddressNotIn?: Array<string> | null;
   };
   url: "/api/v1/analytics/time-series";
 };
@@ -1428,11 +1428,11 @@ export type ApiV1AnalyticsTimeSeriesCumulativeGetCumulativeTimeSeriesData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    start_date: string;
+    startDate: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    end_date: string;
+    endDate: string;
   };
   url: "/api/v1/analytics/time-series/cumulative";
 };
@@ -1474,11 +1474,11 @@ export type ApiV1AnalyticsTopCitiesGetTopCitiesData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    start_date: string;
+    startDate: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    end_date: string;
+    endDate: string;
     /**
      * Maximum number of cities
      */
@@ -1486,7 +1486,7 @@ export type ApiV1AnalyticsTopCitiesGetTopCitiesData = {
     /**
      * Filter to these ISO country codes (repeatable)
      */
-    country_code?: Array<string> | null;
+    countryCode?: Array<string> | null;
     /**
      * Filter to these city names (repeatable)
      */
@@ -1494,11 +1494,11 @@ export type ApiV1AnalyticsTopCitiesGetTopCitiesData = {
     /**
      * Filter to these client IPs (repeatable)
      */
-    ip_address?: Array<string> | null;
+    ipAddress?: Array<string> | null;
     /**
      * Exclude these client IPs (repeatable)
      */
-    ip_address_not_in?: Array<string> | null;
+    ipAddressNotIn?: Array<string> | null;
   };
   url: "/api/v1/analytics/top-cities";
 };
@@ -1539,11 +1539,11 @@ export type ApiV1AnalyticsTopCountriesGetTopCountriesData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    start_date: string;
+    startDate: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    end_date: string;
+    endDate: string;
     /**
      * Maximum number of countries
      */
@@ -1551,7 +1551,7 @@ export type ApiV1AnalyticsTopCountriesGetTopCountriesData = {
     /**
      * Filter to these ISO country codes (repeatable)
      */
-    country_code?: Array<string> | null;
+    countryCode?: Array<string> | null;
     /**
      * Filter to these city names (repeatable)
      */
@@ -1559,11 +1559,11 @@ export type ApiV1AnalyticsTopCountriesGetTopCountriesData = {
     /**
      * Filter to these client IPs (repeatable)
      */
-    ip_address?: Array<string> | null;
+    ipAddress?: Array<string> | null;
     /**
      * Exclude these client IPs (repeatable)
      */
-    ip_address_not_in?: Array<string> | null;
+    ipAddressNotIn?: Array<string> | null;
   };
   url: "/api/v1/analytics/top-countries";
 };
@@ -1604,11 +1604,11 @@ export type ApiV1AnalyticsTopIpsGetTopIpsData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    start_date: string;
+    startDate: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    end_date: string;
+    endDate: string;
     /**
      * Maximum number of IPs
      */
@@ -1616,7 +1616,7 @@ export type ApiV1AnalyticsTopIpsGetTopIpsData = {
     /**
      * Filter to these ISO country codes (repeatable)
      */
-    country_code?: Array<string> | null;
+    countryCode?: Array<string> | null;
     /**
      * Filter to these city names (repeatable)
      */
@@ -1624,11 +1624,11 @@ export type ApiV1AnalyticsTopIpsGetTopIpsData = {
     /**
      * Filter to these client IPs (repeatable)
      */
-    ip_address?: Array<string> | null;
+    ipAddress?: Array<string> | null;
     /**
      * Exclude these client IPs (repeatable)
      */
-    ip_address_not_in?: Array<string> | null;
+    ipAddressNotIn?: Array<string> | null;
   };
   url: "/api/v1/analytics/top-ips";
 };
@@ -1669,11 +1669,11 @@ export type ApiV1AnalyticsTopUrlsGetTopUrlsData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    start_date: string;
+    startDate: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    end_date: string;
+    endDate: string;
     /**
      * Maximum number of URLs to return
      */
@@ -1681,7 +1681,7 @@ export type ApiV1AnalyticsTopUrlsGetTopUrlsData = {
     /**
      * Filter to these ISO country codes (repeatable)
      */
-    country_code?: Array<string> | null;
+    countryCode?: Array<string> | null;
     /**
      * Filter to these city names (repeatable)
      */
@@ -1689,11 +1689,11 @@ export type ApiV1AnalyticsTopUrlsGetTopUrlsData = {
     /**
      * Filter to these client IPs (repeatable)
      */
-    ip_address?: Array<string> | null;
+    ipAddress?: Array<string> | null;
     /**
      * Exclude these client IPs (repeatable)
      */
-    ip_address_not_in?: Array<string> | null;
+    ipAddressNotIn?: Array<string> | null;
   };
   url: "/api/v1/analytics/top-urls";
 };
@@ -1734,11 +1734,11 @@ export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    start_date: string;
+    startDate: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    end_date: string;
+    endDate: string;
     /**
      * Maximum number of user agents to return
      */
@@ -1746,7 +1746,7 @@ export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsData = {
     /**
      * Filter to these ISO country codes (repeatable)
      */
-    country_code?: Array<string> | null;
+    countryCode?: Array<string> | null;
     /**
      * Filter to these city names (repeatable)
      */
@@ -1754,11 +1754,11 @@ export type ApiV1AnalyticsTopUserAgentsGetTopUserAgentsData = {
     /**
      * Filter to these client IPs (repeatable)
      */
-    ip_address?: Array<string> | null;
+    ipAddress?: Array<string> | null;
     /**
      * Exclude these client IPs (repeatable)
      */
-    ip_address_not_in?: Array<string> | null;
+    ipAddressNotIn?: Array<string> | null;
   };
   url: "/api/v1/analytics/top-user-agents";
 };
@@ -1963,8 +1963,8 @@ export type ApiV1CrowdsecBannedLocationsListBannedLocationsData = {
   body?: never;
   path?: never;
   query?: {
-    from_timestamp?: string | null;
-    to_timestamp?: string | null;
+    fromTimestamp?: string | null;
+    toTimestamp?: string | null;
   };
   url: "/api/v1/crowdsec/banned-locations";
 };
@@ -2177,8 +2177,8 @@ export type ApiV1GeoEventsListGeoEventsData = {
      * Field to search
      */
     sortOrder?: "asc" | "desc" | null;
-    from_timestamp?: string | null;
-    to_timestamp?: string | null;
+    fromTimestamp?: string | null;
+    toTimestamp?: string | null;
     /**
      * Filter to these IPs (repeatable)
      */
@@ -2276,11 +2276,11 @@ export type ApiV1GeoEventsLogsGetGeoLogsData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    from_timestamp: string;
+    fromTimestamp: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    to_timestamp: string;
+    toTimestamp: string;
     currentPage?: number;
     pageSize?: number;
     /**
@@ -2359,15 +2359,15 @@ export type ApiV1GeoEventsSummaryGetGeoLogSummaryData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    from_timestamp: string;
+    fromTimestamp: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    to_timestamp: string;
+    toTimestamp: string;
     /**
      * Include comparison with previous period of same length
      */
-    compare_previous?: boolean;
+    comparePrevious?: boolean;
   };
   url: "/api/v1/geo-events/summary";
 };
@@ -2422,11 +2422,11 @@ export type ApiV1GeoEventsTimeSeriesGetGeoLogTimeSeriesData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    from_timestamp: string;
+    fromTimestamp: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    to_timestamp: string;
+    toTimestamp: string;
     /**
      * Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available.
      */
@@ -2485,11 +2485,11 @@ export type ApiV1GeoEventsTopCitiesGetGeoLogTopCitiesData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    from_timestamp: string;
+    fromTimestamp: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    to_timestamp: string;
+    toTimestamp: string;
     /**
      * Maximum number of cities
      */
@@ -2548,11 +2548,11 @@ export type ApiV1GeoEventsTopCountriesGetGeoLogTopCountriesData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    from_timestamp: string;
+    fromTimestamp: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    to_timestamp: string;
+    toTimestamp: string;
     /**
      * Maximum number of countries
      */
@@ -2611,11 +2611,11 @@ export type ApiV1GeoEventsTopIpsGetGeoLogTopIpsData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    from_timestamp: string;
+    fromTimestamp: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    to_timestamp: string;
+    toTimestamp: string;
     /**
      * Maximum number of IPs
      */
@@ -2713,15 +2713,15 @@ export type ApiV1GeoLocationsGeojsonGetGeojsonData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    from_timestamp: string;
+    fromTimestamp: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    to_timestamp: string;
+    toTimestamp: string;
     /**
      * Filter to these ISO country codes (repeatable)
      */
-    country_code?: Array<string> | null;
+    countryCode?: Array<string> | null;
     /**
      * Filter to these city names (repeatable)
      */
@@ -2778,11 +2778,11 @@ export type ApiV1GeoLocationsTopCountriesGetTopCountriesData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    from_timestamp: string;
+    fromTimestamp: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    to_timestamp: string;
+    toTimestamp: string;
     /**
      * Maximum number of countries to return
      */
@@ -2827,11 +2827,11 @@ export type ApiV1GeoLocationsTopIpsGetGlobalTopIpsData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    from_timestamp: string;
+    fromTimestamp: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    to_timestamp: string;
+    toTimestamp: string;
     /**
      * Maximum number of IPs to return
      */
@@ -2878,11 +2878,11 @@ export type ApiV1GeoLocationsLocationIdTopIpsGetLocationTopIpsData = {
     /**
      * Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)
      */
-    from_timestamp: string;
+    fromTimestamp: string;
     /**
      * End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)
      */
-    to_timestamp: string;
+    toTimestamp: string;
     /**
      * Maximum number of IPs to return
      */

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -9,7 +9,7 @@
           "environment": {
             "type": "string"
           },
-          "image_tag": {
+          "imageTag": {
             "oneOf": [
               {
                 "type": "string"
@@ -22,7 +22,7 @@
           "name": {
             "type": "string"
           },
-          "started_at": {
+          "startedAt": {
             "oneOf": [
               {
                 "format": "date-time",
@@ -40,9 +40,9 @@
         "required": [
           "container",
           "environment",
-          "image_tag",
+          "imageTag",
           "name",
-          "started_at",
+          "startedAt",
           "version"
         ],
         "title": "AboutAppView",
@@ -295,7 +295,7 @@
       },
       "AlertView": {
         "properties": {
-          "as_name": {
+          "asName": {
             "oneOf": [
               {
                 "type": "string"
@@ -315,13 +315,13 @@
               }
             ]
           },
-          "created_at": {
+          "createdAt": {
             "type": "string"
           },
-          "decision_count": {
+          "decisionCount": {
             "type": "integer"
           },
-          "events_count": {
+          "eventsCount": {
             "type": "integer"
           },
           "id": {
@@ -334,7 +334,7 @@
               }
             ]
           },
-          "machine_id": {
+          "machineId": {
             "oneOf": [
               {
                 "type": "string"
@@ -358,13 +358,13 @@
           }
         },
         "required": [
-          "as_name",
+          "asName",
           "country",
-          "created_at",
-          "decision_count",
-          "events_count",
+          "createdAt",
+          "decisionCount",
+          "eventsCount",
           "id",
-          "machine_id",
+          "machineId",
           "message",
           "scenario",
           "scope",
@@ -375,24 +375,24 @@
       },
       "AnalyticsSettingsView": {
         "properties": {
-          "compression_after_days": {
+          "compressionAfterDays": {
             "type": "integer"
           },
-          "debug_retention_days": {
+          "debugRetentionDays": {
             "type": "integer"
           },
-          "hourly_retention_days": {
+          "hourlyRetentionDays": {
             "type": "integer"
           },
-          "raw_retention_days": {
+          "rawRetentionDays": {
             "type": "integer"
           }
         },
         "required": [
-          "compression_after_days",
-          "debug_retention_days",
-          "hourly_retention_days",
-          "raw_retention_days"
+          "compressionAfterDays",
+          "debugRetentionDays",
+          "hourlyRetentionDays",
+          "rawRetentionDays"
         ],
         "title": "AnalyticsSettingsView",
         "type": "object"
@@ -444,7 +444,7 @@
           "enabled": {
             "type": "boolean"
           },
-          "lapi_reachable": {
+          "lapiReachable": {
             "oneOf": [
               {
                 "type": "boolean"
@@ -457,20 +457,20 @@
         },
         "required": [
           "enabled",
-          "lapi_reachable"
+          "lapiReachable"
         ],
         "title": "CrowdSecHealth",
         "type": "object"
       },
       "CrowdSecStatsResponse": {
         "properties": {
-          "by_origin": {
+          "byOrigin": {
             "items": {
               "$ref": "#/components/schemas/OriginCount"
             },
             "type": "array"
           },
-          "top_scenarios": {
+          "topScenarios": {
             "items": {
               "$ref": "#/components/schemas/ScenarioCount"
             },
@@ -481,8 +481,8 @@
           }
         },
         "required": [
-          "by_origin",
-          "top_scenarios",
+          "byOrigin",
+          "topScenarios",
           "total"
         ],
         "title": "CrowdSecStatsResponse",
@@ -493,30 +493,30 @@
           "enabled": {
             "type": "boolean"
           },
-          "lapi_reachable": {
+          "lapiReachable": {
             "type": "boolean"
           },
-          "write_enabled": {
+          "writeEnabled": {
             "type": "boolean"
           }
         },
         "required": [
           "enabled",
-          "lapi_reachable",
-          "write_enabled"
+          "lapiReachable",
+          "writeEnabled"
         ],
         "title": "CrowdSecStatusResponse",
         "type": "object"
       },
       "CumulativeDataPoint": {
         "properties": {
-          "cumulative_access_logs": {
+          "cumulativeAccessLogs": {
             "type": "integer"
           },
-          "cumulative_bytes": {
+          "cumulativeBytes": {
             "type": "integer"
           },
-          "cumulative_geo_events": {
+          "cumulativeGeoEvents": {
             "type": "integer"
           },
           "timestamp": {
@@ -524,9 +524,9 @@
           }
         },
         "required": [
-          "cumulative_access_logs",
-          "cumulative_bytes",
-          "cumulative_geo_events",
+          "cumulativeAccessLogs",
+          "cumulativeBytes",
+          "cumulativeGeoEvents",
           "timestamp"
         ],
         "title": "CumulativeDataPoint",
@@ -540,20 +540,20 @@
             },
             "type": "array"
           },
-          "end_date": {
+          "endDate": {
             "type": "string"
           },
           "granularity": {
             "type": "string"
           },
-          "start_date": {
+          "startDate": {
             "type": "string"
           }
         },
         "required": [
-          "end_date",
+          "endDate",
           "granularity",
-          "start_date"
+          "startDate"
         ],
         "title": "CumulativeTimeSeriesResponse",
         "type": "object"
@@ -572,7 +572,7 @@
       },
       "DatabaseInfoResponse": {
         "properties": {
-          "debug_retention_days": {
+          "debugRetentionDays": {
             "type": "integer"
           },
           "hypertables": {
@@ -581,7 +581,7 @@
             },
             "type": "array"
           },
-          "postgres_version": {
+          "postgresVersion": {
             "oneOf": [
               {
                 "type": "string"
@@ -594,10 +594,10 @@
           "reachable": {
             "type": "boolean"
           },
-          "retention_days": {
+          "retentionDays": {
             "type": "integer"
           },
-          "size_bytes": {
+          "sizeBytes": {
             "oneOf": [
               {
                 "type": "integer"
@@ -607,7 +607,7 @@
               }
             ]
           },
-          "timescaledb_version": {
+          "timescaledbVersion": {
             "oneOf": [
               {
                 "type": "string"
@@ -619,20 +619,20 @@
           }
         },
         "required": [
-          "debug_retention_days",
+          "debugRetentionDays",
           "hypertables",
-          "postgres_version",
+          "postgresVersion",
           "reachable",
-          "retention_days",
-          "size_bytes",
-          "timescaledb_version"
+          "retentionDays",
+          "sizeBytes",
+          "timescaledbVersion"
         ],
         "title": "DatabaseInfoResponse",
         "type": "object"
       },
       "DatabaseVersionsView": {
         "properties": {
-          "postgis_version": {
+          "postgisVersion": {
             "oneOf": [
               {
                 "type": "string"
@@ -642,7 +642,7 @@
               }
             ]
           },
-          "postgres_version": {
+          "postgresVersion": {
             "oneOf": [
               {
                 "type": "string"
@@ -652,7 +652,7 @@
               }
             ]
           },
-          "timescaledb_version": {
+          "timescaledbVersion": {
             "oneOf": [
               {
                 "type": "string"
@@ -664,9 +664,9 @@
           }
         },
         "required": [
-          "postgis_version",
-          "postgres_version",
-          "timescaledb_version"
+          "postgisVersion",
+          "postgresVersion",
+          "timescaledbVersion"
         ],
         "title": "DatabaseVersionsView",
         "type": "object"
@@ -683,7 +683,7 @@
               }
             ]
           },
-          "country_code": {
+          "countryCode": {
             "oneOf": [
               {
                 "type": "string"
@@ -693,7 +693,7 @@
               }
             ]
           },
-          "country_name": {
+          "countryName": {
             "oneOf": [
               {
                 "type": "string"
@@ -722,7 +722,7 @@
           "origin": {
             "type": "string"
           },
-          "request_count_24h": {
+          "requestCount24h": {
             "oneOf": [
               {
                 "type": "integer"
@@ -744,13 +744,13 @@
         },
         "required": [
           "city",
-          "country_code",
-          "country_name",
+          "countryCode",
+          "countryName",
           "duration",
           "id",
           "ip",
           "origin",
-          "request_count_24h",
+          "requestCount24h",
           "scenario",
           "scope",
           "type"
@@ -770,7 +770,7 @@
               }
             ]
           },
-          "country_code": {
+          "countryCode": {
             "oneOf": [
               {
                 "type": "string"
@@ -780,7 +780,7 @@
               }
             ]
           },
-          "country_name": {
+          "countryName": {
             "oneOf": [
               {
                 "type": "string"
@@ -858,25 +858,25 @@
           "timestamp": {
             "type": "string"
           },
-          "total_geo_events": {
+          "totalGeoEvents": {
             "type": "integer"
           },
-          "unique_cities": {
+          "uniqueCities": {
             "type": "integer"
           },
-          "unique_countries": {
+          "uniqueCountries": {
             "type": "integer"
           },
-          "unique_ips": {
+          "uniqueIps": {
             "type": "integer"
           }
         },
         "required": [
           "timestamp",
-          "total_geo_events",
-          "unique_cities",
-          "unique_countries",
-          "unique_ips"
+          "totalGeoEvents",
+          "uniqueCities",
+          "uniqueCountries",
+          "uniqueIps"
         ],
         "title": "GeoEventsDataPoint",
         "type": "object"
@@ -889,21 +889,21 @@
             },
             "type": "array"
           },
-          "end_date": {
+          "endDate": {
             "type": "string"
           },
           "granularity": {
             "type": "string"
           },
-          "start_date": {
+          "startDate": {
             "type": "string"
           }
         },
         "required": [
           "data",
-          "end_date",
+          "endDate",
           "granularity",
-          "start_date"
+          "startDate"
         ],
         "title": "GeoEventsTimeSeriesResponse",
         "type": "object"
@@ -913,7 +913,7 @@
           "available": {
             "type": "boolean"
           },
-          "db_build_date": {
+          "dbBuildDate": {
             "oneOf": [
               {
                 "type": "string"
@@ -926,14 +926,14 @@
         },
         "required": [
           "available",
-          "db_build_date"
+          "dbBuildDate"
         ],
         "title": "GeoIPHealth",
         "type": "object"
       },
       "GeoIPInfoView": {
         "properties": {
-          "age_days": {
+          "ageDays": {
             "oneOf": [
               {
                 "type": "integer"
@@ -946,7 +946,7 @@
           "available": {
             "type": "boolean"
           },
-          "build_date": {
+          "buildDate": {
             "oneOf": [
               {
                 "format": "date-time",
@@ -957,15 +957,15 @@
               }
             ]
           },
-          "db_path": {
+          "dbPath": {
             "type": "string"
           }
         },
         "required": [
-          "age_days",
+          "ageDays",
           "available",
-          "build_date",
-          "db_path"
+          "buildDate",
+          "dbPath"
         ],
         "title": "GeoIPInfoView",
         "type": "object"
@@ -1025,13 +1025,13 @@
               }
             ]
           },
-          "country_code": {
+          "countryCode": {
             "type": "string"
           },
-          "country_name": {
+          "countryName": {
             "type": "string"
           },
-          "event_count": {
+          "eventCount": {
             "type": "integer"
           },
           "geohash": {
@@ -1040,7 +1040,7 @@
           "id": {
             "type": "integer"
           },
-          "last_hit": {
+          "lastHit": {
             "oneOf": [
               {
                 "format": "date-time",
@@ -1051,7 +1051,7 @@
               }
             ]
           },
-          "postal_code": {
+          "postalCode": {
             "oneOf": [
               {
                 "type": "string"
@@ -1071,7 +1071,7 @@
               }
             ]
           },
-          "state_code": {
+          "stateCode": {
             "oneOf": [
               {
                 "type": "string"
@@ -1091,7 +1091,7 @@
               }
             ]
           },
-          "top_ips": {
+          "topIps": {
             "items": {
               "$ref": "#/components/schemas/TopIPDTO"
             },
@@ -1100,15 +1100,15 @@
         },
         "required": [
           "city",
-          "country_code",
-          "country_name",
-          "event_count",
+          "countryCode",
+          "countryName",
+          "eventCount",
           "geohash",
           "id",
-          "last_hit",
-          "postal_code",
+          "lastHit",
+          "postalCode",
           "state",
-          "state_code",
+          "stateCode",
           "timezone"
         ],
         "title": "GeoJSONFeatureProperties",
@@ -1429,7 +1429,7 @@
       },
       "GlobalTopIPsResponse": {
         "properties": {
-          "top_ips": {
+          "topIps": {
             "items": {
               "$ref": "#/components/schemas/TopIPDTO"
             },
@@ -1454,7 +1454,7 @@
           "ingestion": {
             "$ref": "#/components/schemas/IngestionHealth"
           },
-          "started_at": {
+          "startedAt": {
             "oneOf": [
               {
                 "type": "string"
@@ -1480,7 +1480,7 @@
           "database",
           "geoip",
           "ingestion",
-          "started_at",
+          "startedAt",
           "status",
           "timestamp"
         ],
@@ -1489,7 +1489,7 @@
       },
       "HypertableStatsView": {
         "properties": {
-          "after_compression_bytes": {
+          "afterCompressionBytes": {
             "oneOf": [
               {
                 "type": "integer"
@@ -1499,7 +1499,7 @@
               }
             ]
           },
-          "approx_rows": {
+          "approxRows": {
             "oneOf": [
               {
                 "type": "integer"
@@ -1509,7 +1509,7 @@
               }
             ]
           },
-          "before_compression_bytes": {
+          "beforeCompressionBytes": {
             "oneOf": [
               {
                 "type": "integer"
@@ -1522,7 +1522,7 @@
           "name": {
             "type": "string"
           },
-          "total_bytes": {
+          "totalBytes": {
             "oneOf": [
               {
                 "type": "integer"
@@ -1534,18 +1534,18 @@
           }
         },
         "required": [
-          "after_compression_bytes",
-          "approx_rows",
-          "before_compression_bytes",
+          "afterCompressionBytes",
+          "approxRows",
+          "beforeCompressionBytes",
           "name",
-          "total_bytes"
+          "totalBytes"
         ],
         "title": "HypertableStatsView",
         "type": "object"
       },
       "IngestionHealth": {
         "properties": {
-          "last_record_at": {
+          "lastRecordAt": {
             "oneOf": [
               {
                 "type": "string"
@@ -1555,16 +1555,16 @@
               }
             ]
           },
-          "missing_files": {
+          "missingFiles": {
             "items": {
               "type": "string"
             },
             "type": "array"
           },
-          "parsed_lines": {
+          "parsedLines": {
             "type": "integer"
           },
-          "pending_records": {
+          "pendingRecords": {
             "type": "integer"
           },
           "running": {
@@ -1572,10 +1572,10 @@
           }
         },
         "required": [
-          "last_record_at",
-          "missing_files",
-          "parsed_lines",
-          "pending_records",
+          "lastRecordAt",
+          "missingFiles",
+          "parsedLines",
+          "pendingRecords",
           "running"
         ],
         "title": "IngestionHealth",
@@ -1583,32 +1583,32 @@
       },
       "IngestionStatsResponse": {
         "properties": {
-          "is_running": {
+          "isRunning": {
             "type": "boolean"
           },
-          "total_ignored_lines": {
+          "totalIgnoredLines": {
             "type": "integer"
           },
-          "total_parsed_lines": {
+          "totalParsedLines": {
             "type": "integer"
           },
-          "total_pending_records": {
+          "totalPendingRecords": {
             "type": "integer"
           },
-          "total_processed": {
+          "totalProcessed": {
             "type": "integer"
           },
-          "total_skipped_lines": {
+          "totalSkippedLines": {
             "type": "integer"
           }
         },
         "required": [
-          "is_running",
-          "total_ignored_lines",
-          "total_parsed_lines",
-          "total_pending_records",
-          "total_processed",
-          "total_skipped_lines"
+          "isRunning",
+          "totalIgnoredLines",
+          "totalParsedLines",
+          "totalPendingRecords",
+          "totalProcessed",
+          "totalSkippedLines"
         ],
         "title": "IngestionStatsResponse",
         "type": "object"
@@ -1625,7 +1625,7 @@
               }
             ]
           },
-          "country_code": {
+          "countryCode": {
             "oneOf": [
               {
                 "type": "string"
@@ -1647,7 +1647,7 @@
         },
         "required": [
           "city",
-          "country_code",
+          "countryCode",
           "ip",
           "latitude",
           "longitude"
@@ -2035,10 +2035,10 @@
       },
       "LocationTopIPsResponse": {
         "properties": {
-          "location_id": {
+          "locationId": {
             "type": "integer"
           },
-          "top_ips": {
+          "topIps": {
             "items": {
               "$ref": "#/components/schemas/TopIPDTO"
             },
@@ -2046,7 +2046,7 @@
           }
         },
         "required": [
-          "location_id"
+          "locationId"
         ],
         "title": "LocationTopIPsResponse",
         "type": "object"
@@ -2064,7 +2064,7 @@
             ],
             "type": "string"
           },
-          "modified_at": {
+          "modifiedAt": {
             "oneOf": [
               {
                 "format": "date-time",
@@ -2078,16 +2078,16 @@
           "name": {
             "type": "string"
           },
-          "size_bytes": {
+          "sizeBytes": {
             "type": "integer"
           }
         },
         "required": [
           "available",
           "kind",
-          "modified_at",
+          "modifiedAt",
           "name",
-          "size_bytes"
+          "sizeBytes"
         ],
         "title": "LogFileView",
         "type": "object"
@@ -2183,30 +2183,30 @@
       },
       "LogparserSettingsView": {
         "properties": {
-          "log_paths": {
+          "logPaths": {
             "items": {
               "type": "string"
             },
             "type": "array"
           },
-          "send_logs": {
+          "sendLogs": {
             "type": "boolean"
           },
-          "store_debug_lines": {
+          "storeDebugLines": {
             "type": "boolean"
           }
         },
         "required": [
-          "log_paths",
-          "send_logs",
-          "store_debug_lines"
+          "logPaths",
+          "sendLogs",
+          "storeDebugLines"
         ],
         "title": "LogparserSettingsView",
         "type": "object"
       },
       "MapSettingsView": {
         "properties": {
-          "home_latitude": {
+          "homeLatitude": {
             "oneOf": [
               {
                 "type": "number"
@@ -2216,7 +2216,7 @@
               }
             ]
           },
-          "home_longitude": {
+          "homeLongitude": {
             "oneOf": [
               {
                 "type": "number"
@@ -2226,7 +2226,7 @@
               }
             ]
           },
-          "home_source": {
+          "homeSource": {
             "enum": [
               "configured",
               "external_ip",
@@ -2239,9 +2239,9 @@
           }
         },
         "required": [
-          "home_latitude",
-          "home_longitude",
-          "home_source"
+          "homeLatitude",
+          "homeLongitude",
+          "homeSource"
         ],
         "title": "MapSettingsView",
         "type": "object"
@@ -2292,7 +2292,7 @@
       },
       "PercentChange": {
         "properties": {
-          "avg_request_time": {
+          "avgRequestTime": {
             "oneOf": [
               {
                 "type": "number"
@@ -2302,7 +2302,7 @@
               }
             ]
           },
-          "bytes_sent": {
+          "bytesSent": {
             "oneOf": [
               {
                 "type": "number"
@@ -2312,7 +2312,7 @@
               }
             ]
           },
-          "error_rate": {
+          "errorRate": {
             "oneOf": [
               {
                 "type": "number"
@@ -2322,7 +2322,7 @@
               }
             ]
           },
-          "geo_records": {
+          "geoRecords": {
             "oneOf": [
               {
                 "type": "number"
@@ -2332,7 +2332,7 @@
               }
             ]
           },
-          "log_records": {
+          "logRecords": {
             "oneOf": [
               {
                 "type": "number"
@@ -2342,7 +2342,7 @@
               }
             ]
           },
-          "malformed_rate": {
+          "malformedRate": {
             "oneOf": [
               {
                 "type": "number"
@@ -2352,7 +2352,7 @@
               }
             ]
           },
-          "unique_ips": {
+          "uniqueIps": {
             "oneOf": [
               {
                 "type": "number"
@@ -2369,64 +2369,64 @@
       },
       "PeriodSummary": {
         "properties": {
-          "avg_bytes_per_request": {
+          "avgBytesPerRequest": {
             "type": "number"
           },
-          "avg_request_time": {
+          "avgRequestTime": {
             "type": "number"
           },
-          "error_rate": {
+          "errorRate": {
             "type": "number"
           },
-          "malformed_requests": {
+          "malformedRequests": {
             "type": "integer"
           },
-          "max_request_time": {
+          "maxRequestTime": {
             "type": "number"
           },
-          "status_2xx": {
+          "status2xx": {
             "type": "integer"
           },
-          "status_3xx": {
+          "status3xx": {
             "type": "integer"
           },
-          "status_4xx": {
+          "status4xx": {
             "type": "integer"
           },
-          "status_5xx": {
+          "status5xx": {
             "type": "integer"
           },
-          "total_bytes_sent": {
+          "totalBytesSent": {
             "type": "integer"
           },
-          "total_geo_events": {
+          "totalGeoEvents": {
             "type": "integer"
           },
-          "total_requests": {
+          "totalRequests": {
             "type": "integer"
           },
-          "unique_countries": {
+          "uniqueCountries": {
             "type": "integer"
           },
-          "unique_ips": {
+          "uniqueIps": {
             "type": "integer"
           }
         },
         "required": [
-          "avg_bytes_per_request",
-          "avg_request_time",
-          "error_rate",
-          "malformed_requests",
-          "max_request_time",
-          "status_2xx",
-          "status_3xx",
-          "status_4xx",
-          "status_5xx",
-          "total_bytes_sent",
-          "total_geo_events",
-          "total_requests",
-          "unique_countries",
-          "unique_ips"
+          "avgBytesPerRequest",
+          "avgRequestTime",
+          "errorRate",
+          "malformedRequests",
+          "maxRequestTime",
+          "status2xx",
+          "status3xx",
+          "status4xx",
+          "status5xx",
+          "totalBytesSent",
+          "totalGeoEvents",
+          "totalRequests",
+          "uniqueCountries",
+          "uniqueIps"
         ],
         "title": "PeriodSummary",
         "type": "object"
@@ -2448,7 +2448,7 @@
           "container": {
             "type": "boolean"
           },
-          "image_tag": {
+          "imageTag": {
             "oneOf": [
               {
                 "type": "string"
@@ -2461,14 +2461,14 @@
         },
         "required": [
           "container",
-          "image_tag"
+          "imageTag"
         ],
         "title": "RuntimeSettingsView",
         "type": "object"
       },
       "RuntimeVersionsView": {
         "properties": {
-          "apscheduler_version": {
+          "apschedulerVersion": {
             "oneOf": [
               {
                 "type": "string"
@@ -2478,7 +2478,7 @@
               }
             ]
           },
-          "litestar_version": {
+          "litestarVersion": {
             "oneOf": [
               {
                 "type": "string"
@@ -2488,14 +2488,14 @@
               }
             ]
           },
-          "python_version": {
+          "pythonVersion": {
             "type": "string"
           }
         },
         "required": [
-          "apscheduler_version",
-          "litestar_version",
-          "python_version"
+          "apschedulerVersion",
+          "litestarVersion",
+          "pythonVersion"
         ],
         "title": "RuntimeVersionsView",
         "type": "object"
@@ -2557,7 +2557,7 @@
           "id": {
             "type": "string"
           },
-          "last_duration_seconds": {
+          "lastDurationSeconds": {
             "oneOf": [
               {
                 "type": "number"
@@ -2567,7 +2567,7 @@
               }
             ]
           },
-          "last_error": {
+          "lastError": {
             "oneOf": [
               {
                 "type": "string"
@@ -2577,7 +2577,7 @@
               }
             ]
           },
-          "last_run_time": {
+          "lastRunTime": {
             "oneOf": [
               {
                 "format": "date-time",
@@ -2588,7 +2588,7 @@
               }
             ]
           },
-          "last_status": {
+          "lastStatus": {
             "enum": [
               "success",
               "error",
@@ -2603,7 +2603,7 @@
           "name": {
             "type": "string"
           },
-          "next_run_time": {
+          "nextRunTime": {
             "oneOf": [
               {
                 "format": "date-time",
@@ -2623,12 +2623,12 @@
         },
         "required": [
           "id",
-          "last_duration_seconds",
-          "last_error",
-          "last_run_time",
-          "last_status",
+          "lastDurationSeconds",
+          "lastError",
+          "lastRunTime",
+          "lastStatus",
           "name",
-          "next_run_time",
+          "nextRunTime",
           "running",
           "trigger"
         ],
@@ -2643,24 +2643,24 @@
             },
             "type": "array"
           },
-          "scheduler_enabled": {
+          "schedulerEnabled": {
             "type": "boolean"
           },
-          "scheduler_running": {
+          "schedulerRunning": {
             "type": "boolean"
           }
         },
         "required": [
           "jobs",
-          "scheduler_enabled",
-          "scheduler_running"
+          "schedulerEnabled",
+          "schedulerRunning"
         ],
         "title": "SchedulerJobsResponse",
         "type": "object"
       },
       "SettingFieldView": {
         "properties": {
-          "computed_source": {
+          "computedSource": {
             "oneOf": [
               {
                 "type": "string"
@@ -2670,7 +2670,7 @@
               }
             ]
           },
-          "computed_value": {},
+          "computedValue": {},
           "default": {},
           "description": {
             "oneOf": [
@@ -2682,7 +2682,7 @@
               }
             ]
           },
-          "env_var": {
+          "envVar": {
             "oneOf": [
               {
                 "type": "string"
@@ -2692,7 +2692,7 @@
               }
             ]
           },
-          "is_secret": {
+          "isSecret": {
             "type": "boolean"
           },
           "key": {
@@ -2703,8 +2703,8 @@
         "required": [
           "default",
           "description",
-          "env_var",
-          "is_secret",
+          "envVar",
+          "isSecret",
           "key",
           "value"
         ],
@@ -2747,13 +2747,13 @@
       },
       "SummaryResponse": {
         "properties": {
-          "current_period": {
+          "currentPeriod": {
             "$ref": "#/components/schemas/PeriodSummary"
           },
-          "end_date": {
+          "endDate": {
             "type": "string"
           },
-          "percent_changes": {
+          "percentChanges": {
             "oneOf": [
               {
                 "$ref": "#/components/schemas/PercentChange"
@@ -2763,7 +2763,7 @@
               }
             ]
           },
-          "previous_period": {
+          "previousPeriod": {
             "oneOf": [
               {
                 "$ref": "#/components/schemas/PeriodSummary"
@@ -2773,14 +2773,14 @@
               }
             ]
           },
-          "start_date": {
+          "startDate": {
             "type": "string"
           }
         },
         "required": [
-          "current_period",
-          "end_date",
-          "start_date"
+          "currentPeriod",
+          "endDate",
+          "startDate"
         ],
         "title": "SummaryResponse",
         "type": "object"
@@ -2802,60 +2802,60 @@
       },
       "TimeSeriesDataPoint": {
         "properties": {
-          "avg_request_time": {
+          "avgRequestTime": {
             "type": "number"
           },
-          "error_rate": {
+          "errorRate": {
             "type": "number"
           },
-          "p50_request_time": {
+          "p50RequestTime": {
             "type": "number"
           },
-          "p95_request_time": {
+          "p95RequestTime": {
             "type": "number"
           },
-          "p99_request_time": {
+          "p99RequestTime": {
             "type": "number"
           },
-          "status_2xx": {
+          "status2xx": {
             "type": "integer"
           },
-          "status_3xx": {
+          "status3xx": {
             "type": "integer"
           },
-          "status_4xx": {
+          "status4xx": {
             "type": "integer"
           },
-          "status_5xx": {
+          "status5xx": {
             "type": "integer"
           },
           "timestamp": {
             "type": "string"
           },
-          "total_bytes_sent": {
+          "totalBytesSent": {
             "type": "integer"
           },
-          "total_geo_events": {
+          "totalGeoEvents": {
             "type": "integer"
           },
-          "total_requests": {
+          "totalRequests": {
             "type": "integer"
           }
         },
         "required": [
-          "avg_request_time",
-          "error_rate",
-          "p50_request_time",
-          "p95_request_time",
-          "p99_request_time",
-          "status_2xx",
-          "status_3xx",
-          "status_4xx",
-          "status_5xx",
+          "avgRequestTime",
+          "errorRate",
+          "p50RequestTime",
+          "p95RequestTime",
+          "p99RequestTime",
+          "status2xx",
+          "status3xx",
+          "status4xx",
+          "status5xx",
           "timestamp",
-          "total_bytes_sent",
-          "total_geo_events",
-          "total_requests"
+          "totalBytesSent",
+          "totalGeoEvents",
+          "totalRequests"
         ],
         "title": "TimeSeriesDataPoint",
         "type": "object"
@@ -2868,28 +2868,28 @@
             },
             "type": "array"
           },
-          "end_date": {
+          "endDate": {
             "type": "string"
           },
           "granularity": {
             "type": "string"
           },
-          "start_date": {
+          "startDate": {
             "type": "string"
           }
         },
         "required": [
           "data",
-          "end_date",
+          "endDate",
           "granularity",
-          "start_date"
+          "startDate"
         ],
         "title": "TimeSeriesResponse",
         "type": "object"
       },
       "TopCitiesResponse": {
         "properties": {
-          "end_date": {
+          "endDate": {
             "type": "string"
           },
           "items": {
@@ -2898,14 +2898,14 @@
             },
             "type": "array"
           },
-          "start_date": {
+          "startDate": {
             "type": "string"
           }
         },
         "required": [
-          "end_date",
+          "endDate",
           "items",
-          "start_date"
+          "startDate"
         ],
         "title": "TopCitiesResponse",
         "type": "object"
@@ -2915,7 +2915,7 @@
           "city": {
             "type": "string"
           },
-          "country_code": {
+          "countryCode": {
             "oneOf": [
               {
                 "type": "string"
@@ -2928,22 +2928,22 @@
           "hits": {
             "type": "integer"
           },
-          "unique_ips": {
+          "uniqueIps": {
             "type": "integer"
           }
         },
         "required": [
           "city",
-          "country_code",
+          "countryCode",
           "hits",
-          "unique_ips"
+          "uniqueIps"
         ],
         "title": "TopCityStatsDTO",
         "type": "object"
       },
       "TopCountriesResponse": {
         "properties": {
-          "top_countries": {
+          "topCountries": {
             "items": {
               "$ref": "#/components/schemas/TopCountryDTO"
             },
@@ -2956,7 +2956,7 @@
       },
       "TopCountriesStatsResponse": {
         "properties": {
-          "end_date": {
+          "endDate": {
             "type": "string"
           },
           "items": {
@@ -2965,24 +2965,24 @@
             },
             "type": "array"
           },
-          "start_date": {
+          "startDate": {
             "type": "string"
           }
         },
         "required": [
-          "end_date",
+          "endDate",
           "items",
-          "start_date"
+          "startDate"
         ],
         "title": "TopCountriesStatsResponse",
         "type": "object"
       },
       "TopCountryDTO": {
         "properties": {
-          "country_code": {
+          "countryCode": {
             "type": "string"
           },
-          "country_name": {
+          "countryName": {
             "oneOf": [
               {
                 "type": "string"
@@ -2992,24 +2992,24 @@
               }
             ]
           },
-          "event_count": {
+          "eventCount": {
             "type": "integer"
           }
         },
         "required": [
-          "country_code",
-          "country_name",
-          "event_count"
+          "countryCode",
+          "countryName",
+          "eventCount"
         ],
         "title": "TopCountryDTO",
         "type": "object"
       },
       "TopCountryStatsDTO": {
         "properties": {
-          "country_code": {
+          "countryCode": {
             "type": "string"
           },
-          "country_name": {
+          "countryName": {
             "oneOf": [
               {
                 "type": "string"
@@ -3022,15 +3022,15 @@
           "hits": {
             "type": "integer"
           },
-          "unique_ips": {
+          "uniqueIps": {
             "type": "integer"
           }
         },
         "required": [
-          "country_code",
-          "country_name",
+          "countryCode",
+          "countryName",
           "hits",
-          "unique_ips"
+          "uniqueIps"
         ],
         "title": "TopCountryStatsDTO",
         "type": "object"
@@ -3182,10 +3182,10 @@
       },
       "TopIPDTO": {
         "properties": {
-          "event_count": {
+          "eventCount": {
             "type": "integer"
           },
-          "ip_address": {
+          "ipAddress": {
             "type": "string"
           },
           "location": {
@@ -3200,8 +3200,8 @@
           }
         },
         "required": [
-          "event_count",
-          "ip_address"
+          "eventCount",
+          "ipAddress"
         ],
         "title": "TopIPDTO",
         "type": "object"
@@ -3218,7 +3218,7 @@
               }
             ]
           },
-          "country_code": {
+          "countryCode": {
             "oneOf": [
               {
                 "type": "string"
@@ -3228,33 +3228,33 @@
               }
             ]
           },
-          "error_hits": {
+          "errorHits": {
             "type": "integer"
           },
           "hits": {
             "type": "integer"
           },
-          "ip_address": {
+          "ipAddress": {
             "type": "string"
           },
-          "total_bytes": {
+          "totalBytes": {
             "type": "integer"
           }
         },
         "required": [
           "city",
-          "country_code",
-          "error_hits",
+          "countryCode",
+          "errorHits",
           "hits",
-          "ip_address",
-          "total_bytes"
+          "ipAddress",
+          "totalBytes"
         ],
         "title": "TopIpDTO",
         "type": "object"
       },
       "TopIpsResponse": {
         "properties": {
-          "end_date": {
+          "endDate": {
             "type": "string"
           },
           "items": {
@@ -3263,30 +3263,30 @@
             },
             "type": "array"
           },
-          "start_date": {
+          "startDate": {
             "type": "string"
           }
         },
         "required": [
-          "end_date",
+          "endDate",
           "items",
-          "start_date"
+          "startDate"
         ],
         "title": "TopIpsResponse",
         "type": "object"
       },
       "TopUrlDTO": {
         "properties": {
-          "avg_request_time": {
+          "avgRequestTime": {
             "type": "number"
           },
-          "error_hits": {
+          "errorHits": {
             "type": "integer"
           },
           "hits": {
             "type": "integer"
           },
-          "total_bytes": {
+          "totalBytes": {
             "type": "integer"
           },
           "url": {
@@ -3294,10 +3294,10 @@
           }
         },
         "required": [
-          "avg_request_time",
-          "error_hits",
+          "avgRequestTime",
+          "errorHits",
           "hits",
-          "total_bytes",
+          "totalBytes",
           "url"
         ],
         "title": "TopUrlDTO",
@@ -3305,7 +3305,7 @@
       },
       "TopUrlsResponse": {
         "properties": {
-          "end_date": {
+          "endDate": {
             "type": "string"
           },
           "items": {
@@ -3314,14 +3314,14 @@
             },
             "type": "array"
           },
-          "start_date": {
+          "startDate": {
             "type": "string"
           }
         },
         "required": [
-          "end_date",
+          "endDate",
           "items",
-          "start_date"
+          "startDate"
         ],
         "title": "TopUrlsResponse",
         "type": "object"
@@ -3331,20 +3331,20 @@
           "hits": {
             "type": "integer"
           },
-          "user_agent": {
+          "userAgent": {
             "type": "string"
           }
         },
         "required": [
           "hits",
-          "user_agent"
+          "userAgent"
         ],
         "title": "TopUserAgentDTO",
         "type": "object"
       },
       "TopUserAgentsResponse": {
         "properties": {
-          "end_date": {
+          "endDate": {
             "type": "string"
           },
           "items": {
@@ -3353,14 +3353,14 @@
             },
             "type": "array"
           },
-          "start_date": {
+          "startDate": {
             "type": "string"
           }
         },
         "required": [
-          "end_date",
+          "endDate",
           "items",
-          "start_date"
+          "startDate"
         ],
         "title": "TopUserAgentsResponse",
         "type": "object"
@@ -3482,7 +3482,7 @@
             "allowReserved": false,
             "deprecated": false,
             "in": "query",
-            "name": "from_timestamp",
+            "name": "fromTimestamp",
             "required": false,
             "schema": {
               "oneOf": [
@@ -3501,7 +3501,7 @@
             "allowReserved": false,
             "deprecated": false,
             "in": "query",
-            "name": "to_timestamp",
+            "name": "toTimestamp",
             "required": false,
             "schema": {
               "oneOf": [
@@ -3713,7 +3713,7 @@
             "allowReserved": false,
             "deprecated": false,
             "in": "query",
-            "name": "from_timestamp",
+            "name": "fromTimestamp",
             "required": false,
             "schema": {
               "oneOf": [
@@ -3732,7 +3732,7 @@
             "allowReserved": false,
             "deprecated": false,
             "in": "query",
-            "name": "to_timestamp",
+            "name": "toTimestamp",
             "required": false,
             "schema": {
               "oneOf": [
@@ -3922,7 +3922,7 @@
             "allowReserved": false,
             "deprecated": false,
             "in": "query",
-            "name": "from_timestamp",
+            "name": "fromTimestamp",
             "required": false,
             "schema": {
               "oneOf": [
@@ -3941,7 +3941,7 @@
             "allowReserved": false,
             "deprecated": false,
             "in": "query",
-            "name": "to_timestamp",
+            "name": "toTimestamp",
             "required": false,
             "schema": {
               "oneOf": [
@@ -4241,7 +4241,7 @@
               }
             },
             "in": "query",
-            "name": "start_date",
+            "name": "startDate",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -4263,7 +4263,7 @@
               }
             },
             "in": "query",
-            "name": "end_date",
+            "name": "endDate",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -4370,7 +4370,7 @@
               }
             },
             "in": "query",
-            "name": "start_date",
+            "name": "startDate",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -4392,7 +4392,7 @@
               }
             },
             "in": "query",
-            "name": "end_date",
+            "name": "endDate",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -4409,7 +4409,7 @@
             "deprecated": false,
             "description": "Include comparison with previous period of same length",
             "in": "query",
-            "name": "compare_previous",
+            "name": "comparePrevious",
             "required": false,
             "schema": {
               "default": false,
@@ -4492,7 +4492,7 @@
               }
             },
             "in": "query",
-            "name": "start_date",
+            "name": "startDate",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -4514,7 +4514,7 @@
               }
             },
             "in": "query",
-            "name": "end_date",
+            "name": "endDate",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -4531,7 +4531,7 @@
             "deprecated": false,
             "description": "Include comparison with previous period of same length",
             "in": "query",
-            "name": "compare_previous",
+            "name": "comparePrevious",
             "required": false,
             "schema": {
               "default": false,
@@ -4614,7 +4614,7 @@
               }
             },
             "in": "query",
-            "name": "start_date",
+            "name": "startDate",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -4636,7 +4636,7 @@
               }
             },
             "in": "query",
-            "name": "end_date",
+            "name": "endDate",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -4674,7 +4674,7 @@
             "deprecated": false,
             "description": "Filter to these ISO country codes (repeatable)",
             "in": "query",
-            "name": "country_code",
+            "name": "countryCode",
             "required": false,
             "schema": {
               "description": "Filter to these ISO country codes (repeatable)",
@@ -4720,7 +4720,7 @@
             "deprecated": false,
             "description": "Filter to these client IPs (repeatable)",
             "in": "query",
-            "name": "ip_address",
+            "name": "ipAddress",
             "required": false,
             "schema": {
               "description": "Filter to these client IPs (repeatable)",
@@ -4743,7 +4743,7 @@
             "deprecated": false,
             "description": "Exclude these client IPs (repeatable)",
             "in": "query",
-            "name": "ip_address_not_in",
+            "name": "ipAddressNotIn",
             "required": false,
             "schema": {
               "description": "Exclude these client IPs (repeatable)",
@@ -4835,7 +4835,7 @@
               }
             },
             "in": "query",
-            "name": "start_date",
+            "name": "startDate",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -4857,7 +4857,7 @@
               }
             },
             "in": "query",
-            "name": "end_date",
+            "name": "endDate",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -4943,7 +4943,7 @@
               }
             },
             "in": "query",
-            "name": "start_date",
+            "name": "startDate",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -4965,7 +4965,7 @@
               }
             },
             "in": "query",
-            "name": "end_date",
+            "name": "endDate",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -4998,7 +4998,7 @@
             "deprecated": false,
             "description": "Filter to these ISO country codes (repeatable)",
             "in": "query",
-            "name": "country_code",
+            "name": "countryCode",
             "required": false,
             "schema": {
               "description": "Filter to these ISO country codes (repeatable)",
@@ -5044,7 +5044,7 @@
             "deprecated": false,
             "description": "Filter to these client IPs (repeatable)",
             "in": "query",
-            "name": "ip_address",
+            "name": "ipAddress",
             "required": false,
             "schema": {
               "description": "Filter to these client IPs (repeatable)",
@@ -5067,7 +5067,7 @@
             "deprecated": false,
             "description": "Exclude these client IPs (repeatable)",
             "in": "query",
-            "name": "ip_address_not_in",
+            "name": "ipAddressNotIn",
             "required": false,
             "schema": {
               "description": "Exclude these client IPs (repeatable)",
@@ -5159,7 +5159,7 @@
               }
             },
             "in": "query",
-            "name": "start_date",
+            "name": "startDate",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -5181,7 +5181,7 @@
               }
             },
             "in": "query",
-            "name": "end_date",
+            "name": "endDate",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -5214,7 +5214,7 @@
             "deprecated": false,
             "description": "Filter to these ISO country codes (repeatable)",
             "in": "query",
-            "name": "country_code",
+            "name": "countryCode",
             "required": false,
             "schema": {
               "description": "Filter to these ISO country codes (repeatable)",
@@ -5260,7 +5260,7 @@
             "deprecated": false,
             "description": "Filter to these client IPs (repeatable)",
             "in": "query",
-            "name": "ip_address",
+            "name": "ipAddress",
             "required": false,
             "schema": {
               "description": "Filter to these client IPs (repeatable)",
@@ -5283,7 +5283,7 @@
             "deprecated": false,
             "description": "Exclude these client IPs (repeatable)",
             "in": "query",
-            "name": "ip_address_not_in",
+            "name": "ipAddressNotIn",
             "required": false,
             "schema": {
               "description": "Exclude these client IPs (repeatable)",
@@ -5375,7 +5375,7 @@
               }
             },
             "in": "query",
-            "name": "start_date",
+            "name": "startDate",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -5397,7 +5397,7 @@
               }
             },
             "in": "query",
-            "name": "end_date",
+            "name": "endDate",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -5430,7 +5430,7 @@
             "deprecated": false,
             "description": "Filter to these ISO country codes (repeatable)",
             "in": "query",
-            "name": "country_code",
+            "name": "countryCode",
             "required": false,
             "schema": {
               "description": "Filter to these ISO country codes (repeatable)",
@@ -5476,7 +5476,7 @@
             "deprecated": false,
             "description": "Filter to these client IPs (repeatable)",
             "in": "query",
-            "name": "ip_address",
+            "name": "ipAddress",
             "required": false,
             "schema": {
               "description": "Filter to these client IPs (repeatable)",
@@ -5499,7 +5499,7 @@
             "deprecated": false,
             "description": "Exclude these client IPs (repeatable)",
             "in": "query",
-            "name": "ip_address_not_in",
+            "name": "ipAddressNotIn",
             "required": false,
             "schema": {
               "description": "Exclude these client IPs (repeatable)",
@@ -5591,7 +5591,7 @@
               }
             },
             "in": "query",
-            "name": "start_date",
+            "name": "startDate",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -5613,7 +5613,7 @@
               }
             },
             "in": "query",
-            "name": "end_date",
+            "name": "endDate",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -5646,7 +5646,7 @@
             "deprecated": false,
             "description": "Filter to these ISO country codes (repeatable)",
             "in": "query",
-            "name": "country_code",
+            "name": "countryCode",
             "required": false,
             "schema": {
               "description": "Filter to these ISO country codes (repeatable)",
@@ -5692,7 +5692,7 @@
             "deprecated": false,
             "description": "Filter to these client IPs (repeatable)",
             "in": "query",
-            "name": "ip_address",
+            "name": "ipAddress",
             "required": false,
             "schema": {
               "description": "Filter to these client IPs (repeatable)",
@@ -5715,7 +5715,7 @@
             "deprecated": false,
             "description": "Exclude these client IPs (repeatable)",
             "in": "query",
-            "name": "ip_address_not_in",
+            "name": "ipAddressNotIn",
             "required": false,
             "schema": {
               "description": "Exclude these client IPs (repeatable)",
@@ -5807,7 +5807,7 @@
               }
             },
             "in": "query",
-            "name": "start_date",
+            "name": "startDate",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -5829,7 +5829,7 @@
               }
             },
             "in": "query",
-            "name": "end_date",
+            "name": "endDate",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -5862,7 +5862,7 @@
             "deprecated": false,
             "description": "Filter to these ISO country codes (repeatable)",
             "in": "query",
-            "name": "country_code",
+            "name": "countryCode",
             "required": false,
             "schema": {
               "description": "Filter to these ISO country codes (repeatable)",
@@ -5908,7 +5908,7 @@
             "deprecated": false,
             "description": "Filter to these client IPs (repeatable)",
             "in": "query",
-            "name": "ip_address",
+            "name": "ipAddress",
             "required": false,
             "schema": {
               "description": "Filter to these client IPs (repeatable)",
@@ -5931,7 +5931,7 @@
             "deprecated": false,
             "description": "Exclude these client IPs (repeatable)",
             "in": "query",
-            "name": "ip_address_not_in",
+            "name": "ipAddressNotIn",
             "required": false,
             "schema": {
               "description": "Exclude these client IPs (repeatable)",
@@ -6352,7 +6352,7 @@
             "allowReserved": false,
             "deprecated": false,
             "in": "query",
-            "name": "from_timestamp",
+            "name": "fromTimestamp",
             "required": false,
             "schema": {
               "oneOf": [
@@ -6371,7 +6371,7 @@
             "allowReserved": false,
             "deprecated": false,
             "in": "query",
-            "name": "to_timestamp",
+            "name": "toTimestamp",
             "required": false,
             "schema": {
               "oneOf": [
@@ -6847,7 +6847,7 @@
             "allowReserved": false,
             "deprecated": false,
             "in": "query",
-            "name": "from_timestamp",
+            "name": "fromTimestamp",
             "required": false,
             "schema": {
               "oneOf": [
@@ -6866,7 +6866,7 @@
             "allowReserved": false,
             "deprecated": false,
             "in": "query",
-            "name": "to_timestamp",
+            "name": "toTimestamp",
             "required": false,
             "schema": {
               "oneOf": [
@@ -7179,7 +7179,7 @@
               }
             },
             "in": "query",
-            "name": "from_timestamp",
+            "name": "fromTimestamp",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -7201,7 +7201,7 @@
               }
             },
             "in": "query",
-            "name": "to_timestamp",
+            "name": "toTimestamp",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -7477,7 +7477,7 @@
               }
             },
             "in": "query",
-            "name": "from_timestamp",
+            "name": "fromTimestamp",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -7499,7 +7499,7 @@
               }
             },
             "in": "query",
-            "name": "to_timestamp",
+            "name": "toTimestamp",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -7516,7 +7516,7 @@
             "deprecated": false,
             "description": "Include comparison with previous period of same length",
             "in": "query",
-            "name": "compare_previous",
+            "name": "comparePrevious",
             "required": false,
             "schema": {
               "default": false,
@@ -7710,7 +7710,7 @@
               }
             },
             "in": "query",
-            "name": "from_timestamp",
+            "name": "fromTimestamp",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -7732,7 +7732,7 @@
               }
             },
             "in": "query",
-            "name": "to_timestamp",
+            "name": "toTimestamp",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -7950,7 +7950,7 @@
               }
             },
             "in": "query",
-            "name": "from_timestamp",
+            "name": "fromTimestamp",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -7972,7 +7972,7 @@
               }
             },
             "in": "query",
-            "name": "to_timestamp",
+            "name": "toTimestamp",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -8185,7 +8185,7 @@
               }
             },
             "in": "query",
-            "name": "from_timestamp",
+            "name": "fromTimestamp",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -8207,7 +8207,7 @@
               }
             },
             "in": "query",
-            "name": "to_timestamp",
+            "name": "toTimestamp",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -8420,7 +8420,7 @@
               }
             },
             "in": "query",
-            "name": "from_timestamp",
+            "name": "fromTimestamp",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -8442,7 +8442,7 @@
               }
             },
             "in": "query",
-            "name": "to_timestamp",
+            "name": "toTimestamp",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -8653,7 +8653,7 @@
               }
             },
             "in": "query",
-            "name": "from_timestamp",
+            "name": "fromTimestamp",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -8675,7 +8675,7 @@
               }
             },
             "in": "query",
-            "name": "to_timestamp",
+            "name": "toTimestamp",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -8692,7 +8692,7 @@
             "deprecated": false,
             "description": "Filter to these ISO country codes (repeatable)",
             "in": "query",
-            "name": "country_code",
+            "name": "countryCode",
             "required": false,
             "schema": {
               "description": "Filter to these ISO country codes (repeatable)",
@@ -8876,7 +8876,7 @@
               }
             },
             "in": "query",
-            "name": "from_timestamp",
+            "name": "fromTimestamp",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -8898,7 +8898,7 @@
               }
             },
             "in": "query",
-            "name": "to_timestamp",
+            "name": "toTimestamp",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -9000,7 +9000,7 @@
               }
             },
             "in": "query",
-            "name": "from_timestamp",
+            "name": "fromTimestamp",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -9022,7 +9022,7 @@
               }
             },
             "in": "query",
-            "name": "to_timestamp",
+            "name": "toTimestamp",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",
@@ -9133,7 +9133,7 @@
               }
             },
             "in": "query",
-            "name": "from_timestamp",
+            "name": "fromTimestamp",
             "required": true,
             "schema": {
               "description": "Start datetime (ISO 8601 with timezone, e.g., 2024-01-01T00:00:00Z)",
@@ -9155,7 +9155,7 @@
               }
             },
             "in": "query",
-            "name": "to_timestamp",
+            "name": "toTimestamp",
             "required": true,
             "schema": {
               "description": "End datetime (ISO 8601 with timezone, e.g., 2024-12-31T23:59:59Z)",

--- a/resources/generated/routes.json
+++ b/resources/generated/routes.json
@@ -36,8 +36,8 @@
         "GET"
       ],
       "queryParameters": {
-        "from_timestamp": "DateTime | undefined",
-        "to_timestamp": "DateTime | undefined"
+        "fromTimestamp": "DateTime | undefined",
+        "toTimestamp": "DateTime | undefined"
       },
       "uri": "/api/v1/access-log-debug/stats"
     },
@@ -54,8 +54,8 @@
         "GET"
       ],
       "queryParameters": {
-        "end_date": "DateTime",
-        "start_date": "DateTime"
+        "endDate": "DateTime",
+        "startDate": "DateTime"
       },
       "uri": "/api/v1/analytics/time-series/cumulative"
     },
@@ -80,13 +80,13 @@
       ],
       "queryParameters": {
         "cityIn": "string[] | undefined",
-        "compare_previous": "boolean | undefined",
+        "comparePrevious": "boolean | undefined",
         "countryCodeIn": "string[] | undefined",
-        "from_timestamp": "DateTime",
+        "fromTimestamp": "DateTime",
         "hostnameIn": "string[] | undefined",
         "ipAddressIn": "string[] | undefined",
         "ipAddressNotIn": "string[] | undefined",
-        "to_timestamp": "DateTime"
+        "toTimestamp": "DateTime"
       },
       "uri": "/api/v1/geo-events/summary"
     },
@@ -98,12 +98,12 @@
       "queryParameters": {
         "cityIn": "string[] | undefined",
         "countryCodeIn": "string[] | undefined",
-        "from_timestamp": "DateTime",
+        "fromTimestamp": "DateTime",
         "granularity": "\"hourly\" | \"daily\" | undefined",
         "hostnameIn": "string[] | undefined",
         "ipAddressIn": "string[] | undefined",
         "ipAddressNotIn": "string[] | undefined",
-        "to_timestamp": "DateTime"
+        "toTimestamp": "DateTime"
       },
       "uri": "/api/v1/geo-events/time-series"
     },
@@ -115,12 +115,12 @@
       "queryParameters": {
         "cityIn": "string[] | undefined",
         "countryCodeIn": "string[] | undefined",
-        "from_timestamp": "DateTime",
+        "fromTimestamp": "DateTime",
         "hostnameIn": "string[] | undefined",
         "ipAddressIn": "string[] | undefined",
         "ipAddressNotIn": "string[] | undefined",
         "limit": "number | undefined",
-        "to_timestamp": "DateTime"
+        "toTimestamp": "DateTime"
       },
       "uri": "/api/v1/geo-events/top-cities"
     },
@@ -132,12 +132,12 @@
       "queryParameters": {
         "cityIn": "string[] | undefined",
         "countryCodeIn": "string[] | undefined",
-        "from_timestamp": "DateTime",
+        "fromTimestamp": "DateTime",
         "hostnameIn": "string[] | undefined",
         "ipAddressIn": "string[] | undefined",
         "ipAddressNotIn": "string[] | undefined",
         "limit": "number | undefined",
-        "to_timestamp": "DateTime"
+        "toTimestamp": "DateTime"
       },
       "uri": "/api/v1/geo-events/top-countries"
     },
@@ -149,12 +149,12 @@
       "queryParameters": {
         "cityIn": "string[] | undefined",
         "countryCodeIn": "string[] | undefined",
-        "from_timestamp": "DateTime",
+        "fromTimestamp": "DateTime",
         "hostnameIn": "string[] | undefined",
         "ipAddressIn": "string[] | undefined",
         "ipAddressNotIn": "string[] | undefined",
         "limit": "number | undefined",
-        "to_timestamp": "DateTime"
+        "toTimestamp": "DateTime"
       },
       "uri": "/api/v1/geo-events/top-ips"
     },
@@ -167,14 +167,14 @@
         "cityIn": "string[] | undefined",
         "countryCodeIn": "string[] | undefined",
         "currentPage": "number | undefined",
-        "from_timestamp": "DateTime",
+        "fromTimestamp": "DateTime",
         "hostnameIn": "string[] | undefined",
         "ipAddressIn": "string[] | undefined",
         "ipAddressNotIn": "string[] | undefined",
         "orderBy": "string | undefined",
         "pageSize": "number | undefined",
         "sortOrder": "\"asc\" | \"desc\" | undefined",
-        "to_timestamp": "DateTime"
+        "toTimestamp": "DateTime"
       },
       "uri": "/api/v1/geo-events/logs"
     },
@@ -184,9 +184,9 @@
         "GET"
       ],
       "queryParameters": {
-        "end_date": "DateTime",
+        "endDate": "DateTime",
         "granularity": "\"hourly\" | \"daily\" | undefined",
-        "start_date": "DateTime"
+        "startDate": "DateTime"
       },
       "uri": "/api/v1/analytics/geo-time-series"
     },
@@ -197,12 +197,12 @@
       ],
       "queryParameters": {
         "city": "string[] | undefined",
-        "country_code": "string[] | undefined",
-        "from_timestamp": "DateTime",
+        "countryCode": "string[] | undefined",
+        "fromTimestamp": "DateTime",
         "hostnameIn": "string[] | undefined",
         "ipAddressIn": "string[] | undefined",
         "ipAddressNotIn": "string[] | undefined",
-        "to_timestamp": "DateTime"
+        "toTimestamp": "DateTime"
       },
       "uri": "/api/v1/geo-locations/geojson"
     },
@@ -212,9 +212,9 @@
         "GET"
       ],
       "queryParameters": {
-        "from_timestamp": "DateTime",
+        "fromTimestamp": "DateTime",
         "limit": "number | undefined",
-        "to_timestamp": "DateTime"
+        "toTimestamp": "DateTime"
       },
       "uri": "/api/v1/geo-locations/top-ips"
     },
@@ -224,9 +224,9 @@
         "GET"
       ],
       "queryParameters": {
-        "compare_previous": "boolean | undefined",
-        "end_date": "DateTime",
-        "start_date": "DateTime"
+        "comparePrevious": "boolean | undefined",
+        "endDate": "DateTime",
+        "startDate": "DateTime"
       },
       "uri": "/api/v1/analytics/live-summary"
     },
@@ -242,9 +242,9 @@
         "location_id"
       ],
       "queryParameters": {
-        "from_timestamp": "DateTime",
+        "fromTimestamp": "DateTime",
         "limit": "number | undefined",
-        "to_timestamp": "DateTime"
+        "toTimestamp": "DateTime"
       },
       "uri": "/api/v1/geo-locations/{location_id}/top-ips"
     },
@@ -275,9 +275,9 @@
         "GET"
       ],
       "queryParameters": {
-        "compare_previous": "boolean | undefined",
-        "end_date": "DateTime",
-        "start_date": "DateTime"
+        "comparePrevious": "boolean | undefined",
+        "endDate": "DateTime",
+        "startDate": "DateTime"
       },
       "uri": "/api/v1/analytics/summary"
     },
@@ -295,12 +295,12 @@
       ],
       "queryParameters": {
         "city": "string[] | undefined",
-        "country_code": "string[] | undefined",
-        "end_date": "DateTime",
+        "countryCode": "string[] | undefined",
+        "endDate": "DateTime",
         "granularity": "\"hourly\" | \"daily\" | undefined",
-        "ip_address": "string[] | undefined",
-        "ip_address_not_in": "string[] | undefined",
-        "start_date": "DateTime"
+        "ipAddress": "string[] | undefined",
+        "ipAddressNotIn": "string[] | undefined",
+        "startDate": "DateTime"
       },
       "uri": "/api/v1/analytics/time-series"
     },
@@ -311,12 +311,12 @@
       ],
       "queryParameters": {
         "city": "string[] | undefined",
-        "country_code": "string[] | undefined",
-        "end_date": "DateTime",
-        "ip_address": "string[] | undefined",
-        "ip_address_not_in": "string[] | undefined",
+        "countryCode": "string[] | undefined",
+        "endDate": "DateTime",
+        "ipAddress": "string[] | undefined",
+        "ipAddressNotIn": "string[] | undefined",
         "limit": "number | undefined",
-        "start_date": "DateTime"
+        "startDate": "DateTime"
       },
       "uri": "/api/v1/analytics/top-cities"
     },
@@ -327,12 +327,12 @@
       ],
       "queryParameters": {
         "city": "string[] | undefined",
-        "country_code": "string[] | undefined",
-        "end_date": "DateTime",
-        "ip_address": "string[] | undefined",
-        "ip_address_not_in": "string[] | undefined",
+        "countryCode": "string[] | undefined",
+        "endDate": "DateTime",
+        "ipAddress": "string[] | undefined",
+        "ipAddressNotIn": "string[] | undefined",
         "limit": "number | undefined",
-        "start_date": "DateTime"
+        "startDate": "DateTime"
       },
       "uri": "/api/v1/analytics/top-countries"
     },
@@ -342,9 +342,9 @@
         "GET"
       ],
       "queryParameters": {
-        "from_timestamp": "DateTime",
+        "fromTimestamp": "DateTime",
         "limit": "number | undefined",
-        "to_timestamp": "DateTime"
+        "toTimestamp": "DateTime"
       },
       "uri": "/api/v1/geo-locations/top-countries"
     },
@@ -355,12 +355,12 @@
       ],
       "queryParameters": {
         "city": "string[] | undefined",
-        "country_code": "string[] | undefined",
-        "end_date": "DateTime",
-        "ip_address": "string[] | undefined",
-        "ip_address_not_in": "string[] | undefined",
+        "countryCode": "string[] | undefined",
+        "endDate": "DateTime",
+        "ipAddress": "string[] | undefined",
+        "ipAddressNotIn": "string[] | undefined",
         "limit": "number | undefined",
-        "start_date": "DateTime"
+        "startDate": "DateTime"
       },
       "uri": "/api/v1/analytics/top-ips"
     },
@@ -371,12 +371,12 @@
       ],
       "queryParameters": {
         "city": "string[] | undefined",
-        "country_code": "string[] | undefined",
-        "end_date": "DateTime",
-        "ip_address": "string[] | undefined",
-        "ip_address_not_in": "string[] | undefined",
+        "countryCode": "string[] | undefined",
+        "endDate": "DateTime",
+        "ipAddress": "string[] | undefined",
+        "ipAddressNotIn": "string[] | undefined",
         "limit": "number | undefined",
-        "start_date": "DateTime"
+        "startDate": "DateTime"
       },
       "uri": "/api/v1/analytics/top-urls"
     },
@@ -387,12 +387,12 @@
       ],
       "queryParameters": {
         "city": "string[] | undefined",
-        "country_code": "string[] | undefined",
-        "end_date": "DateTime",
-        "ip_address": "string[] | undefined",
-        "ip_address_not_in": "string[] | undefined",
+        "countryCode": "string[] | undefined",
+        "endDate": "DateTime",
+        "ipAddress": "string[] | undefined",
+        "ipAddressNotIn": "string[] | undefined",
         "limit": "number | undefined",
-        "start_date": "DateTime"
+        "startDate": "DateTime"
       },
       "uri": "/api/v1/analytics/top-user-agents"
     },
@@ -419,7 +419,7 @@
         "cityIn": "string[] | undefined",
         "countryCodeIn": "string[] | undefined",
         "currentPage": "number | undefined",
-        "from_timestamp": "DateTime | undefined",
+        "fromTimestamp": "DateTime | undefined",
         "ipAddressIn": "string[] | undefined",
         "malformed": "boolean | undefined",
         "orderBy": "string | undefined",
@@ -427,7 +427,7 @@
         "searchIgnoreCase": "boolean | undefined",
         "searchString": "string | undefined",
         "sortOrder": "\"asc\" | \"desc\" | undefined",
-        "to_timestamp": "DateTime | undefined"
+        "toTimestamp": "DateTime | undefined"
       },
       "uri": "/api/v1/access-log-debug"
     },
@@ -440,7 +440,7 @@
         "cityIn": "string[] | undefined",
         "countryCodeIn": "string[] | undefined",
         "currentPage": "number | undefined",
-        "from_timestamp": "DateTime | undefined",
+        "fromTimestamp": "DateTime | undefined",
         "hostIn": "string[] | undefined",
         "hostNotIn": "string[] | undefined",
         "ipAddressIn": "string[] | undefined",
@@ -452,7 +452,7 @@
         "searchString": "string | undefined",
         "sortOrder": "\"asc\" | \"desc\" | undefined",
         "statusIn": "number[] | undefined",
-        "to_timestamp": "DateTime | undefined"
+        "toTimestamp": "DateTime | undefined"
       },
       "uri": "/api/v1/access-logs"
     },
@@ -482,8 +482,8 @@
         "GET"
       ],
       "queryParameters": {
-        "from_timestamp": "DateTime | undefined",
-        "to_timestamp": "DateTime | undefined"
+        "fromTimestamp": "DateTime | undefined",
+        "toTimestamp": "DateTime | undefined"
       },
       "uri": "/api/v1/crowdsec/banned-locations"
     },
@@ -513,14 +513,14 @@
       ],
       "queryParameters": {
         "currentPage": "number | undefined",
-        "from_timestamp": "DateTime | undefined",
+        "fromTimestamp": "DateTime | undefined",
         "hostnameIn": "string[] | undefined",
         "ipAddressIn": "string[] | undefined",
         "ipAddressNotIn": "string[] | undefined",
         "orderBy": "string | undefined",
         "pageSize": "number | undefined",
         "sortOrder": "\"asc\" | \"desc\" | undefined",
-        "to_timestamp": "DateTime | undefined"
+        "toTimestamp": "DateTime | undefined"
       },
       "uri": "/api/v1/geo-events"
     },

--- a/resources/generated/routes.ts
+++ b/resources/generated/routes.ts
@@ -140,175 +140,175 @@ export interface RouteQueryParams {
   'download': Record<string, never>;
   'get_about': Record<string, never>;
   'get_access_log_debug_stats': {
-    from_timestamp?: DateTime;
-    to_timestamp?: DateTime;
+    fromTimestamp?: DateTime;
+    toTimestamp?: DateTime;
   };
   'get_access_log_facets': Record<string, never>;
   'get_cumulative_time_series': {
-    end_date: DateTime;
-    start_date: DateTime;
+    endDate: DateTime;
+    startDate: DateTime;
   };
   'get_database_info': Record<string, never>;
   'get_geo_log_facets': Record<string, never>;
   'get_geo_log_summary': {
     cityIn?: string[];
-    compare_previous?: boolean;
+    comparePrevious?: boolean;
     countryCodeIn?: string[];
-    from_timestamp: DateTime;
+    fromTimestamp: DateTime;
     hostnameIn?: string[];
     ipAddressIn?: string[];
     ipAddressNotIn?: string[];
-    to_timestamp: DateTime;
+    toTimestamp: DateTime;
   };
   'get_geo_log_time_series': {
     cityIn?: string[];
     countryCodeIn?: string[];
-    from_timestamp: DateTime;
+    fromTimestamp: DateTime;
     granularity?: "hourly" | "daily";
     hostnameIn?: string[];
     ipAddressIn?: string[];
     ipAddressNotIn?: string[];
-    to_timestamp: DateTime;
+    toTimestamp: DateTime;
   };
   'get_geo_log_top_cities': {
     cityIn?: string[];
     countryCodeIn?: string[];
-    from_timestamp: DateTime;
+    fromTimestamp: DateTime;
     hostnameIn?: string[];
     ipAddressIn?: string[];
     ipAddressNotIn?: string[];
     limit?: number;
-    to_timestamp: DateTime;
+    toTimestamp: DateTime;
   };
   'get_geo_log_top_countries': {
     cityIn?: string[];
     countryCodeIn?: string[];
-    from_timestamp: DateTime;
+    fromTimestamp: DateTime;
     hostnameIn?: string[];
     ipAddressIn?: string[];
     ipAddressNotIn?: string[];
     limit?: number;
-    to_timestamp: DateTime;
+    toTimestamp: DateTime;
   };
   'get_geo_log_top_ips': {
     cityIn?: string[];
     countryCodeIn?: string[];
-    from_timestamp: DateTime;
+    fromTimestamp: DateTime;
     hostnameIn?: string[];
     ipAddressIn?: string[];
     ipAddressNotIn?: string[];
     limit?: number;
-    to_timestamp: DateTime;
+    toTimestamp: DateTime;
   };
   'get_geo_logs': {
     cityIn?: string[];
     countryCodeIn?: string[];
     currentPage?: number;
-    from_timestamp: DateTime;
+    fromTimestamp: DateTime;
     hostnameIn?: string[];
     ipAddressIn?: string[];
     ipAddressNotIn?: string[];
     orderBy?: string;
     pageSize?: number;
     sortOrder?: "asc" | "desc";
-    to_timestamp: DateTime;
+    toTimestamp: DateTime;
   };
   'get_geo_time_series': {
-    end_date: DateTime;
+    endDate: DateTime;
     granularity?: "hourly" | "daily";
-    start_date: DateTime;
+    startDate: DateTime;
   };
   'get_geojson': {
     city?: string[];
-    country_code?: string[];
-    from_timestamp: DateTime;
+    countryCode?: string[];
+    fromTimestamp: DateTime;
     hostnameIn?: string[];
     ipAddressIn?: string[];
     ipAddressNotIn?: string[];
-    to_timestamp: DateTime;
+    toTimestamp: DateTime;
   };
   'get_global_top_ips': {
-    from_timestamp: DateTime;
+    fromTimestamp: DateTime;
     limit?: number;
-    to_timestamp: DateTime;
+    toTimestamp: DateTime;
   };
   'get_live_summary': {
-    compare_previous?: boolean;
-    end_date: DateTime;
-    start_date: DateTime;
+    comparePrevious?: boolean;
+    endDate: DateTime;
+    startDate: DateTime;
   };
   'get_location_top_ips': {
-    from_timestamp: DateTime;
+    fromTimestamp: DateTime;
     limit?: number;
-    to_timestamp: DateTime;
+    toTimestamp: DateTime;
   };
   'get_scheduler_jobs': Record<string, never>;
   'get_stats': Record<string, never>;
   'get_status': Record<string, never>;
   'get_summary': {
-    compare_previous?: boolean;
-    end_date: DateTime;
-    start_date: DateTime;
+    comparePrevious?: boolean;
+    endDate: DateTime;
+    startDate: DateTime;
   };
   'get_system_settings': Record<string, never>;
   'get_time_series': {
     city?: string[];
-    country_code?: string[];
-    end_date: DateTime;
+    countryCode?: string[];
+    endDate: DateTime;
     granularity?: "hourly" | "daily";
-    ip_address?: string[];
-    ip_address_not_in?: string[];
-    start_date: DateTime;
+    ipAddress?: string[];
+    ipAddressNotIn?: string[];
+    startDate: DateTime;
   };
   'get_top_cities': {
     city?: string[];
-    country_code?: string[];
-    end_date: DateTime;
-    ip_address?: string[];
-    ip_address_not_in?: string[];
+    countryCode?: string[];
+    endDate: DateTime;
+    ipAddress?: string[];
+    ipAddressNotIn?: string[];
     limit?: number;
-    start_date: DateTime;
+    startDate: DateTime;
   };
   'get_top_countries': {
     city?: string[];
-    country_code?: string[];
-    end_date: DateTime;
-    ip_address?: string[];
-    ip_address_not_in?: string[];
+    countryCode?: string[];
+    endDate: DateTime;
+    ipAddress?: string[];
+    ipAddressNotIn?: string[];
     limit?: number;
-    start_date: DateTime;
+    startDate: DateTime;
   };
   'get_top_countries_api_v1_geo_locations_top_countries': {
-    from_timestamp: DateTime;
+    fromTimestamp: DateTime;
     limit?: number;
-    to_timestamp: DateTime;
+    toTimestamp: DateTime;
   };
   'get_top_ips': {
     city?: string[];
-    country_code?: string[];
-    end_date: DateTime;
-    ip_address?: string[];
-    ip_address_not_in?: string[];
+    countryCode?: string[];
+    endDate: DateTime;
+    ipAddress?: string[];
+    ipAddressNotIn?: string[];
     limit?: number;
-    start_date: DateTime;
+    startDate: DateTime;
   };
   'get_top_urls': {
     city?: string[];
-    country_code?: string[];
-    end_date: DateTime;
-    ip_address?: string[];
-    ip_address_not_in?: string[];
+    countryCode?: string[];
+    endDate: DateTime;
+    ipAddress?: string[];
+    ipAddressNotIn?: string[];
     limit?: number;
-    start_date: DateTime;
+    startDate: DateTime;
   };
   'get_top_user_agents': {
     city?: string[];
-    country_code?: string[];
-    end_date: DateTime;
-    ip_address?: string[];
-    ip_address_not_in?: string[];
+    countryCode?: string[];
+    endDate: DateTime;
+    ipAddress?: string[];
+    ipAddressNotIn?: string[];
     limit?: number;
-    start_date: DateTime;
+    startDate: DateTime;
   };
   'health': Record<string, never>;
   'health_ready': Record<string, never>;
@@ -316,7 +316,7 @@ export interface RouteQueryParams {
     cityIn?: string[];
     countryCodeIn?: string[];
     currentPage?: number;
-    from_timestamp?: DateTime;
+    fromTimestamp?: DateTime;
     ipAddressIn?: string[];
     malformed?: boolean;
     orderBy?: string;
@@ -324,13 +324,13 @@ export interface RouteQueryParams {
     searchIgnoreCase?: boolean;
     searchString?: string;
     sortOrder?: "asc" | "desc";
-    to_timestamp?: DateTime;
+    toTimestamp?: DateTime;
   };
   'list_access_logs': {
     cityIn?: string[];
     countryCodeIn?: string[];
     currentPage?: number;
-    from_timestamp?: DateTime;
+    fromTimestamp?: DateTime;
     hostIn?: string[];
     hostNotIn?: string[];
     ipAddressIn?: string[];
@@ -342,7 +342,7 @@ export interface RouteQueryParams {
     searchString?: string;
     sortOrder?: "asc" | "desc";
     statusIn?: number[];
-    to_timestamp?: DateTime;
+    toTimestamp?: DateTime;
   };
   'list_alerts': {
     ip?: string;
@@ -352,8 +352,8 @@ export interface RouteQueryParams {
   };
   'list_banned_ips': Record<string, never>;
   'list_banned_locations': {
-    from_timestamp?: DateTime;
-    to_timestamp?: DateTime;
+    fromTimestamp?: DateTime;
+    toTimestamp?: DateTime;
   };
   'list_decisions': {
     currentPage?: number;
@@ -363,14 +363,14 @@ export interface RouteQueryParams {
   'list_files': Record<string, never>;
   'list_geo_events': {
     currentPage?: number;
-    from_timestamp?: DateTime;
+    fromTimestamp?: DateTime;
     hostnameIn?: string[];
     ipAddressIn?: string[];
     ipAddressNotIn?: string[];
     orderBy?: string;
     pageSize?: number;
     sortOrder?: "asc" | "desc";
-    to_timestamp?: DateTime;
+    toTimestamp?: DateTime;
   };
   'list_geo_locations': {
     currentPage?: number;
@@ -431,7 +431,7 @@ export const routeDefinitions = {
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['from_timestamp', 'to_timestamp'] as const,
+    queryParams: ['fromTimestamp', 'toTimestamp'] as const,
   },
   'get_access_log_facets': {
     path: '/api/v1/access-logs/facets',
@@ -445,7 +445,7 @@ export const routeDefinitions = {
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['end_date', 'start_date'] as const,
+    queryParams: ['endDate', 'startDate'] as const,
   },
   'get_database_info': {
     path: '/api/v1/system/database',
@@ -466,77 +466,77 @@ export const routeDefinitions = {
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['cityIn', 'compare_previous', 'countryCodeIn', 'from_timestamp', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'to_timestamp'] as const,
+    queryParams: ['cityIn', 'comparePrevious', 'countryCodeIn', 'fromTimestamp', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'toTimestamp'] as const,
   },
   'get_geo_log_time_series': {
     path: '/api/v1/geo-events/time-series',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['cityIn', 'countryCodeIn', 'from_timestamp', 'granularity', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'to_timestamp'] as const,
+    queryParams: ['cityIn', 'countryCodeIn', 'fromTimestamp', 'granularity', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'toTimestamp'] as const,
   },
   'get_geo_log_top_cities': {
     path: '/api/v1/geo-events/top-cities',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['cityIn', 'countryCodeIn', 'from_timestamp', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'limit', 'to_timestamp'] as const,
+    queryParams: ['cityIn', 'countryCodeIn', 'fromTimestamp', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'limit', 'toTimestamp'] as const,
   },
   'get_geo_log_top_countries': {
     path: '/api/v1/geo-events/top-countries',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['cityIn', 'countryCodeIn', 'from_timestamp', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'limit', 'to_timestamp'] as const,
+    queryParams: ['cityIn', 'countryCodeIn', 'fromTimestamp', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'limit', 'toTimestamp'] as const,
   },
   'get_geo_log_top_ips': {
     path: '/api/v1/geo-events/top-ips',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['cityIn', 'countryCodeIn', 'from_timestamp', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'limit', 'to_timestamp'] as const,
+    queryParams: ['cityIn', 'countryCodeIn', 'fromTimestamp', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'limit', 'toTimestamp'] as const,
   },
   'get_geo_logs': {
     path: '/api/v1/geo-events/logs',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['cityIn', 'countryCodeIn', 'currentPage', 'from_timestamp', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'orderBy', 'pageSize', 'sortOrder', 'to_timestamp'] as const,
+    queryParams: ['cityIn', 'countryCodeIn', 'currentPage', 'fromTimestamp', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'orderBy', 'pageSize', 'sortOrder', 'toTimestamp'] as const,
   },
   'get_geo_time_series': {
     path: '/api/v1/analytics/geo-time-series',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['end_date', 'granularity', 'start_date'] as const,
+    queryParams: ['endDate', 'granularity', 'startDate'] as const,
   },
   'get_geojson': {
     path: '/api/v1/geo-locations/geojson',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['city', 'country_code', 'from_timestamp', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'to_timestamp'] as const,
+    queryParams: ['city', 'countryCode', 'fromTimestamp', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'toTimestamp'] as const,
   },
   'get_global_top_ips': {
     path: '/api/v1/geo-locations/top-ips',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['from_timestamp', 'limit', 'to_timestamp'] as const,
+    queryParams: ['fromTimestamp', 'limit', 'toTimestamp'] as const,
   },
   'get_live_summary': {
     path: '/api/v1/analytics/live-summary',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['compare_previous', 'end_date', 'start_date'] as const,
+    queryParams: ['comparePrevious', 'endDate', 'startDate'] as const,
   },
   'get_location_top_ips': {
     path: '/api/v1/geo-locations/{location_id}/top-ips',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: ['location_id'] as const,
-    queryParams: ['from_timestamp', 'limit', 'to_timestamp'] as const,
+    queryParams: ['fromTimestamp', 'limit', 'toTimestamp'] as const,
   },
   'get_scheduler_jobs': {
     path: '/api/v1/system/scheduler/jobs',
@@ -564,7 +564,7 @@ export const routeDefinitions = {
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['compare_previous', 'end_date', 'start_date'] as const,
+    queryParams: ['comparePrevious', 'endDate', 'startDate'] as const,
   },
   'get_system_settings': {
     path: '/api/v1/system/settings',
@@ -578,49 +578,49 @@ export const routeDefinitions = {
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['city', 'country_code', 'end_date', 'granularity', 'ip_address', 'ip_address_not_in', 'start_date'] as const,
+    queryParams: ['city', 'countryCode', 'endDate', 'granularity', 'ipAddress', 'ipAddressNotIn', 'startDate'] as const,
   },
   'get_top_cities': {
     path: '/api/v1/analytics/top-cities',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['city', 'country_code', 'end_date', 'ip_address', 'ip_address_not_in', 'limit', 'start_date'] as const,
+    queryParams: ['city', 'countryCode', 'endDate', 'ipAddress', 'ipAddressNotIn', 'limit', 'startDate'] as const,
   },
   'get_top_countries': {
     path: '/api/v1/analytics/top-countries',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['city', 'country_code', 'end_date', 'ip_address', 'ip_address_not_in', 'limit', 'start_date'] as const,
+    queryParams: ['city', 'countryCode', 'endDate', 'ipAddress', 'ipAddressNotIn', 'limit', 'startDate'] as const,
   },
   'get_top_countries_api_v1_geo_locations_top_countries': {
     path: '/api/v1/geo-locations/top-countries',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['from_timestamp', 'limit', 'to_timestamp'] as const,
+    queryParams: ['fromTimestamp', 'limit', 'toTimestamp'] as const,
   },
   'get_top_ips': {
     path: '/api/v1/analytics/top-ips',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['city', 'country_code', 'end_date', 'ip_address', 'ip_address_not_in', 'limit', 'start_date'] as const,
+    queryParams: ['city', 'countryCode', 'endDate', 'ipAddress', 'ipAddressNotIn', 'limit', 'startDate'] as const,
   },
   'get_top_urls': {
     path: '/api/v1/analytics/top-urls',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['city', 'country_code', 'end_date', 'ip_address', 'ip_address_not_in', 'limit', 'start_date'] as const,
+    queryParams: ['city', 'countryCode', 'endDate', 'ipAddress', 'ipAddressNotIn', 'limit', 'startDate'] as const,
   },
   'get_top_user_agents': {
     path: '/api/v1/analytics/top-user-agents',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['city', 'country_code', 'end_date', 'ip_address', 'ip_address_not_in', 'limit', 'start_date'] as const,
+    queryParams: ['city', 'countryCode', 'endDate', 'ipAddress', 'ipAddressNotIn', 'limit', 'startDate'] as const,
   },
   'health': {
     path: '/health',
@@ -641,14 +641,14 @@ export const routeDefinitions = {
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['cityIn', 'countryCodeIn', 'currentPage', 'from_timestamp', 'ipAddressIn', 'malformed', 'orderBy', 'pageSize', 'searchIgnoreCase', 'searchString', 'sortOrder', 'to_timestamp'] as const,
+    queryParams: ['cityIn', 'countryCodeIn', 'currentPage', 'fromTimestamp', 'ipAddressIn', 'malformed', 'orderBy', 'pageSize', 'searchIgnoreCase', 'searchString', 'sortOrder', 'toTimestamp'] as const,
   },
   'list_access_logs': {
     path: '/api/v1/access-logs',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['cityIn', 'countryCodeIn', 'currentPage', 'from_timestamp', 'hostIn', 'hostNotIn', 'ipAddressIn', 'ipAddressNotIn', 'methodIn', 'orderBy', 'pageSize', 'searchIgnoreCase', 'searchString', 'sortOrder', 'statusIn', 'to_timestamp'] as const,
+    queryParams: ['cityIn', 'countryCodeIn', 'currentPage', 'fromTimestamp', 'hostIn', 'hostNotIn', 'ipAddressIn', 'ipAddressNotIn', 'methodIn', 'orderBy', 'pageSize', 'searchIgnoreCase', 'searchString', 'sortOrder', 'statusIn', 'toTimestamp'] as const,
   },
   'list_alerts': {
     path: '/api/v1/crowdsec/alerts',
@@ -669,7 +669,7 @@ export const routeDefinitions = {
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['from_timestamp', 'to_timestamp'] as const,
+    queryParams: ['fromTimestamp', 'toTimestamp'] as const,
   },
   'list_decisions': {
     path: '/api/v1/crowdsec/decisions',
@@ -690,7 +690,7 @@ export const routeDefinitions = {
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['currentPage', 'from_timestamp', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'orderBy', 'pageSize', 'sortOrder', 'to_timestamp'] as const,
+    queryParams: ['currentPage', 'fromTimestamp', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'orderBy', 'pageSize', 'sortOrder', 'toTimestamp'] as const,
   },
   'list_geo_locations': {
     path: '/api/v1/geo-locations',

--- a/resources/lib/api.ts
+++ b/resources/lib/api.ts
@@ -93,23 +93,23 @@ export async function fetchMe(): Promise<MeResponse> {
 
 export interface HealthIngestionStatus {
   running: boolean
-  parsed_lines: number
-  pending_records: number
+  parsedLines: number
+  pendingRecords: number
   /** Tailed log files that disappeared mid-flight; ingestion waits for them. */
-  missing_files: string[]
+  missingFiles: string[]
   /** Wall-clock of the most recent ingested record; null before the first. */
-  last_record_at: string | null
+  lastRecordAt: string | null
 }
 
 export interface HealthResponse {
   status: "healthy" | "degraded"
   /** App start time; null in test harnesses without lifecycle startup. */
-  started_at: string | null
+  startedAt: string | null
   ingestion: HealthIngestionStatus
   database: { reachable: boolean }
-  /** db_build_date is the GeoLite2 build from the mmdb metadata. */
-  geoip: { available: boolean; db_build_date: string | null }
-  crowdsec: { enabled: boolean; lapi_reachable: boolean | null }
+  /** dbBuildDate is the GeoLite2 build from the mmdb metadata. */
+  geoip: { available: boolean; dbBuildDate: string | null }
+  crowdsec: { enabled: boolean; lapiReachable: boolean | null }
   timestamp: string
 }
 
@@ -120,38 +120,38 @@ export type RuntimeSettings = SafeSettingsResponse
 // ============================================================================
 
 export interface PeriodSummary {
-  total_requests: number
-  total_geo_events: number
-  unique_ips: number
-  unique_countries: number
-  total_bytes_sent: number
-  avg_bytes_per_request: number
-  status_2xx: number
-  status_3xx: number
-  status_4xx: number
-  status_5xx: number
-  avg_request_time: number
-  max_request_time: number
-  malformed_requests: number
-  error_rate: number
+  totalRequests: number
+  totalGeoEvents: number
+  uniqueIps: number
+  uniqueCountries: number
+  totalBytesSent: number
+  avgBytesPerRequest: number
+  status2xx: number
+  status3xx: number
+  status4xx: number
+  status5xx: number
+  avgRequestTime: number
+  maxRequestTime: number
+  malformedRequests: number
+  errorRate: number
 }
 
 export interface PercentChange {
-  log_records: number | null
-  geo_records: number | null
-  unique_ips: number | null
-  bytes_sent: number | null
-  avg_request_time: number | null
-  error_rate: number | null
-  malformed_rate: number | null
+  logRecords: number | null
+  geoRecords: number | null
+  uniqueIps: number | null
+  bytesSent: number | null
+  avgRequestTime: number | null
+  errorRate: number | null
+  malformedRate: number | null
 }
 
 export interface SummaryResponse {
-  start_date: string
-  end_date: string
-  current_period: PeriodSummary
-  previous_period: PeriodSummary | null
-  percent_changes: PercentChange | null
+  startDate: string
+  endDate: string
+  currentPeriod: PeriodSummary
+  previousPeriod: PeriodSummary | null
+  percentChanges: PercentChange | null
 }
 
 // Time-series shapes come from the generated client (the old manual
@@ -172,13 +172,13 @@ export interface EmbeddedLocationDTO {
   latitude: number
   longitude: number
   city: string | null
-  country_code: string | null
-  country_name: string | null
+  countryCode: string | null
+  countryName: string | null
 }
 
 export interface TopIPDTO {
-  ip_address: string
-  event_count: number
+  ipAddress: string
+  eventCount: number
   location: EmbeddedLocationDTO | null
 }
 
@@ -208,12 +208,12 @@ export async function fetchHealth(): Promise<HealthResponse> {
 /** Ingestion counters from /api/v1/stats; mirrors the backend's typed
  *  IngestionStatsResponse (geometrikks/domain/system/controllers/stats.py). */
 export interface StatsResponse {
-  total_parsed_lines: number
-  total_skipped_lines: number
-  total_pending_records: number
-  total_ignored_lines: number
-  total_processed: number
-  is_running: boolean
+  totalParsedLines: number
+  totalSkippedLines: number
+  totalPendingRecords: number
+  totalIgnoredLines: number
+  totalProcessed: number
+  isRunning: boolean
 }
 
 export async function fetchStats(): Promise<StatsResponse> {
@@ -302,8 +302,8 @@ export async function fetchCrowdsecBannedLocations(params?: {
 }): Promise<IpLocation[]> {
   const { data } = await api.get<IpLocation[]>("/crowdsec/banned-locations", {
     params: {
-      from_timestamp: params?.fromTimestamp,
-      to_timestamp: params?.toTimestamp,
+      fromTimestamp: params?.fromTimestamp,
+      toTimestamp: params?.toTimestamp,
     },
   })
   return data
@@ -355,9 +355,9 @@ export interface SummaryParams {
 export async function fetchSummary(params: SummaryParams): Promise<SummaryResponse> {
   const { data } = await api.get<SummaryResponse>("/analytics/summary", {
     params: {
-      start_date: params.startDate,
-      end_date: params.endDate,
-      compare_previous: params.comparePrevious ?? true,
+      startDate: params.startDate,
+      endDate: params.endDate,
+      comparePrevious: params.comparePrevious ?? true,
     },
   })
   return data
@@ -366,9 +366,9 @@ export async function fetchSummary(params: SummaryParams): Promise<SummaryRespon
 export async function fetchLiveSummary(params: SummaryParams): Promise<SummaryResponse> {
   const { data } = await api.get<SummaryResponse>("/analytics/live-summary", {
     params: {
-      start_date: params.startDate,
-      end_date: params.endDate,
-      compare_previous: params.comparePrevious ?? true,
+      startDate: params.startDate,
+      endDate: params.endDate,
+      comparePrevious: params.comparePrevious ?? true,
     },
   })
   return data
@@ -399,9 +399,9 @@ export interface GeoJSONParams {
 export async function fetchGeoJSON(params: GeoJSONParams): Promise<GeoJSONFeatureCollection> {
   const { data } = await api.get<GeoJSONFeatureCollection>("/geo-locations/geojson", {
     params: {
-      from_timestamp: params.fromTimestamp,
-      to_timestamp: params.toTimestamp,
-      country_code: params.countryCodes?.length ? params.countryCodes : undefined,
+      fromTimestamp: params.fromTimestamp,
+      toTimestamp: params.toTimestamp,
+      countryCode: params.countryCodes?.length ? params.countryCodes : undefined,
       city: params.cities?.length ? params.cities : undefined,
       ipAddressIn: params.ips?.length ? params.ips : undefined,
       ipAddressNotIn: params.ipsExclude?.length ? params.ipsExclude : undefined,
@@ -419,7 +419,7 @@ export async function fetchGeoJSON(params: GeoJSONParams): Promise<GeoJSONFeatur
 // ============================================================================
 
 export interface GlobalTopIPsResponse {
-  top_ips: TopIPDTO[]
+  topIps: TopIPDTO[]
 }
 
 // ============================================================================
@@ -427,13 +427,13 @@ export interface GlobalTopIPsResponse {
 // ============================================================================
 
 export interface TopCountryDTO {
-  country_code: string
-  country_name: string | null
-  event_count: number
+  countryCode: string
+  countryName: string | null
+  eventCount: number
 }
 
 export interface TopCountriesResponse {
-  top_countries: TopCountryDTO[]
+  topCountries: TopCountryDTO[]
 }
 
 // ============================================================================
@@ -442,21 +442,21 @@ export interface TopCountriesResponse {
 
 export interface CumulativeDataPoint {
   timestamp: string
-  cumulative_geo_events: number
-  cumulative_access_logs: number
-  cumulative_bytes: number
+  cumulativeGeoEvents: number
+  cumulativeAccessLogs: number
+  cumulativeBytes: number
 }
 
 export interface CumulativeTimeSeriesResponse {
   granularity: "hourly" | "daily"
-  start_date: string
-  end_date: string
+  startDate: string
+  endDate: string
   data: CumulativeDataPoint[]
 }
 
 export interface LocationTopIPsResponse {
-  location_id: number
-  top_ips: TopIPDTO[]
+  locationId: number
+  topIps: TopIPDTO[]
 }
 
 export interface TopIPsParams {
@@ -475,8 +475,8 @@ export interface LocationTopIPsParams extends TopIPsParams {
 export async function fetchGlobalTopIPs(params: TopIPsParams): Promise<GlobalTopIPsResponse> {
   const { data } = await api.get<GlobalTopIPsResponse>("/geo-locations/top-ips", {
     params: {
-      from_timestamp: params.fromTimestamp,
-      to_timestamp: params.toTimestamp,
+      fromTimestamp: params.fromTimestamp,
+      toTimestamp: params.toTimestamp,
       limit: params.limit ?? 5,
     },
   })
@@ -491,8 +491,8 @@ export async function fetchLocationTopIPs(params: LocationTopIPsParams): Promise
     `/geo-locations/${params.locationId}/top-ips`,
     {
       params: {
-        from_timestamp: params.fromTimestamp,
-        to_timestamp: params.toTimestamp,
+        fromTimestamp: params.fromTimestamp,
+        toTimestamp: params.toTimestamp,
         limit: params.limit ?? 5,
       },
     }
@@ -506,8 +506,8 @@ export async function fetchLocationTopIPs(params: LocationTopIPsParams): Promise
 export async function fetchTopCountries(params: TopIPsParams): Promise<TopCountriesResponse> {
   const { data } = await api.get<TopCountriesResponse>("/geo-locations/top-countries", {
     params: {
-      from_timestamp: params.fromTimestamp,
-      to_timestamp: params.toTimestamp,
+      fromTimestamp: params.fromTimestamp,
+      toTimestamp: params.toTimestamp,
       limit: params.limit ?? 10,
     },
   })
@@ -534,13 +534,13 @@ export interface AnalyticsFilterParams {
 export async function fetchTimeSeries(params: TimeSeriesParams & AnalyticsFilterParams) {
   const { data } = await apiV1AnalyticsTimeSeriesGetTimeSeries({
     query: {
-      start_date: params.startDate,
-      end_date: params.endDate,
+      startDate: params.startDate,
+      endDate: params.endDate,
       granularity: params.granularity,
-      country_code: params.countryCodes?.length ? params.countryCodes : undefined,
+      countryCode: params.countryCodes?.length ? params.countryCodes : undefined,
       city: params.cities?.length ? params.cities : undefined,
-      ip_address: params.ips?.length ? params.ips : undefined,
-      ip_address_not_in: params.ipsExclude?.length ? params.ipsExclude : undefined,
+      ipAddress: params.ips?.length ? params.ips : undefined,
+      ipAddressNotIn: params.ipsExclude?.length ? params.ipsExclude : undefined,
     },
     throwOnError: true,
   })
@@ -549,7 +549,7 @@ export async function fetchTimeSeries(params: TimeSeriesParams & AnalyticsFilter
 
 export async function fetchGeoTimeSeries(params: TimeSeriesParams) {
   const { data } = await apiV1AnalyticsGeoTimeSeriesGetGeoTimeSeries({
-    query: { start_date: params.startDate, end_date: params.endDate, granularity: params.granularity },
+    query: { startDate: params.startDate, endDate: params.endDate, granularity: params.granularity },
     throwOnError: true,
   })
   return data
@@ -558,13 +558,13 @@ export async function fetchGeoTimeSeries(params: TimeSeriesParams) {
 export async function fetchTopUrls(params: TimeSeriesParams & { limit?: number } & AnalyticsFilterParams) {
   const { data } = await apiV1AnalyticsTopUrlsGetTopUrls({
     query: {
-      start_date: params.startDate,
-      end_date: params.endDate,
+      startDate: params.startDate,
+      endDate: params.endDate,
       limit: params.limit ?? 25,
-      country_code: params.countryCodes?.length ? params.countryCodes : undefined,
+      countryCode: params.countryCodes?.length ? params.countryCodes : undefined,
       city: params.cities?.length ? params.cities : undefined,
-      ip_address: params.ips?.length ? params.ips : undefined,
-      ip_address_not_in: params.ipsExclude?.length ? params.ipsExclude : undefined,
+      ipAddress: params.ips?.length ? params.ips : undefined,
+      ipAddressNotIn: params.ipsExclude?.length ? params.ipsExclude : undefined,
     },
     throwOnError: true,
   })
@@ -574,13 +574,13 @@ export async function fetchTopUrls(params: TimeSeriesParams & { limit?: number }
 export async function fetchTopUserAgents(params: TimeSeriesParams & { limit?: number } & AnalyticsFilterParams) {
   const { data } = await apiV1AnalyticsTopUserAgentsGetTopUserAgents({
     query: {
-      start_date: params.startDate,
-      end_date: params.endDate,
+      startDate: params.startDate,
+      endDate: params.endDate,
       limit: params.limit ?? 25,
-      country_code: params.countryCodes?.length ? params.countryCodes : undefined,
+      countryCode: params.countryCodes?.length ? params.countryCodes : undefined,
       city: params.cities?.length ? params.cities : undefined,
-      ip_address: params.ips?.length ? params.ips : undefined,
-      ip_address_not_in: params.ipsExclude?.length ? params.ipsExclude : undefined,
+      ipAddress: params.ips?.length ? params.ips : undefined,
+      ipAddressNotIn: params.ipsExclude?.length ? params.ipsExclude : undefined,
     },
     throwOnError: true,
   })
@@ -590,13 +590,13 @@ export async function fetchTopUserAgents(params: TimeSeriesParams & { limit?: nu
 export async function fetchTopIpStats(params: TimeSeriesParams & { limit?: number } & AnalyticsFilterParams) {
   const { data } = await apiV1AnalyticsTopIpsGetTopIps({
     query: {
-      start_date: params.startDate,
-      end_date: params.endDate,
+      startDate: params.startDate,
+      endDate: params.endDate,
       limit: params.limit ?? 25,
-      country_code: params.countryCodes?.length ? params.countryCodes : undefined,
+      countryCode: params.countryCodes?.length ? params.countryCodes : undefined,
       city: params.cities?.length ? params.cities : undefined,
-      ip_address: params.ips?.length ? params.ips : undefined,
-      ip_address_not_in: params.ipsExclude?.length ? params.ipsExclude : undefined,
+      ipAddress: params.ips?.length ? params.ips : undefined,
+      ipAddressNotIn: params.ipsExclude?.length ? params.ipsExclude : undefined,
     },
     throwOnError: true,
   })
@@ -606,13 +606,13 @@ export async function fetchTopIpStats(params: TimeSeriesParams & { limit?: numbe
 export async function fetchTopCountryStats(params: TimeSeriesParams & { limit?: number } & AnalyticsFilterParams) {
   const { data } = await apiV1AnalyticsTopCountriesGetTopCountries({
     query: {
-      start_date: params.startDate,
-      end_date: params.endDate,
+      startDate: params.startDate,
+      endDate: params.endDate,
       limit: params.limit ?? 25,
-      country_code: params.countryCodes?.length ? params.countryCodes : undefined,
+      countryCode: params.countryCodes?.length ? params.countryCodes : undefined,
       city: params.cities?.length ? params.cities : undefined,
-      ip_address: params.ips?.length ? params.ips : undefined,
-      ip_address_not_in: params.ipsExclude?.length ? params.ipsExclude : undefined,
+      ipAddress: params.ips?.length ? params.ips : undefined,
+      ipAddressNotIn: params.ipsExclude?.length ? params.ipsExclude : undefined,
     },
     throwOnError: true,
   })
@@ -622,13 +622,13 @@ export async function fetchTopCountryStats(params: TimeSeriesParams & { limit?: 
 export async function fetchTopCityStats(params: TimeSeriesParams & { limit?: number } & AnalyticsFilterParams) {
   const { data } = await apiV1AnalyticsTopCitiesGetTopCities({
     query: {
-      start_date: params.startDate,
-      end_date: params.endDate,
+      startDate: params.startDate,
+      endDate: params.endDate,
       limit: params.limit ?? 25,
-      country_code: params.countryCodes?.length ? params.countryCodes : undefined,
+      countryCode: params.countryCodes?.length ? params.countryCodes : undefined,
       city: params.cities?.length ? params.cities : undefined,
-      ip_address: params.ips?.length ? params.ips : undefined,
-      ip_address_not_in: params.ipsExclude?.length ? params.ipsExclude : undefined,
+      ipAddress: params.ips?.length ? params.ips : undefined,
+      ipAddressNotIn: params.ipsExclude?.length ? params.ipsExclude : undefined,
     },
     throwOnError: true,
   })
@@ -641,8 +641,8 @@ export async function fetchTopCityStats(params: TimeSeriesParams & { limit?: num
 export async function fetchCumulativeTimeSeries(params: TimeSeriesParams): Promise<CumulativeTimeSeriesResponse> {
   const { data } = await api.get<CumulativeTimeSeriesResponse>("/analytics/time-series/cumulative", {
     params: {
-      start_date: params.startDate,
-      end_date: params.endDate,
+      startDate: params.startDate,
+      endDate: params.endDate,
     },
   })
   return data
@@ -718,8 +718,8 @@ export async function fetchGeoLogs(
 ) {
   const { data } = await apiV1GeoEventsLogsGetGeoLogs({
     query: {
-      from_timestamp: params.fromTimestamp,
-      to_timestamp: params.toTimestamp,
+      fromTimestamp: params.fromTimestamp,
+      toTimestamp: params.toTimestamp,
       currentPage: params.currentPage ?? 1,
       pageSize: params.pageSize ?? 50,
       orderBy: params.sortField ? GEO_LOG_SORT_FIELD_TO_COLUMN[params.sortField] : undefined,
@@ -736,9 +736,9 @@ export async function fetchGeoLogSummary(
 ) {
   const { data } = await apiV1GeoEventsSummaryGetGeoLogSummary({
     query: {
-      from_timestamp: params.fromTimestamp,
-      to_timestamp: params.toTimestamp,
-      compare_previous: params.comparePrevious ?? true,
+      fromTimestamp: params.fromTimestamp,
+      toTimestamp: params.toTimestamp,
+      comparePrevious: params.comparePrevious ?? true,
       ...geoLogFilterQuery(params),
     },
     throwOnError: true,
@@ -751,8 +751,8 @@ export async function fetchGeoLogTimeSeries(
 ) {
   const { data } = await apiV1GeoEventsTimeSeriesGetGeoLogTimeSeries({
     query: {
-      from_timestamp: params.fromTimestamp,
-      to_timestamp: params.toTimestamp,
+      fromTimestamp: params.fromTimestamp,
+      toTimestamp: params.toTimestamp,
       granularity: params.granularity,
       ...geoLogFilterQuery(params),
     },
@@ -766,8 +766,8 @@ export async function fetchGeoLogTopIps(
 ) {
   const { data } = await apiV1GeoEventsTopIpsGetGeoLogTopIps({
     query: {
-      from_timestamp: params.fromTimestamp,
-      to_timestamp: params.toTimestamp,
+      fromTimestamp: params.fromTimestamp,
+      toTimestamp: params.toTimestamp,
       limit: params.limit ?? 10,
       ...geoLogFilterQuery(params),
     },
@@ -781,8 +781,8 @@ export async function fetchGeoLogTopCountries(
 ) {
   const { data } = await apiV1GeoEventsTopCountriesGetGeoLogTopCountries({
     query: {
-      from_timestamp: params.fromTimestamp,
-      to_timestamp: params.toTimestamp,
+      fromTimestamp: params.fromTimestamp,
+      toTimestamp: params.toTimestamp,
       limit: params.limit ?? 10,
       ...geoLogFilterQuery(params),
     },
@@ -796,8 +796,8 @@ export async function fetchGeoLogTopCities(
 ) {
   const { data } = await apiV1GeoEventsTopCitiesGetGeoLogTopCities({
     query: {
-      from_timestamp: params.fromTimestamp,
-      to_timestamp: params.toTimestamp,
+      fromTimestamp: params.fromTimestamp,
+      toTimestamp: params.toTimestamp,
       limit: params.limit ?? 10,
       ...geoLogFilterQuery(params),
     },
@@ -890,8 +890,8 @@ export interface AccessLogsParams {
 export async function fetchAccessLogs(params: AccessLogsParams): Promise<AccessLogsPage> {
   const { data } = await api.get<AccessLogsPage>("/access-logs/", {
     params: {
-      from_timestamp: params.fromTimestamp,
-      to_timestamp: params.toTimestamp,
+      fromTimestamp: params.fromTimestamp,
+      toTimestamp: params.toTimestamp,
       currentPage: params.currentPage ?? 1,
       pageSize: params.pageSize ?? 50,
       searchString: params.searchString || undefined,
@@ -1008,8 +1008,8 @@ export async function fetchAccessLogDebug(
 ): Promise<AccessLogDebugPage> {
   const { data } = await api.get<AccessLogDebugPage>("/access-log-debug/", {
     params: {
-      from_timestamp: params.fromTimestamp,
-      to_timestamp: params.toTimestamp,
+      fromTimestamp: params.fromTimestamp,
+      toTimestamp: params.toTimestamp,
       currentPage: params.currentPage ?? 1,
       pageSize: params.pageSize ?? 50,
       searchString: params.searchString || undefined,
@@ -1043,8 +1043,8 @@ export async function fetchAccessLogDebugStats(params: {
 }): Promise<AccessLogDebugStats> {
   const { data } = await api.get<AccessLogDebugStats>("/access-log-debug/stats", {
     params: {
-      from_timestamp: params.fromTimestamp,
-      to_timestamp: params.toTimestamp,
+      fromTimestamp: params.fromTimestamp,
+      toTimestamp: params.toTimestamp,
     },
   })
   return data

--- a/resources/lib/api.ts
+++ b/resources/lib/api.ts
@@ -315,7 +315,7 @@ export async function fetchCrowdsecStats(): Promise<CrowdSecStatsResponse> {
   return data
 }
 
-/** Recent LAPI alert history; requires write_enabled (machine credentials). */
+/** Recent LAPI alert history; requires writeEnabled (machine credentials). */
 export async function fetchCrowdsecAlerts(params?: {
   limit?: number
   since?: string
@@ -330,7 +330,7 @@ export async function fetchCrowdsecAlerts(params?: {
 }
 
 /** Ban one IP. `duration` is a Go duration string (4h, 24h, 168h); server
- *  defaults apply to omitted duration/reason. Requires write_enabled. The
+ *  defaults apply to omitted duration/reason. Requires writeEnabled. The
  *  reason ends up in the alert message and the audit log. */
 export async function banIp(
   ip: string,
@@ -407,8 +407,8 @@ export async function fetchGeoJSON(params: GeoJSONParams): Promise<GeoJSONFeatur
       ipAddressNotIn: params.ipsExclude?.length ? params.ipsExclude : undefined,
       hostnameIn: params.hostnames?.length ? params.hostnames : undefined,
     },
-    // Litestar expects repeated keys (?country_code=NO&country_code=SE),
-    // not axios' default bracket form (country_code[]=NO).
+    // Litestar expects repeated keys (?countryCode=NO&countryCode=SE),
+    // not axios' default bracket form (countryCode[]=NO).
     paramsSerializer: { indexes: null },
   })
   return data
@@ -521,7 +521,7 @@ export async function fetchTopCountries(params: TopIPsParams): Promise<TopCountr
 /**
  * Country/city/IP filters shared by the analytics page's six filterable
  * endpoints (not geo-time-series, which stays unfiltered). The generated
- * fetch client serializes arrays as repeated keys (?country_code=NO&country_code=SE)
+ * fetch client serializes arrays as repeated keys (?countryCode=NO&countryCode=SE)
  * by default, matching what Litestar expects.
  */
 export interface AnalyticsFilterParams {

--- a/resources/lib/crowdsec-live.test.ts
+++ b/resources/lib/crowdsec-live.test.ts
@@ -41,12 +41,12 @@ describe("applyBannedIpsDelta", () => {
 })
 
 describe("applyStatusFrame", () => {
-  it("patches lapi_reachable and preserves the other fields", () => {
-    const status = { enabled: true, write_enabled: true, lapi_reachable: true }
+  it("patches lapiReachable and preserves the other fields", () => {
+    const status = { enabled: true, writeEnabled: true, lapiReachable: true }
     expect(applyStatusFrame(status, statusFrame)).toEqual({
       enabled: true,
-      write_enabled: true,
-      lapi_reachable: false,
+      writeEnabled: true,
+      lapiReachable: false,
     })
   })
 

--- a/resources/lib/crowdsec-live.ts
+++ b/resources/lib/crowdsec-live.ts
@@ -55,5 +55,5 @@ export function applyStatusFrame(
   frame: CrowdsecStatusFrame,
 ): CrowdSecStatusResponse | undefined {
   if (!status) return status
-  return { ...status, lapi_reachable: frame.lapi_reachable }
+  return { ...status, lapiReachable: frame.lapi_reachable }
 }

--- a/resources/lib/queries.ts
+++ b/resources/lib/queries.ts
@@ -323,7 +323,7 @@ export function useCrowdsecAlerts(params: { since?: string; limit?: number }) {
   return useQuery({
     queryKey: queryKeys.crowdsec.alerts(params),
     queryFn: () => fetchCrowdsecAlerts(params),
-    enabled: status?.write_enabled === true,
+    enabled: status?.writeEnabled === true,
     placeholderData: (previous) => previous,
     refetchInterval: 60_000,
   })
@@ -392,7 +392,7 @@ export function useCrowdsecLiveUpdates() {
           )
           // Recovery: refetch decisions/alerts/stats immediately so the page
           // leaves its stale state without waiting for the 60s intervals.
-          if (frame.lapi_reachable && previous?.lapi_reachable === false) {
+          if (frame.lapi_reachable && previous?.lapiReachable === false) {
             queryClient.invalidateQueries({ queryKey: ["crowdsec"] })
           }
           return

--- a/resources/routes/security.tsx
+++ b/resources/routes/security.tsx
@@ -62,7 +62,7 @@ function SecurityPage() {
       <CrowdsecUnreachableBanner />
       <SecurityStatCards />
       <DecisionsTable />
-      {status.write_enabled && <AlertsTable />}
+      {status.writeEnabled && <AlertsTable />}
     </div>
   )
 }

--- a/tests/test_auth_endpoints.py
+++ b/tests/test_auth_endpoints.py
@@ -11,6 +11,7 @@ from geometrikks.config.settings import Settings
 from geometrikks.domain.auth.controllers import AuthController
 from geometrikks.domain.realtime.controllers import crowdsec_feed, live_feed, logs_feed
 from geometrikks.server.auth import build_auth_state, create_session_auth
+from geometrikks.server.routes import create_api_v1_router
 
 from tests.test_live_ws import FakeIngestion
 
@@ -35,7 +36,8 @@ def make_app(**settings_kwargs) -> Litestar:
     session_auth = create_session_auth(settings)
     app = Litestar(
         route_handlers=[
-            AuthController, protected, fake_health, live_feed, crowdsec_feed, logs_feed
+            create_api_v1_router([AuthController]),
+            protected, fake_health, live_feed, crowdsec_feed, logs_feed,
         ],
         on_app_init=[session_auth.on_app_init],
         logging_config=None,

--- a/tests/test_crowdsec_controller.py
+++ b/tests/test_crowdsec_controller.py
@@ -12,6 +12,7 @@ from geometrikks.server.exceptions import EXCEPTION_HANDLERS
 from geometrikks.domain.security.repositories import SecurityEnrichmentRepository
 from geometrikks.domain.security.schemas import IpEnrichment
 from geometrikks.services.crowdsec import CrowdSecService, Decision
+from geometrikks.server.routes import create_api_v1_router
 from tests.support import ambient_settings_dependency
 
 import pytest
@@ -73,7 +74,7 @@ def make_app(
         }
 
     app = Litestar(
-        route_handlers=[_TestController],
+        route_handlers=[create_api_v1_router([_TestController])],
         # limit_offset comes controller-scoped from CrowdSecController itself.
         dependencies=ambient_settings_dependency(),
         # Production wiring: create_app() registers the same central map.

--- a/tests/test_crowdsec_controller.py
+++ b/tests/test_crowdsec_controller.py
@@ -95,8 +95,8 @@ async def test_status_disabled():
     assert resp.status_code == 200
     assert resp.json() == {
         "enabled": False,
-        "write_enabled": False,
-        "lapi_reachable": False,
+        "writeEnabled": False,
+        "lapiReachable": False,
     }
 
 
@@ -109,8 +109,8 @@ async def test_status_enabled_read_only(monkeypatch, tmp_path):
         resp = await client.get("/api/v1/crowdsec/status")
     assert resp.json() == {
         "enabled": True,
-        "write_enabled": False,
-        "lapi_reachable": True,
+        "writeEnabled": False,
+        "lapiReachable": True,
     }
 
 
@@ -121,7 +121,7 @@ async def test_status_write_enabled(monkeypatch):
     monkeypatch.setenv("CROWDSEC_MACHINE_PASSWORD", "pass")
     async with AsyncTestClient(app=make_app(FakeCrowdSec([]))) as client:
         resp = await client.get("/api/v1/crowdsec/status")
-    assert resp.json()["write_enabled"] is True
+    assert resp.json()["writeEnabled"] is True
 
 
 async def test_status_reports_unreachable_lapi():
@@ -129,7 +129,7 @@ async def test_status_reports_unreachable_lapi():
         app=make_app(FakeCrowdSec([], reachable=False))
     ) as client:
         resp = await client.get("/api/v1/crowdsec/status")
-    assert resp.json()["lapi_reachable"] is False
+    assert resp.json()["lapiReachable"] is False
 
 
 async def test_decisions_404_when_disabled():
@@ -155,13 +155,13 @@ async def test_decisions_enriches_ip_scope_only():
     assert body["total"] == 2
     first, second = body["items"]
     assert first["ip"] == "1.2.3.4"
-    assert first["country_code"] == "NO"
+    assert first["countryCode"] == "NO"
     assert first["city"] == "Oslo"
-    assert first["request_count_24h"] == 7
+    assert first["requestCount24h"] == 7
     assert second["ip"] == "10.0.0.0/24"
     assert second["scope"] == "Range"
-    assert second["country_code"] is None
-    assert second["request_count_24h"] is None
+    assert second["countryCode"] is None
+    assert second["requestCount24h"] is None
     # Only Ip-scope values ever reach the enrichment query
     assert enrichment.calls == [["1.2.3.4"]]
 
@@ -222,9 +222,9 @@ async def test_stats_counts_by_origin_and_scenario():
     assert resp.status_code == 200
     body = resp.json()
     assert body["total"] == 3
-    assert {"origin": "crowdsec", "count": 2} in body["by_origin"]
-    assert {"origin": "cscli", "count": 1} in body["by_origin"]
-    assert body["top_scenarios"][0] == {
+    assert {"origin": "crowdsec", "count": 2} in body["byOrigin"]
+    assert {"origin": "cscli", "count": 1} in body["byOrigin"]
+    assert body["topScenarios"][0] == {
         "scenario": "crowdsecurity/ssh-bf",
         "count": 2,
     }
@@ -433,10 +433,10 @@ async def test_alerts_returns_flattened_views(monkeypatch):
     assert alert["scenario"] == "crowdsecurity/ssh-bf"
     assert alert["value"] == "1.2.3.4"
     assert alert["country"] == "NO"
-    assert alert["as_name"] == "Telenor"
-    assert alert["machine_id"] == "gateway"
-    assert alert["events_count"] == 6
-    assert alert["decision_count"] == 1
+    assert alert["asName"] == "Telenor"
+    assert alert["machineId"] == "gateway"
+    assert alert["eventsCount"] == 6
+    assert alert["decisionCount"] == 1
     assert service.alert_calls == [{"limit": 25, "ip": None, "scenario": None, "since": "24h"}]
 
 
@@ -490,7 +490,7 @@ async def test_banned_locations_join_banned_ips_with_geo():
     assert resp.status_code == 200
     (loc,) = resp.json()
     assert loc == {"ip": "1.2.3.4", "latitude": 59.91, "longitude": 10.79,
-                   "city": "Oslo", "country_code": "NO"}
+                   "city": "Oslo", "countryCode": "NO"}
     # All origins queried; only Ip-scope values reach the geo join
     assert service.calls == [{}]
     assert enrichment.location_calls == [["1.2.3.4", "9.9.9.9"]]
@@ -518,8 +518,8 @@ async def test_banned_locations_forwards_time_window():
         resp = await client.get(
             "/api/v1/crowdsec/banned-locations",
             params={
-                "from_timestamp": "2026-07-01T00:00:00Z",
-                "to_timestamp": "2026-07-02T00:00:00Z",
+                "fromTimestamp": "2026-07-01T00:00:00Z",
+                "toTimestamp": "2026-07-02T00:00:00Z",
             },
         )
     assert resp.status_code == 200
@@ -565,7 +565,7 @@ async def test_status_uses_poller_state_without_ping(monkeypatch, tmp_path):
     app.state.crowdsec_stream_poller = StubPoller(lapi_reachable=False)
     async with AsyncTestClient(app=app) as client:
         resp = await client.get("/api/v1/crowdsec/status")
-    assert resp.json()["lapi_reachable"] is False
+    assert resp.json()["lapiReachable"] is False
 
 
 async def test_status_falls_back_to_ping_before_first_poll(monkeypatch, tmp_path):
@@ -576,4 +576,4 @@ async def test_status_falls_back_to_ping_before_first_poll(monkeypatch, tmp_path
     app.state.crowdsec_stream_poller = StubPoller(lapi_reachable=None)
     async with AsyncTestClient(app=app) as client:
         resp = await client.get("/api/v1/crowdsec/status")
-    assert resp.json()["lapi_reachable"] is True
+    assert resp.json()["lapiReachable"] is True

--- a/tests/test_crowdsec_lifecycle.py
+++ b/tests/test_crowdsec_lifecycle.py
@@ -92,10 +92,14 @@ async def test_shutdown_closes_service():
 
 
 def test_controller_registered_in_routes():
-    from geometrikks.domain.security.controllers import CrowdSecController
+    from litestar import Router
+
     from geometrikks.server.routes import get_route_handlers
 
-    assert CrowdSecController in get_route_handlers()
+    handlers = get_route_handlers()
+    api_router = next(h for h in handlers if isinstance(h, Router))
+    assert api_router.path == "/api/v1"
+    assert any(route.path.startswith("/api/v1/crowdsec") for route in api_router.routes)
 
 
 async def test_startup_creates_stream_poller_when_enabled(monkeypatch):

--- a/tests/test_error_contract.py
+++ b/tests/test_error_contract.py
@@ -1,0 +1,108 @@
+"""Pins the public error envelope: Litestar's native shape.
+
+The 0.7.0 wire-format policy (docs/api-conventions.md) keeps Litestar's
+native HTTP error envelope as the public error contract:
+
+    {"status_code": <int>, "detail": <str>, "extra"?: [...]}
+
+Envelope keys are the framework's and stay snake_case even though success
+payloads are camelCase; "extra" appears only on request-validation errors.
+Every error path, framework-raised or translated from a domain exception,
+must produce this shape.
+"""
+from __future__ import annotations
+
+import pytest
+from litestar.testing import AsyncTestClient
+
+from geometrikks.config.settings import DatabaseSettings, Settings
+from geometrikks.server.core import create_app
+
+pytestmark = pytest.mark.anyio
+
+
+def _hermetic_settings(**overrides) -> Settings:
+    return Settings(
+        auth_disabled=True,
+        # Unroutable database -> degraded startup; no test touches a real DB.
+        database=DatabaseSettings(host="127.0.0.1", port=59999),
+        **overrides,
+    )
+
+
+async def test_unknown_api_route_is_native_404_envelope():
+    app = create_app(settings=_hermetic_settings())
+    async with AsyncTestClient(app=app) as client:
+        resp = await client.get("/api/v1/does-not-exist")
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["status_code"] == 404
+    assert isinstance(body["detail"], str)
+
+
+def test_non_api_404_keeps_empty_body():
+    """Non-API 404s keep the empty-body behavior the vite plugin uses for
+    static-asset misses; only API paths render the JSON envelope."""
+    from litestar.exceptions import NotFoundException
+    from litestar.testing import RequestFactory
+
+    from geometrikks.server.exceptions import handle_not_found
+
+    request = RequestFactory().get("/some/asset.js")
+    response = handle_not_found(request, NotFoundException())
+    assert response.status_code == 404
+    assert response.content == b""
+
+
+async def test_method_not_allowed_is_native_405_envelope():
+    app = create_app(settings=_hermetic_settings())
+    async with AsyncTestClient(app=app) as client:
+        resp = await client.post("/api/v1/settings")
+    assert resp.status_code == 405
+    body = resp.json()
+    assert body["status_code"] == 405
+    assert isinstance(body["detail"], str)
+
+
+async def test_request_validation_error_is_native_400_envelope():
+    """Framework validation (bad datetime) fails before the handler runs."""
+    app = create_app(settings=_hermetic_settings())
+    async with AsyncTestClient(app=app) as client:
+        resp = await client.get(
+            "/api/v1/access-logs/", params={"fromTimestamp": "not-a-date"}
+        )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["status_code"] == 400
+    assert isinstance(body["detail"], str)
+    # "extra" carries the per-field breakdown on validation errors only.
+    assert "extra" in body
+
+
+async def test_domain_validation_error_shares_the_envelope():
+    """Translated DomainValidationError is indistinguishable in shape."""
+    app = create_app(settings=_hermetic_settings())
+    async with AsyncTestClient(app=app) as client:
+        resp = await client.get(
+            "/api/v1/geo-events/", params={"ipAddressIn": "not-an-ip"}
+        )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["status_code"] == 400
+    assert "Invalid IP address" in body["detail"]
+
+
+async def test_unauthenticated_api_request_is_native_401_envelope():
+    app = create_app(
+        settings=Settings(
+            admin_user="admin",
+            admin_password="bestpasswordintheworldnojoke",
+            database=DatabaseSettings(host="127.0.0.1", port=59999),
+        )
+    )
+    async with AsyncTestClient(app=app) as client:
+        resp = await client.get("/api/v1/settings")
+    assert resp.status_code == 401
+    body = resp.json()
+    assert body["status_code"] == 401
+    assert isinstance(body["detail"], str)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -79,7 +79,7 @@ def test_health_degraded_when_tailed_file_missing(monkeypatch):
         body = client.get("/health").json()
     assert body["status"] == "degraded"
     assert body["ingestion"]["running"] is True
-    assert body["ingestion"]["missing_files"] == ["nginx_logs/access.log"]
+    assert body["ingestion"]["missingFiles"] == ["nginx_logs/access.log"]
 
 
 def test_health_exposes_uptime_and_activity_fields(monkeypatch):
@@ -93,9 +93,9 @@ def test_health_exposes_uptime_and_activity_fields(monkeypatch):
     with TestClient(app=make_app()) as client:
         body = client.get("/health").json()
     # make_app has no started_at in state and no ingestion service
-    assert body["started_at"] is None
-    assert body["ingestion"]["last_record_at"] is None
-    assert "db_build_date" in body["geoip"]
+    assert body["startedAt"] is None
+    assert body["ingestion"]["lastRecordAt"] is None
+    assert "dbBuildDate" in body["geoip"]
 
 
 def test_health_started_at_from_app_state(monkeypatch):
@@ -109,7 +109,7 @@ def test_health_started_at_from_app_state(monkeypatch):
     app.state.started_at = datetime(2026, 7, 31, 8, 0, 0, tzinfo=timezone.utc)
     with TestClient(app=app) as client:
         body = client.get("/health").json()
-    assert body["started_at"] == "2026-07-31T08:00:00+00:00"
+    assert body["startedAt"] == "2026-07-31T08:00:00+00:00"
 
 
 def test_health_no_missing_files_stays_healthy(monkeypatch):
@@ -122,7 +122,7 @@ def test_health_no_missing_files_stays_healthy(monkeypatch):
     with TestClient(app=app) as client:
         body = client.get("/health").json()
     assert body["status"] == "healthy"
-    assert body["ingestion"]["missing_files"] == []
+    assert body["ingestion"]["missingFiles"] == []
 
 
 def test_health_crowdsec_disabled_by_default(monkeypatch):
@@ -132,7 +132,7 @@ def test_health_crowdsec_disabled_by_default(monkeypatch):
 
     with TestClient(app=make_app()) as client:
         body = client.get("/health").json()
-    assert body["crowdsec"] == {"enabled": False, "lapi_reachable": None}
+    assert body["crowdsec"] == {"enabled": False, "lapiReachable": None}
 
 
 def test_health_crowdsec_enabled_and_down(monkeypatch):
@@ -145,6 +145,6 @@ def test_health_crowdsec_enabled_and_down(monkeypatch):
     app.state.crowdsec_stream_poller = SimpleNamespace(lapi_reachable=False)
     with TestClient(app=app) as client:
         body = client.get("/health").json()
-    assert body["crowdsec"] == {"enabled": True, "lapi_reachable": False}
+    assert body["crowdsec"] == {"enabled": True, "lapiReachable": False}
     # CrowdSec being down must not degrade the app status by itself
     assert body["status"] == "degraded"  # degraded because no ingestion in make_app

--- a/tests/test_logs_controller.py
+++ b/tests/test_logs_controller.py
@@ -8,6 +8,7 @@ from litestar import Litestar
 from litestar.testing import TestClient
 
 from geometrikks.domain.system.controllers.logs import LogsController
+from geometrikks.server.routes import create_api_v1_router
 from tests.support import ambient_settings_dependency
 
 
@@ -28,7 +29,8 @@ def client(tmp_path, monkeypatch):
     get_settings.cache_clear()
     with TestClient(
         app=Litestar(
-            route_handlers=[LogsController], dependencies=ambient_settings_dependency()
+            route_handlers=[create_api_v1_router([LogsController])],
+            dependencies=ambient_settings_dependency(),
         )
     ) as c:
         yield c

--- a/tests/test_logs_controller.py
+++ b/tests/test_logs_controller.py
@@ -16,8 +16,16 @@ from tests.support import ambient_settings_dependency
 def client(tmp_path, monkeypatch):
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
+    # First line carries raw structlog context keys: the tail endpoint must
+    # pass historical log records through unrenamed (see docs/api-conventions.md).
+    context_line = json.dumps(
+        {"event": "request_finished", "level": "info", "request_id": "abc", "status_code": 200}
+    )
     (log_dir / "geometrikks.log").write_text(
-        "\n".join(json.dumps({"event": f"e{i}", "level": "info"}) for i in range(20)) + "\n",
+        context_line
+        + "\n"
+        + "\n".join(json.dumps({"event": f"e{i}", "level": "info"}) for i in range(20))
+        + "\n",
         encoding="utf-8",
     )
     (log_dir / "login.log").write_text("2026-07-23T00:00:00Z logout user=\"a\" ip=-\n", encoding="utf-8")
@@ -42,6 +50,16 @@ class TestTailEndpoint:
         assert resp.status_code == 200
         records = resp.json()["records"]
         assert [r["event"] for r in records] == ["e15", "e16", "e17", "e18", "e19"]
+
+    def test_structlog_context_keys_pass_through_unrenamed(self, client):
+        """Raw log context is data, not schema: snake_case keys recorded by
+        structlog (request_id, status_code, ...) must reach the wire as-is,
+        exempt from the camelCase response policy."""
+        resp = client.get("/api/v1/logs/tail", params={"lines": 100})
+        assert resp.status_code == 200
+        (record,) = [r for r in resp.json()["records"] if r["event"] == "request_finished"]
+        assert record["request_id"] == "abc"
+        assert record["status_code"] == 200
 
     def test_lines_clamped_to_2000(self, client):
         assert client.get("/api/v1/logs/tail", params={"lines": 999999}).status_code == 200

--- a/tests/test_settings_endpoint.py
+++ b/tests/test_settings_endpoint.py
@@ -33,13 +33,13 @@ def test_settings_response_is_whitelisted():
     assert body["name"]
     assert body["version"]
     assert body["environment"]
-    assert body["runtime"] == {"container": False, "image_tag": None}
-    assert "log_paths" in body["logparser"]
-    assert "raw_retention_days" in body["analytics"]
+    assert body["runtime"] == {"container": False, "imageTag": None}
+    assert "logPaths" in body["logparser"]
+    assert "rawRetentionDays" in body["analytics"]
     assert body["map"] == {
-        "home_latitude": 40.7128,
-        "home_longitude": -74.006,
-        "home_source": "external_ip",
+        "homeLatitude": 40.7128,
+        "homeLongitude": -74.006,
+        "homeSource": "external_ip",
     }
 
     # Credential material absent anywhere in the payload
@@ -57,5 +57,5 @@ def test_settings_reports_container_build_metadata(monkeypatch):
 
     assert body["runtime"] == {
         "container": True,
-        "image_tag": "v0.2.2-dev.4",
+        "imageTag": "v0.2.2-dev.4",
     }

--- a/tests/test_settings_endpoint.py
+++ b/tests/test_settings_endpoint.py
@@ -6,12 +6,14 @@ from litestar.testing import TestClient
 
 from geometrikks.domain.system.controllers.settings import read_settings
 from geometrikks.services.geoip.home import HomeLocation
+from geometrikks.server.routes import create_api_v1_router
 from tests.support import ambient_settings_dependency
 
 
 def make_app() -> Litestar:
     app = Litestar(
-        route_handlers=[read_settings], dependencies=ambient_settings_dependency()
+        route_handlers=[create_api_v1_router([read_settings])],
+        dependencies=ambient_settings_dependency(),
     )
     app.state.map_home_location = HomeLocation(40.7128, -74.006, "external_ip")
     return app

--- a/tests/test_system_controller.py
+++ b/tests/test_system_controller.py
@@ -75,15 +75,15 @@ async def test_lists_jobs_with_run_info():
         resp = await client.get("/api/v1/system/scheduler/jobs")
     assert resp.status_code == 200
     body = resp.json()
-    assert body["scheduler_enabled"] is True
+    assert body["schedulerEnabled"] is True
     assert len(body["jobs"]) == 1
     job = body["jobs"][0]
     assert job["id"] == "job-a"
     assert job["name"] == "Job A"
-    assert job["next_run_time"] is not None
+    assert job["nextRunTime"] is not None
     assert job["running"] is False
-    assert job["last_run_time"] is None
-    assert job["last_status"] is None
+    assert job["lastRunTime"] is None
+    assert job["lastStatus"] is None
 
 
 async def test_no_scheduler_reports_disabled():
@@ -91,8 +91,8 @@ async def test_no_scheduler_reports_disabled():
         resp = await client.get("/api/v1/system/scheduler/jobs")
     assert resp.status_code == 200
     assert resp.json() == {
-        "scheduler_enabled": False,
-        "scheduler_running": False,
+        "schedulerEnabled": False,
+        "schedulerRunning": False,
         "jobs": [],
     }
 
@@ -135,23 +135,23 @@ async def test_about_reports_app_runtime_and_geoip_metadata(monkeypatch):
 
     assert body["app"]["name"]
     assert body["app"]["version"]
-    assert body["runtime"]["python_version"]
-    assert body["runtime"]["litestar_version"]
-    assert body["runtime"]["apscheduler_version"]
+    assert body["runtime"]["pythonVersion"]
+    assert body["runtime"]["litestarVersion"]
+    assert body["runtime"]["apschedulerVersion"]
 
     # Reported whether or not a database is reachable, never a 500. A local
     # dev database yields real versions; CI without one yields nulls.
     assert set(body["database"]) == {
-        "postgres_version",
-        "timescaledb_version",
-        "postgis_version",
+        "postgresVersion",
+        "timescaledbVersion",
+        "postgisVersion",
     }
     assert all(v is None or isinstance(v, str) for v in body["database"].values())
 
     # The test mmdb has real metadata
     assert body["geoip"]["available"] is True
-    assert body["geoip"]["build_date"] is not None
-    assert body["geoip"]["age_days"] is not None
+    assert body["geoip"]["buildDate"] is not None
+    assert body["geoip"]["ageDays"] is not None
 
     assert body["links"]["repository"] == "https://github.com/GilbN/geometrikks"
     assert body["links"]["issues"].endswith("/issues")
@@ -164,7 +164,7 @@ async def test_about_geoip_degrades_when_db_missing(monkeypatch):
     assert resp.status_code == 200
     geoip = resp.json()["geoip"]
     assert geoip["available"] is False
-    assert geoip["build_date"] is None
+    assert geoip["buildDate"] is None
 
 
 async def test_about_database_degrades_when_db_unreachable(monkeypatch):
@@ -179,9 +179,9 @@ async def test_about_database_degrades_when_db_unreachable(monkeypatch):
         resp = await client.get("/api/v1/system/about")
     assert resp.status_code == 200
     assert resp.json()["database"] == {
-        "postgres_version": None,
-        "timescaledb_version": None,
-        "postgis_version": None,
+        "postgresVersion": None,
+        "timescaledbVersion": None,
+        "postgisVersion": None,
     }
 
 
@@ -212,17 +212,17 @@ async def test_system_settings_surface_computed_values(monkeypatch):
 
     lat = field("map", "home_latitude")
     assert lat["value"] is None
-    assert lat["computed_value"] == 59.91
-    assert lat["computed_source"] == "external_ip"
+    assert lat["computedValue"] == 59.91
+    assert lat["computedSource"] == "external_ip"
 
     avail = field("geoip", "available")
-    assert avail["computed_value"] is True
-    assert avail["computed_source"] == "runtime"
-    assert avail["env_var"] is None
+    assert avail["computedValue"] is True
+    assert avail["computedSource"] == "runtime"
+    assert avail["envVar"] is None
 
     enabled = field("crowdsec", "enabled")
-    assert enabled["computed_value"] is True
-    assert enabled["computed_source"] == "runtime"
+    assert enabled["computedValue"] is True
+    assert enabled["computedSource"] == "runtime"
 
 
 async def test_system_settings_no_computed_home_when_absent():
@@ -231,11 +231,11 @@ async def test_system_settings_no_computed_home_when_absent():
         resp = await client.get("/api/v1/system/settings")
     sections = {s["name"]: s for s in resp.json()["sections"]}
     lat = next(f for f in sections["map"]["fields"] if f["key"] == "home_latitude")
-    assert lat["computed_value"] is None
+    assert lat["computedValue"] is None
 
     avail = next(f for f in sections["geoip"]["fields"] if f["key"] == "available")
-    assert avail["computed_value"] is False
-    assert avail["computed_source"] == "runtime"
+    assert avail["computedValue"] is False
+    assert avail["computedSource"] == "runtime"
 
 
 async def test_database_info_degraded_without_db(monkeypatch):
@@ -249,9 +249,9 @@ async def test_database_info_degraded_without_db(monkeypatch):
     assert resp.status_code == 200
     body = resp.json()
     assert body["reachable"] is False
-    assert body["size_bytes"] is None
-    assert body["postgres_version"] is None
-    assert body["timescaledb_version"] is None
-    assert isinstance(body["retention_days"], int)
-    assert isinstance(body["debug_retention_days"], int)
+    assert body["sizeBytes"] is None
+    assert body["postgresVersion"] is None
+    assert body["timescaledbVersion"] is None
+    assert isinstance(body["retentionDays"], int)
+    assert isinstance(body["debugRetentionDays"], int)
     assert body["hypertables"] == []

--- a/tests/test_system_controller.py
+++ b/tests/test_system_controller.py
@@ -11,6 +11,7 @@ from litestar.testing import AsyncTestClient
 
 from geometrikks.domain.system.controllers.system import SystemController
 from geometrikks.server.scheduler_tracking import JobRunTracker
+from geometrikks.server.routes import create_api_v1_router
 from tests.support import ambient_settings_dependency
 
 pytestmark = pytest.mark.anyio
@@ -63,7 +64,7 @@ def make_app(*, with_scheduler: bool = True) -> Litestar:
         app.state.scheduler_tracker = tracker
 
     return Litestar(
-        route_handlers=[SystemController],
+        route_handlers=[create_api_v1_router([SystemController])],
         on_startup=[startup],
         dependencies=ambient_settings_dependency(),
     )
@@ -197,7 +198,7 @@ async def test_system_settings_surface_computed_values(monkeypatch):
         app.state.geoip_available = True
 
     app = Litestar(
-        route_handlers=[SystemController],
+        route_handlers=[create_api_v1_router([SystemController])],
         on_startup=[startup],
         dependencies=ambient_settings_dependency(),
     )


### PR DESCRIPTION
Phase 4 of the 0.7 plan: the coordinated wire-format release. Both maintainer decisions are recorded and applied: public payloads standardize on camelCase, and Litestar's native error envelope stays the public error contract. The full policy lives in the new `docs/api-conventions.md`.

**Breaking:** all REST JSON fields and query parameters are now camelCase. External API consumers must rename fields; the bundled frontend is migrated in this PR. The changelog carries the migration note.

## Versioned router

One `Router(path="/api/v1")` in `server/routes.py`; controllers own only their domain segment. Proven wire-neutral: paths, methods, and operation IDs are byte-identical, so generated client method names did not change. Controller unit tests mount their subject through the same `create_api_v1_router()` helper to keep production URLs.

## camelCase everywhere

- Snake_case response dataclasses (analytics, system, settings, stats, health, CrowdSec, geo top-IPs/GeoJSON, log files) became msgspec Structs with `rename="camel"`: the idiom the geo schemas already used, so the API now has one mechanism. Python attributes stay snake_case.
- Digit-adjacent fields pin their wire names explicitly (`status2xx`, `requestCount24h`) because the camel strategy would render `status2Xx`.
- Query parameters carry explicit camelCase names: `fromTimestamp`/`toTimestamp`, `startDate`/`endDate`, `countryCode`, `ipAddress`, `ipAddressNotIn`, `comparePrevious`.
- Deliberately unchanged: path segments (`{location_id}`, `{job_id}`), WebSocket frame payloads (phase 5 owns realtime), `orderBy` column values, `SettingFieldView.key` data values, and raw structlog context keys in `/api/v1/logs/tail` records (documented data exception with a regression test).

## Error contract

- `tests/test_error_contract.py` pins the native `{status_code, detail}` envelope across 400 (framework and domain validation), 401, 404, and 405.
- Fix that fell out: litestar-vite's global NotFoundException handler was returning empty 404 bodies even on API routes. A `handle_not_found` in `server/exceptions.py` now renders the JSON envelope for API paths while non-API static misses keep the empty body.

## Frontend migration

One client regeneration (`services.gen.ts` untouched: method names stable), then consumer updates: response field access, query-param call sites, the hand-written mirrors in `lib/api.ts` (including the inline `/health` types), recharts dataKeys/chart configs, and the MapLibre expressions reading GeoJSON properties (`eventCount`, cluster sum input) in both map sources. WebSocket frame handling stays snake_case by design.

## Verification

- 52 operations: no path, method, or operation-ID changes; no snake_case query parameters or modeled success-response properties remain
- 581 backend tests pass (463 non-integration + 118 integration), `ty` clean
- `tsc` clean, 127 vitest tests pass, production build passes
- Config docs unchanged; changelog migration note included
- Review notes from the pre-push review are addressed (log-tail data exception + regression test, Struct-idiom stragglers, stale comment wire names)
