### PR TITLE
feat: 0.7 phase 5 - lifespan resource ownership, migration gate, realtime consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `{status_code, detail}` JSON envelope; non-API 404s are unchanged.
 - All REST endpoints are mounted through a single versioned `/api/v1` router;
   URLs, operation IDs, and generated client method names are unchanged.
+- Application startup and shutdown are now composed of focused lifespan
+  phases (core state, GeoIP, CrowdSec, database, scheduler, ingestion), each
+  owning its own cleanup. A failure during startup now stops the services
+  that had already started instead of leaking them; teardown order and the
+  DB-degraded and geo-degraded behaviors are unchanged.
 - `create_app()` accepts an explicit settings object and app-level dependency
   overrides, and request handlers now receive settings through dependency
   injection instead of resolving the process-cached factory inline. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GEOMETRIKKS_ENV_FILE` environment variable to override the `.env` file
   path; an empty value disables dotenv loading entirely (the test suite uses
   this so results never depend on a local `.env`).
+- `DB_MIGRATE_ON_STARTUP` setting (default `true`). Set to `false` to run
+  schema migrations as a separate deployment step with
+  `litestar database upgrade` instead of at every app startup; the app then
+  fails startup deliberately if the schema was left unusable.
 
 ### Changed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,7 @@ from real environment variables. It is read once at import time.
 | `DB_PORT` | `5432` | Database port |
 | `DB_DATABASE` | `geometrikks` | Database name |
 | `DB_DROP_ON_STARTUP` | `false` | Drop all tables on startup (development only) |
+| `DB_MIGRATE_ON_STARTUP` | `true` | Run alembic migrations automatically at app startup. Disable when migrations run as a separate deployment step (`litestar database upgrade`); the app then expects the schema to already be at head and fails startup if it is not usable |
 
 ## GeoIP
 

--- a/geometrikks/config/settings.py
+++ b/geometrikks/config/settings.py
@@ -62,6 +62,15 @@ class DatabaseSettings(BaseSettings):
     port: int = Field(default=5432, description="Database port")
     database: str = Field(default="geometrikks", description="Database name")
     drop_on_startup: bool = Field(default=False, description="Drop all tables on startup (development only)")
+    migrate_on_startup: bool = Field(
+        default=True,
+        description=(
+            "Run alembic migrations automatically at app startup. Disable when "
+            "migrations run as a separate deployment step (`litestar database "
+            "upgrade`); the app then expects the schema to already be at head "
+            "and fails startup if it is not usable"
+        ),
+    )
     
     @property
     def url(self) -> str:

--- a/geometrikks/domain/realtime/controllers.py
+++ b/geometrikks/domain/realtime/controllers.py
@@ -10,28 +10,42 @@ proxies don't cut the socket.
 
 Auth: /ws/ paths are NOT excluded in AUTH_EXCLUDE_PATTERNS, so the session
 middleware authenticates the handshake exactly like an API request.
+
+Subscription lifecycle, batching, heartbeats, and the transport loop live in
+stream.py; this module owns each feed's event conversion, filters, snapshot
+frames, and cadences.
 """
 
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from litestar import WebSocket, websocket
-from litestar.exceptions import WebSocketDisconnect
 
+from geometrikks.domain.realtime.stream import (
+    batched_frames,
+    close_service_unavailable,
+    passthrough_frames,
+    stream_json_frames,
+    subscription,
+)
 from geometrikks.server import runtime
 from geometrikks.server.logging import get_logger, log_broadcaster, register_success_level
 from geometrikks.services.logparser.schemas import ParsedLogRecord
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from geometrikks.domain.realtime.stream import Frame
 
 logger = get_logger(__name__)
 
 FLUSH_INTERVAL = 0.15          # seconds -> ~6.7 frames/s, under the ~10/s cap
 MAX_EVENTS_PER_FRAME = 100
 # Reverse proxies cut idle upstream sockets (nginx proxy_read_timeout defaults
-# to 60s; SWAG ships 240s). Both handlers are send-only and silent when no
+# to 60s; SWAG ships 240s). All handlers are send-only and silent when no
 # events flow, so emit an empty frame of the endpoint's own type as a
 # keepalive — existing clients treat it as a no-op and reset their backoff.
 HEARTBEAT_INTERVAL = 30.0
@@ -79,18 +93,6 @@ def record_to_events(record: ParsedLogRecord) -> list[dict[str, Any]]:
     return events
 
 
-async def _watch_disconnect(socket: WebSocket) -> None:
-    """Consume incoming messages so a client disconnect is noticed.
-
-    The handler is send-only; without a reader, a client that disconnects
-    while no events are flowing is never observed and its queue stays
-    subscribed forever (dead connections accumulate on quiet log files).
-    litestar raises WebSocketDisconnect from receive on close.
-    """
-    while True:
-        await socket.receive_data(mode="text")
-
-
 @websocket("/ws/crowdsec", tags=["Live Feed"])
 async def crowdsec_feed(socket: WebSocket) -> None:
     """Stream CrowdSec ban/unban deltas from the decision-stream poller.
@@ -104,45 +106,27 @@ async def crowdsec_feed(socket: WebSocket) -> None:
     poller = runtime.get_crowdsec_poller(socket.app)
     await socket.accept()
     if poller is None:
-        logger.warning("ws_rejected_service_unavailable", endpoint="/ws/crowdsec")
-        await socket.close(code=1013, reason="crowdsec stream not running")  # 1013 = try again later
+        await close_service_unavailable(
+            socket, endpoint="/ws/crowdsec", reason="crowdsec stream not running"
+        )
         return
 
-    queue = poller.subscribe()
-    logger.info("ws_client_connected", endpoint="/ws/crowdsec")
+    async def stream() -> AsyncGenerator[Frame]:
+        async with subscription(poller, endpoint="/ws/crowdsec") as queue:
+            # A freshly loaded page must not wait for the next reachability
+            # transition to learn the current state.
+            if poller.lapi_reachable is not None:
+                yield {"type": "crowdsec_status", "lapi_reachable": poller.lapi_reachable}
+            async for frame in passthrough_frames(
+                queue,
+                heartbeat_interval=HEARTBEAT_INTERVAL,
+                make_heartbeat=lambda: {
+                    "type": "crowdsec_decisions", "added": [], "deleted": []
+                },
+            ):
+                yield frame
 
-    watcher = asyncio.create_task(_watch_disconnect(socket))
-    try:
-        # A freshly loaded page must not wait for the next reachability
-        # transition to learn the current state.
-        if poller.lapi_reachable is not None:
-            await socket.send_json(
-                {"type": "crowdsec_status", "lapi_reachable": poller.lapi_reachable}
-            )
-
-        loop = asyncio.get_running_loop()
-        last_send = loop.time()
-        while not watcher.done():
-            try:
-                frame = await asyncio.wait_for(queue.get(), timeout=0.5)
-            except asyncio.TimeoutError:
-                if not watcher.done() and loop.time() - last_send >= HEARTBEAT_INTERVAL:
-                    await socket.send_json(
-                        {"type": "crowdsec_decisions", "added": [], "deleted": []}
-                    )
-                    last_send = loop.time()
-                continue
-            if not watcher.done():
-                await socket.send_json(frame)
-                last_send = loop.time()
-    except WebSocketDisconnect:
-        pass  # client went away between the watcher check and the send
-    finally:
-        watcher.cancel()
-        with contextlib.suppress(asyncio.CancelledError, WebSocketDisconnect):
-            await watcher
-        poller.unsubscribe(queue)
-        logger.info("ws_client_disconnected", endpoint="/ws/crowdsec")
+    await stream_json_frames(socket, stream())
 
 
 @websocket("/ws/live", tags=["Live Feed"])
@@ -151,49 +135,26 @@ async def live_feed(socket: WebSocket) -> None:
     ingestion = runtime.get_ingestion_service(socket.app)
     await socket.accept()
     if ingestion is None:
-        logger.warning("ws_rejected_service_unavailable", endpoint="/ws/live")
-        await socket.close(code=1013, reason="ingestion not running")  # 1013 = try again later
+        await close_service_unavailable(
+            socket, endpoint="/ws/live", reason="ingestion not running"
+        )
         return
 
-    queue = ingestion.subscribe()
-    logger.info("ws_client_connected", endpoint="/ws/live")
-    watcher = asyncio.create_task(_watch_disconnect(socket))
-    try:
-        loop = asyncio.get_running_loop()
-        last_send = loop.time()
-        pending: list[dict[str, Any]] = []
-        dropped = 0
-        while not watcher.done():
-            # Drain until the flush deadline.
-            deadline = loop.time() + FLUSH_INTERVAL
-            while True:
-                remaining = deadline - loop.time()
-                if remaining <= 0:
-                    break
-                try:
-                    record = await asyncio.wait_for(queue.get(), timeout=remaining)
-                except asyncio.TimeoutError:
-                    break
-                for event in record_to_events(record):
-                    if len(pending) >= MAX_EVENTS_PER_FRAME:
-                        dropped += 1
-                    else:
-                        pending.append(event)
+    async def stream() -> AsyncGenerator[Frame]:
+        async with subscription(ingestion, endpoint="/ws/live") as queue:
+            async for frame in batched_frames(
+                queue,
+                flush_interval=FLUSH_INTERVAL,
+                max_items=MAX_EVENTS_PER_FRAME,
+                heartbeat_interval=HEARTBEAT_INTERVAL,
+                expand=record_to_events,
+                make_frame=lambda events, dropped: {
+                    "type": "batch", "events": events, "dropped": dropped
+                },
+            ):
+                yield frame
 
-            if watcher.done():
-                break
-            if pending or dropped or loop.time() - last_send >= HEARTBEAT_INTERVAL:
-                await socket.send_json({"type": "batch", "events": pending, "dropped": dropped})
-                pending, dropped = [], 0
-                last_send = loop.time()
-    except WebSocketDisconnect:
-        pass  # client went away between the watcher check and the send
-    finally:
-        watcher.cancel()
-        with contextlib.suppress(asyncio.CancelledError, WebSocketDisconnect):
-            await watcher  # retrieve its exception so no "never retrieved" warning
-        ingestion.unsubscribe(queue)
-        logger.info("ws_client_disconnected", endpoint="/ws/live")
+    await stream_json_frames(socket, stream())
 
 
 LOG_FLUSH_INTERVAL = 0.25
@@ -222,43 +183,22 @@ async def logs_feed(socket: WebSocket) -> None:
     register_success_level()
     level_names = logging.getLevelNamesMapping()
 
-    queue = log_broadcaster.subscribe()
-    logger.info("ws_client_connected", endpoint="/ws/logs")
-    watcher = asyncio.create_task(_watch_disconnect(socket))
-    try:
-        loop = asyncio.get_running_loop()
-        last_send = loop.time()
-        pending: list[dict[str, Any]] = []
-        dropped = 0
-        while not watcher.done():
-            deadline = loop.time() + LOG_FLUSH_INTERVAL
-            while True:
-                remaining = deadline - loop.time()
-                if remaining <= 0:
-                    break
-                try:
-                    record = await asyncio.wait_for(queue.get(), timeout=remaining)
-                except asyncio.TimeoutError:
-                    break
-                levelno = level_names.get(str(record.get("level", "")).upper(), 0)
-                if levelno < min_levelno:
-                    continue
-                if len(pending) >= MAX_RECORDS_PER_FRAME:
-                    dropped += 1
-                else:
-                    pending.append(record)
+    def at_or_above_level(record: dict[str, Any]) -> tuple[dict[str, Any], ...]:
+        levelno = level_names.get(str(record.get("level", "")).upper(), 0)
+        return (record,) if levelno >= min_levelno else ()
 
-            if watcher.done():
-                break
-            if pending or dropped or loop.time() - last_send >= HEARTBEAT_INTERVAL:
-                await socket.send_json({"type": "log_batch", "records": pending, "dropped": dropped})
-                pending, dropped = [], 0
-                last_send = loop.time()
-    except WebSocketDisconnect:
-        pass  # client went away between the watcher check and the send
-    finally:
-        watcher.cancel()
-        with contextlib.suppress(asyncio.CancelledError, WebSocketDisconnect):
-            await watcher
-        log_broadcaster.unsubscribe(queue)
-        logger.info("ws_client_disconnected", endpoint="/ws/logs")
+    async def stream() -> AsyncGenerator[Frame]:
+        async with subscription(log_broadcaster, endpoint="/ws/logs") as queue:
+            async for frame in batched_frames(
+                queue,
+                flush_interval=LOG_FLUSH_INTERVAL,
+                max_items=MAX_RECORDS_PER_FRAME,
+                heartbeat_interval=HEARTBEAT_INTERVAL,
+                expand=at_or_above_level,
+                make_frame=lambda records, dropped: {
+                    "type": "log_batch", "records": records, "dropped": dropped
+                },
+            ):
+                yield frame
+
+    await stream_json_frames(socket, stream())

--- a/geometrikks/domain/realtime/stream.py
+++ b/geometrikks/domain/realtime/stream.py
@@ -179,5 +179,14 @@ async def stream_json_frames(socket: WebSocket, stream: AsyncGenerator[Frame]) -
             listen_for_disconnect=True,
             warn_on_data_discard=False,
         )
-    except WebSocketDisconnect:
-        pass  # client went away between the disconnect check and the send
+    except* WebSocketDisconnect:
+        # Client went away between the disconnect check and the send. The
+        # AnyIO task group inside send_websocket_stream wraps exceptions from
+        # its child tasks in an ExceptionGroup, so a plain `except` would let
+        # the grouped disconnect escape; except* handles bare and grouped.
+        pass
+    finally:
+        # A disconnect raised from the send leaves the generator suspended at
+        # its yield; close it explicitly so subscription cleanup runs before
+        # the handler returns instead of at garbage collection.
+        await stream.aclose()

--- a/geometrikks/domain/realtime/stream.py
+++ b/geometrikks/domain/realtime/stream.py
@@ -1,0 +1,183 @@
+"""Shared machinery for the /ws feeds.
+
+The three live feeds share one shape: subscribe to a process-local broker,
+stream JSON frames until the client goes away, heartbeat when idle, and
+always unsubscribe. This module owns that machinery once:
+
+- :func:`subscription` - subscribe/unsubscribe lifecycle with connect and
+  disconnect audit logs.
+- :func:`batched_frames` / :func:`passthrough_frames` - the two delivery
+  policies (drain-and-flush with drop accounting vs one frame per item).
+- :func:`stream_json_frames` - the transport wrapper over Litestar's
+  ``send_websocket_stream``, which supplies the send loop and disconnect
+  detection.
+- :func:`close_service_unavailable` - the degraded-mode 1013 closure.
+
+Feed-specific concerns (event conversion, level filters, snapshot frames,
+cadences, frame caps) stay in the handlers in ``controllers.py``.
+
+Transport decisions (0.7.0): Litestar's ``send_websocket_stream`` function is
+the adopted wrapper; the ``@websocket_stream`` decorator was not, because the
+feeds must accept and then close 1013 in degraded mode before any streaming
+starts. ``ChannelsPlugin`` was evaluated and deliberately not adopted: these
+are fixed, process-local feeds with no dynamic topics, history, or
+cross-process fan-out, and an in-memory Channels backend would not lift the
+single-worker constraint. Revisit only if those requirements appear.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any, Protocol
+
+from litestar.exceptions import WebSocketDisconnect
+from litestar.handlers import send_websocket_stream
+
+from geometrikks.server.logging import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Callable, Iterable
+
+    from litestar import WebSocket
+
+logger = get_logger(__name__)
+
+Frame = dict[str, Any]
+
+
+class Subscribable(Protocol):
+    """The broker shape all three feeds share (ingestion service,
+    CrowdSec stream poller, log broadcaster)."""
+
+    def subscribe(self) -> asyncio.Queue: ...
+
+    def unsubscribe(self, queue: asyncio.Queue) -> None: ...
+
+
+async def close_service_unavailable(socket: WebSocket, *, endpoint: str, reason: str) -> None:
+    """Close 1013 (try again later): the feed's backing service is not running.
+
+    Clients treat 1013 as a signal to fall back to periodic refetch instead
+    of reconnect-looping against a degraded server.
+    """
+    logger.warning("ws_rejected_service_unavailable", endpoint=endpoint)
+    await socket.close(code=1013, reason=reason)
+
+
+@asynccontextmanager
+async def subscription(
+    broker: Subscribable, *, endpoint: str
+) -> AsyncGenerator[asyncio.Queue]:
+    """Subscribe to a broker for the lifetime of the block; always unsubscribe.
+
+    The ``finally`` runs on client disconnect, server-side cancellation
+    (shutdown), and send errors alike, so dead connections can never leave
+    their queue subscribed.
+    """
+    queue = broker.subscribe()
+    logger.info("ws_client_connected", endpoint=endpoint)
+    try:
+        yield queue
+    finally:
+        broker.unsubscribe(queue)
+        logger.info("ws_client_disconnected", endpoint=endpoint)
+
+
+async def batched_frames(
+    queue: asyncio.Queue,
+    *,
+    flush_interval: float,
+    max_items: int,
+    heartbeat_interval: float,
+    make_frame: Callable[[list[Any], int], Frame],
+    expand: Callable[[Any], Iterable[Any]] | None = None,
+) -> AsyncGenerator[Frame]:
+    """Drain the queue in flush windows and yield batch frames.
+
+    Items beyond ``max_items`` per frame are counted, not silently lost:
+    ``make_frame(items, dropped)`` receives the overflow count so the client
+    gets a rate signal instead of melting. ``expand`` maps one queue item to
+    zero or more frame items (event conversion, level filtering). When idle,
+    an empty frame is yielded every ``heartbeat_interval`` seconds so reverse
+    proxies don't cut the socket.
+    """
+    loop = asyncio.get_running_loop()
+    last_send = loop.time()
+    pending: list[Any] = []
+    dropped = 0
+    while True:
+        # Drain until the flush deadline.
+        deadline = loop.time() + flush_interval
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                break
+            try:
+                item = await asyncio.wait_for(queue.get(), timeout=remaining)
+            except asyncio.TimeoutError:
+                break
+            for entry in expand(item) if expand is not None else (item,):
+                if len(pending) >= max_items:
+                    dropped += 1
+                else:
+                    pending.append(entry)
+
+        if pending or dropped or loop.time() - last_send >= heartbeat_interval:
+            yield make_frame(pending, dropped)
+            pending, dropped = [], 0
+            last_send = loop.time()
+
+
+async def passthrough_frames(
+    queue: asyncio.Queue,
+    *,
+    heartbeat_interval: float,
+    make_heartbeat: Callable[[], Frame],
+    poll_interval: float = 0.5,
+) -> AsyncGenerator[Frame]:
+    """Yield each queued frame as-is; heartbeat when idle.
+
+    For low-volume feeds whose broker already produces wire frames
+    (the CrowdSec decision stream), so batching would only add latency.
+    """
+    loop = asyncio.get_running_loop()
+    last_send = loop.time()
+    while True:
+        try:
+            frame = await asyncio.wait_for(queue.get(), timeout=poll_interval)
+        except asyncio.TimeoutError:
+            if loop.time() - last_send >= heartbeat_interval:
+                yield make_heartbeat()
+                last_send = loop.time()
+            continue
+        yield frame
+        last_send = loop.time()
+
+
+async def _send_json(socket: WebSocket, frame: Frame) -> None:
+    await socket.send_json(frame)
+
+
+async def stream_json_frames(socket: WebSocket, stream: AsyncGenerator[Frame]) -> None:
+    """Send every frame from ``stream`` as a JSON text message until the
+    client disconnects.
+
+    ``send_websocket_stream`` supplies the send loop and the background
+    disconnect listener; on disconnect it cancels the generator, whose
+    ``finally`` blocks (subscription cleanup) still run.
+
+    ``warn_on_data_discard=False`` is the documented inbound-frame policy:
+    these feeds are send-only and unexpected client frames are consumed and
+    ignored (covered by tests), not warned about.
+    """
+    try:
+        await send_websocket_stream(
+            socket,
+            stream,
+            send_handler=_send_json,
+            listen_for_disconnect=True,
+            warn_on_data_discard=False,
+        )
+    except WebSocketDisconnect:
+        pass  # client went away between the disconnect check and the send

--- a/geometrikks/domain/system/controllers/system.py
+++ b/geometrikks/domain/system/controllers/system.py
@@ -19,6 +19,7 @@ from litestar.exceptions import NotFoundException
 from litestar.params import FromPath, SkipValidation
 from litestar.status_codes import HTTP_202_ACCEPTED
 from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from geometrikks.config.introspection import (
     ComputedField,
@@ -99,12 +100,9 @@ def _dist_version(name: str) -> str | None:
         return None
 
 
-async def _database_versions(app: Litestar) -> DatabaseVersionsView:
+async def _database_versions(engine: AsyncEngine) -> DatabaseVersionsView:
     """Server and extension versions; nulls when the DB is unreachable."""
-    from geometrikks.server.plugins import get_app_db_config
-
     try:
-        engine = get_app_db_config(app).get_engine()
         async with engine.connect() as conn:
             pg = (await conn.execute(text("SHOW server_version"))).scalar_one()
             rows = (
@@ -151,17 +149,14 @@ class DatabaseInfoResponse(msgspec.Struct, rename="camel"):
 HYPERTABLE_NAMES = ("geo_events", "access_logs", "access_log_debug")
 
 
-async def _database_stats(app: Litestar) -> tuple[int | None, list[HypertableStatsView]]:
+async def _database_stats(engine: AsyncEngine) -> tuple[int | None, list[HypertableStatsView]]:
     """Database size and per-hypertable stats; (None, []) when unreachable.
 
     Uses TimescaleDB catalog-backed functions (approximate_row_count,
     hypertable_size, hypertable_compression_stats), so this stays fast at
     tens of millions of rows.
     """
-    from geometrikks.server.plugins import get_app_db_config
-
     try:
-        engine = get_app_db_config(app).get_engine()
         async with engine.connect() as conn:
             size = (
                 await conn.execute(text("SELECT pg_database_size(current_database())"))
@@ -267,7 +262,10 @@ class SystemController(Controller):
 
     @get("/about")
     async def get_about(
-        self, request: Request, settings: NamedDependency[SkipValidation[Settings]]
+        self,
+        request: Request,
+        settings: NamedDependency[SkipValidation[Settings]],
+        db_engine: NamedDependency[SkipValidation[AsyncEngine]],
     ) -> AboutResponse:
         """App, runtime, database, and GeoIP metadata for the About page."""
         s = settings
@@ -285,22 +283,26 @@ class SystemController(Controller):
                 litestar_version=_dist_version("litestar"),
                 apscheduler_version=_dist_version("apscheduler"),
             ),
-            database=await _database_versions(request.app),
+            database=await _database_versions(db_engine),
             geoip=geoip_info(s.geoip.db_path),
             links=AboutLinksView(repository=REPO_URL, issues=f"{REPO_URL}/issues"),
         )
 
     @get("/database")
     async def get_database_info(
-        self, request: Request, settings: NamedDependency[SkipValidation[Settings]]
+        self,
+        settings: NamedDependency[SkipValidation[Settings]],
+        db_engine: NamedDependency[SkipValidation[AsyncEngine]],
     ) -> DatabaseInfoResponse:
         """Size, versions, retention and hypertable stats for the Status page.
 
-        Renders nulls instead of failing in DB-degraded mode.
+        Renders nulls instead of failing in DB-degraded mode: the plugin's
+        db_engine provider hands out the engine without connecting, so
+        failures surface at query time inside the try/except blocks.
         """
         s = settings
-        versions = await _database_versions(request.app)
-        size_bytes, hypertables = await _database_stats(request.app)
+        versions = await _database_versions(db_engine)
+        size_bytes, hypertables = await _database_stats(db_engine)
         return DatabaseInfoResponse(
             reachable=size_bytes is not None,
             size_bytes=size_bytes,

--- a/geometrikks/server/core.py
+++ b/geometrikks/server/core.py
@@ -12,7 +12,7 @@ from litestar.config.compression import CompressionConfig
 from geometrikks.config.settings import Settings, get_settings
 from geometrikks.server import plugins
 from geometrikks.server.exceptions import EXCEPTION_HANDLERS
-from geometrikks.server.lifecycle import on_startup, on_shutdown
+from geometrikks.server.lifecycle import LIFESPAN
 from geometrikks.server.routes import get_route_handlers
 from geometrikks.server.dependencies import create_settings_provider
 
@@ -93,8 +93,7 @@ def create_app(
     app = Litestar(
         debug=settings.debug,
         route_handlers=get_route_handlers(include_auth=not settings.auth_disabled),
-        on_startup=[on_startup],
-        on_shutdown=[on_shutdown],
+        lifespan=list(LIFESPAN),
         plugins=plugins.create_plugins(settings, db_config=db_config),
         dependencies=dependency_map,
         openapi_config=openapi_config,

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -1,13 +1,28 @@
-"""Application lifecycle hooks for startup and shutdown."""
+"""Application lifecycle as focused lifespan context managers.
+
+Each concern owns both its startup and its cleanup in one async context
+manager. ``create_app()`` passes :data:`LIFESPAN` to Litestar, which enters
+the managers in order on an ``AsyncExitStack`` and exits them in reverse:
+
+- teardown order is the exact reverse of startup (ingestion stops first,
+  the scheduler second, the CrowdSec client closes after both), and
+- a failure during startup unwinds only the managers that already started,
+  so partial startup no longer leaks running services.
+
+Degraded modes are decided once: :func:`database_lifespan` records
+``app.state.db_available`` and the scheduler and ingestion managers no-op
+when it is False. Missing GeoLite2 puts the app in geo-degraded mode
+(API/UI up, ingestion inert) without failing startup.
+"""
 
 from __future__ import annotations
 
 import asyncio
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from geometrikks.config.settings import get_settings
@@ -27,9 +42,21 @@ from geometrikks.server.scheduler import create_scheduler
 from geometrikks.server.scheduler_tracking import JobRunTracker
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from geometrikks.config.settings import Settings
     from litestar import Litestar
 
 logger = get_logger(__name__)
+
+
+def _resolve_settings(app: "Litestar") -> "Settings":
+    """The settings the app was composed with.
+
+    create_app() stores its composed settings on state; the fallback keeps
+    hand-built test apps that attach these managers directly working.
+    """
+    return getattr(app.state, "settings", None) or get_settings()
 
 
 async def _db_available(app: "Litestar", timeout: float = 10.0) -> bool:
@@ -46,35 +73,35 @@ async def _db_available(app: "Litestar", timeout: float = 10.0) -> bool:
         return False
 
 
-async def on_startup(app: "Litestar") -> None:
-    """Run alembic migrations and start ingestion when DB is reachable.
+@asynccontextmanager
+async def core_state_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
+    """Process start time and the log broadcaster's event loop binding.
 
-    - If DB is unavailable, start the API in a degraded mode (no migrations,
-      no ingestion) instead of failing app startup.
-    - If the DB is reachable but the migration fails, that failure propagates
-      and fails startup deliberately: a reachable DB with a broken schema is
-      an error to surface, not an outage to degrade around.
-    - Sets up TimescaleDB hypertables and continuous aggregates after migrations.
+    Runs first so /about reports uptime even when later managers degrade.
     """
-    # Set before anything else so /about reports uptime even in degraded mode.
     app.state.started_at = datetime.now(timezone.utc)
 
     from geometrikks.server.logging import log_broadcaster
     log_broadcaster.bind_loop(asyncio.get_running_loop())
 
-    # create_app() stores its composed settings on state; the fallback keeps
-    # hand-built test apps that attach this hook directly working.
-    settings = getattr(app.state, "settings", None) or get_settings()
-
+    settings = _resolve_settings(app)
     if settings.api.log_level is not None:
         logger.warning(
             "API_LOG_LEVEL is deprecated and will be removed in a future "
             "release; set LOG_LEVEL instead."
         )
+    yield
 
-    # GeoIP: download/refresh if credentials are configured; degrade otherwise.
-    # Runs before the DB gate — geo enrichment does not need the database, and
-    # /health must report geoip state accurately even in DB-degraded mode.
+
+@asynccontextmanager
+async def geoip_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
+    """GeoLite2 download/refresh and home-location detection.
+
+    Runs before the DB gate: geo enrichment does not need the database, and
+    /health must report geoip state accurately even in DB-degraded mode.
+    Missing credentials or database degrade the feature, never startup.
+    """
+    settings = _resolve_settings(app)
     geoip_available: bool = await ensure_geoip_database(settings.geoip)
     app.state.geoip_available = geoip_available
     app.state.map_home_location = await resolve_home_location(
@@ -88,9 +115,22 @@ async def on_startup(app: "Litestar") -> None:
             "not start until a GeoLite2 database file is present (restart "
             "after configuring MAXMINDDB_USER_ID/MAXMINDDB_LICENSE_KEY)."
         )
+    yield
 
-    # CrowdSec: LAPI client needs no database, so it is wired before the DB
-    # gate; missing config degrades the feature instead of failing startup.
+
+@asynccontextmanager
+async def crowdsec_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
+    """CrowdSec LAPI client and decision-stream poller wiring.
+
+    The LAPI client needs no database, so this runs before the DB gate;
+    missing config degrades the feature instead of failing startup. The
+    database manager may later null the poller in DB-degraded mode (the poll
+    job runs on the scheduler, which never starts without a database).
+
+    Teardown closes the LAPI client; it exits after the scheduler and
+    ingestion managers, so nothing that could still use the client outlives it.
+    """
+    settings = _resolve_settings(app)
     if settings.crowdsec.enabled:
         app.state.crowdsec_service = CrowdSecService(settings.crowdsec)
         app.state.crowdsec_stream_poller = CrowdSecStreamPoller(app.state.crowdsec_service)
@@ -100,10 +140,32 @@ async def on_startup(app: "Litestar") -> None:
     else:
         app.state.crowdsec_service = None
         app.state.crowdsec_stream_poller = None
+    try:
+        yield
+    finally:
+        crowdsec_service = runtime.get_crowdsec_service(app)
+        if crowdsec_service:
+            await crowdsec_service.aclose()
+
+
+@asynccontextmanager
+async def database_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
+    """Database gate: availability probe, migrations, TimescaleDB objects.
+
+    - If the DB is unavailable, record ``db_available = False`` and serve in
+      degraded mode (no migrations; scheduler and ingestion never start).
+    - If the DB is reachable but migration fails, that failure propagates
+      and fails startup deliberately: a reachable DB with a broken schema is
+      an error to surface, not an outage to degrade around.
+
+    Engine disposal belongs to the SQLAlchemy plugin, so there is no teardown.
+    """
+    settings = _resolve_settings(app)
 
     if not await _db_available(app):
         logger.warning("Starting without database: skipping migrations and ingestion.")
-        if app.state.crowdsec_stream_poller is not None:
+        app.state.db_available = False
+        if runtime.get_crowdsec_poller(app) is not None:
             # The poll job runs on the scheduler, which never starts without a
             # database; a live poller would leave /ws/crowdsec clients hanging
             # instead of closing 1013 so they fall back to periodic refetch.
@@ -112,23 +174,69 @@ async def on_startup(app: "Litestar") -> None:
                 "CrowdSec live updates disabled: the scheduler does not run "
                 "in DB-degraded mode."
             )
+        yield
         return
 
-    db_config = get_app_db_config(app)
-    engine = db_config.get_engine()
+    app.state.db_available = True
+    engine = get_app_db_config(app).get_engine()
 
     # Schema is owned by alembic (migrations/versions). A failed upgrade
-    # raises and fails startup deliberately: a reachable DB with a broken
-    # schema is an error to surface, not an outage to degrade around.
+    # raises and fails startup deliberately.
     await migrate_database(engine, settings)
 
     # TimescaleDB objects (hypertables, CAGGs, policies) deliberately stay
     # out of alembic: the DDL is idempotent, timescale-version-sensitive,
     # and alembic autogenerate can neither model nor diff them.
     await setup_timescaledb(engine, settings.analytics)
+    yield
 
-    # Session factory: ingestion opens a short-lived session per batch flush
-    session_maker: Callable[[], AsyncSession] = db_config.create_session_maker()
+
+@asynccontextmanager
+async def scheduler_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
+    """APScheduler with job-run tracking; no-op in DB-degraded mode."""
+    if not getattr(app.state, "db_available", False):
+        yield
+        return
+
+    settings = _resolve_settings(app)
+    session_maker = get_app_db_config(app).create_session_maker()
+
+    # Tracker must attach before start so no event is missed.
+    scheduler: AsyncIOScheduler = await create_scheduler(
+        session_maker,
+        settings,
+        crowdsec_poller=runtime.get_crowdsec_poller(app),
+    )
+    scheduler_tracker = JobRunTracker()
+    scheduler_tracker.attach(scheduler)
+    scheduler.start()
+    logger.info("Started APScheduler")
+
+    app.state.scheduler = scheduler
+    app.state.scheduler_tracker = scheduler_tracker
+    try:
+        yield
+    finally:
+        running = runtime.get_scheduler(app)
+        if running and running.running:
+            running.shutdown(wait=True)
+            logger.info("Stopped APScheduler")
+
+
+@asynccontextmanager
+async def ingestion_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
+    """Log tailing -> parse -> GeoIP -> DB pipeline; no-op in DB-degraded mode.
+
+    Enters last and therefore exits first: ingestion stops before the
+    scheduler and the CrowdSec client so nothing keeps writing during teardown.
+    """
+    if not getattr(app.state, "db_available", False):
+        yield
+        return
+
+    settings = _resolve_settings(app)
+    # Ingestion opens a short-lived session per batch flush.
+    session_maker = get_app_db_config(app).create_session_maker()
 
     parsers = [
         LogParser(
@@ -151,44 +259,25 @@ async def on_startup(app: "Litestar") -> None:
         commit_interval=settings.logparser.commit_interval,
         store_debug_lines=settings.logparser.store_debug_lines,
     )
-
-    # Create and start scheduler; tracker must attach before start so no
-    # event is missed.
-    scheduler: AsyncIOScheduler = await create_scheduler(
-        session_maker,
-        settings,
-        crowdsec_poller=runtime.get_crowdsec_poller(app),
-    )
-    scheduler_tracker = JobRunTracker()
-    scheduler_tracker.attach(scheduler)
-    scheduler.start()
-    logger.info("Started APScheduler")
-
-    # Store in app state for shutdown and API access
     app.state.ingestion_service = ingestion_service
-    app.state.scheduler = scheduler
-    app.state.scheduler_tracker = scheduler_tracker
 
-    # Start ingestion service
     await ingestion_service.start(
         skip_validation=settings.logparser.skip_validation,
     )
+    try:
+        yield
+    finally:
+        service = runtime.get_ingestion_service(app)
+        if service:
+            await service.stop(timeout=5.0)
 
 
-async def on_shutdown(app: "Litestar") -> None:
-    """Gracefully stop background services and clean up resources."""
-    # Stop ingestion service first
-    ingestion_service = runtime.get_ingestion_service(app)
-    if ingestion_service:
-        await ingestion_service.stop(timeout=5.0)
-
-    # Stop scheduler
-    scheduler = runtime.get_scheduler(app)
-    if scheduler and scheduler.running:
-        scheduler.shutdown(wait=True)
-        logger.info("Stopped APScheduler")
-
-    # Close the CrowdSec LAPI client
-    crowdsec_service = runtime.get_crowdsec_service(app)
-    if crowdsec_service:
-        await crowdsec_service.aclose()
+# Entered in order by Litestar's lifespan AsyncExitStack; exited in reverse.
+LIFESPAN = [
+    core_state_lifespan,
+    geoip_lifespan,
+    crowdsec_lifespan,
+    database_lifespan,
+    scheduler_lifespan,
+    ingestion_lifespan,
+]

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -181,8 +181,17 @@ async def database_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
     engine = get_app_db_config(app).get_engine()
 
     # Schema is owned by alembic (migrations/versions). A failed upgrade
-    # raises and fails startup deliberately.
-    await migrate_database(engine, settings)
+    # raises and fails startup deliberately. Multi-process deployments run
+    # migrations as a separate step instead (litestar database upgrade) and
+    # disable this; TimescaleDB setup below still requires the schema to be
+    # at head and fails startup if the external step was skipped.
+    if settings.database.migrate_on_startup:
+        await migrate_database(engine, settings)
+    else:
+        logger.info(
+            "Startup migrations disabled (DB_MIGRATE_ON_STARTUP=false); "
+            "expecting an external 'litestar database upgrade' step."
+        )
 
     # TimescaleDB objects (hypertables, CAGGs, policies) deliberately stay
     # out of alembic: the DDL is idempotent, timescale-version-sensitive,

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -131,19 +131,23 @@ async def crowdsec_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
     ingestion managers, so nothing that could still use the client outlives it.
     """
     settings = _resolve_settings(app)
-    if settings.crowdsec.enabled:
-        app.state.crowdsec_service = CrowdSecService(settings.crowdsec)
-        app.state.crowdsec_stream_poller = CrowdSecStreamPoller(app.state.crowdsec_service)
-        logger.info(
-            "CrowdSec integration enabled (write=%s)", settings.crowdsec.write_enabled
-        )
-    else:
-        app.state.crowdsec_service = None
-        app.state.crowdsec_stream_poller = None
+    service: CrowdSecService | None = None
+    # The finally covers the setup phase too: if wiring fails after the LAPI
+    # client exists (e.g. poller construction), the client is still closed.
     try:
+        if settings.crowdsec.enabled:
+            service = CrowdSecService(settings.crowdsec)
+            app.state.crowdsec_service = service
+            app.state.crowdsec_stream_poller = CrowdSecStreamPoller(service)
+            logger.info(
+                "CrowdSec integration enabled (write=%s)", settings.crowdsec.write_enabled
+            )
+        else:
+            app.state.crowdsec_service = None
+            app.state.crowdsec_stream_poller = None
         yield
     finally:
-        crowdsec_service = runtime.get_crowdsec_service(app)
+        crowdsec_service = runtime.get_crowdsec_service(app) or service
         if crowdsec_service:
             await crowdsec_service.aclose()
 
@@ -216,17 +220,19 @@ async def scheduler_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
         settings,
         crowdsec_poller=runtime.get_crowdsec_poller(app),
     )
-    scheduler_tracker = JobRunTracker()
-    scheduler_tracker.attach(scheduler)
-    scheduler.start()
-    logger.info("Started APScheduler")
-
-    app.state.scheduler = scheduler
-    app.state.scheduler_tracker = scheduler_tracker
+    # The finally covers start() itself: if it activates the scheduler and
+    # then raises, the running scheduler is still shut down.
     try:
+        scheduler_tracker = JobRunTracker()
+        scheduler_tracker.attach(scheduler)
+        scheduler.start()
+        logger.info("Started APScheduler")
+
+        app.state.scheduler = scheduler
+        app.state.scheduler_tracker = scheduler_tracker
         yield
     finally:
-        running = runtime.get_scheduler(app)
+        running = runtime.get_scheduler(app) or scheduler
         if running and running.running:
             running.shutdown(wait=True)
             logger.info("Stopped APScheduler")
@@ -270,13 +276,15 @@ async def ingestion_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
     )
     app.state.ingestion_service = ingestion_service
 
-    await ingestion_service.start(
-        skip_validation=settings.logparser.skip_validation,
-    )
+    # The finally covers start() itself: if it activates tailers and then
+    # raises, the partially started service is still stopped.
     try:
+        await ingestion_service.start(
+            skip_validation=settings.logparser.skip_validation,
+        )
         yield
     finally:
-        service = runtime.get_ingestion_service(app)
+        service = runtime.get_ingestion_service(app) or ingestion_service
         if service:
             await service.stop(timeout=5.0)
 

--- a/geometrikks/server/runtime.py
+++ b/geometrikks/server/runtime.py
@@ -53,7 +53,7 @@ def get_scheduler_tracker(app: Litestar) -> JobRunTracker:
 
 
 def get_started_at(app: Litestar) -> datetime | None:
-    """Process start time; None before on_startup has run."""
+    """Process start time; None before lifespan startup has run."""
     return getattr(app.state, "started_at", None)
 
 
@@ -65,7 +65,7 @@ def get_map_home_location(app: Litestar) -> HomeLocation | None:
 def is_geoip_available(app: Litestar, *, default: bool = False) -> bool:
     """Whether a usable GeoLite2 database is loaded.
 
-    ``default`` is returned before on_startup has recorded the real value:
+    ``default`` is returned before lifespan startup has recorded the real value:
     the health endpoint passes True (don't report degraded during boot),
     settings introspection passes False (don't claim a database exists).
     """

--- a/tests/support.py
+++ b/tests/support.py
@@ -1,9 +1,15 @@
 """Shared helpers for hand-built test apps."""
 from __future__ import annotations
 
+from contextlib import AsyncExitStack, asynccontextmanager
+from typing import TYPE_CHECKING
+
 from litestar.di import Provide
 
 from geometrikks.config.settings import get_settings
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
 
 
 def ambient_settings_dependency() -> dict[str, Provide]:
@@ -15,3 +21,19 @@ def ambient_settings_dependency() -> dict[str, Provide]:
     Full-app tests should prefer ``create_app(settings=...)`` instead.
     """
     return {"settings": Provide(get_settings, sync_to_thread=False)}
+
+
+@asynccontextmanager
+async def enter_lifespan(app) -> AsyncGenerator[None]:
+    """Enter every lifecycle manager in order and exit in reverse.
+
+    Mirrors how Litestar runs ``LIFESPAN`` on its ``AsyncExitStack``, for
+    lifecycle tests that drive a bare stand-in app instead of a real
+    Litestar instance.
+    """
+    from geometrikks.server import lifecycle
+
+    async with AsyncExitStack() as stack:
+        for manager in lifecycle.LIFESPAN:
+            await stack.enter_async_context(manager(app))
+        yield

--- a/tests/test_crowdsec_lifecycle.py
+++ b/tests/test_crowdsec_lifecycle.py
@@ -1,10 +1,11 @@
-"""Startup wires the CrowdSec service into app state; shutdown closes it."""
+"""Lifespan startup wires the CrowdSec service into app state; exit closes it."""
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 from geometrikks.services.crowdsec import CrowdSecService
+from tests.support import enter_lifespan
 from tests.test_lifecycle_geoip import _patch_startup_collaborators
 
 import pytest
@@ -26,9 +27,8 @@ async def test_startup_creates_service_when_enabled(monkeypatch):
     )
 
     app = make_app()
-    await lc.on_startup(app)
-    assert isinstance(app.state.crowdsec_service, CrowdSecService)
-    await app.state.crowdsec_service.aclose()
+    async with enter_lifespan(app):
+        assert isinstance(app.state.crowdsec_service, CrowdSecService)
 
 
 async def test_startup_without_config_sets_none(monkeypatch, tmp_path):
@@ -43,8 +43,8 @@ async def test_startup_without_config_sets_none(monkeypatch, tmp_path):
     )
 
     app = make_app()
-    await lc.on_startup(app)
-    assert app.state.crowdsec_service is None
+    async with enter_lifespan(app):
+        assert app.state.crowdsec_service is None
 
 
 async def test_startup_creates_service_even_without_database(monkeypatch):
@@ -58,9 +58,8 @@ async def test_startup_creates_service_even_without_database(monkeypatch):
     )
 
     app = make_app()
-    await lc.on_startup(app)
-    assert isinstance(app.state.crowdsec_service, CrowdSecService)
-    await app.state.crowdsec_service.aclose()
+    async with enter_lifespan(app):
+        assert isinstance(app.state.crowdsec_service, CrowdSecService)
 
 
 async def test_startup_without_database_disables_stream_poller(monkeypatch):
@@ -76,18 +75,24 @@ async def test_startup_without_database_disables_stream_poller(monkeypatch):
     )
 
     app = make_app()
-    await lc.on_startup(app)
-    assert app.state.crowdsec_stream_poller is None
-    assert isinstance(app.state.crowdsec_service, CrowdSecService)
-    await app.state.crowdsec_service.aclose()
+    async with enter_lifespan(app):
+        assert app.state.crowdsec_stream_poller is None
+        assert isinstance(app.state.crowdsec_service, CrowdSecService)
 
 
-async def test_shutdown_closes_service():
+async def test_crowdsec_lifespan_closes_service_on_exit(monkeypatch):
+    """The manager owns its own cleanup: exit closes the LAPI client."""
     from geometrikks.server import lifecycle as lc
 
+    monkeypatch.setenv("CROWDSEC_LAPI_URL", "http://crowdsec:8080")
+    monkeypatch.setenv("CROWDSEC_BOUNCER_API_KEY", "key")
     service = AsyncMock(spec=CrowdSecService)
-    app = SimpleNamespace(state=SimpleNamespace(crowdsec_service=service))
-    await lc.on_shutdown(app)
+    monkeypatch.setattr(lc, "CrowdSecService", MagicMock(return_value=service))
+    monkeypatch.setattr(lc, "CrowdSecStreamPoller", MagicMock())
+
+    app = make_app()
+    async with lc.crowdsec_lifespan(app):
+        service.aclose.assert_not_awaited()
     service.aclose.assert_awaited_once()
 
 
@@ -113,12 +118,11 @@ async def test_startup_creates_stream_poller_when_enabled(monkeypatch):
     )
 
     app = make_app()
-    await lc.on_startup(app)
-    assert isinstance(app.state.crowdsec_stream_poller, CrowdSecStreamPoller)
-    # The scheduler factory received the poller so the poll job gets registered
-    lc.create_scheduler.assert_awaited_once()
-    assert (
-        lc.create_scheduler.await_args.kwargs["crowdsec_poller"]
-        is app.state.crowdsec_stream_poller
-    )
-    await app.state.crowdsec_service.aclose()
+    async with enter_lifespan(app):
+        assert isinstance(app.state.crowdsec_stream_poller, CrowdSecStreamPoller)
+        # The scheduler factory received the poller so the poll job gets registered
+        lc.create_scheduler.assert_awaited_once()
+        assert (
+            lc.create_scheduler.await_args.kwargs["crowdsec_poller"]
+            is app.state.crowdsec_stream_poller
+        )

--- a/tests/test_lifecycle_geoip.py
+++ b/tests/test_lifecycle_geoip.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from tests.support import enter_lifespan
+
 pytestmark = pytest.mark.anyio
 
 
@@ -19,6 +21,7 @@ def _patch_startup_collaborators(monkeypatch, lc, *, db_available: bool, ensure:
 
     ingestion = MagicMock()
     ingestion.start = AsyncMock()
+    ingestion.stop = AsyncMock()
 
     monkeypatch.setattr(lc, "_db_available", fake_db_available)
     monkeypatch.setattr(lc, "get_app_db_config", lambda app: sqlalchemy_config)
@@ -42,7 +45,8 @@ async def test_startup_records_geoip_availability(monkeypatch):
     )
 
     app = SimpleNamespace(state=SimpleNamespace())
-    await lc.on_startup(app)
+    async with enter_lifespan(app):
+        pass
 
     ensure.assert_awaited_once()
     resolve_home.assert_awaited_once()
@@ -63,7 +67,8 @@ async def test_startup_sets_geoip_flag_even_without_database(monkeypatch):
     )
 
     app = SimpleNamespace(state=SimpleNamespace())
-    await lc.on_startup(app)
+    async with enter_lifespan(app):
+        pass
 
     ensure.assert_awaited_once()
     resolve_home.assert_awaited_once()

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -73,6 +73,67 @@ async def test_startup_failure_unwinds_started_managers(monkeypatch):
     lc.LogIngestionService.assert_not_called()
 
 
+async def test_crowdsec_wiring_failure_still_closes_client(monkeypatch):
+    """If setup fails after the LAPI client exists (poller construction),
+    the manager's own cleanup must close the client."""
+    from geometrikks.server import lifecycle as lc
+
+    _enable_crowdsec(monkeypatch)
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=True, ensure=AsyncMock(return_value=True)
+    )
+    service = _patch_crowdsec_service(monkeypatch, lc)
+    monkeypatch.setattr(
+        lc, "CrowdSecStreamPoller", MagicMock(side_effect=RuntimeError("poller boom"))
+    )
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    with pytest.raises(RuntimeError, match="poller boom"):
+        async with enter_lifespan(app):
+            pass
+
+    service.aclose.assert_awaited_once()
+
+
+async def test_scheduler_start_failure_still_shuts_down(monkeypatch):
+    """If start() activates the scheduler and then raises, the running
+    scheduler must still be shut down; ingestion never starts."""
+    from geometrikks.server import lifecycle as lc
+
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=True, ensure=AsyncMock(return_value=True)
+    )
+    scheduler = lc.create_scheduler.return_value
+    scheduler.start = MagicMock(side_effect=RuntimeError("job store down"))
+    scheduler.running = True
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    with pytest.raises(RuntimeError, match="job store down"):
+        async with enter_lifespan(app):
+            pass
+
+    scheduler.shutdown.assert_called_once_with(wait=True)
+    lc.LogIngestionService.assert_not_called()
+
+
+async def test_ingestion_start_failure_still_stops_service(monkeypatch):
+    """If start() activates tailers and then raises, the partially started
+    service must still be stopped."""
+    from geometrikks.server import lifecycle as lc
+
+    ingestion, _ = _patch_startup_collaborators(
+        monkeypatch, lc, db_available=True, ensure=AsyncMock(return_value=True)
+    )
+    ingestion.start = AsyncMock(side_effect=RuntimeError("tailer exploded"))
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    with pytest.raises(RuntimeError, match="tailer exploded"):
+        async with enter_lifespan(app):
+            pass
+
+    ingestion.stop.assert_awaited_once()
+
+
 async def test_db_degraded_mode_skips_scheduler_and_ingestion(monkeypatch):
     """DB-degraded mode serves the API but never starts DB-bound services."""
     from geometrikks.server import lifecycle as lc

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -1,0 +1,91 @@
+"""Lifespan managers: teardown ordering, partial-failure unwind, degraded mode."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.support import enter_lifespan
+from tests.test_lifecycle_geoip import _patch_startup_collaborators
+
+pytestmark = pytest.mark.anyio
+
+
+def _enable_crowdsec(monkeypatch) -> None:
+    monkeypatch.setenv("CROWDSEC_LAPI_URL", "http://crowdsec:8080")
+    monkeypatch.setenv("CROWDSEC_BOUNCER_API_KEY", "key")
+
+
+def _patch_crowdsec_service(monkeypatch, lc) -> MagicMock:
+    service = MagicMock()
+    service.aclose = AsyncMock()
+    monkeypatch.setattr(lc, "CrowdSecService", MagicMock(return_value=service))
+    monkeypatch.setattr(lc, "CrowdSecStreamPoller", MagicMock())
+    return service
+
+
+async def test_teardown_runs_in_reverse_startup_order(monkeypatch):
+    """Ingestion stops before the scheduler, which stops before the CrowdSec
+    client closes: nothing keeps writing or polling during teardown."""
+    from geometrikks.server import lifecycle as lc
+
+    _enable_crowdsec(monkeypatch)
+    ingestion, _ = _patch_startup_collaborators(
+        monkeypatch, lc, db_available=True, ensure=AsyncMock(return_value=True)
+    )
+
+    order: list[str] = []
+    service = _patch_crowdsec_service(monkeypatch, lc)
+    service.aclose = AsyncMock(side_effect=lambda: order.append("crowdsec"))
+    scheduler = lc.create_scheduler.return_value
+    scheduler.running = True
+    scheduler.shutdown = MagicMock(side_effect=lambda wait=True: order.append("scheduler"))
+    ingestion.stop = AsyncMock(side_effect=lambda timeout=None: order.append("ingestion"))
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    async with enter_lifespan(app):
+        assert order == []
+
+    assert order == ["ingestion", "scheduler", "crowdsec"]
+
+
+async def test_startup_failure_unwinds_started_managers(monkeypatch):
+    """A migration failure fails startup, but the CrowdSec client the earlier
+    manager already opened must still be closed (partial-startup cleanup)."""
+    from geometrikks.server import lifecycle as lc
+
+    _enable_crowdsec(monkeypatch)
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=True, ensure=AsyncMock(return_value=True)
+    )
+    service = _patch_crowdsec_service(monkeypatch, lc)
+    monkeypatch.setattr(lc, "migrate_database", AsyncMock(side_effect=RuntimeError("boom")))
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    with pytest.raises(RuntimeError, match="boom"):
+        async with enter_lifespan(app):
+            pass  # pragma: no cover - startup fails before the body runs
+
+    service.aclose.assert_awaited_once()
+    # The failure happened before the scheduler and ingestion managers entered.
+    lc.create_scheduler.assert_not_awaited()
+    lc.LogIngestionService.assert_not_called()
+
+
+async def test_db_degraded_mode_skips_scheduler_and_ingestion(monkeypatch):
+    """DB-degraded mode serves the API but never starts DB-bound services."""
+    from geometrikks.server import lifecycle as lc
+
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=False, ensure=AsyncMock(return_value=True)
+    )
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    async with enter_lifespan(app):
+        assert app.state.db_available is False
+        assert not hasattr(app.state, "scheduler")
+        assert not hasattr(app.state, "ingestion_service")
+
+    lc.create_scheduler.assert_not_awaited()
+    lc.LogIngestionService.assert_not_called()

--- a/tests/test_live_ws.py
+++ b/tests/test_live_ws.py
@@ -171,6 +171,27 @@ class FakeSocket:
     async def close(self, code: int = 1000, reason: str = "") -> None: ...
 
 
+class DisconnectingSendSocket(FakeSocket):
+    """The client vanishes exactly between the disconnect check and the send."""
+
+    async def send_json(self, data: dict) -> None:
+        raise WebSocketDisconnect(detail="client gone")
+
+
+@pytest.mark.anyio
+async def test_ws_disconnect_during_send_is_suppressed_and_unsubscribes():
+    """A WebSocketDisconnect raised from send_json travels through AnyIO's
+    task group as an ExceptionGroup; the handler must suppress it (not let
+    the group escape) and unsubscribe before returning."""
+    from geometrikks.domain.realtime.controllers import live_feed
+
+    ingestion = FakeIngestion()
+    ingestion.queue.put_nowait(make_record())
+    socket = DisconnectingSendSocket(SimpleNamespace(ingestion_service=ingestion))
+    await live_feed.fn(socket)  # must not raise
+    assert ingestion.unsubscribed is True
+
+
 @pytest.mark.anyio
 async def test_ws_cancellation_still_unsubscribes():
     """Server-side cancellation (shutdown) must run the cleanup path."""

--- a/tests/test_live_ws.py
+++ b/tests/test_live_ws.py
@@ -153,6 +153,8 @@ def test_ws_ignores_unexpected_inbound_frames():
 class FakeSocket:
     """Bare-bones WebSocket standing in for a connected, quiet client."""
 
+    connection_state = "connect"
+
     def __init__(self, state: SimpleNamespace) -> None:
         self.app = SimpleNamespace(state=state)
         self.sent: list[dict] = []

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -223,3 +223,25 @@ async def test_lifespan_migrates_before_timescale(monkeypatch) -> None:
         pass
 
     assert order == ["migrate", "timescale", "ingestion"]
+
+
+async def test_lifespan_skips_migrations_when_disabled(monkeypatch) -> None:
+    """DB_MIGRATE_ON_STARTUP=false defers schema ownership to an external
+    'litestar database upgrade' step; TimescaleDB setup still runs and is
+    the deliberate startup failure if that step was skipped."""
+    from geometrikks.server import lifecycle as lc
+    from tests.support import enter_lifespan
+    from tests.test_lifecycle_geoip import _patch_startup_collaborators
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setenv("DB_MIGRATE_ON_STARTUP", "false")
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=True, ensure=AsyncMock(return_value=True)
+    )
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    async with enter_lifespan(app):
+        pass
+
+    lc.migrate_database.assert_not_awaited()
+    lc.setup_timescaledb.assert_awaited_once()

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,8 +1,17 @@
 """Alembic migration-chain sanity — no database required."""
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from alembic.config import Config
 from alembic.script import ScriptDirectory
+
+from geometrikks.config.settings import DatabaseSettings, Settings
+from tests.support import enter_lifespan
+from tests.test_lifecycle_geoip import _patch_startup_collaborators
+
+pytestmark = pytest.mark.anyio
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -26,13 +35,6 @@ def test_revisions_parse_and_chain() -> None:
     assert revisions, "no revisions found — baseline revision missing"
     # walk_revisions yields head → base; the last one is the root.
     assert revisions[-1].down_revision is None
-
-
-from unittest.mock import AsyncMock, MagicMock
-
-import pytest
-
-from geometrikks.config.settings import DatabaseSettings, Settings
 
 
 class _FakeConn:
@@ -171,16 +173,10 @@ def test_upgrade_to_head_honors_explicit_url(monkeypatch) -> None:
     assert config.connection_string == "postgresql+asyncpg://x:y@explicit.invalid:5432/appdb"
 
 
-from types import SimpleNamespace
-
-pytestmark = pytest.mark.anyio
-
-
 async def test_lifespan_migrates_before_timescale(monkeypatch) -> None:
     """Migrations own the schema; setup_timescaledb depends on the tables
     existing, so it must run strictly after migrate_database."""
     from geometrikks.server import lifecycle as lc
-    from tests.support import enter_lifespan
 
     order: list[str] = []
 
@@ -230,9 +226,6 @@ async def test_lifespan_skips_migrations_when_disabled(monkeypatch) -> None:
     'litestar database upgrade' step; TimescaleDB setup still runs and is
     the deliberate startup failure if that step was skipped."""
     from geometrikks.server import lifecycle as lc
-    from tests.support import enter_lifespan
-    from tests.test_lifecycle_geoip import _patch_startup_collaborators
-    from unittest.mock import AsyncMock
 
     monkeypatch.setenv("DB_MIGRATE_ON_STARTUP", "false")
     _patch_startup_collaborators(

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -28,7 +28,7 @@ def test_revisions_parse_and_chain() -> None:
     assert revisions[-1].down_revision is None
 
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -176,10 +176,11 @@ from types import SimpleNamespace
 pytestmark = pytest.mark.anyio
 
 
-async def test_on_startup_migrates_before_timescale(monkeypatch) -> None:
+async def test_lifespan_migrates_before_timescale(monkeypatch) -> None:
     """Migrations own the schema; setup_timescaledb depends on the tables
     existing, so it must run strictly after migrate_database."""
     from geometrikks.server import lifecycle as lc
+    from tests.support import enter_lifespan
 
     order: list[str] = []
 
@@ -203,6 +204,7 @@ async def test_on_startup_migrates_before_timescale(monkeypatch) -> None:
         order.append("ingestion")
 
     ingestion.start = fake_start
+    ingestion.stop = AsyncMock()
 
     sqlalchemy_config = MagicMock()
     sqlalchemy_config.get_engine.return_value = MagicMock()
@@ -217,6 +219,7 @@ async def test_on_startup_migrates_before_timescale(monkeypatch) -> None:
     monkeypatch.setattr(lc, "LogIngestionService", MagicMock(return_value=ingestion))
 
     app = SimpleNamespace(state=SimpleNamespace())
-    await lc.on_startup(app)
+    async with enter_lifespan(app):
+        pass
 
     assert order == ["migrate", "timescale", "ingestion"]

--- a/tests/test_server_imports.py
+++ b/tests/test_server_imports.py
@@ -8,7 +8,7 @@ def test_server_imports_without_geoip_db() -> None:
     """Importing the app factory must succeed even when the GeoIP mmdb is missing.
 
     Settings construction (which validates the mmdb path) must happen inside
-    create_app()/on_startup, never at import time. Runs in a subprocess so this
+    create_app()/lifespan startup, never at import time. Runs in a subprocess so this
     test is immune to modules already imported by the test session."""
     env = os.environ | {
         "GEOIP_DB_PATH": "/nonexistent/GeoLite2-City.mmdb",

--- a/tests/test_system_controller.py
+++ b/tests/test_system_controller.py
@@ -7,6 +7,7 @@ import pytest
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 from litestar import Litestar
+from litestar.di import Provide
 from litestar.testing import AsyncTestClient
 
 from geometrikks.domain.system.controllers.system import SystemController
@@ -19,26 +20,16 @@ pytestmark = pytest.mark.anyio
 FUTURE = datetime(2030, 1, 1, tzinfo=timezone.utc)
 
 
-@pytest.fixture(autouse=True)
-async def _dispose_cached_db_engine():
-    """Dispose the process-cached engine on the loop that used it.
+class UnreachableEngine:
+    """db_engine stand-in whose connections always fail (DB-degraded mode).
 
-    The /about tests may open a real pooled asyncpg connection through the
-    lru_cached SQLAlchemy config. Each test runs on its own event loop, so a
-    pooled connection left behind outlives its loop; when asyncpg later
-    finalizes it, the close-timeout path leaks an unawaited
-    Connection._cancel coroutine (RuntimeWarning). Disposing before the loop
-    closes keeps every connection loop-local.
+    The real provider hands out the engine without connecting, so an
+    unreachable database surfaces at query time; this stub fails at the
+    same point.
     """
-    yield
-    from geometrikks.server import plugins
 
-    config_factory = plugins.get_sqlalchemy_config
-    cache_info = getattr(config_factory, "cache_info", None)
-    if cache_info is None or cache_info().currsize == 0:
-        return
-    await config_factory().get_engine().dispose()
-    config_factory.cache_clear()
+    def connect(self):
+        raise RuntimeError("database unavailable")
 
 
 async def noop() -> None:
@@ -66,7 +57,10 @@ def make_app(*, with_scheduler: bool = True) -> Litestar:
     return Litestar(
         route_handlers=[create_api_v1_router([SystemController])],
         on_startup=[startup],
-        dependencies=ambient_settings_dependency(),
+        dependencies={
+            **ambient_settings_dependency(),
+            "db_engine": Provide(UnreachableEngine, sync_to_thread=False),
+        },
     )
 
 
@@ -167,14 +161,11 @@ async def test_about_geoip_degrades_when_db_missing(monkeypatch):
     assert geoip["buildDate"] is None
 
 
-async def test_about_database_degrades_when_db_unreachable(monkeypatch):
-    """An unreachable database must null the versions, never fail the page."""
-    import geometrikks.server.plugins as plugins
+async def test_about_database_degrades_when_db_unreachable():
+    """An unreachable database must null the versions, never fail the page.
 
-    def boom():
-        raise RuntimeError("no database")
-
-    monkeypatch.setattr(plugins, "get_sqlalchemy_config", boom)
+    make_app() provides the UnreachableEngine db_engine stub, failing at
+    connect time exactly like a real engine with the database down."""
     async with AsyncTestClient(app=make_app()) as client:
         resp = await client.get("/api/v1/system/about")
     assert resp.status_code == 200
@@ -200,7 +191,10 @@ async def test_system_settings_surface_computed_values(monkeypatch):
     app = Litestar(
         route_handlers=[create_api_v1_router([SystemController])],
         on_startup=[startup],
-        dependencies=ambient_settings_dependency(),
+        dependencies={
+            **ambient_settings_dependency(),
+            "db_engine": Provide(UnreachableEngine, sync_to_thread=False),
+        },
     )
     async with AsyncTestClient(app=app) as client:
         resp = await client.get("/api/v1/system/settings")
@@ -238,12 +232,8 @@ async def test_system_settings_no_computed_home_when_absent():
     assert avail["computedSource"] == "runtime"
 
 
-async def test_database_info_degraded_without_db(monkeypatch):
+async def test_database_info_degraded_without_db():
     """/system/database renders nulls (not 500) when the DB is unreachable."""
-    def no_db():
-        raise RuntimeError("database unavailable")
-
-    monkeypatch.setattr("geometrikks.server.plugins.get_sqlalchemy_config", no_db)
     async with AsyncTestClient(app=make_app(with_scheduler=False)) as client:
         resp = await client.get("/api/v1/system/database")
     assert resp.status_code == 200


### PR DESCRIPTION
Phase 5 of the 0.7 plan: resource ownership and realtime. No wire-format changes: the OpenAPI document, WS frame shapes, cadences, and caps are all unchanged.

## Lifespan context managers

`on_startup`/`on_shutdown` became six focused async context managers (core state, GeoIP, CrowdSec, database gate, scheduler, ingestion) passed as `lifespan=`, so Litestar runs them on an `AsyncExitStack`. Teardown order is the exact reverse of startup, identical to the old shutdown hook (ingestion stops first, the CrowdSec client closes last). The real improvement is failure handling: a mid-startup failure now unwinds the managers that already started, and each manager's `finally` also covers its own construction/start phase, so a `start()` that activates work and then raises still gets cleaned up. `tests/test_lifespan.py` pins ordering, unwind, per-manager start-failure cleanup, and the DB-degraded skips independently.

Ordinary request work now prefers the plugin-registered engine: `/about` and `/system/database` inject `db_engine` via DI instead of reaching for the config module. Degraded rendering still happens at query time (the provider hands out the engine without connecting), and the tests replaced module monkeypatching with a failing-engine DI stub, which also retired the cached-engine dispose workaround fixture. The `/health` probe keeps direct access deliberately: it is the degraded-mode probe.

## Migration ownership

New `DB_MIGRATE_ON_STARTUP` setting, default `true` (single-container homelab flow unchanged). Setting it to `false` defers schema ownership to a separate `litestar database upgrade` deployment step, which works out of the box because Advanced Alchemy's CLI defaults match this repo's alembic layout. TimescaleDB setup still runs at startup either way: it is idempotent, requires the schema at head, and is the deliberate startup failure when the external step was skipped. Config docs regenerated; changelog entries included.

## Realtime consolidation

The disconnect-watcher/heartbeat/batching/drop-accounting machinery that was copy-pasted across the three feeds now lives once in `domain/realtime/stream.py`:

- `subscription()` owns subscribe/unsubscribe-in-finally plus the connect/disconnect audit logs.
- `batched_frames()` (live, logs) and `passthrough_frames()` (CrowdSec) are the two delivery policies.
- `stream_json_frames()` wraps Litestar's `send_websocket_stream`, which supplies the send loop and background disconnect listener with proper cancellation. `warn_on_data_discard=False` is the explicit, tested inbound-frame policy. Task-group-wrapped disconnects are suppressed with `except*`, and the frame generator is closed deterministically so subscription cleanup completes before the handler returns.
- The degraded-mode 1013 + reason closure still happens before any streaming.

Feed-specific logic (event conversion, level filter, snapshot status frame, cadences, caps) stays in the handlers. The Phase 2 WS test suite passes unmodified except for the `FakeSocket` stub gaining `connection_state`, plus a new send/disconnect race regression test.

Decisions recorded in `stream.py`: the `@websocket_stream` decorator form was not adopted (feeds must accept and then close 1013 in degraded mode before streaming starts); `ChannelsPlugin` was evaluated and deliberately not adopted (fixed process-local feeds, no dynamic topics/history/cross-process fan-out, and an in-memory backend would not lift the single-worker constraint).

## Transaction policy

Nothing left to change: the dead app-level transaction provider was removed in Phase 1, the API surface is read-only, and the CrowdSec controller-scoped pagination provider is the audited exception (it paginates an in-memory LAPI result).

## Verification

- 590 non-integration + 118 integration backend tests pass (708 total), `ty` clean
- `tsc` clean, 127 vitest tests pass
- OpenAPI document verified byte-identical after the DI change; no generated-client changes
- Both pre-merge review findings (ExceptionGroup disconnect escape, startup-phase cleanup gaps) are fixed with regression tests verified to fail against the pre-fix code
