### PR TITLE
Phase 7 pre-checks: Litestar 3 gate status and structlog test isolation

### DIFF
--- a/geometrikks/server/logging.py
+++ b/geometrikks/server/logging.py
@@ -472,4 +472,12 @@ def create_logging_config(settings: "Settings") -> StructLoggingConfig:
         wrapper_class=SuccessBoundLogger,
         standard_lib_logging_config=standard_lib,
         log_exceptions="always",
+        # Litestar defaults this to True, which freezes each module-level
+        # logger onto whatever processors list is current at its first use.
+        # Every create_app() builds a fresh list, so cached loggers silently
+        # bypass later reconfiguration and structlog.testing.capture_logs
+        # (which mutates only the current list). The lookup this skips is a
+        # dict read per log call; actual rendering and IO happen on the
+        # queue-listener thread either way.
+        cache_logger_on_first_use=False,
     )

--- a/tests/test_crowdsec_lifecycle.py
+++ b/tests/test_crowdsec_lifecycle.py
@@ -100,15 +100,14 @@ async def test_crowdsec_lifespan_closes_service_on_exit(monkeypatch):
     service.aclose.assert_awaited_once()
 
 
-def test_controller_registered_in_routes():
-    from litestar import Router
+def test_controller_registered_in_routes(monkeypatch):
+    # Assert via app.routes, not Router.routes: Litestar 3 moves route access
+    # to the application object.
+    monkeypatch.setenv("APP_AUTH_DISABLED", "true")
+    from geometrikks.server.core import create_app
 
-    from geometrikks.server.routes import get_route_handlers
-
-    handlers = get_route_handlers()
-    api_router = next(h for h in handlers if isinstance(h, Router))
-    assert api_router.path == "/api/v1"
-    assert any(route.path.startswith("/api/v1/crowdsec") for route in api_router.routes)
+    app = create_app()
+    assert any(route.path.startswith("/api/v1/crowdsec") for route in app.routes)
 
 
 async def test_startup_creates_stream_poller_when_enabled(monkeypatch):


### PR DESCRIPTION
Phase 7 of the 0.7 plan is the Litestar 3 compatibility gate. Both external prerequisites are still unshipped (PyPI has no Litestar 3 release, not even a beta, and Advanced Alchemy is still 1.11.0 with no fix for its generated filter providers), so the upgrade itself stays blocked. This PR lands the pre-checks that are releasable now, plus one real bug they surfaced.

## Structlog test-isolation fix (the one behavior change)

Litestar's `StructLoggingConfig` defaults `cache_logger_on_first_use=True`, which freezes each module-level logger onto whatever processors list is current at its first use. Every `create_app()` builds a fresh list, so a cached logger silently bypassed later reconfiguration and `structlog.testing.capture_logs()`, which mutates only the current list. Result: the auth login-logging test failed whenever any `create_app()`-calling test ran before `tests/test_auth_endpoints.py`, meaning log assertions depended on pytest execution order.

`create_logging_config` now pins `cache_logger_on_first_use=False`. Production is unaffected: the app configures logging once at startup, so the frozen copy and the live config were always identical there; the skipped lookup is a dict read per log call, and rendering plus IO stay on the queue-listener thread either way. Verified against the failing ordering, a second ordering (`test_route_surface.py` first), and two full-suite runs.

## Litestar 3 pre-checks (all clean or fixed)

- **Implicit-Optional sweep:** every nullable HTTP request parameter (`T | None`) carries an explicit `= None`, including all multiline `Annotated` params and every usage site of the shared filter aliases in `lib/parameters.py`. The 12 defaultless `NamedDependency[X | None]` injections are intentionally left alone: the dependency is required while its provider may return None in degraded mode; they get verified against Litestar 3's released DI contract at upgrade time.
- **`Router.routes`:** the single access in the tree (`test_crowdsec_lifecycle.py`) is rewritten to build the app and assert on `app.routes`, valid on both 2.24 and 3.0.
- **MessagePack:** zero references in backend, tests, or frontend.
- **Extras audit:** no yaml usage, polyfactory is already an explicit dev dependency; the only upgrade-time action is adding `[testing]` to dev extras (the extra does not exist on 2.24, so it cannot be pre-added).

Deliberately not done: removing the `<3` bound, adding speculative extras, or a compatibility CI job that would fail at import time for already-known reasons. Phase 7 remains a monitored post-0.7.0 gate.

## Verification

- 590 tests pass (472 non-integration + 118 integration), twice, plus the three targeted ordering runs
- `ty check geometrikks tests` clean
- No wire-format or generated-contract changes
