### PR TITLE
Fix mobile Settings navigation overflow

### DIFF
--- a/resources/components/ui/sidebar.tsx
+++ b/resources/components/ui/sidebar.tsx
@@ -336,7 +336,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 relative flex w-full flex-1 flex-col",
+        "bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 relative flex min-w-0 w-full flex-1 flex-col",
         className
       )}
       {...props}

--- a/resources/routes/__root.tsx
+++ b/resources/routes/__root.tsx
@@ -59,8 +59,8 @@ function AppBreadcrumb() {
   const isSettingsChild = pathname.startsWith("/settings/")
 
   return (
-    <Breadcrumb>
-      <BreadcrumbList>
+    <Breadcrumb className="min-w-0 flex-1">
+      <BreadcrumbList className="min-w-0 flex-nowrap overflow-hidden">
         <BreadcrumbItem className="hidden md:block">
           <BreadcrumbLink href="/">GeoMetrikks</BreadcrumbLink>
         </BreadcrumbItem>
@@ -73,8 +73,8 @@ function AppBreadcrumb() {
             <BreadcrumbSeparator className="hidden md:block" />
           </>
         )}
-        <BreadcrumbItem>
-          <BreadcrumbPage>{currentLabel}</BreadcrumbPage>
+        <BreadcrumbItem className="min-w-0">
+          <BreadcrumbPage className="block truncate">{currentLabel}</BreadcrumbPage>
         </BreadcrumbItem>
       </BreadcrumbList>
     </Breadcrumb>
@@ -137,18 +137,18 @@ function RootLayout() {
               <OfflineBanner />
               <GeoDegradedBanner />
               {/* Top header bar */}
-              <header className="flex h-14 shrink-0 items-center justify-between gap-2 border-b border-border/50 px-4 pt-[env(safe-area-inset-top,0px)] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] box-content">
-                <div className="flex items-center gap-2">
+              <header className="flex h-14 shrink-0 items-center justify-between gap-1 border-b border-border/50 px-2 pt-[env(safe-area-inset-top,0px)] pl-[max(0.5rem,env(safe-area-inset-left,0px))] pr-[max(0.5rem,env(safe-area-inset-right,0px))] box-content sm:gap-2 sm:px-4 sm:pl-[max(1rem,env(safe-area-inset-left,0px))] sm:pr-[max(1rem,env(safe-area-inset-right,0px))]">
+                <div className="flex min-w-0 flex-1 items-center gap-2">
                   <SidebarTrigger className="-ml-1" />
-                  <Separator orientation="vertical" className="h-4 mr-2" />
+                  <Separator orientation="vertical" className="mr-2 hidden h-4 sm:block" />
                   <AppBreadcrumb />
                 </div>
-                <div className="flex items-center gap-3">
+                <div className="flex shrink-0 items-center gap-1 sm:gap-3">
                   <TimeRangeToolbar />
                   {/* Portal target for page-specific header actions (e.g. the
                       mobile map-controls drawer trigger in MapControls). */}
                   <span id="header-actions-slot" className="contents" />
-                  <Separator orientation="vertical" className="h-6" />
+                  <Separator orientation="vertical" className="hidden h-6 sm:block" />
                   <ModeToggle />
                 </div>
               </header>

--- a/resources/routes/settings.tsx
+++ b/resources/routes/settings.tsx
@@ -1,4 +1,12 @@
-import { createFileRoute, Link, Outlet } from "@tanstack/react-router"
+import { createFileRoute, Link, Outlet, useRouterState } from "@tanstack/react-router"
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 
 export const Route = createFileRoute("/settings")({
   component: SettingsLayout,
@@ -13,9 +21,35 @@ const tabs = [
 ] as const
 
 function SettingsLayout() {
+  const navigate = Route.useNavigate()
+  const pathname = useRouterState({ select: (state) => state.location.pathname })
+  const activeTab = tabs.find((tab) => pathname.startsWith(tab.to)) ?? tabs[0]
+
+  const handleTabChange = (value: string) => {
+    const tab = tabs.find((candidate) => candidate.to === value)
+    if (tab) {
+      void navigate({ to: tab.to })
+    }
+  }
+
   return (
     <div className="p-4 space-y-4">
-      <div className="inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground">
+      <Select value={activeTab.to} onValueChange={handleTabChange}>
+        <SelectTrigger aria-label="Settings section" className="h-10 w-full sm:hidden">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {tabs.map((tab) => (
+            <SelectItem key={tab.to} value={tab.to}>
+              {tab.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <nav
+        aria-label="Settings"
+        className="hidden h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground sm:inline-flex"
+      >
         {tabs.map((tab) => (
           <Link
             key={tab.to}
@@ -26,7 +60,7 @@ function SettingsLayout() {
             {tab.label}
           </Link>
         ))}
-      </div>
+      </nav>
       <Outlet />
     </div>
   )

--- a/tests/browser/container-smoke.pw.ts
+++ b/tests/browser/container-smoke.pw.ts
@@ -104,6 +104,73 @@ test("production image serves the authenticated dashboard without browser errors
     fullPage: true,
   })
 
+  // Settings navigation collapses to a route-aware select on phones instead
+  // of making the tab row or page shell horizontally scrollable.
+  await page.setViewportSize({ width: 375, height: 812 })
+  await page.goto("/settings/status")
+  const settingsSelect = page.getByRole("combobox", { name: "Settings section" })
+  await expect(settingsSelect).toBeVisible()
+  await expect(page.getByRole("navigation", { name: "Settings" })).toBeHidden()
+
+  const pageWidths = await page.evaluate(() => {
+    const content = document.querySelector<HTMLElement>("main.overflow-auto")
+    if (!content) {
+      throw new Error("Scrollable page content was not found")
+    }
+    return {
+      document: [document.documentElement.clientWidth, document.documentElement.scrollWidth],
+      body: [document.body.clientWidth, document.body.scrollWidth],
+      content: [content.clientWidth, content.scrollWidth],
+    }
+  })
+  expect(pageWidths.document[1]).toBe(pageWidths.document[0])
+  expect(pageWidths.body[1]).toBe(pageWidths.body[0])
+  expect(pageWidths.content[1]).toBe(pageWidths.content[0])
+
+  await settingsSelect.click()
+  await page.getByRole("option", { name: "Environment" }).click()
+  await expect(page).toHaveURL(/\/settings\/environment$/)
+  await expect(settingsSelect).toHaveText("Environment")
+
+  // Long breadcrumb labels must shrink beside the mobile toolbar rather than
+  // making the document wider on very narrow phones.
+  await page.setViewportSize({ width: 320, height: 812 })
+  await page.goto("/settings/environment")
+  const narrowWidths = await page.evaluate(() => {
+    const content = document.querySelector<HTMLElement>("main.overflow-auto")
+    if (!content) {
+      throw new Error("Scrollable page content was not found")
+    }
+    return {
+      document: [document.documentElement.clientWidth, document.documentElement.scrollWidth],
+      body: [document.body.clientWidth, document.body.scrollWidth],
+      content: [content.clientWidth, content.scrollWidth],
+    }
+  })
+  expect(narrowWidths.document[1]).toBe(narrowWidths.document[0])
+  expect(narrowWidths.body[1]).toBe(narrowWidths.body[0])
+  expect(narrowWidths.content[1]).toBe(narrowWidths.content[0])
+
+  // At the desktop-sidebar breakpoint, its flex sibling must be allowed to
+  // shrink into the viewport instead of retaining the toolbar's min width.
+  await page.setViewportSize({ width: 768, height: 812 })
+  await expect(page.getByRole("navigation", { name: "Settings" })).toBeVisible()
+  await expect(page.getByRole("combobox", { name: "Settings section" })).toBeHidden()
+  const breakpointWidths = await page.evaluate(() => {
+    const content = document.querySelector<HTMLElement>("main.overflow-auto")
+    if (!content) {
+      throw new Error("Scrollable page content was not found")
+    }
+    return {
+      document: [document.documentElement.clientWidth, document.documentElement.scrollWidth],
+      body: [document.body.clientWidth, document.body.scrollWidth],
+      content: [content.clientWidth, content.scrollWidth],
+    }
+  })
+  expect(breakpointWidths.document[1]).toBe(breakpointWidths.document[0])
+  expect(breakpointWidths.body[1]).toBe(breakpointWidths.body[0])
+  expect(breakpointWidths.content[1]).toBe(breakpointWidths.content[0])
+
   expect(consoleErrors, "browser console errors").toEqual([])
   expect(pageErrors, "uncaught page errors").toEqual([])
   expect(failedRequests, "failed browser requests").toEqual([])


### PR DESCRIPTION
## Summary

- replace the overflowing mobile Settings tab row with a route-aware shadcn Select
- preserve the existing linked tab navigation at the `sm` breakpoint and above
- let the breadcrumb, header, and sidebar inset shrink correctly at narrow and sidebar-breakpoint widths
- add production browser-smoke coverage for mobile navigation and document-width regressions

## Root cause

The five non-wrapping tabs had an intrinsic width of 393 px, while the Settings content area was only 343 px wide on a 375 px viewport. The tab row therefore widened the scrollable page container. The status cards were responsive and did not contribute to the overflow.

Two related shell constraints were also exposed during breakpoint testing: the header breadcrumb could not shrink beside the mobile controls, and `SidebarInset` retained its automatic minimum width at the 768 px sidebar breakpoint.

## User impact

On phones, Settings sections are now selected from a compact, accessible shadcn Select that reflects the active route. The page can no longer be dragged horizontally. Desktop navigation remains the existing single-row tab list.

## Validation

- `bun run typecheck`
- `bun run test` — 127 tests passed
- `bun run build`
- responsive Playwright checks against the production build served through Litestar at 320, 375, 768, and 1024 px
- verified mobile Select navigation from Status to Environment
- generated API contracts remained unchanged
