### PR TITLE
Fix: end the tailer's waits as soon as a stop is requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Shutdown is no longer delayed when a log file is missing or has not yet
+  received a parseable line. The tailer's waits now end as soon as a stop is
+  requested, instead of occupying a worker thread for up to 60 seconds and
+  leaving the container to be force-killed part-way through teardown. This
+  was reachable on a fresh install, where nginx has created the access log
+  but not yet written to it.
+
 ## [0.7.0] - 2026-08-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Shutdown is no longer delayed when a log file is missing or has not yet
-  received a parseable line. The tailer's waits now end as soon as a stop is
-  requested, instead of occupying a worker thread for up to 60 seconds and
-  leaving the container to be force-killed part-way through teardown. This
-  was reachable on a fresh install, where nginx has created the access log
-  but not yet written to it.
-
 ## [0.7.0] - 2026-08-02
 
 ### Added
@@ -40,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   container previously killed the server without running any teardown
   because the CLI wrapper did not forward SIGTERM to Granian; the server
   now runs in Granian's direct process mode under a tini init.
+- Shutdown is no longer delayed when a log file is missing or has not yet
+  received a parseable line. The tailer's waits now end as soon as a stop is
+  requested, instead of occupying a worker thread for up to 60 seconds and
+  leaving the container to be force-killed part-way through teardown. This
+  was reachable on a fresh install, where nginx has created the access log
+  but not yet written to it.
 
 ### Changed
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,10 +40,9 @@ Timeout budget: ingestion waits up to 5s for its tail tasks before
 cancelling them, and the image sets Granian's worker kill timeout to 15s,
 so give Docker at least 20s (`docker stop -t 20`, or compose
 `stop_grace_period: 20s`) to keep Docker's own SIGKILL out of the picture.
-Known edge: if the configured log file does not exist, the tailer's
-blocking validation loop ignores the stop signal; teardown then falls back
-to cancellation after the 5s ingestion window and the worker can be
-force-killed at the kill-timeout boundary instead of finishing cleanly.
+A tail task still waiting for its log file to appear, or waiting for that
+file to receive its first parseable line, ends that wait as soon as the
+stop is signalled rather than sitting out its own 60s timeout.
 
 ### Logging
 

--- a/geometrikks/lib/__init__.py
+++ b/geometrikks/lib/__init__.py
@@ -1,6 +1,7 @@
-from .utils import wait, wait_for_path
+from .utils import retries_disabled, sleep_unless_stopped, wait_for_path
 
 __all__ = [
-    "wait",
+    "retries_disabled",
+    "sleep_unless_stopped",
     "wait_for_path",
 ]

--- a/geometrikks/lib/utils.py
+++ b/geometrikks/lib/utils.py
@@ -49,7 +49,7 @@ async def sleep_unless_stopped(
         return False
     try:
         await asyncio.wait_for(stop_event.wait(), timeout=seconds)
-    except TimeoutError:
+    except asyncio.TimeoutError:
         return False
     return True
 

--- a/geometrikks/lib/utils.py
+++ b/geometrikks/lib/utils.py
@@ -1,9 +1,7 @@
 import os
 import time
 import asyncio
-from functools import wraps
 from pathlib import Path
-from typing import ParamSpec, Callable
 
 
 import msgspec
@@ -18,7 +16,6 @@ from geometrikks.server.logging import get_logger
 
 logger = get_logger(__name__)
 
-P = ParamSpec("P")
 
 class GeoIPInfoView(msgspec.Struct, rename="camel"):
     available: bool
@@ -26,38 +23,42 @@ class GeoIPInfoView(msgspec.Struct, rename="camel"):
     build_date: datetime | None
     age_days: int | None
 
-def wait(timeout_seconds: int = 60) -> Callable[[Callable[P, bool]], Callable[P, bool]]:
-    """Factory Decorator to wait for a function to return True for a given amount of time.
+def retries_disabled() -> bool:
+    """Whether retry loops should collapse to a single attempt (test hook)."""
+    return os.getenv("DISABLE_WAIT", "false").lower() == "true"
+
+
+async def sleep_unless_stopped(
+    seconds: float, stop_event: asyncio.Event | None = None
+) -> bool:
+    """Sleep, waking early if a stop is requested.
+
+    Retry loops that only sleep and re-check their stop event on the next
+    iteration keep a shutdown waiting for up to a full interval. Racing the
+    event instead makes the wait end as soon as the stop is signalled.
 
     Args:
-        timeout_seconds (int, optional): Defaults to 60.
+        seconds: Maximum seconds to sleep.
+        stop_event: Event that ends the sleep early when set.
+
+    Returns:
+        True if a stop was requested, False if the full interval elapsed.
     """
-
-    def decorator(func: Callable[P, bool]) -> Callable[P, bool]:
-        @wraps(func)
-        def wrapper(*args: P.args, **kwargs: P.kwargs) -> bool:
-            # Allow tests to bypass retry loops
-            if os.getenv("DISABLE_WAIT", "false").lower() == "true":
-                return bool(func(*args, **kwargs))
-            timeout: float = time.time() + timeout_seconds
-            while time.time() < timeout:
-                if func(*args, **kwargs):
-                    return True
-                time.sleep(1)
-            logger.error(
-                f"Timeout of {timeout_seconds} seconds reached on {getattr(func, '__name__', 'unknown')} function."
-            )
-            return False
-
-        return wrapper
-
-    return decorator
+    if stop_event is None:
+        await asyncio.sleep(seconds)
+        return False
+    try:
+        await asyncio.wait_for(stop_event.wait(), timeout=seconds)
+    except TimeoutError:
+        return False
+    return True
 
 
 async def wait_for_path(
     path: Path | str,
     timeout_seconds: float = 60.0,
     check_interval: float = 1.0,
+    stop_event: asyncio.Event | None = None,
 ) -> bool:
     """Wait for a file path to exist.
 
@@ -67,19 +68,24 @@ async def wait_for_path(
         path: File path to check for existence.
         timeout_seconds: Maximum seconds to wait.
         check_interval: Seconds between existence checks.
+        stop_event: Ends the wait early when set, so a shutdown does not have
+            to wait out the timeout (or be resolved by cancellation).
 
     Returns:
-        True if path exists, False if timeout reached.
+        True if path exists, False if the timeout is reached or a stop was
+        requested.
 
     Raises:
         asyncio.CancelledError: If the task is cancelled (e.g., SIGINT).
     """
     # Allow tests to bypass retry loops
-    if os.getenv("DISABLE_WAIT", "false").lower() == "true":
+    if retries_disabled():
         return await aiofiles.os.path.exists(path)
 
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
+        if stop_event is not None and stop_event.is_set():
+            return False
         if await aiofiles.os.path.exists(path):
             logger.info("Path found: %s", path)
             return True
@@ -87,7 +93,8 @@ async def wait_for_path(
         logger.debug(
             "Path %s not found, retrying in %.1f seconds...", path, check_interval
         )
-        await asyncio.sleep(check_interval)
+        if await sleep_unless_stopped(check_interval, stop_event):
+            return False
 
     logger.error(
         "Timeout of %.1f seconds reached waiting for path: %s", timeout_seconds, path

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -207,7 +207,11 @@ class LogIngestionService:
     async def _tail_file(self, parser: LogParser, reader: Reader, skip_validation: bool) -> None:
         """Tail a single log file, pushing parsed records onto the shared queue."""
         logger.debug("Waiting for log file: %s", parser.log_path)
-        if not await wait_for_path(parser.log_path, timeout_seconds=60.0):
+        if not await wait_for_path(
+            parser.log_path, timeout_seconds=60.0, stop_event=self._stop_event
+        ):
+            if self._stop_event and self._stop_event.is_set():
+                return  # shutting down, not a missing-file problem
             logger.error("Skipping ingestion for missing log file: %s", parser.log_path)
             return
         assert self._queue is not None

--- a/geometrikks/services/logparser/logparser.py
+++ b/geometrikks/services/logparser/logparser.py
@@ -1,6 +1,7 @@
 from collections.abc import AsyncGenerator, Callable
 import re
 import os
+import time
 import asyncio
 from functools import lru_cache
 from datetime import datetime, timezone
@@ -23,7 +24,7 @@ from .constants import (
     ipv6_geo_pattern
 )
 from .schemas import ParsedLogRecord, ParsedGeoData, ParsedAccessLog
-from geometrikks.lib.utils import wait
+from geometrikks.lib.utils import retries_disabled, sleep_unless_stopped
 from geometrikks.server.logging import get_logger
 
 
@@ -192,9 +193,12 @@ class LogParser:
         # If we are not sending logs but only geo data, only validate the IP address and the timestamp
         return ipv4_geo_pattern().match(log_line) or ipv6_geo_pattern().match(log_line)
 
-    @wait(timeout_seconds=60)
     def validate_log_format(self, log_path: Path) -> bool:  # regex tester
-        """Try for 60 seconds and validate that the log format is correct by checking the last 3 lines."""
+        """Validate the log format once by checking the last 3 lines.
+
+        Blocking (opens and reads the file); callers on the event loop go
+        through ``await_valid_log_format`` instead of calling this directly.
+        """
         LAST_LINE_COUNT = 3
         position = LAST_LINE_COUNT + 1
         log_lines_capture: list[str] = []
@@ -216,6 +220,50 @@ class LogParser:
                 return True
         logger.debug("Testing log format")
         return False
+
+    async def await_valid_log_format(
+        self,
+        timeout_seconds: float = 60.0,
+        check_interval: float = 1.0,
+    ) -> bool:
+        """Retry the format check until it passes, times out, or a stop is requested.
+
+        Each attempt offloads the blocking file read to a worker thread, but
+        the waiting between attempts happens here on the event loop. A thread
+        handed to ``asyncio.to_thread`` cannot be cancelled, so retrying
+        inside the thread (the previous behaviour) kept the process busy for
+        the full timeout after shutdown had been requested: the awaiting task
+        raised ``CancelledError`` immediately while the thread kept sleeping,
+        and the interpreter could not finish exiting until it returned. This
+        is reachable whenever the configured log file exists but is empty or
+        in an unrecognised format, which is the normal state of a fresh
+        install before nginx writes its first line.
+
+        Args:
+            timeout_seconds: Maximum seconds to keep retrying.
+            check_interval: Seconds between attempts.
+
+        Returns:
+            True if the format validated, False on timeout or stop request.
+        """
+        if retries_disabled():
+            return await asyncio.to_thread(self.validate_log_format, self.log_path)
+
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            if self._stop_event and self._stop_event.is_set():
+                return False
+            if await asyncio.to_thread(self.validate_log_format, self.log_path):
+                return True
+            if time.monotonic() >= deadline:
+                logger.error(
+                    "Timeout of %.0f seconds reached validating the log format of %s",
+                    timeout_seconds,
+                    self.log_path,
+                )
+                return False
+            if await sleep_unless_stopped(check_interval, self._stop_event):
+                return False
 
     def parse_line(
         self, line: str, lookup: Callable[[str], City | None]
@@ -555,8 +603,11 @@ class LogParser:
         """
         if not skip_validation:
             logger.debug("Validating log file format.")
-            # Run sync validation in thread to avoid blocking
-            valid = await asyncio.to_thread(self.validate_log_format, self.log_path)
+            valid = await self.await_valid_log_format()
+            if self._stop_event and self._stop_event.is_set():
+                # Stopped while waiting for a parseable line; say nothing about
+                # the format, the tail loop below would exit immediately anyway.
+                return
             if not valid:
                 self.send_logs = False
                 logger.warning(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,8 +30,10 @@ def anyio_backend() -> str:
 def disable_wait_env():
     """Ensure retry loops are disabled during test runs.
 
-    Sets DISABLE_WAIT=true for the entire pytest session so any @wait-decorated
-    functions run once and return immediately, preventing slow/hanging tests.
+    Sets DISABLE_WAIT=true for the entire pytest session so retry loops
+    (log-file existence, log-format validation) run once and return
+    immediately, preventing slow/hanging tests. Tests that exercise the
+    retry behaviour itself opt back in with monkeypatch.
     """
     os.environ["DISABLE_WAIT"] = "true"
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -241,6 +241,30 @@ async def test_missing_file_does_not_block_other_tails(tmp_path: Path) -> None:
     assert service.total_geo_records == 1
 
 
+async def test_stop_ends_the_wait_for_a_missing_log_file(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Shutdown does not wait out the missing-file timeout.
+
+    With retries enabled the tail task sits in wait_for_path; before the stop
+    event was threaded through, stop() waited its full timeout and then
+    resorted to cancelling the task.
+    """
+    monkeypatch.setenv("DISABLE_WAIT", "false")
+    missing = tmp_path / "missing.log"
+    service, _repos, _sessions = make_service([make_parser(missing)])
+
+    await service.start(skip_validation=True)
+    await asyncio.sleep(0.05)
+
+    started = time.monotonic()
+    await service.stop(timeout=5.0)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 2.0, f"stop() took {elapsed:.1f}s waiting for a missing file"
+    assert all(task.done() and not task.cancelled() for task in service._tail_tasks)
+
+
 async def test_all_tails_dead_stops_service_and_clears_is_running(tmp_path: Path) -> None:
     """When every tail task exits (all log files missing), the consumer must
     shut down and is_running must flip to False so /health reports degraded.

--- a/tests/test_logparser.py
+++ b/tests/test_logparser.py
@@ -211,29 +211,94 @@ def test_validate_log_line_unmatched(log_parser: LogParser, load_unparseable_log
     for line in load_unparseable_logs:
         assert log_parser.validate_log_line(line) is None
 
-def test_validate_log_format_true(tmp_path: Path, log_parser: LogParser, monkeypatch) -> None:
+def test_validate_log_format_true(tmp_path: Path, log_parser: LogParser) -> None:
     """validate_log_format returns True when last lines contain valid format."""
     # Create a temp log file and copy some valid lines
     log_file = tmp_path / "access.log"
     valid_lines = Path("tests/valid_ipv4_log.txt").read_text(encoding="utf-8")
     log_file.write_text(valid_lines, encoding="utf-8")
 
-    # Speed up wait decorator: monkeypatch time.sleep to no-op
-    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
-
     # validate_log_format now takes log_path as parameter
     assert log_parser.validate_log_format(log_file) is True
 
-def test_validate_log_format_false(tmp_path: Path, log_parser: LogParser, monkeypatch) -> None:
+def test_validate_log_format_false(tmp_path: Path, log_parser: LogParser) -> None:
     """validate_log_format returns False when trailing lines are unparseable."""
     log_file = tmp_path / "access.log"
     unparseable = Path(UNPARSEABLE_LOG_PATH).read_text(encoding="utf-8")
     log_file.write_text(unparseable, encoding="utf-8")
 
     log_parser.send_logs = True
-    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
 
     assert log_parser.validate_log_format(log_file) is False
+
+
+async def test_await_valid_log_format_returns_when_stop_requested(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A stop ends the retry loop instead of blocking for the whole timeout.
+
+    The empty file never validates, so with retries enabled the old blocking
+    loop would have occupied a worker thread for the full timeout regardless
+    of the stop event.
+    """
+    monkeypatch.setenv("DISABLE_WAIT", "false")
+    log_file = tmp_path / "access.log"
+    log_file.write_text("", encoding="utf-8")
+    parser = LogParser(log_path=log_file, send_logs=True, hostname="localhost")
+    stop_event = asyncio.Event()
+    parser.set_stop_event(stop_event)
+    stop_event.set()
+
+    started = time.monotonic()
+    assert await parser.await_valid_log_format(timeout_seconds=60.0) is False
+    assert time.monotonic() - started < 1.0
+
+
+async def test_await_valid_log_format_wakes_on_stop_between_attempts(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A stop arriving mid-wait ends the loop without sitting out the interval."""
+    monkeypatch.setenv("DISABLE_WAIT", "false")
+    log_file = tmp_path / "access.log"
+    log_file.write_text("", encoding="utf-8")
+    parser = LogParser(log_path=log_file, send_logs=True, hostname="localhost")
+    stop_event = asyncio.Event()
+    parser.set_stop_event(stop_event)
+
+    async def stop_soon() -> None:
+        await asyncio.sleep(0.05)
+        stop_event.set()
+
+    started = time.monotonic()
+    result, _ = await asyncio.gather(
+        parser.await_valid_log_format(timeout_seconds=60.0, check_interval=30.0),
+        stop_soon(),
+    )
+    assert result is False
+    assert time.monotonic() - started < 5.0
+
+
+async def test_await_valid_log_format_retries_until_the_file_is_parseable(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An empty file that gains a valid line mid-wait still validates."""
+    monkeypatch.setenv("DISABLE_WAIT", "false")
+    log_file = tmp_path / "access.log"
+    log_file.write_text("", encoding="utf-8")
+    parser = LogParser(log_path=log_file, send_logs=True, hostname="localhost")
+    parser.set_stop_event(asyncio.Event())
+
+    async def append_valid_line() -> None:
+        await asyncio.sleep(0.05)
+        log_file.write_text(
+            Path(VALID_LOG_PATH).read_text(encoding="utf-8"), encoding="utf-8"
+        )
+
+    result, _ = await asyncio.gather(
+        parser.await_valid_log_format(timeout_seconds=10.0, check_interval=0.02),
+        append_valid_line(),
+    )
+    assert result is True
 
 def test_nonstandard_lines_match_loosened_pattern(load_nonstandard_logs: list[str], ipv4_log_pattern: re.Pattern[str]) -> None:
     """The loosened request group ([^"]*) accepts nonstandard/garbage requests so they


### PR DESCRIPTION
Fixes the shutdown edge that was documented as a known limitation in `docs/deployment.md` during phase 6. This is option B from the follow-up discussion: make the waits cancellable rather than shortening or hiding the timeout.

## The bug

`LogParser.validate_log_format` carried a `@wait(timeout_seconds=60)` decorator, a blocking `time.sleep(1)` retry loop, and the tailer ran it through `asyncio.to_thread`. A thread handed to `to_thread` cannot be cancelled: once shutdown was requested the awaiting task raised `CancelledError` immediately while the worker thread kept sleeping for the rest of its 60 second budget, and the interpreter could not finish exiting until it returned. In a container that meant teardown stopped part-way through and Granian force-killed the worker at its kill-timeout boundary.

The trigger is narrower than the original note implied. The log file must exist (a missing file is skipped earlier) but be empty or in an unrecognised format, which is exactly the state of a fresh install where nginx has created the access log but not yet written a parseable line to it.

A second, milder version of the same problem sat in `_tail_file`: `wait_for_path` sleeps cooperatively and so responds to cancellation, but it never consulted the stop event, so `stop()` always waited out its full timeout before resorting to cancelling the task.

## The fix

The retry moves onto the event loop. Each attempt offloads only the blocking file read to a thread, so the uncancellable window shrinks from 60 seconds to a single short read, and the waits between attempts end as soon as the stop event is set. `wait_for_path` now takes the same stop event.

Both waits share a small `sleep_unless_stopped` helper that races the stop event instead of sleeping the full interval and re-checking afterwards, so shutdown latency is not rounded up to a whole retry interval.

The `wait` decorator has no callers left. It is removed rather than left available to reintroduce the same trap.

## Behaviour that is deliberately unchanged

- The 60 second validation budget and the 60 second missing-file budget are the same. This fixes cancellability, not the timeouts.
- A file that is genuinely unparseable after the timeout still falls back to `send_logs = False` and the same warning.
- Stopping mid-validation now ends iteration quietly rather than logging a format warning that describes a shutdown rather than the file.
- `DISABLE_WAIT=true` still collapses both loops to a single attempt, which is how the suite stays fast; the new tests opt back in with monkeypatch.

## Verification

- 594 tests pass (476 non-integration + 118 integration), `ty check geometrikks tests` clean, config-docs gate clean
- Four new tests: stop already requested, stop arriving mid-wait, a file that becomes parseable while waiting, and service-level `stop()` with a missing log file
- The service-level test was confirmed to fail against the old code, reproducing the exact symptom (`stop()` burning its full 5s timeout and then logging "Tail task did not stop gracefully, cancelling")
- The intermittent `PytestUnhandledThreadExceptionWarning` in `test_logging_pipeline.py` is pre-existing and unrelated; it reproduces on develop at the same rate (once in three full runs, with and without this change)
