### PR TITLE
fix(frontend): keep analytics charts readable on dense and spike-dominated data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Time-series charts (requests, bandwidth, latency, status classes, geo events)
+  now auto-clamp the y-axis when a single traffic burst dwarfs the rest of the
+  range, keeping normal traffic readable. Clamped charts show a
+  "y-axis clipped at ..." note in the card header; spike buckets clip at the
+  top edge and tooltips keep the true values.
+
 ### Changed
 
 - `GET /api/v1/auth/me` now reports an auth mode: `{"mode": "session",
@@ -21,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/logout` is now a route of its own, not only a sidebar button.
 
 ### Fixed
+
+- The status-classes chart no longer renders near-invisible bars on dense
+  views such as 7d+ with hourly granularity: past 48 buckets it switches to a
+  stacked area chart with the same colors and stack order. The card-colored
+  spacer strokes between bar segments were wider than the sub-pixel bars
+  themselves, erasing the fill entirely.
 
 - Chart tooltips now show the bucket time in the browser's timezone instead of
   the raw UTC ISO string, matching the X axis ticks. Affected the requests,

--- a/resources/components/analytics/bytes-chart.tsx
+++ b/resources/components/analytics/bytes-chart.tsx
@@ -1,5 +1,5 @@
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   ChartContainer,
   ChartTooltip,
@@ -7,6 +7,7 @@ import {
 } from "@/components/ui/chart"
 import { Skeleton } from "@/components/ui/skeleton"
 import { formatBytes } from "@/lib/api"
+import { clampedYMax } from "@/lib/chart-scale"
 import { formatTs } from "@/lib/datetime"
 import { useTimeSeries } from "@/lib/queries"
 import { TimeSeriesTooltip } from "./time-series-tooltip"
@@ -17,11 +18,17 @@ const chartConfig = {
 
 export function BytesChart() {
   const { data, isLoading } = useTimeSeries()
+  const clipMax = clampedYMax((data?.data ?? []).map((d) => d.totalBytesSent))
 
   return (
     <Card>
       <CardHeader>
         <CardTitle className="text-sm font-medium">Bandwidth</CardTitle>
+        {clipMax != null && (
+          <CardAction className="text-xs text-muted-foreground">
+            y-axis clipped at {formatBytes(clipMax)}
+          </CardAction>
+        )}
       </CardHeader>
       <CardContent>
         {isLoading || !data ? (
@@ -41,6 +48,8 @@ export function BytesChart() {
                 axisLine={false}
                 width={64}
                 tickFormatter={(v: number) => formatBytes(v)}
+                domain={clipMax != null ? [0, clipMax] : undefined}
+                allowDataOverflow={clipMax != null}
               />
               <ChartTooltip
                 content={

--- a/resources/components/analytics/latency-chart.tsx
+++ b/resources/components/analytics/latency-chart.tsx
@@ -1,5 +1,5 @@
 import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   ChartContainer,
   ChartLegend,
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/chart"
 import { Skeleton } from "@/components/ui/skeleton"
 import { formatDuration } from "@/lib/api"
+import { clampedYMax } from "@/lib/chart-scale"
 import { formatTs } from "@/lib/datetime"
 import { useTimeSeries } from "@/lib/queries"
 import { TimeSeriesTooltip } from "./time-series-tooltip"
@@ -24,11 +25,19 @@ const SERIES = Object.keys(chartConfig) as (keyof typeof chartConfig)[]
 
 export function LatencyChart() {
   const { data, isLoading } = useTimeSeries()
+  const clipMax = clampedYMax(
+    (data?.data ?? []).flatMap((d) => SERIES.map((key) => d[key])),
+  )
 
   return (
     <Card>
       <CardHeader>
         <CardTitle className="text-sm font-medium">Latency (avg / p50 / p95 / p99)</CardTitle>
+        {clipMax != null && (
+          <CardAction className="text-xs text-muted-foreground">
+            y-axis clipped at {formatDuration(clipMax * 1000)}
+          </CardAction>
+        )}
       </CardHeader>
       <CardContent>
         {isLoading || !data ? (
@@ -49,6 +58,8 @@ export function LatencyChart() {
                 width={56}
                 // request_time is seconds; formatDuration takes ms
                 tickFormatter={(v: number) => formatDuration(v * 1000)}
+                domain={clipMax != null ? [0, clipMax] : undefined}
+                allowDataOverflow={clipMax != null}
               />
               <ChartTooltip
                 content={

--- a/resources/components/analytics/requests-chart.tsx
+++ b/resources/components/analytics/requests-chart.tsx
@@ -1,5 +1,5 @@
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   ChartContainer,
   ChartTooltip,
@@ -7,6 +7,7 @@ import {
 } from "@/components/ui/chart"
 import { Skeleton } from "@/components/ui/skeleton"
 import { formatNumber } from "@/lib/api"
+import { clampedYMax } from "@/lib/chart-scale"
 import { formatTs } from "@/lib/datetime"
 import { useTimeSeries } from "@/lib/queries"
 import { TimeSeriesTooltip } from "./time-series-tooltip"
@@ -17,11 +18,17 @@ const chartConfig = {
 
 export function RequestsChart() {
   const { data, isLoading } = useTimeSeries()
+  const clipMax = clampedYMax((data?.data ?? []).map((d) => d.totalRequests))
 
   return (
     <Card>
       <CardHeader>
         <CardTitle className="text-sm font-medium">Requests</CardTitle>
+        {clipMax != null && (
+          <CardAction className="text-xs text-muted-foreground">
+            y-axis clipped at {formatNumber(clipMax)}
+          </CardAction>
+        )}
       </CardHeader>
       <CardContent>
         {isLoading || !data ? (
@@ -41,6 +48,8 @@ export function RequestsChart() {
                 axisLine={false}
                 width={48}
                 tickFormatter={(v: number) => formatNumber(v)}
+                domain={clipMax != null ? [0, clipMax] : undefined}
+                allowDataOverflow={clipMax != null}
               />
               <ChartTooltip content={<TimeSeriesTooltip granularity={data.granularity} />} />
               <Area

--- a/resources/components/analytics/status-chart.tsx
+++ b/resources/components/analytics/status-chart.tsx
@@ -1,5 +1,5 @@
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts"
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   ChartContainer,
   ChartLegend,
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/chart"
 import { Skeleton } from "@/components/ui/skeleton"
 import { formatNumber } from "@/lib/api"
+import { clampedYMax } from "@/lib/chart-scale"
 import { formatTs } from "@/lib/datetime"
 import { useTimeSeries } from "@/lib/queries"
 import { TimeSeriesTooltip } from "./time-series-tooltip"
@@ -22,20 +23,38 @@ const chartConfig = {
   status5xx: { label: "5xx", color: "var(--chart-4)" },
 } satisfies ChartConfig
 
+const STATUS_KEYS = Object.keys(chartConfig) as (keyof typeof chartConfig)[]
+
+// Above this many buckets the per-bar surface spacers are wider than the bars
+// themselves (the card-colored strokes erase the fill entirely on 7d+ hourly
+// views), so the stack switches to areas, which have no per-mark spacer.
+const DENSE_BUCKETS = 48
+
 export function StatusChart() {
   const { data, isLoading } = useTimeSeries()
+  const buckets = data?.data ?? []
+  const dense = buckets.length > DENSE_BUCKETS
+  const clipMax = clampedYMax(
+    buckets.map((d) => STATUS_KEYS.reduce((sum, key) => sum + (d[key] ?? 0), 0)),
+  )
+  const SeriesChart = dense ? AreaChart : BarChart
 
   return (
     <Card>
       <CardHeader>
         <CardTitle className="text-sm font-medium">Status classes</CardTitle>
+        {clipMax != null && (
+          <CardAction className="text-xs text-muted-foreground">
+            y-axis clipped at {formatNumber(clipMax)}
+          </CardAction>
+        )}
       </CardHeader>
       <CardContent>
         {isLoading || !data ? (
           <Skeleton className="h-[240px] w-full" />
         ) : (
           <ChartContainer config={chartConfig} className="h-[240px] w-full">
-            <BarChart data={data.data}>
+            <SeriesChart data={data.data}>
               <CartesianGrid vertical={false} />
               <XAxis
                 dataKey="timestamp"
@@ -48,15 +67,36 @@ export function StatusChart() {
                 axisLine={false}
                 width={48}
                 tickFormatter={(v: number) => formatNumber(v)}
+                domain={clipMax != null ? [0, clipMax] : undefined}
+                allowDataOverflow={clipMax != null}
               />
               <ChartTooltip content={<TimeSeriesTooltip granularity={data.granularity} />} />
               <ChartLegend content={<ChartLegendContent />} />
-              {/* stroke = card surface: the 2px spacer between stacked segments */}
-              <Bar dataKey="status2xx" stackId="s" fill="var(--color-status2xx)" stroke="var(--card)" strokeWidth={1} />
-              <Bar dataKey="status3xx" stackId="s" fill="var(--color-status3xx)" stroke="var(--card)" strokeWidth={1} />
-              <Bar dataKey="status4xx" stackId="s" fill="var(--color-status4xx)" stroke="var(--card)" strokeWidth={1} />
-              <Bar dataKey="status5xx" stackId="s" fill="var(--color-status5xx)" stroke="var(--card)" strokeWidth={1} radius={[2, 2, 0, 0]} />
-            </BarChart>
+              {STATUS_KEYS.map((key, i) =>
+                dense ? (
+                  <Area
+                    key={key}
+                    dataKey={key}
+                    stackId="s"
+                    type="monotone"
+                    fill={`var(--color-${key})`}
+                    fillOpacity={1}
+                    stroke="none"
+                  />
+                ) : (
+                  // stroke = card surface: the 2px spacer between stacked segments
+                  <Bar
+                    key={key}
+                    dataKey={key}
+                    stackId="s"
+                    fill={`var(--color-${key})`}
+                    stroke="var(--card)"
+                    strokeWidth={1}
+                    radius={i === STATUS_KEYS.length - 1 ? [2, 2, 0, 0] : undefined}
+                  />
+                ),
+              )}
+            </SeriesChart>
           </ChartContainer>
         )}
       </CardContent>

--- a/resources/components/geo-logs/geo-logs-chart.tsx
+++ b/resources/components/geo-logs/geo-logs-chart.tsx
@@ -3,7 +3,7 @@
  * unique IPs, honoring the shared filter set and the global time range.
  */
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   ChartContainer,
   ChartTooltip,
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/chart"
 import { Skeleton } from "@/components/ui/skeleton"
 import { formatNumber } from "@/lib/api"
+import { clampedYMax } from "@/lib/chart-scale"
 import { formatTs } from "@/lib/datetime"
 import { useGeoLogTimeSeries } from "@/lib/queries"
 import { TimeSeriesTooltip } from "@/components/analytics/time-series-tooltip"
@@ -22,11 +23,19 @@ const chartConfig = {
 
 export function GeoLogsChart() {
   const { data, isLoading } = useGeoLogTimeSeries()
+  const clipMax = clampedYMax(
+    (data?.data ?? []).flatMap((d) => [d.totalEvents, d.uniqueIps]),
+  )
 
   return (
     <Card>
       <CardHeader>
         <CardTitle className="text-sm font-medium">Geo Events Over Time</CardTitle>
+        {clipMax != null && (
+          <CardAction className="text-xs text-muted-foreground">
+            y-axis clipped at {formatNumber(clipMax)}
+          </CardAction>
+        )}
       </CardHeader>
       <CardContent>
         {isLoading || !data ? (
@@ -46,6 +55,8 @@ export function GeoLogsChart() {
                 axisLine={false}
                 width={48}
                 tickFormatter={(v: number) => formatNumber(v)}
+                domain={clipMax != null ? [0, clipMax] : undefined}
+                allowDataOverflow={clipMax != null}
               />
               <ChartTooltip content={<TimeSeriesTooltip granularity={data.granularity} />} />
               <Area

--- a/resources/lib/chart-scale.test.ts
+++ b/resources/lib/chart-scale.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { clampedYMax, niceCeil } from "./chart-scale"
+
+describe("niceCeil", () => {
+  it("rounds up to the next 1/2/2.5/5 step of the decade", () => {
+    expect(niceCeil(360)).toBe(500)
+    expect(niceCeil(1000)).toBe(1000)
+    expect(niceCeil(1100)).toBe(2000)
+    expect(niceCeil(2400)).toBe(2500)
+    expect(niceCeil(0.06)).toBeCloseTo(0.1)
+  })
+})
+
+describe("clampedYMax", () => {
+  it("returns null when no bucket dwarfs the rest", () => {
+    const values = Array.from({ length: 168 }, (_, i) => 100 + i)
+    expect(clampedYMax(values)).toBeNull()
+  })
+
+  it("clamps to a nice max just above the non-spike buckets", () => {
+    const values = [...Array(167).fill(300), 18000]
+    expect(clampedYMax(values)).toBe(500)
+  })
+
+  it("returns null for short series even with a spike", () => {
+    expect(clampedYMax([0, 0, 5000])).toBeNull()
+  })
+
+  it("returns null when everything except the spike is zero", () => {
+    expect(clampedYMax([...Array(100).fill(0), 9000])).toBeNull()
+  })
+
+  it("ignores null and undefined buckets", () => {
+    const values = [...Array(167).fill(300), null, undefined, 18000]
+    expect(clampedYMax(values)).toBe(500)
+  })
+
+  it("clamps fractional series such as latency seconds", () => {
+    expect(clampedYMax([...Array(100).fill(0.05), 3])).toBeCloseTo(0.1)
+  })
+})

--- a/resources/lib/chart-scale.ts
+++ b/resources/lib/chart-scale.ts
@@ -1,0 +1,30 @@
+/**
+ * Y-axis scaling helpers for the time-series charts.
+ */
+
+/** Round up to the next 1 / 2 / 2.5 / 5 / 10 step of the value's decade. */
+export function niceCeil(x: number): number {
+  const base = 10 ** Math.floor(Math.log10(x))
+  const step = [1, 2, 2.5, 5, 10].find((s) => x / base <= s) ?? 10
+  return step * base
+}
+
+/**
+ * Y-axis max for spike-dominated series, or null when no clamping is needed.
+ *
+ * A single burst bucket can stretch a linear axis until normal traffic renders
+ * sub-pixel. When the true max dwarfs the top-2% reference bucket, return a
+ * nice-rounded axis max just above that reference; marks beyond it clip at the
+ * plot edge (tooltips still carry the real values).
+ */
+export function clampedYMax(values: Array<number | null | undefined>): number | null {
+  const finite = values.filter((v): v is number => Number.isFinite(v))
+  if (finite.length < 6) return null
+  const sorted = [...finite].sort((a, b) => a - b)
+  const spikeCount = Math.max(1, Math.floor(sorted.length * 0.02))
+  const reference = sorted[sorted.length - 1 - spikeCount]
+  const max = sorted[sorted.length - 1]
+  if (reference <= 0 || max <= reference * 2.5) return null
+  const clamped = niceCeil(reference * 1.2)
+  return clamped < max ? clamped : null
+}


### PR DESCRIPTION
## Summary

Two related readability fixes for the time-series charts, prompted by the near-invisible status-classes chart on 7d+ hourly views (#125 screenshots show the same symptom).

- **Status classes chart**: past 48 buckets it now renders a stacked area chart with the same colors and stack order instead of bars. Root cause: each bar segment carried a card-colored spacer stroke, and on dense views the bars are sub-pixel wide, so the strokes erased the fill entirely. At 48 buckets or fewer the original bars with spacers remain.
- **Y-axis auto-clamp**: all five time-series charts (requests, bandwidth, latency, status classes, geo events) clamp the y-axis when a single burst bucket dwarfs the rest of the range (max > 2.5x the top-2% reference bucket). Normal traffic stays readable, spike buckets clip flat at the plot edge, a muted "y-axis clipped at ..." note appears in the card header, and tooltips keep the true values.

The clamp logic lives in `resources/lib/chart-scale.ts` with unit tests.

Note: the "today + daily granularity shows two days" issue is UTC day bucketing and will be a separate PR.

## Test plan

- [x] `bun run test` (159 passed, includes new chart-scale suite)
- [x] `bun run typecheck`
- [x] Browser check: 7d + hourly status chart readable on narrow viewports; burst ranges show the clipped note and readable baseline traffic