### PR TITLE
fix(analytics): bucket daily chart data into browser-local days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Selecting "Today" (or any range not starting at UTC midnight) with daily
+  granularity no longer renders an extra full day in the charts. The frontend
+  now sends the browser's timezone as a new optional `tz` query parameter on
+  the time-series endpoints, and daily buckets are computed as local days in
+  that zone for ranges up to 30 days (rolled up from hourly data: counts
+  summed, latency sketches and unique-count HLLs merged). Ranges beyond 30
+  days keep UTC day buckets, since only the daily aggregates reach that far
+  back.
+
 - Chart tooltips now show the bucket time in the browser's timezone instead of
   the raw UTC ISO string, matching the X axis ticks. Affected the requests,
   bandwidth, latency, status-class and geo-events charts.

--- a/geometrikks/domain/analytics/controllers.py
+++ b/geometrikks/domain/analytics/controllers.py
@@ -49,8 +49,9 @@ from geometrikks.lib.parameters import (
     IpAddressExcludeFilter,
     IpAddressFilter,
     StartDate,
+    Timezone,
 )
-from geometrikks.lib.validation import validate_ip_addresses
+from geometrikks.lib.validation import validate_ip_addresses, validate_timezone
 
 
 def _calculate_percent_change(current: float, previous: float) -> float | None:
@@ -413,6 +414,7 @@ class AnalyticsController(Controller):
         city: CityFilter = None,
         ip_address: IpAddressFilter = None,
         ip_address_not_in: IpAddressExcludeFilter = None,
+        tz: Timezone = None,
     ) -> TimeSeriesResponse:
         """Get per-bucket access-log metrics (requests, status, bytes, latency).
 
@@ -425,14 +427,16 @@ class AnalyticsController(Controller):
         """
         filters = _build_filters(country_code, city, ip_address, ip_address_not_in)
         resolved = _resolve_chart_granularity(start_date, end_date, granularity)
+        if tz is not None:
+            validate_timezone(tz)
         if filters.is_active():
             interval = "1 hour" if resolved == StatsGranularity.HOURLY else "1 day"
             rows = await live_stats_repo.get_time_series(
-                start_date, end_date, bucket_interval=interval, filters=filters
+                start_date, end_date, bucket_interval=interval, filters=filters, tz=tz
             )
         else:
             rows = await summary_stats_repo.get_time_series(
-                start_date, end_date, granularity=resolved
+                start_date, end_date, granularity=resolved, tz=tz
             )
         return TimeSeriesResponse(
             granularity=resolved.value,
@@ -472,10 +476,15 @@ class AnalyticsController(Controller):
                 required=False,
             ),
         ] = None,
+        tz: Timezone = None,
     ) -> GeoEventsTimeSeriesResponse:
         """Get per-bucket geo-event metrics (events, unique IPs/countries/cities)."""
         resolved = _resolve_chart_granularity(start_date, end_date, granularity)
-        rows = await summary_stats_repo.get_geo_time_series(start_date, end_date, granularity=resolved)
+        if tz is not None:
+            validate_timezone(tz)
+        rows = await summary_stats_repo.get_geo_time_series(
+            start_date, end_date, granularity=resolved, tz=tz
+        )
         return GeoEventsTimeSeriesResponse(
             granularity=resolved.value,
             start_date=start_date.isoformat(),

--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -71,6 +71,27 @@ def get_stats_granularity(start: datetime, end: datetime) -> StatsGranularity:
     return StatsGranularity.DAILY
 
 
+def use_local_days(
+    granularity: StatsGranularity,
+    start: datetime,
+    end: datetime,
+    tz: str | None,
+) -> bool:
+    """True when daily buckets should be local days in ``tz``.
+
+    Daily buckets in a non-UTC zone can only be assembled from hourly source
+    data. Ranges that route to the daily CAGGs (> 30 days) keep UTC day
+    buckets: hourly CAGG retention is not guaranteed to reach that far back,
+    and the daily CAGGs are baked as UTC days.
+    """
+    return (
+        granularity == StatsGranularity.DAILY
+        and tz is not None
+        and tz != "UTC"
+        and get_stats_granularity(start, end) != StatsGranularity.DAILY
+    )
+
+
 def _floor_to_hour(dt: datetime) -> datetime:
     """Truncate datetime to the start of its hour."""
     result = dt.replace(minute=0, second=0, microsecond=0)
@@ -379,6 +400,7 @@ class SummaryStatsRepository:
         start: datetime,
         end: datetime,
         granularity: StatsGranularity | None = None,
+        tz: str | None = None,
     ) -> Sequence[SummaryStatsRow]:
         """Get time series data for charts.
 
@@ -387,6 +409,9 @@ class SummaryStatsRepository:
             end: End datetime.
             granularity: Explicit bucket granularity override. None auto-routes
                 via get_stats_granularity (RAW is clamped to HOURLY).
+            tz: IANA timezone for daily buckets. When set (and non-UTC), daily
+                buckets are local days rolled up from the hourly CAGG; ranges
+                routed to the daily CAGGs keep UTC days (see use_local_days).
 
         Returns:
             List of SummaryStatsRow ordered by bucket ascending.
@@ -395,30 +420,61 @@ class SummaryStatsRepository:
             granularity = get_stats_granularity(start, end)
         if granularity == StatsGranularity.RAW:
             granularity = StatsGranularity.HOURLY  # no raw CAGG; hourly + real-time agg covers <=24h
-        table = f"summary_{granularity.value}_stats"
-        bucket_interval = "1 hour" if granularity == StatsGranularity.HOURLY else "1 day"
 
-        stmt = text(f"""
-            SELECT
-                bucket,
-                total_requests,
-                total_bytes,
-                status_2xx,
-                status_3xx,
-                status_4xx,
-                status_5xx,
-                avg_request_time,
-                max_request_time,
-                approx_percentile(0.50, pct_agg) AS p50_request_time,
-                approx_percentile(0.95, pct_agg) AS p95_request_time,
-                approx_percentile(0.99, pct_agg) AS p99_request_time
-            FROM {table}
-            WHERE bucket >= time_bucket('{bucket_interval}', CAST(:start AS timestamptz))
-              AND bucket < :end
-            ORDER BY bucket ASC
-        """)
+        if use_local_days(granularity, start, end, tz):
+            # Local days assembled from hourly buckets: counts sum, sketches
+            # merge via rollup(), and the mean is request-weighted. The CAGG's
+            # AVG skips NULL request_time rows while total_requests counts
+            # them, so the weighted mean drifts slightly when NULLs cluster.
+            # GROUP BY 1: a bare "bucket" would resolve to the source column.
+            stmt = text("""
+                SELECT
+                    time_bucket('1 day', bucket, CAST(:tz AS TEXT)) AS bucket,
+                    CAST(SUM(total_requests) AS BIGINT) AS total_requests,
+                    CAST(COALESCE(SUM(total_bytes), 0) AS BIGINT) AS total_bytes,
+                    CAST(SUM(status_2xx) AS BIGINT) AS status_2xx,
+                    CAST(SUM(status_3xx) AS BIGINT) AS status_3xx,
+                    CAST(SUM(status_4xx) AS BIGINT) AS status_4xx,
+                    CAST(SUM(status_5xx) AS BIGINT) AS status_5xx,
+                    SUM(avg_request_time * total_requests)
+                        / NULLIF(SUM(total_requests), 0) AS avg_request_time,
+                    MAX(max_request_time) AS max_request_time,
+                    approx_percentile(0.50, rollup(pct_agg)) AS p50_request_time,
+                    approx_percentile(0.95, rollup(pct_agg)) AS p95_request_time,
+                    approx_percentile(0.99, rollup(pct_agg)) AS p99_request_time
+                FROM summary_hourly_stats
+                WHERE bucket >= time_bucket('1 day', CAST(:start AS timestamptz), CAST(:tz AS TEXT))
+                  AND bucket < :end
+                GROUP BY 1
+                ORDER BY 1 ASC
+            """)
+            params: dict = {"start": start, "end": end, "tz": tz}
+        else:
+            table = f"summary_{granularity.value}_stats"
+            bucket_interval = "1 hour" if granularity == StatsGranularity.HOURLY else "1 day"
 
-        result = await self.session.execute(stmt, {"start": start, "end": end})
+            stmt = text(f"""
+                SELECT
+                    bucket,
+                    total_requests,
+                    total_bytes,
+                    status_2xx,
+                    status_3xx,
+                    status_4xx,
+                    status_5xx,
+                    avg_request_time,
+                    max_request_time,
+                    approx_percentile(0.50, pct_agg) AS p50_request_time,
+                    approx_percentile(0.95, pct_agg) AS p95_request_time,
+                    approx_percentile(0.99, pct_agg) AS p99_request_time
+                FROM {table}
+                WHERE bucket >= time_bucket('{bucket_interval}', CAST(:start AS timestamptz))
+                  AND bucket < :end
+                ORDER BY bucket ASC
+            """)
+            params = {"start": start, "end": end}
+
+        result = await self.session.execute(stmt, params)
         rows = result.fetchall()
 
         return [
@@ -444,6 +500,7 @@ class SummaryStatsRepository:
         start: datetime,
         end: datetime,
         granularity: StatsGranularity | None = None,
+        tz: str | None = None,
     ) -> Sequence[dict]:
         """Get geo event time series data for charts.
 
@@ -454,6 +511,7 @@ class SummaryStatsRepository:
             end: End datetime.
             granularity: Explicit bucket granularity override. None auto-routes
                 via get_stats_granularity (RAW is clamped to HOURLY).
+            tz: IANA timezone for daily buckets (see get_time_series).
 
         Returns:
             List of dicts with bucket, total_events, unique_ips, unique_countries, unique_cities.
@@ -462,23 +520,42 @@ class SummaryStatsRepository:
             granularity = get_stats_granularity(start, end)
         if granularity == StatsGranularity.RAW:
             granularity = StatsGranularity.HOURLY  # no raw CAGG; hourly + real-time agg covers <=24h
-        table = f"geo_summary_{granularity.value}_stats"
-        bucket_interval = "1 hour" if granularity == StatsGranularity.HOURLY else "1 day"
 
-        stmt = text(f"""
-            SELECT
-                bucket,
-                total_events,
-                distinct_count(hll_ips) AS unique_ips,
-                distinct_count(hll_countries) AS unique_countries,
-                distinct_count(hll_cities) AS unique_cities
-            FROM {table}
-            WHERE bucket >= time_bucket('{bucket_interval}', CAST(:start AS timestamptz))
-              AND bucket < :end
-            ORDER BY bucket ASC
-        """)
+        if use_local_days(granularity, start, end, tz):
+            # GROUP BY 1: a bare "bucket" would resolve to the source column.
+            stmt = text("""
+                SELECT
+                    time_bucket('1 day', bucket, CAST(:tz AS TEXT)) AS bucket,
+                    CAST(SUM(total_events) AS BIGINT) AS total_events,
+                    distinct_count(rollup(hll_ips)) AS unique_ips,
+                    distinct_count(rollup(hll_countries)) AS unique_countries,
+                    distinct_count(rollup(hll_cities)) AS unique_cities
+                FROM geo_summary_hourly_stats
+                WHERE bucket >= time_bucket('1 day', CAST(:start AS timestamptz), CAST(:tz AS TEXT))
+                  AND bucket < :end
+                GROUP BY 1
+                ORDER BY 1 ASC
+            """)
+            params: dict = {"start": start, "end": end, "tz": tz}
+        else:
+            table = f"geo_summary_{granularity.value}_stats"
+            bucket_interval = "1 hour" if granularity == StatsGranularity.HOURLY else "1 day"
 
-        result = await self.session.execute(stmt, {"start": start, "end": end})
+            stmt = text(f"""
+                SELECT
+                    bucket,
+                    total_events,
+                    distinct_count(hll_ips) AS unique_ips,
+                    distinct_count(hll_countries) AS unique_countries,
+                    distinct_count(hll_cities) AS unique_cities
+                FROM {table}
+                WHERE bucket >= time_bucket('{bucket_interval}', CAST(:start AS timestamptz))
+                  AND bucket < :end
+                ORDER BY bucket ASC
+            """)
+            params = {"start": start, "end": end}
+
+        result = await self.session.execute(stmt, params)
         return [dict(row._mapping) for row in result.fetchall()]
 
     async def get_cumulative_time_series(
@@ -1057,18 +1134,29 @@ class LiveStatsRepository:
         *,
         bucket_interval: str,
         filters: AnalyticsFilters | None = None,
+        tz: str | None = None,
     ) -> Sequence[SummaryStatsRow]:
         """Bucketed access-log metrics from the raw hypertable.
 
         Used when dimension filters are active (CAGGs cannot filter).
         bucket_interval is '1 hour' or '1 day' (validated by the caller).
+        With a non-UTC ``tz``, daily buckets are local days; raw rows carry
+        exact timestamps, so this needs no range restriction.
         """
         if bucket_interval not in ("1 hour", "1 day"):
             raise ValueError("bucket_interval must be '1 hour' or '1 day'")
+        local_days = bucket_interval == "1 day" and tz is not None and tz != "UTC"
+        bucket_expr = (
+            "time_bucket('1 day', timestamp, CAST(:tz AS TEXT))"
+            if local_days
+            else f"time_bucket('{bucket_interval}', timestamp)"
+        )
         filter_sql, filter_params = (filters or AnalyticsFilters()).sql_conditions()
+        if local_days:
+            filter_params = {**filter_params, "tz": tz}
         stmt = text(f"""
             SELECT
-                time_bucket('{bucket_interval}', timestamp) AS bucket,
+                {bucket_expr} AS bucket,
                 CAST(COUNT(*) AS BIGINT) AS total_requests,
                 CAST(COALESCE(SUM(bytes_sent), 0) AS BIGINT) AS total_bytes,
                 COUNT(*) FILTER (WHERE status_code >= 200 AND status_code < 300) AS status_2xx,

--- a/geometrikks/domain/geo/controllers/events.py
+++ b/geometrikks/domain/geo/controllers/events.py
@@ -37,9 +37,10 @@ from geometrikks.lib.parameters import (
     IpAddressIn,
     IpAddressNotIn,
     FromTimestamp,
+    Timezone,
 )
 from geometrikks.lib.time import ensure_utc
-from geometrikks.lib.validation import validate_ip_addresses
+from geometrikks.lib.validation import validate_ip_addresses, validate_timezone
 
 
 
@@ -278,6 +279,7 @@ class GeoEventController(Controller):
                 required=False,
             ),
         ] = None,
+        tz: Timezone = None,
     ) -> GeoLogTimeSeriesResponse:
         """Bucketed totals + unique IPs.
 
@@ -288,8 +290,10 @@ class GeoEventController(Controller):
         from_timestamp = ensure_utc(from_timestamp)
         to_timestamp = ensure_utc(to_timestamp)
         resolved = _resolve_chart_granularity(from_timestamp, to_timestamp, granularity)
+        if tz is not None:
+            validate_timezone(tz)
         points = await geo_event_service.get_time_series(
-            from_timestamp, to_timestamp, resolved, geo_filters
+            from_timestamp, to_timestamp, resolved, geo_filters, tz=tz
         )
         return GeoLogTimeSeriesResponse(
             granularity=resolved.value,

--- a/geometrikks/domain/geo/repositories.py
+++ b/geometrikks/domain/geo/repositories.py
@@ -63,6 +63,26 @@ def get_stats_granularity(from_timestamp: datetime, to_timestamp: datetime) -> S
         return StatsGranularity.DAILY
 
 
+def use_local_days(
+    granularity: StatsGranularity,
+    start: datetime,
+    end: datetime,
+    tz: str | None,
+) -> bool:
+    """True when daily buckets should be local days in ``tz``.
+
+    Mirrors the analytics twin (this domain keeps its own granularity
+    routing): non-UTC daily buckets need hourly source data, so windows
+    routed to the daily CAGGs (> 30 days) keep UTC days.
+    """
+    return (
+        granularity == StatsGranularity.DAILY
+        and tz is not None
+        and tz != "UTC"
+        and get_stats_granularity(start, end) != StatsGranularity.DAILY
+    )
+
+
 IP_LOCATION_CAGGS = {
     StatsGranularity.HOURLY: ("ip_location_hourly_stats", "1 hour"),
     StatsGranularity.DAILY: ("ip_location_daily_stats", "1 day"),

--- a/geometrikks/domain/geo/services.py
+++ b/geometrikks/domain/geo/services.py
@@ -30,6 +30,7 @@ from geometrikks.domain.geo.repositories import (
     get_stats_granularity,
     stitch_params,
     stitched_ip_location_cte,
+    use_local_days,
 )
 from geometrikks.domain.geo.schemas import (
     GeoCountryFacet,
@@ -254,6 +255,7 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
         end: datetime,
         granularity: StatsGranularity,
         filters: GeoEventFilters,
+        tz: str | None = None,
     ) -> list[GeoLogTimeSeriesPoint]:
         """Bucketed event totals + unique IPs for the chart.
 
@@ -267,6 +269,11 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
         and the stitched per-IP CAGGs only carry the daily rollup there.
         Other country/city/IP-filtered ranges use the stitched per-IP CAGGs;
         unfiltered ranges > 24h use the HLL geo_summary CAGGs.
+
+        With a non-UTC ``tz``, daily buckets are local days: the raw path
+        re-buckets exact timestamps, the CAGG paths roll up hourly buckets.
+        Windows routed to the daily CAGGs (> 30 days) keep UTC days (see
+        use_local_days); the raw path honors ``tz`` regardless of span.
         """
         if granularity not in (StatsGranularity.HOURLY, StatsGranularity.DAILY):
             raise ValueError("granularity must be HOURLY or DAILY")
@@ -275,6 +282,10 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
         # requested bucket size above: a <= 24h span must stay on raw even
         # when the caller asks for hourly buckets on it.
         data_granularity = get_stats_granularity(start, end)
+        local_days = use_local_days(granularity, start, end, tz)
+        raw_local_days = (
+            granularity == StatsGranularity.DAILY and tz is not None and tz != "UTC"
+        )
 
         if (
             filters.forces_raw
@@ -285,10 +296,15 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                 and data_granularity == StatsGranularity.DAILY
             )
         ):
+            bucket_expr = (
+                "time_bucket('1 day', ge.timestamp, CAST(:tz AS TEXT))"
+                if raw_local_days
+                else f"time_bucket('{interval}', ge.timestamp)"
+            )
             filter_sql, filter_params = filters.sql_conditions("ge", "gl")
             stmt = text(f"""
                 SELECT
-                    time_bucket('{interval}', ge.timestamp) AS bucket,
+                    {bucket_expr} AS bucket,
                     CAST(COUNT(*) AS BIGINT) AS total_events,
                     CAST(COUNT(DISTINCT ge.ip_address) AS BIGINT) AS unique_ips
                 FROM geo_events ge
@@ -299,15 +315,27 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                 ORDER BY bucket ASC
             """)
             params = {"start": start, "end": end, **filter_params}
+            if raw_local_days:
+                params["tz"] = tz
         elif filters.is_active():
             # Country/city/IP filters: stitched per-IP CAGG rows re-bucketed.
             # CAGG-leg rows carry last_seen = bucket; raw edge rows carry the
             # exact timestamp, so partial head/tail buckets fold correctly.
+            # Local days stitch on the hourly CAGG (a daily-CAGG leg would fold
+            # a whole UTC day into one local day).
+            stitch_granularity = (
+                StatsGranularity.HOURLY if local_days else granularity
+            )
+            bucket_expr = (
+                "time_bucket('1 day', c.last_seen, CAST(:tz AS TEXT))"
+                if local_days
+                else f"time_bucket('{interval}', c.last_seen)"
+            )
             filter_sql, filter_params = filters.sql_conditions("c", "gl")
             stmt = text(f"""
-                {stitched_ip_location_cte(granularity)}
+                {stitched_ip_location_cte(stitch_granularity)}
                 SELECT
-                    time_bucket('{interval}', c.last_seen) AS bucket,
+                    {bucket_expr} AS bucket,
                     CAST(SUM(c.event_count) AS BIGINT) AS total_events,
                     CAST(COUNT(DISTINCT c.ip_address) AS BIGINT) AS unique_ips
                 FROM combined c
@@ -317,7 +345,23 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                 GROUP BY bucket
                 ORDER BY bucket ASC
             """)
-            params = {**stitch_params(start, end, granularity), **filter_params}
+            params = {**stitch_params(start, end, stitch_granularity), **filter_params}
+            if local_days:
+                params["tz"] = tz
+        elif local_days:
+            # GROUP BY 1: a bare "bucket" would resolve to the source column.
+            stmt = text("""
+                SELECT
+                    time_bucket('1 day', bucket, CAST(:tz AS TEXT)) AS bucket,
+                    CAST(SUM(total_events) AS BIGINT) AS total_events,
+                    CAST(distinct_count(rollup(hll_ips)) AS BIGINT) AS unique_ips
+                FROM geo_summary_hourly_stats
+                WHERE bucket >= time_bucket('1 day', CAST(:start AS timestamptz), CAST(:tz AS TEXT))
+                  AND bucket < :end
+                GROUP BY 1
+                ORDER BY 1 ASC
+            """)
+            params = {"start": start, "end": end, "tz": tz}
         else:
             table = f"geo_summary_{granularity.value}_stats"
             stmt = text(f"""

--- a/geometrikks/lib/parameters.py
+++ b/geometrikks/lib/parameters.py
@@ -50,6 +50,19 @@ EndDate = Annotated[
     ),
 ]
 
+Timezone = Annotated[
+    str | None,
+    QueryParameter(
+        name="tz",
+        description="IANA timezone for daily buckets (e.g. Europe/Oslo). When "
+        "set, daily buckets are local days in this zone for ranges the hourly "
+        "source data can serve (<= 30 days); longer ranges keep UTC days. "
+        "Hourly buckets are unaffected.",
+        examples=[Example(value="Europe/Oslo")],
+        required=False,
+    ),
+]
+
 CountryCodeFilter = Annotated[
     list[str] | None,
     QueryParameter(name="countryCode", description="Filter to these ISO country codes (repeatable)", required=False),

--- a/geometrikks/lib/validation.py
+++ b/geometrikks/lib/validation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ipaddress
+import zoneinfo
 from collections.abc import Iterable
 
 from geometrikks.domain.exceptions import DomainValidationError
@@ -28,3 +29,20 @@ def validate_ip_addresses(values: Iterable[str]) -> None:
     """Validate every value with :func:`validate_ip_address`."""
     for raw in values:
         validate_ip_address(raw)
+
+
+def validate_timezone(value: str) -> str:
+    """Reject anything that is not an installed IANA timezone name.
+
+    The value is only ever bound as a query parameter, but an unknown zone
+    would make ``time_bucket()`` raise mid-query and surface a 500 instead
+    of a 400.
+
+    Raises:
+        DomainValidationError: If the value is not a known timezone.
+    """
+    try:
+        zoneinfo.ZoneInfo(value)
+    except (zoneinfo.ZoneInfoNotFoundError, ValueError) as exc:
+        raise DomainValidationError(f"Unknown timezone: {value!r}") from exc
+    return value

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -1233,6 +1233,10 @@ export type ApiV1AnalyticsGeoTimeSeriesGetGeoTimeSeriesData = {
      * Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available.
      */
     granularity?: "hourly" | "daily" | null;
+    /**
+     * IANA timezone for daily buckets (e.g. Europe/Oslo). When set, daily buckets are local days in this zone for ranges the hourly source data can serve (<= 30 days); longer ranges keep UTC days. Hourly buckets are unaffected.
+     */
+    tz?: string | null;
   };
   url: "/api/v1/analytics/geo-time-series";
 };
@@ -1396,6 +1400,10 @@ export type ApiV1AnalyticsTimeSeriesGetTimeSeriesData = {
      * Exclude these client IPs (repeatable)
      */
     ipAddressNotIn?: Array<string> | null;
+    /**
+     * IANA timezone for daily buckets (e.g. Europe/Oslo). When set, daily buckets are local days in this zone for ranges the hourly source data can serve (<= 30 days); longer ranges keep UTC days. Hourly buckets are unaffected.
+     */
+    tz?: string | null;
   };
   url: "/api/v1/analytics/time-series";
 };
@@ -2439,6 +2447,10 @@ export type ApiV1GeoEventsTimeSeriesGetGeoLogTimeSeriesData = {
      * Bucket size override. Omit to auto-select (hourly <= 30 days, daily above). RAW is never available.
      */
     granularity?: "hourly" | "daily" | null;
+    /**
+     * IANA timezone for daily buckets (e.g. Europe/Oslo). When set, daily buckets are local days in this zone for ranges the hourly source data can serve (<= 30 days); longer ranges keep UTC days. Hourly buckets are unaffected.
+     */
+    tz?: string | null;
   };
   url: "/api/v1/geo-events/time-series";
 };

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -4312,6 +4312,34 @@
                 "string"
               ]
             }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "IANA timezone for daily buckets (e.g. Europe/Oslo). When set, daily buckets are local days in this zone for ranges the hourly source data can serve (<= 30 days); longer ranges keep UTC days. Hourly buckets are unaffected.",
+            "examples": {
+              "tz-example-1": {
+                "value": "Europe/Oslo"
+              }
+            },
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "description": "IANA timezone for daily buckets (e.g. Europe/Oslo). When set, daily buckets are local days in this zone for ranges the hourly source data can serve (<= 30 days); longer ranges keep UTC days. Hourly buckets are unaffected.",
+              "examples": [
+                "Europe/Oslo"
+              ],
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
           }
         ],
         "responses": {
@@ -4771,6 +4799,34 @@
                     "type": "string"
                   },
                   "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "IANA timezone for daily buckets (e.g. Europe/Oslo). When set, daily buckets are local days in this zone for ranges the hourly source data can serve (<= 30 days); longer ranges keep UTC days. Hourly buckets are unaffected.",
+            "examples": {
+              "tz-example-1": {
+                "value": "Europe/Oslo"
+              }
+            },
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "description": "IANA timezone for daily buckets (e.g. Europe/Oslo). When set, daily buckets are local days in this zone for ranges the hourly source data can serve (<= 30 days); longer ranges keep UTC days. Hourly buckets are unaffected.",
+              "examples": [
+                "Europe/Oslo"
+              ],
+              "oneOf": [
+                {
+                  "type": "string"
                 },
                 {
                   "type": "null"
@@ -7793,6 +7849,34 @@
               "type": [
                 "null",
                 "string"
+              ]
+            }
+          },
+          {
+            "allowEmptyValue": false,
+            "allowReserved": false,
+            "deprecated": false,
+            "description": "IANA timezone for daily buckets (e.g. Europe/Oslo). When set, daily buckets are local days in this zone for ranges the hourly source data can serve (<= 30 days); longer ranges keep UTC days. Hourly buckets are unaffected.",
+            "examples": {
+              "tz-example-1": {
+                "value": "Europe/Oslo"
+              }
+            },
+            "in": "query",
+            "name": "tz",
+            "required": false,
+            "schema": {
+              "description": "IANA timezone for daily buckets (e.g. Europe/Oslo). When set, daily buckets are local days in this zone for ranges the hourly source data can serve (<= 30 days); longer ranges keep UTC days. Hourly buckets are unaffected.",
+              "examples": [
+                "Europe/Oslo"
+              ],
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
               ]
             }
           }

--- a/resources/generated/routes.json
+++ b/resources/generated/routes.json
@@ -103,7 +103,8 @@
         "hostnameIn": "string[] | undefined",
         "ipAddressIn": "string[] | undefined",
         "ipAddressNotIn": "string[] | undefined",
-        "toTimestamp": "DateTime"
+        "toTimestamp": "DateTime",
+        "tz": "string | undefined"
       },
       "uri": "/api/v1/geo-events/time-series"
     },
@@ -186,7 +187,8 @@
       "queryParameters": {
         "endDate": "DateTime",
         "granularity": "\"hourly\" | \"daily\" | undefined",
-        "startDate": "DateTime"
+        "startDate": "DateTime",
+        "tz": "string | undefined"
       },
       "uri": "/api/v1/analytics/geo-time-series"
     },
@@ -300,7 +302,8 @@
         "granularity": "\"hourly\" | \"daily\" | undefined",
         "ipAddress": "string[] | undefined",
         "ipAddressNotIn": "string[] | undefined",
-        "startDate": "DateTime"
+        "startDate": "DateTime",
+        "tz": "string | undefined"
       },
       "uri": "/api/v1/analytics/time-series"
     },

--- a/resources/generated/routes.ts
+++ b/resources/generated/routes.ts
@@ -169,6 +169,7 @@ export interface RouteQueryParams {
     ipAddressIn?: string[];
     ipAddressNotIn?: string[];
     toTimestamp: DateTime;
+    tz?: string;
   };
   'get_geo_log_top_cities': {
     cityIn?: string[];
@@ -217,6 +218,7 @@ export interface RouteQueryParams {
     endDate: DateTime;
     granularity?: "hourly" | "daily";
     startDate: DateTime;
+    tz?: string;
   };
   'get_geojson': {
     city?: string[];
@@ -259,6 +261,7 @@ export interface RouteQueryParams {
     ipAddress?: string[];
     ipAddressNotIn?: string[];
     startDate: DateTime;
+    tz?: string;
   };
   'get_top_cities': {
     city?: string[];
@@ -473,7 +476,7 @@ export const routeDefinitions = {
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['cityIn', 'countryCodeIn', 'fromTimestamp', 'granularity', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'toTimestamp'] as const,
+    queryParams: ['cityIn', 'countryCodeIn', 'fromTimestamp', 'granularity', 'hostnameIn', 'ipAddressIn', 'ipAddressNotIn', 'toTimestamp', 'tz'] as const,
   },
   'get_geo_log_top_cities': {
     path: '/api/v1/geo-events/top-cities',
@@ -508,7 +511,7 @@ export const routeDefinitions = {
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['endDate', 'granularity', 'startDate'] as const,
+    queryParams: ['endDate', 'granularity', 'startDate', 'tz'] as const,
   },
   'get_geojson': {
     path: '/api/v1/geo-locations/geojson',
@@ -578,7 +581,7 @@ export const routeDefinitions = {
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,
-    queryParams: ['city', 'countryCode', 'endDate', 'granularity', 'ipAddress', 'ipAddressNotIn', 'startDate'] as const,
+    queryParams: ['city', 'countryCode', 'endDate', 'granularity', 'ipAddress', 'ipAddressNotIn', 'startDate', 'tz'] as const,
   },
   'get_top_cities': {
     path: '/api/v1/analytics/top-cities',

--- a/resources/lib/api.ts
+++ b/resources/lib/api.ts
@@ -19,6 +19,7 @@ import {
   apiV1AnalyticsTopUrlsGetTopUrls,
   apiV1AnalyticsTopUserAgentsGetTopUserAgents,
 } from "@/generated/api/sdk.gen"
+import { BROWSER_TZ } from "@/lib/datetime"
 import type {
   GeoJsonFeatureCollection as GeoJSONFeatureCollection,
   SafeSettingsResponse,
@@ -541,6 +542,7 @@ export async function fetchTimeSeries(params: TimeSeriesParams & AnalyticsFilter
       startDate: params.startDate,
       endDate: params.endDate,
       granularity: params.granularity,
+      tz: BROWSER_TZ,
       countryCode: params.countryCodes?.length ? params.countryCodes : undefined,
       city: params.cities?.length ? params.cities : undefined,
       ipAddress: params.ips?.length ? params.ips : undefined,
@@ -553,7 +555,12 @@ export async function fetchTimeSeries(params: TimeSeriesParams & AnalyticsFilter
 
 export async function fetchGeoTimeSeries(params: TimeSeriesParams) {
   const { data } = await apiV1AnalyticsGeoTimeSeriesGetGeoTimeSeries({
-    query: { startDate: params.startDate, endDate: params.endDate, granularity: params.granularity },
+    query: {
+      startDate: params.startDate,
+      endDate: params.endDate,
+      granularity: params.granularity,
+      tz: BROWSER_TZ,
+    },
     throwOnError: true,
   })
   return data
@@ -758,6 +765,7 @@ export async function fetchGeoLogTimeSeries(
       fromTimestamp: params.fromTimestamp,
       toTimestamp: params.toTimestamp,
       granularity: params.granularity,
+      tz: BROWSER_TZ,
       ...geoLogFilterQuery(params),
     },
     throwOnError: true,

--- a/resources/lib/datetime.ts
+++ b/resources/lib/datetime.ts
@@ -10,6 +10,12 @@
  * way on the gridline and another way in the tooltip.
  */
 
+/**
+ * The browser's IANA timezone, sent as the `tz` query param so the API can
+ * bucket daily chart data into local days instead of UTC days.
+ */
+export const BROWSER_TZ = new Intl.DateTimeFormat().resolvedOptions().timeZone
+
 const HOURLY = new Intl.DateTimeFormat(undefined, {
   month: "short",
   day: "numeric",

--- a/tests/integration/test_local_day_buckets_pg.py
+++ b/tests/integration/test_local_day_buckets_pg.py
@@ -1,0 +1,178 @@
+"""Daily chart buckets in the caller's timezone.
+
+A "today" range in a non-UTC browser starts mid-UTC-day; UTC day buckets then
+pull in the whole previous UTC day and render an extra bar. With ``tz`` the
+daily buckets are local days assembled from hourly source data.
+
+Uses Etc/GMT-2 (fixed UTC+2, POSIX sign is inverted) so expectations don't
+shift with DST.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import text
+
+from geometrikks.domain.analytics.repositories import (
+    AnalyticsFilters,
+    LiveStatsRepository,
+    StatsGranularity,
+    SummaryStatsRepository,
+)
+from geometrikks.domain.geo.repositories import StatsGranularity as GeoStatsGranularity
+from geometrikks.domain.geo.schemas import GeoEventFilters
+from geometrikks.domain.geo.services import GeoEventService
+from geometrikks.server.timescale import refresh_caggs_range
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+TZ = "Etc/GMT-2"
+
+# Wall-clock derived, hour-aligned (see test_repositories_pg.py for why).
+NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+
+# Base UTC day two days ago. Local (UTC+2) midnight of the *next* local day
+# falls at BASE+22h; the window mimics "today" selected shortly after noon.
+BASE = (NOW - timedelta(days=2)).replace(hour=0)
+LOCAL_MIDNIGHT = BASE + timedelta(hours=22)
+WINDOW_END = BASE + timedelta(days=1, hours=12)
+
+# Event instants: e1 belongs to the earlier local day; e2/e3 to the local day
+# starting at LOCAL_MIDNIGHT. In UTC days, e1+e2 share BASE and e3 is alone.
+E1 = BASE + timedelta(hours=21)
+E2 = BASE + timedelta(hours=23)
+E3 = BASE + timedelta(days=1, hours=10)
+
+
+async def _insert_log(session, *, ts, rt=0.01, ip="10.0.0.1"):
+    # access_logs is an id-only base: no created_at/updated_at columns.
+    await session.execute(text(
+        "INSERT INTO access_logs (timestamp, ip_address, method, url, "
+        "status_code, bytes_sent, request_time) "
+        "VALUES (:ts, :ip, 'GET', '/x', 200, 100, :rt)"
+    ), {"ts": ts, "ip": ip, "rt": rt})
+
+
+async def _seed_access_logs(session_maker) -> None:
+    async with session_maker() as session:
+        await _insert_log(session, ts=E1)
+        await _insert_log(session, ts=E2, rt=0.01)
+        await _insert_log(session, ts=E3, rt=0.03)
+        await session.commit()
+
+
+async def _seed_geo_events(session_maker) -> None:
+    async with session_maker() as session:
+        result = await session.execute(
+            text(
+                "INSERT INTO geo_locations "
+                "(geohash, latitude, longitude, geographic_point, country_code, "
+                " country_name, city, last_hit, created_at, updated_at) "
+                "VALUES ('gltz1', 59.91, 10.75, "
+                " ST_SetSRID(ST_MakePoint(10.75, 59.91), 4326)::geography, "
+                " 'NO', 'Norway', 'Oslo', now(), now(), now()) RETURNING id"
+            )
+        )
+        loc = result.scalar_one()
+        for ts, ip in ((E1, "1.1.1.1"), (E2, "1.1.1.1"), (E3, "2.2.2.2")):
+            await session.execute(
+                text(
+                    "INSERT INTO geo_events (timestamp, ip_address, hostname, location_id) "
+                    "VALUES (:ts, :ip, 'web1', :loc)"
+                ),
+                {"ts": ts, "ip": ip, "loc": loc},
+            )
+        await session.commit()
+
+
+async def _refresh(pg_engine) -> None:
+    await refresh_caggs_range(
+        pg_engine, start=BASE - timedelta(days=1), end=NOW + timedelta(hours=1)
+    )
+
+
+class TestSummaryTimeSeries:
+    async def test_daily_buckets_are_local_days(self, pg_engine, pg_session_maker, clean_tables):
+        await _seed_access_logs(pg_session_maker)
+        await _refresh(pg_engine)
+        async with pg_session_maker() as session:
+            rows = await SummaryStatsRepository(session=session).get_time_series(
+                LOCAL_MIDNIGHT, WINDOW_END, granularity=StatsGranularity.DAILY, tz=TZ
+            )
+        assert [(r.bucket, r.total_requests) for r in rows] == [(LOCAL_MIDNIGHT, 2)]
+        row = rows[0]
+        assert row.total_bytes == 200
+        # Weighted mean of the two in-window hourly buckets (0.01 and 0.03).
+        assert row.avg_request_time == pytest.approx(0.02, rel=0.01)
+        assert 0.005 < row.p50_request_time < 0.035
+
+    async def test_daily_buckets_stay_utc_without_tz(self, pg_engine, pg_session_maker, clean_tables):
+        """The pre-existing UTC behavior is unchanged when no tz is sent."""
+        await _seed_access_logs(pg_session_maker)
+        await _refresh(pg_engine)
+        async with pg_session_maker() as session:
+            rows = await SummaryStatsRepository(session=session).get_time_series(
+                LOCAL_MIDNIGHT, WINDOW_END, granularity=StatsGranularity.DAILY
+            )
+        assert [(r.bucket, r.total_requests) for r in rows] == [
+            (BASE, 2),
+            (BASE + timedelta(days=1), 1),
+        ]
+
+
+class TestFilteredLiveTimeSeries:
+    async def test_daily_buckets_are_local_days(self, pg_session_maker, clean_tables):
+        await _seed_access_logs(pg_session_maker)
+        async with pg_session_maker() as session:
+            rows = await LiveStatsRepository(session=session).get_time_series(
+                LOCAL_MIDNIGHT,
+                WINDOW_END,
+                bucket_interval="1 day",
+                filters=AnalyticsFilters(ip_addresses=["10.0.0.1"]),
+                tz=TZ,
+            )
+        assert [(r.bucket, r.total_requests) for r in rows] == [(LOCAL_MIDNIGHT, 2)]
+
+
+class TestAnalyticsGeoTimeSeries:
+    async def test_daily_buckets_are_local_days(self, pg_engine, pg_session_maker, clean_tables):
+        await _seed_geo_events(pg_session_maker)
+        await _refresh(pg_engine)
+        async with pg_session_maker() as session:
+            rows = await SummaryStatsRepository(session=session).get_geo_time_series(
+                LOCAL_MIDNIGHT, WINDOW_END, granularity=StatsGranularity.DAILY, tz=TZ
+            )
+        assert [(r["bucket"], r["total_events"], r["unique_ips"]) for r in rows] == [
+            (LOCAL_MIDNIGHT, 2, 2)
+        ]
+
+
+class TestGeoTimeSeries:
+    async def test_unfiltered_daily_buckets_are_local_days(self, pg_engine, pg_session_maker, clean_tables):
+        await _seed_geo_events(pg_session_maker)
+        await _refresh(pg_engine)
+        async with pg_session_maker() as session:
+            points = await GeoEventService(session=session).get_time_series(
+                LOCAL_MIDNIGHT, WINDOW_END, GeoStatsGranularity.DAILY, GeoEventFilters(), tz=TZ
+            )
+        assert [(p.timestamp, p.total_events, p.unique_ips) for p in points] == [
+            (LOCAL_MIDNIGHT, 2, 2)
+        ]
+
+    async def test_filtered_daily_buckets_are_local_days(self, pg_engine, pg_session_maker, clean_tables):
+        """Country-filtered daily buckets ride the hourly stitched CAGGs."""
+        await _seed_geo_events(pg_session_maker)
+        await _refresh(pg_engine)
+        async with pg_session_maker() as session:
+            points = await GeoEventService(session=session).get_time_series(
+                LOCAL_MIDNIGHT,
+                WINDOW_END,
+                GeoStatsGranularity.DAILY,
+                GeoEventFilters(country_codes=["NO"]),
+                tz=TZ,
+            )
+        assert [(p.timestamp, p.total_events, p.unique_ips) for p in points] == [
+            (LOCAL_MIDNIGHT, 2, 2)
+        ]

--- a/tests/test_analytics_granularity.py
+++ b/tests/test_analytics_granularity.py
@@ -8,7 +8,7 @@ import pytest
 from geometrikks.domain.exceptions import DomainValidationError
 
 from geometrikks.domain.analytics.controllers import _build_filters, _resolve_chart_granularity
-from geometrikks.domain.analytics.repositories import StatsGranularity
+from geometrikks.domain.analytics.repositories import StatsGranularity, use_local_days
 
 NOW = datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc)
 
@@ -29,6 +29,29 @@ def test_fallback_matches_get_stats_granularity():
 def test_raw_is_never_returned():
     # <= 24h falls back to RAW internally but must clamp to HOURLY for charts
     assert _resolve_chart_granularity(NOW - timedelta(hours=6), NOW, None) is StatsGranularity.HOURLY
+
+
+def test_local_days_apply_to_short_daily_ranges_in_non_utc_zone():
+    start = NOW - timedelta(days=7)
+    assert use_local_days(StatsGranularity.DAILY, start, NOW, "Europe/Oslo") is True
+
+
+def test_local_days_ignored_without_a_zone_or_for_utc():
+    start = NOW - timedelta(days=7)
+    assert use_local_days(StatsGranularity.DAILY, start, NOW, None) is False
+    assert use_local_days(StatsGranularity.DAILY, start, NOW, "UTC") is False
+
+
+def test_local_days_ignored_when_range_routes_to_daily_caggs():
+    # > 30 days: hourly source data is not guaranteed to exist (retention),
+    # so daily buckets stay UTC days.
+    start = NOW - timedelta(days=90)
+    assert use_local_days(StatsGranularity.DAILY, start, NOW, "Europe/Oslo") is False
+
+
+def test_local_days_never_apply_to_hourly_buckets():
+    start = NOW - timedelta(days=7)
+    assert use_local_days(StatsGranularity.HOURLY, start, NOW, "Europe/Oslo") is False
 
 
 def test_build_filters_accepts_valid_ipv4():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,25 @@
+"""Timezone validation for the chart ``tz`` query parameter."""
+from __future__ import annotations
+
+import pytest
+
+from geometrikks.domain.exceptions import DomainValidationError
+from geometrikks.lib.validation import validate_timezone
+
+
+def test_accepts_iana_name():
+    assert validate_timezone("Europe/Oslo") == "Europe/Oslo"
+
+
+def test_accepts_utc():
+    assert validate_timezone("UTC") == "UTC"
+
+
+def test_rejects_unknown_zone():
+    with pytest.raises(DomainValidationError):
+        validate_timezone("Mars/Olympus_Mons")
+
+
+def test_rejects_path_like_values():
+    with pytest.raises(DomainValidationError):
+        validate_timezone("../etc/passwd")


### PR DESCRIPTION
## Summary

Fixes the "Today + daily granularity returns two days" issue: a today range in a non-UTC browser starts mid-UTC-day, and the daily bucket floor (`bucket >= time_bucket('1 day', :start)`) pulled the entire previous UTC day into the response, rendering an extra full-size bar. Deeper down, daily buckets were always UTC days while the UI labels them as browser-local days.

- The three time-series endpoints (`/analytics/time-series`, `/analytics/geo-time-series`, `/geo-events/time-series`) accept an optional `tz` query parameter (IANA name, validated to a 400 on unknown zones).
- With a non-UTC zone, daily buckets are local days assembled from hourly source data: counts summed, `pct_agg` latency sketches and HLL uniques merged via `rollup()`, mean request-weighted. The filtered raw-scan paths pass the zone to `time_bucket()` directly, and the stitched per-IP geo CAGG path stitches on the hourly CAGG instead of the daily one.
- Ranges beyond 30 days keep UTC day buckets: they route to the daily CAGGs, whose buckets are baked as UTC days, and hourly CAGG retention (60d default) is not guaranteed to cover them. At that scale each bar spans 30+ days of axis, so the 1-2h boundary shift is invisible. Half-hour-offset zones (e.g. India) are approximated to the nearest hour by the hourly rollup.
- The frontend sends `Intl.DateTimeFormat().resolvedOptions().timeZone` on all three fetches. Hourly buckets are unaffected. Omitting `tz` keeps the exact previous behavior, so external API consumers see no change.
- Bonus: local-day rollups read the hourly CAGG, which real-time aggregates the current day, so forced-daily "today" views are no longer subject to the daily CAGG's next-day watermark staleness.

## Test plan

- [x] `uv run pytest` (624 passed; new unit tests for `validate_timezone` and the `use_local_days` routing)
- [x] `uv run pytest -m integration` (124 passed; new `test_local_day_buckets_pg.py` covers all four SQL paths with a fixed-offset zone plus a UTC-unchanged control test)
- [x] `uv run ty check geometrikks`
- [x] `bun run typecheck` / `bun run test` (client regenerated via `litestar assets generate-types`)
- [x] Browser check: Today + daily granularity shows a single bar; geo-logs chart likewise; 90d + daily unchanged