### PR TITLE
feat: per-file source hostnames (LOGPARSER_HOST_NAME list)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `LOGPARSER_HOST_NAME` accepts a JSON list matched positionally to
+  `LOGPARSER_LOG_PATHS`, so one instance tailing logs shipped from several
+  machines records each file under its source hostname. `litestar
+  import-logs` gained `--hostname` to set the stamped hostname per import.
+
 ## [0.8.0] - 2026-08-16
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,7 +86,7 @@ from real environment variables. It is read once at import time.
 | `LOGPARSER_LOG_FORMATS` | *(computed)* | Log format per tailed file: 'auto' (default, detected from the file's content), 'nginx', or 'traefik-json'. Env accepts a single value applied to every path, or a JSON list matching LOGPARSER_LOG_PATHS by position. |
 | `LOGPARSER_POLL_INTERVAL` | `1.0` | Interval in seconds to poll the log file for new entries |
 | `LOGPARSER_SEND_LOGS` | `true` | Send parsed logs to the database |
-| `LOGPARSER_HOST_NAME` | *(computed)* | Host name for log parser (used in log entries) |
+| `LOGPARSER_HOST_NAME` | *(computed)* | Source hostname stamped on ingested records. Env accepts a single value applied to every tailed file, or a JSON list matching LOGPARSER_LOG_PATHS by position. Default: this machine's hostname. |
 | `LOGPARSER_BATCH_SIZE` | `100` | Max records before forced commit. |
 | `LOGPARSER_COMMIT_INTERVAL` | `5.0` | Maximum time interval in seconds between database commits. This will commit even if batch_size is not reached. |
 | `LOGPARSER_SKIP_VALIDATION` | `false` | Skip validation of log lines. |

--- a/geometrikks/cli.py
+++ b/geometrikks/cli.py
@@ -49,6 +49,10 @@ def import_logs_command(
     that is also being live-tailed will double-count — import archived
     (rotated) files only.
     """
+    if hostname is not None:
+        hostname = hostname.strip()
+        if not hostname:
+            raise click.BadParameter("must not be blank", param_hint="'--hostname'")
     asyncio.run(
         _run_import(
             list(paths), force=force, batch_size=batch_size, log_format=log_format, hostname=hostname

--- a/geometrikks/cli.py
+++ b/geometrikks/cli.py
@@ -31,7 +31,17 @@ from litestar.plugins import CLIPlugin
     type=click.Choice(["auto", "nginx", "traefik-json"]),
     help="Log format of the given files (auto = detect per file).",
 )
-def import_logs_command(paths: tuple[Path, ...], force: bool, batch_size: int, log_format: str) -> None:
+@click.option(
+    "--hostname",
+    default=None,
+    help=(
+        "Source hostname stamped on imported records. Default: the first "
+        "LOGPARSER_HOST_NAME value."
+    ),
+)
+def import_logs_command(
+    paths: tuple[Path, ...], force: bool, batch_size: int, log_format: str, hostname: str | None
+) -> None:
     """Import historical access-log files (plain or .gz) into the database.
 
     Reads whole files, uses log-line timestamps, refreshes the continuous
@@ -39,10 +49,16 @@ def import_logs_command(paths: tuple[Path, ...], force: bool, batch_size: int, l
     that is also being live-tailed will double-count — import archived
     (rotated) files only.
     """
-    asyncio.run(_run_import(list(paths), force=force, batch_size=batch_size, log_format=log_format))
+    asyncio.run(
+        _run_import(
+            list(paths), force=force, batch_size=batch_size, log_format=log_format, hostname=hostname
+        )
+    )
 
 
-async def _run_import(paths: list[Path], *, force: bool, batch_size: int, log_format: str) -> None:
+async def _run_import(
+    paths: list[Path], *, force: bool, batch_size: int, log_format: str, hostname: str | None
+) -> None:
     from geoip2.database import Reader
 
     from geometrikks.config.settings import get_settings
@@ -71,7 +87,7 @@ async def _run_import(paths: list[Path], *, force: bool, batch_size: int, log_fo
         session_maker=session_maker,
         geoip_path=settings.geoip.db_path,
         locales=settings.geoip.locales,
-        hostname=settings.logparser.host_name,
+        hostname=hostname or settings.logparser.resolved_hostnames()[0],
         store_debug_lines=settings.logparser.store_debug_lines,
     )
 

--- a/geometrikks/config/settings.py
+++ b/geometrikks/config/settings.py
@@ -236,9 +236,15 @@ class LogParserSettings(BaseSettings):
         description="Interval in seconds to poll the log file for new entries",
     )
     send_logs: bool = Field(default=True, description="Send parsed logs to the database")
-    host_name: str = Field(
-        default_factory=socket.gethostname,
-        description="Host name for log parser (used in log entries)",
+    host_name: Annotated[list[str], NoDecode] = Field(
+        default_factory=lambda: [socket.gethostname()],
+        min_length=1,
+        description=(
+            "Source hostname stamped on ingested records. Env accepts a "
+            "single value applied to every tailed file, or a JSON list "
+            "matching LOGPARSER_LOG_PATHS by position. Default: this "
+            "machine's hostname."
+        ),
     )
     batch_size: int = Field(
         default=100,
@@ -316,6 +322,46 @@ class LogParserSettings(BaseSettings):
         if len(self.log_formats) == 1:
             return self.log_formats * len(self.log_paths)
         return list(self.log_formats)
+
+    @field_validator("host_name", mode="before")
+    @classmethod
+    def parse_host_name(cls, value: object) -> object:
+        """Accept a single hostname or a JSON list of hostnames."""
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped.startswith("["):
+                return json.loads(stripped)
+            return [stripped]
+        return value
+
+    @field_validator("host_name")
+    @classmethod
+    def validate_host_name_entries(cls, value: list[str]) -> list[str]:
+        """Fail at startup on empty entries; '' would silently un-stamp records."""
+        if any(not entry.strip() for entry in value):
+            raise ValueError("LOGPARSER_HOST_NAME entries must be non-empty")
+        return value
+
+    @model_validator(mode="after")
+    def validate_host_name_length(self) -> "LogParserSettings":
+        """Reject hostname list lengths that cannot map to log_paths."""
+        if len(self.host_name) not in (1, len(self.log_paths)):
+            raise ValueError(
+                "LOGPARSER_HOST_NAME must be one value or match "
+                f"LOGPARSER_LOG_PATHS in length ({len(self.log_paths)})"
+            )
+        return self
+
+    def resolved_hostnames(self) -> list[str]:
+        """Return one hostname per log path.
+
+        Returns:
+            The configured hostnames, fanning a single value out across all
+            log paths when only one value was provided.
+        """
+        if len(self.host_name) == 1:
+            return self.host_name * len(self.log_paths)
+        return list(self.host_name)
 
     @field_validator("ignore_ips", mode="before")
     @classmethod

--- a/geometrikks/config/settings.py
+++ b/geometrikks/config/settings.py
@@ -340,7 +340,7 @@ class LogParserSettings(BaseSettings):
         """Fail at startup on empty entries; '' would silently un-stamp records."""
         if any(not entry.strip() for entry in value):
             raise ValueError("LOGPARSER_HOST_NAME entries must be non-empty")
-        return value
+        return [entry.strip() for entry in value]
 
     @model_validator(mode="after")
     def validate_host_name_length(self) -> "LogParserSettings":

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -258,11 +258,15 @@ async def ingestion_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
             log_path=path,
             send_logs=settings.logparser.send_logs,
             poll_interval=settings.logparser.poll_interval,
-            hostname=settings.logparser.host_name,
+            hostname=host,
             ignore_ips=settings.logparser.ignore_ips,
             log_format=fmt,
         )
-        for path, fmt in zip(settings.logparser.log_paths, settings.logparser.resolved_formats())
+        for path, fmt, host in zip(
+            settings.logparser.log_paths,
+            settings.logparser.resolved_formats(),
+            settings.logparser.resolved_hostnames(),
+        )
     ]
 
     ingestion_service = LogIngestionService(
@@ -270,7 +274,7 @@ async def ingestion_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
         session_maker=session_maker,
         geoip_path=settings.geoip.db_path,
         locales=settings.geoip.locales,
-        hostname=settings.logparser.host_name,
+        hostname=settings.logparser.resolved_hostnames()[0],
         batch_size=settings.logparser.batch_size,
         commit_interval=settings.logparser.commit_interval,
         store_debug_lines=settings.logparser.store_debug_lines,

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -253,6 +253,7 @@ async def ingestion_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
     # Ingestion opens a short-lived session per batch flush.
     session_maker = get_app_db_config(app).create_session_maker()
 
+    hostnames = settings.logparser.resolved_hostnames()
     parsers = [
         LogParser(
             log_path=path,
@@ -265,7 +266,7 @@ async def ingestion_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
         for path, fmt, host in zip(
             settings.logparser.log_paths,
             settings.logparser.resolved_formats(),
-            settings.logparser.resolved_hostnames(),
+            hostnames,
         )
     ]
 
@@ -274,7 +275,7 @@ async def ingestion_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
         session_maker=session_maker,
         geoip_path=settings.geoip.db_path,
         locales=settings.geoip.locales,
-        hostname=settings.logparser.resolved_hostnames()[0],
+        hostname=hostnames[0],
         batch_size=settings.logparser.batch_size,
         commit_interval=settings.logparser.commit_interval,
         store_debug_lines=settings.logparser.store_debug_lines,

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -108,7 +108,8 @@ class LogIngestionService:
             geoip_path: Path|str, GeoIP2 database file path.
             locales: GeoIP2 locales to use for lookups.
             repos_factory: Builds the IngestionRepos bundle from a session.
-            hostname: Hostname recorded on GeoEvent records.
+            hostname: Fallback hostname for records that carry none (the
+                importer path); tail-path records are stamped by their parser.
             batch_size: Maximum records before forced commit.
             commit_interval: Maximum seconds between commits.
             store_debug_lines: If True, store all raw lines in debug table.

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -568,7 +568,7 @@ class LogIngestionService:
             parsed: The parsed access log fields.
             log_format: The format adapter that produced this record (e.g.
                 'nginx', 'traefik-json'), stamped onto the row alongside the
-                writer's hostname.
+                source hostname.
             hostname: Source hostname for the row; empty/None falls back to the service default.
 
         Returns:

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -322,7 +322,7 @@ class LogIngestionService:
                 geo_event = GeoEvent(
                     timestamp=record.geo_data.timestamp,
                     ip_address=record.ip_address,
-                    hostname=self.hostname,
+                    hostname=record.hostname or self.hostname,
                     location_id=location_id,
                 )
                 # Plain session.add: repo.add() flushes + refreshes per call
@@ -334,7 +334,11 @@ class LogIngestionService:
                 flushed["geo"] += 1
 
         if record.access_log:
-            access_log_model = self._to_access_log_model(record.access_log, log_format=record.log_format)
+            access_log_model = self._to_access_log_model(
+                record.access_log,
+                log_format=record.log_format,
+                hostname=record.hostname or self.hostname,
+            )
             repos.access_log.session.add(access_log_model)
             self.total_log_records += 1
             flushed["log"] += 1
@@ -554,7 +558,8 @@ class LogIngestionService:
                         pass
 
     def _to_access_log_model(
-        self, parsed: ParsedAccessLog, log_format: str | None = None
+        self, parsed: ParsedAccessLog, log_format: str | None = None,
+        hostname: str | None = None,
     ) -> AccessLog:
         """Convert ParsedAccessLog schema to ORM model, stamping source info.
 
@@ -563,6 +568,7 @@ class LogIngestionService:
             log_format: The format adapter that produced this record (e.g.
                 'nginx', 'traefik-json'), stamped onto the row alongside the
                 writer's hostname.
+            hostname: Source hostname for the row; empty/None falls back to the service default.
 
         Returns:
             An unpersisted AccessLog ORM instance ready to be added to a
@@ -585,7 +591,7 @@ class LogIngestionService:
             country_code=parsed.country_code,
             country_name=parsed.country_name,
             city=parsed.city,
-            hostname=self.hostname,
+            hostname=hostname or self.hostname,
             log_format=log_format,
         )
 

--- a/geometrikks/services/logparser/logparser.py
+++ b/geometrikks/services/logparser/logparser.py
@@ -102,7 +102,7 @@ class LogParser:
         log_path: Path,
         send_logs: bool = False,
         poll_interval: float = 1.0,
-        hostname: str = "localhost",
+        hostname: str = "",
         ignore_ips: list[str] | None = None,
         log_format: str = "auto",
     ) -> None:
@@ -112,7 +112,9 @@ class LogParser:
             log_path (Path): The path to the log file.
             send_logs (bool, optional): If True, parse full access log data. Defaults to False.
             poll_interval (float, optional): How often to check for new log lines. Defaults to 1.0.
-            hostname (str, optional): Hostname to tag geo events with. Defaults to "localhost".
+            hostname (str, optional): Source hostname stamped onto parsed
+                records. Empty (default): the ingestion service's fallback
+                hostname applies.
             ignore_ips (list[str] | None, optional): IPs/CIDRs whose lines are dropped entirely. Defaults to None.
             log_format (str, optional): A registry name from ``formats.FORMATS`` (e.g. "nginx"),
                 or "auto" to sniff the format from the first parseable line. Defaults to "auto".
@@ -327,6 +329,7 @@ class LogParser:
                 parse_error="Line did not match expected log format",
                 source=str(self.log_path),
                 log_format=self.format.name if self.format else None,
+                hostname=self.hostname,
             )
 
         ip = norm.ip_address
@@ -362,6 +365,7 @@ class LogParser:
             parse_error=parse_error,
             source=str(self.log_path),
             log_format=self.format.name if self.format else None,
+            hostname=self.hostname,
         )
 
     async def _is_rotated_async(self, prev_stat: os.stat_result) -> bool:

--- a/geometrikks/services/logparser/schemas.py
+++ b/geometrikks/services/logparser/schemas.py
@@ -60,3 +60,4 @@ class ParsedLogRecord:
     parse_error: str | None = field(default=None)
     source: str = field(default="")
     log_format: str | None = field(default=None)
+    hostname: str = field(default="")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,6 +31,19 @@ def test_import_logs_help_runs_without_app() -> None:
     assert "--force" in result.output
 
 
+def test_import_logs_help_lists_hostname_option() -> None:
+    import click
+    from geometrikks.cli import ImportLogsCLIPlugin
+
+    @click.group()
+    def cli() -> None: ...
+
+    ImportLogsCLIPlugin().on_cli_init(cli)
+    result = CliRunner().invoke(cli, ["import-logs", "--help"])
+    assert result.exit_code == 0
+    assert "--hostname" in result.output
+
+
 def test_cli_plugin_registers_backfill_hostname() -> None:
     import click
     from geometrikks.cli import ImportLogsCLIPlugin

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,23 @@ def test_cli_plugin_registers_command() -> None:
     assert "import-logs" in cli.commands
 
 
+def test_import_logs_rejects_blank_hostname(tmp_path) -> None:
+    """Whitespace-only --hostname must fail fast, matching the settings-side
+    rejection of blank entries, instead of stamping whitespace into rows."""
+    import click
+    from geometrikks.cli import ImportLogsCLIPlugin
+
+    @click.group()
+    def cli() -> None: ...
+
+    ImportLogsCLIPlugin().on_cli_init(cli)
+    log = tmp_path / "a.log"
+    log.write_text("", encoding="utf-8")
+    result = CliRunner().invoke(cli, ["import-logs", "--hostname", "  ", str(log)])
+    assert result.exit_code != 0
+    assert "hostname" in result.output.lower()
+
+
 def test_import_logs_help_runs_without_app() -> None:
     """--help must not construct settings/engine (import-time safety)."""
     import click

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -323,6 +323,14 @@ def test_host_name_empty_entry_rejected(monkeypatch) -> None:
         LogParserSettings()
 
 
+def test_host_name_entries_are_stripped(monkeypatch) -> None:
+    """Whitespace around JSON-list entries must not leak into stamped hostnames."""
+    monkeypatch.setenv("LOGPARSER_LOG_PATHS", '["/a.log", "/b.log"]')
+    monkeypatch.setenv("LOGPARSER_HOST_NAME", '["vps-1 ", " vps-2"]')
+    settings = LogParserSettings()
+    assert settings.resolved_hostnames() == ["vps-1", "vps-2"]
+
+
 class TestAuthSettings:
     """APP_ADMIN_USER / APP_ADMIN_PASSWORD / APP_AUTH_DISABLED."""
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 """Tests for configuration management."""
 
+import socket
 from pathlib import Path
 
 import pytest
@@ -278,6 +279,46 @@ def test_log_formats_length_mismatch_rejected(monkeypatch) -> None:
 def test_log_formats_unknown_value_rejected(monkeypatch) -> None:
     """An unrecognized format name fails settings validation."""
     monkeypatch.setenv("LOGPARSER_LOG_FORMATS", "apache")
+    with pytest.raises(ValidationError):
+        LogParserSettings()
+
+
+def test_host_name_default_is_machine_hostname(monkeypatch) -> None:
+    """No LOGPARSER_HOST_NAME set: the machine hostname applies to every path."""
+    monkeypatch.delenv("LOGPARSER_HOST_NAME", raising=False)
+    settings = LogParserSettings()
+    assert settings.host_name == [socket.gethostname()]
+    assert settings.resolved_hostnames() == [socket.gethostname()] * len(settings.log_paths)
+
+
+def test_host_name_single_value_fans_out(monkeypatch) -> None:
+    """A single hostname value applies to every configured log path."""
+    monkeypatch.setenv("LOGPARSER_LOG_PATHS", '["/a.log", "/b.log"]')
+    monkeypatch.setenv("LOGPARSER_HOST_NAME", "edge-1")
+    settings = LogParserSettings()
+    assert settings.resolved_hostnames() == ["edge-1", "edge-1"]
+
+
+def test_host_name_json_list_positional(monkeypatch) -> None:
+    """A JSON list of hostnames maps positionally onto log_paths."""
+    monkeypatch.setenv("LOGPARSER_LOG_PATHS", '["/a.log", "/b.log"]')
+    monkeypatch.setenv("LOGPARSER_HOST_NAME", '["vps-1", "vps-2"]')
+    settings = LogParserSettings()
+    assert settings.resolved_hostnames() == ["vps-1", "vps-2"]
+
+
+def test_host_name_length_mismatch_rejected(monkeypatch) -> None:
+    """A hostname list whose length matches neither 1 nor len(log_paths) fails."""
+    monkeypatch.setenv("LOGPARSER_LOG_PATHS", '["/a.log", "/b.log", "/c.log"]')
+    monkeypatch.setenv("LOGPARSER_HOST_NAME", '["vps-1", "vps-2"]')
+    with pytest.raises(ValidationError):
+        LogParserSettings()
+
+
+def test_host_name_empty_entry_rejected(monkeypatch) -> None:
+    """An empty hostname would silently un-stamp records; fail at startup."""
+    monkeypatch.setenv("LOGPARSER_HOST_NAME", '["vps-1", ""]')
+    monkeypatch.setenv("LOGPARSER_LOG_PATHS", '["/a.log", "/b.log"]')
     with pytest.raises(ValidationError):
         LogParserSettings()
 

--- a/tests/test_ingestion_stamping.py
+++ b/tests/test_ingestion_stamping.py
@@ -1,9 +1,11 @@
 """Ingestion stamps writer hostname and source format onto AccessLog rows."""
 from datetime import datetime, timezone
 from typing import Any, cast
+import pytest
+from unittest.mock import MagicMock
 
 from geometrikks.services.ingestion.service import LogIngestionService
-from geometrikks.services.logparser.schemas import ParsedAccessLog
+from geometrikks.services.logparser.schemas import ParsedAccessLog, ParsedGeoData, ParsedLogRecord
 
 
 def _parsed(ts: datetime) -> ParsedAccessLog:
@@ -26,3 +28,46 @@ def test_to_access_log_model_stamps_hostname_and_format() -> None:
     assert model.hostname == "myserver"
     assert model.log_format == "traefik-json"
     assert model.url == "/admin"
+
+
+def test_to_access_log_model_record_hostname_wins() -> None:
+    service = LogIngestionService(
+        parsers=[], session_maker=cast("Any", None), geoip_path="unused", hostname="myserver",
+    )
+    model = service._to_access_log_model(
+        _parsed(datetime.now(timezone.utc)), log_format="nginx", hostname="vps-2"
+    )
+    assert model.hostname == "vps-2"
+
+
+def test_to_access_log_model_empty_hostname_falls_back() -> None:
+    service = LogIngestionService(
+        parsers=[], session_maker=cast("Any", None), geoip_path="unused", hostname="myserver",
+    )
+    model = service._to_access_log_model(
+        _parsed(datetime.now(timezone.utc)), log_format="nginx", hostname=None
+    )
+    assert model.hostname == "myserver"
+
+
+@pytest.mark.anyio
+async def test_process_record_stamps_record_hostname_on_geo_event() -> None:
+    service = LogIngestionService(
+        parsers=[], session_maker=cast("Any", None), geoip_path="unused", hostname="myserver",
+    )
+    geo = ParsedGeoData(
+        latitude=51.5, longitude=-0.1, geohash="gcpvj0", country_code="GB",
+        country_name="United Kingdom", timestamp=datetime.now(timezone.utc),
+    )
+    record = ParsedLogRecord(
+        ip_address="203.0.113.7", geo_data=geo, access_log=None,
+        raw_line="raw", hostname="vps-2",
+    )
+    service._location_cache[geo.geohash] = 42  # skip the DB get-or-create path
+    repos = MagicMock()
+
+    await service._process_record(record, repos, {"geo": 0, "log": 0, "debug": 0})
+
+    added = repos.geo_event.session.add.call_args[0][0]
+    assert added.hostname == "vps-2"
+    assert added.location_id == 42

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -151,3 +151,27 @@ async def test_db_degraded_mode_skips_scheduler_and_ingestion(monkeypatch):
 
     cast("AsyncMock", lc.create_scheduler).assert_not_awaited()
     cast("MagicMock", lc.LogIngestionService).assert_not_called()
+
+
+async def test_ingestion_wires_per_file_hostnames(monkeypatch):
+    """Each tailed file's parser gets its positional hostname; the service
+    fallback gets the first resolved hostname."""
+    from geometrikks.server import lifecycle as lc
+    from geometrikks.config.settings import Settings
+
+    monkeypatch.setenv("LOGPARSER_LOG_PATHS", '["/a.log", "/b.log"]')
+    monkeypatch.setenv("LOGPARSER_HOST_NAME", '["vps-1", "vps-2"]')
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=True, ensure=AsyncMock(return_value=True)
+    )
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    app.state.settings = Settings()
+    async with enter_lifespan(app):
+        pass
+
+    hostnames = [
+        call.kwargs["hostname"] for call in cast("MagicMock", lc.LogParser).call_args_list
+    ]
+    assert hostnames == ["vps-1", "vps-2"]
+    assert cast("MagicMock", lc.LogIngestionService).call_args.kwargs["hostname"] == "vps-1"

--- a/tests/test_logparser.py
+++ b/tests/test_logparser.py
@@ -641,6 +641,30 @@ class TestParseLine:
         assert record is not None
         assert parser.ignored_lines == 0
 
+    def test_parse_line_stamps_parser_hostname(self, geoip_reader):
+        from geometrikks.services.logparser.logparser import LogParser, make_cached_city_lookup
+        parser = LogParser(log_path=Path("/dev/null"), send_logs=True, hostname="vps-1")
+        lookup = make_cached_city_lookup(geoip_reader)
+        record = parser.parse_line(make_log_line("2.125.160.216"), lookup)
+        assert record is not None
+        assert record.hostname == "vps-1"
+
+    def test_parse_line_unmatched_line_still_stamps_hostname(self, geoip_reader):
+        from geometrikks.services.logparser.logparser import LogParser, make_cached_city_lookup
+        parser = LogParser(log_path=Path("/dev/null"), send_logs=True, hostname="vps-1")
+        lookup = make_cached_city_lookup(geoip_reader)
+        record = parser.parse_line("total garbage\n", lookup)
+        assert record is not None
+        assert record.hostname == "vps-1"
+
+    def test_parse_line_default_hostname_is_empty(self, geoip_reader):
+        from geometrikks.services.logparser.logparser import LogParser, make_cached_city_lookup
+        parser = LogParser(log_path=Path("/dev/null"), send_logs=True)
+        lookup = make_cached_city_lookup(geoip_reader)
+        record = parser.parse_line(make_log_line("2.125.160.216"), lookup)
+        assert record is not None
+        assert record.hostname == ""
+
 
 class TestAutoFormatSniffing:
     """log_format='auto' locks a format on the first line it recognizes."""


### PR DESCRIPTION
## What

Phase 1 of multi-source ingestion: the hostname recorded on `geo_events` and `access_logs` rows now travels with each parsed record instead of being a single service-level stamp.

- `ParsedLogRecord` gains a `hostname` field, stamped by each `LogParser` at parse time.
- `LogIngestionService` writes `record.hostname or self.hostname`; the service-level value remains only as the fallback for the importer path.
- `LOGPARSER_HOST_NAME` accepts a single value (fans out to every tailed file, exactly as before) or a JSON list matched positionally to `LOGPARSER_LOG_PATHS`, mirroring the `LOGPARSER_LOG_FORMATS` pattern. Entries are validated non-empty and whitespace-stripped.
- `litestar import-logs` gains `--hostname` to set the stamped hostname per import (default: first configured value).
- Config docs regenerated; changelog entry under Unreleased.

## Why

Tailing logs shipped from several machines into one instance previously collapsed every source into one hostname, making the existing `hostnameIn` filters useless for source separation. With per-file hostnames, a central instance keeps sources separated end to end. This also lays the record-level groundwork for the planned cross-process live feed and agent mode.

## Backward compatibility

Unset or single-value `LOGPARSER_HOST_NAME` behaves exactly as today (machine hostname applied to every path); the importer falls back to the service-level default as before. No schema changes.

## Testing

- TDD throughout; new unit tests for parser stamping, ingestion fallback (including the GeoEvent path), settings validators/fan-out, lifecycle wiring, and CLI option.
- Full suite green: 693 passed (integration suite included against timescale_db), `ty check` clean.