### PR TITLE
feat: live feed over Postgres LISTEN/NOTIFY (channels)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   them.
 - Concurrent GeoMetrikks instances sharing one database no longer drop an
   ingestion batch when racing to create the same geo location.
+- The live-events channel publisher no longer dies permanently on a
+  transient database outage; a failed publish is logged and the event is
+  dropped instead of wedging the channel worker (and eventually hanging
+  shutdown). A dropped LISTEN connection now logs an error instead of
+  silently going dead until restart.
 
 ## [0.7.1] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `LOGPARSER_LOG_PATHS` default is now `/var/log/access/access.log`. If your
   `.env` sets `LOGPARSER_LOG_PATHS` with `/var/log/nginx/...` paths, change
   them to `/var/log/access/...` when upgrading the compose file.
+- The live map feed (`/ws/live`) now fans out through PostgreSQL
+  LISTEN/NOTIFY, so committed traffic from any writer process reaches the
+  map, and live events carry the source hostname. Batch imports no longer
+  feed the live map.
 
 ### Fixed
 

--- a/geometrikks/config/settings.py
+++ b/geometrikks/config/settings.py
@@ -84,7 +84,15 @@ class DatabaseSettings(BaseSettings):
             f"{quote(self.password.get_secret_value(), safe='')}"
             f"@{self.host}:{self.port}/{self.database}"
         )
-    
+
+    @property
+    def asyncpg_dsn(self) -> str:
+        """The connection URL as a plain postgresql:// DSN.
+
+        AsyncPgChannelsBackend hands the DSN straight to asyncpg, which does
+        not understand SQLAlchemy's +asyncpg driver suffix.
+        """
+        return self.url.replace("postgresql+asyncpg://", "postgresql://", 1)
 
     @model_validator(mode="after")
     def validate_db_url(self) -> "DatabaseSettings":

--- a/geometrikks/domain/realtime/controllers.py
+++ b/geometrikks/domain/realtime/controllers.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 from litestar import WebSocket, websocket
 
+from geometrikks.domain.realtime.events import record_to_events
 from geometrikks.domain.realtime.stream import (
     batched_frames,
     close_service_unavailable,
@@ -49,48 +50,6 @@ MAX_EVENTS_PER_FRAME = 100
 # events flow, so emit an empty frame of the endpoint's own type as a
 # keepalive — existing clients treat it as a no-op and reset their backoff.
 HEARTBEAT_INTERVAL = 30.0
-
-
-def record_to_events(record: ParsedLogRecord) -> list[dict[str, Any]]:
-    """Convert one committed record to wire events (0, 1, or 2)."""
-    events: list[dict[str, Any]] = []
-    if record.geo_data and record.ip_address:
-        g = record.geo_data
-        events.append({
-            "type": "geo_event",
-            "data": {
-                "timestamp": g.timestamp.isoformat(),
-                "ip_address": record.ip_address,
-                "latitude": g.latitude,
-                "longitude": g.longitude,
-                "city": g.city,
-                "country_code": g.country_code,
-            },
-        })
-    if record.access_log:
-        a = record.access_log
-        events.append({
-            "type": "access_log",
-            "data": {
-                "timestamp": a.timestamp.isoformat(),
-                "ip_address": a.ip_address,
-                "remote_user": a.remote_user,
-                "method": a.method,
-                "url": a.url,
-                "http_version": a.http_version,
-                "status_code": a.status_code,
-                "bytes_sent": a.bytes_sent,
-                "referrer": a.referrer,
-                "user_agent": a.user_agent,
-                "request_time": a.request_time,
-                "upstream_response_time": a.upstream_response_time,
-                "host": a.host,
-                "country_code": a.country_code,
-                "country_name": a.country_name,
-                "city": a.city,
-            },
-        })
-    return events
 
 
 @websocket("/ws/crowdsec", tags=["Live Feed"])

--- a/geometrikks/domain/realtime/controllers.py
+++ b/geometrikks/domain/realtime/controllers.py
@@ -12,8 +12,8 @@ Auth: /ws/ paths are NOT excluded in AUTH_EXCLUDE_PATTERNS, so the session
 middleware authenticates the handshake exactly like an API request.
 
 Subscription lifecycle, batching, heartbeats, and the transport loop live in
-stream.py; this module owns each feed's event conversion, filters, snapshot
-frames, and cadences.
+stream.py; live-feed event conversion lives in events.py. This module owns
+the handlers themselves, filters, snapshot frames, and cadences.
 """
 
 from __future__ import annotations

--- a/geometrikks/domain/realtime/controllers.py
+++ b/geometrikks/domain/realtime/controllers.py
@@ -19,6 +19,7 @@ frames, and cadences.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -51,6 +52,11 @@ MAX_EVENTS_PER_FRAME = 100
 # events flow, so emit an empty frame of the endpoint's own type as a
 # keepalive — existing clients treat it as a no-op and reset their backoff.
 HEARTBEAT_INTERVAL = 30.0
+# The pump's local relay queue between the channel subscriber and
+# batched_frames. Bursts beyond this drop the oldest queued event first
+# (never blocks the channel pump); a separate, counted drop happens later in
+# batched_frames when a single flush window has more than MAX_EVENTS_PER_FRAME.
+LIVE_QUEUE_MAXSIZE = 1000
 
 
 @websocket("/ws/crowdsec", tags=["Live Feed"])
@@ -106,19 +112,31 @@ async def live_feed(socket: WebSocket) -> None:
 
     async def stream() -> AsyncGenerator[Frame]:
         logger.info("ws_client_connected", endpoint="/ws/live")
-        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=1000)
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=LIVE_QUEUE_MAXSIZE)
 
         async def pump() -> None:
-            async for raw in subscriber.iter_events():
-                event = msgspec_json.decode(raw)
-                try:
-                    queue.put_nowait(event)
-                except asyncio.QueueFull:
+            # A malformed payload or any other per-event failure must not kill
+            # the pump for the rest of the connection: log it and keep going.
+            try:
+                async for raw in subscriber.iter_events():
                     try:
-                        queue.get_nowait()
-                        queue.put_nowait(event)
-                    except (asyncio.QueueEmpty, asyncio.QueueFull):
-                        pass
+                        event = msgspec_json.decode(raw)
+                        try:
+                            queue.put_nowait(event)
+                        except asyncio.QueueFull:
+                            try:
+                                queue.get_nowait()
+                                queue.put_nowait(event)
+                            except (asyncio.QueueEmpty, asyncio.QueueFull):
+                                pass
+                    except Exception:
+                        logger.exception("ws_live_pump_event_failed", endpoint="/ws/live")
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # Defensive: iter_events() itself failing would otherwise silently
+                # degrade the feed to heartbeat-only with no trace in the logs.
+                logger.exception("ws_live_pump_failed", endpoint="/ws/live")
 
         async with channels.start_subscription(LIVE_EVENTS_CHANNEL) as subscriber:
             pump_task = asyncio.create_task(pump(), name="ws-live-pump")
@@ -135,6 +153,8 @@ async def live_feed(socket: WebSocket) -> None:
                     yield frame
             finally:
                 pump_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await pump_task
                 logger.info("ws_client_disconnected", endpoint="/ws/live")
 
     await stream_json_frames(socket, stream())

--- a/geometrikks/domain/realtime/controllers.py
+++ b/geometrikks/domain/realtime/controllers.py
@@ -23,8 +23,10 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from litestar import WebSocket, websocket
+from litestar.channels import ChannelsPlugin
+from msgspec import json as msgspec_json
 
-from geometrikks.domain.realtime.events import record_to_events
+from geometrikks.domain.realtime.events import LIVE_EVENTS_CHANNEL
 from geometrikks.domain.realtime.stream import (
     batched_frames,
     close_service_unavailable,
@@ -34,7 +36,6 @@ from geometrikks.domain.realtime.stream import (
 )
 from geometrikks.server import runtime
 from geometrikks.server.logging import get_logger, log_broadcaster, register_success_level
-from geometrikks.services.logparser.schemas import ParsedLogRecord
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -90,28 +91,51 @@ async def crowdsec_feed(socket: WebSocket) -> None:
 
 @websocket("/ws/live", tags=["Live Feed"])
 async def live_feed(socket: WebSocket) -> None:
-    """Stream committed ingestion events, batched and coalesced."""
-    ingestion = runtime.get_ingestion_service(socket.app)
+    """Stream committed ingestion events from the live_events channel, batched
+    and coalesced. Fan-out is cross-process (Postgres LISTEN/NOTIFY via
+    ChannelsPlugin), not tied to this worker's own ingestion instance, so the
+    gate is DB availability rather than "is ingestion running here"."""
     await socket.accept()
-    if ingestion is None:
+    if not getattr(socket.app.state, "db_available", False):
         await close_service_unavailable(
-            socket, endpoint="/ws/live", reason="ingestion not running"
+            socket, endpoint="/ws/live", reason="live feed unavailable (database down)"
         )
         return
 
+    channels = socket.app.plugins.get(ChannelsPlugin)
+
     async def stream() -> AsyncGenerator[Frame]:
-        async with subscription(ingestion, endpoint="/ws/live") as queue:
-            async for frame in batched_frames(
-                queue,
-                flush_interval=FLUSH_INTERVAL,
-                max_items=MAX_EVENTS_PER_FRAME,
-                heartbeat_interval=HEARTBEAT_INTERVAL,
-                expand=record_to_events,
-                make_frame=lambda events, dropped: {
-                    "type": "batch", "events": events, "dropped": dropped
-                },
-            ):
-                yield frame
+        logger.info("ws_client_connected", endpoint="/ws/live")
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=1000)
+
+        async def pump() -> None:
+            async for raw in subscriber.iter_events():
+                event = msgspec_json.decode(raw)
+                try:
+                    queue.put_nowait(event)
+                except asyncio.QueueFull:
+                    try:
+                        queue.get_nowait()
+                        queue.put_nowait(event)
+                    except (asyncio.QueueEmpty, asyncio.QueueFull):
+                        pass
+
+        async with channels.start_subscription(LIVE_EVENTS_CHANNEL) as subscriber:
+            pump_task = asyncio.create_task(pump(), name="ws-live-pump")
+            try:
+                async for frame in batched_frames(
+                    queue,
+                    flush_interval=FLUSH_INTERVAL,
+                    max_items=MAX_EVENTS_PER_FRAME,
+                    heartbeat_interval=HEARTBEAT_INTERVAL,
+                    make_frame=lambda events, dropped: {
+                        "type": "batch", "events": events, "dropped": dropped
+                    },
+                ):
+                    yield frame
+            finally:
+                pump_task.cancel()
+                logger.info("ws_client_disconnected", endpoint="/ws/live")
 
     await stream_json_frames(socket, stream())
 

--- a/geometrikks/domain/realtime/events.py
+++ b/geometrikks/domain/realtime/events.py
@@ -1,0 +1,76 @@
+"""Wire schema for the live_events channel.
+
+One committed ParsedLogRecord becomes 0-2 compact JSON events published to
+Postgres NOTIFY. NOTIFY payloads cap at 8000 bytes, so attacker-controlled
+fields are truncated here and encode_guard() drops anything still over
+budget - the DB row is untouched; the live feed is a preview.
+"""
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from geometrikks.services.logparser.schemas import ParsedLogRecord
+
+LIVE_EVENTS_CHANNEL = "live_events"
+
+URL_MAX = 2000
+REFERRER_MAX = 1000
+USER_AGENT_MAX = 500
+PAYLOAD_MAX = 7500
+
+
+def _clip(value: str | None, limit: int) -> str | None:
+    if value is None or len(value) <= limit:
+        return value
+    return value[:limit]
+
+
+def record_to_events(record: "ParsedLogRecord") -> list[dict[str, Any]]:
+    """Convert one committed record to wire events (0, 1, or 2)."""
+    events: list[dict[str, Any]] = []
+    if record.geo_data and record.ip_address:
+        g = record.geo_data
+        events.append({
+            "type": "geo_event",
+            "data": {
+                "timestamp": g.timestamp.isoformat(),
+                "ip_address": record.ip_address,
+                "latitude": g.latitude,
+                "longitude": g.longitude,
+                "city": g.city,
+                "country_code": g.country_code,
+                "hostname": record.hostname,
+            },
+        })
+    if record.access_log:
+        a = record.access_log
+        events.append({
+            "type": "access_log",
+            "data": {
+                "timestamp": a.timestamp.isoformat(),
+                "ip_address": a.ip_address,
+                "remote_user": a.remote_user,
+                "method": a.method,
+                "url": _clip(a.url, URL_MAX),
+                "http_version": a.http_version,
+                "status_code": a.status_code,
+                "bytes_sent": a.bytes_sent,
+                "referrer": _clip(a.referrer, REFERRER_MAX),
+                "user_agent": _clip(a.user_agent, USER_AGENT_MAX),
+                "request_time": a.request_time,
+                "upstream_response_time": a.upstream_response_time,
+                "host": a.host,
+                "country_code": a.country_code,
+                "country_name": a.country_name,
+                "city": a.city,
+                "hostname": record.hostname,
+            },
+        })
+    return events
+
+
+def encode_guard(event: dict[str, Any]) -> bool:
+    """True when the encoded event fits the NOTIFY budget; False = drop it."""
+    return len(json.dumps(event)) <= PAYLOAD_MAX

--- a/geometrikks/domain/realtime/stream.py
+++ b/geometrikks/domain/realtime/stream.py
@@ -19,10 +19,12 @@ cadences, frame caps) stay in the handlers in ``controllers.py``.
 Transport decisions (0.7.0): Litestar's ``send_websocket_stream`` function is
 the adopted wrapper; the ``@websocket_stream`` decorator was not, because the
 feeds must accept and then close 1013 in degraded mode before any streaming
-starts. ``ChannelsPlugin`` was evaluated and deliberately not adopted: these
-are fixed, process-local feeds with no dynamic topics, history, or
-cross-process fan-out, and an in-memory Channels backend would not lift the
-single-worker constraint. Revisit only if those requirements appear.
+starts. ``/ws/live`` now fans out via ``ChannelsPlugin`` over Postgres
+LISTEN/NOTIFY instead of this module's ``subscription()`` helper: cross-process
+fan-out became a requirement once ingestion could run as multiple instances,
+which an in-process broker cannot serve. ``/ws/crowdsec`` and ``/ws/logs``
+have no such requirement (one poller, one broadcaster per process) and stay
+on ``subscription()``.
 """
 
 from __future__ import annotations

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -249,9 +249,23 @@ async def ingestion_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
         yield
         return
 
+    from litestar.channels import ChannelsPlugin
+
     settings = _resolve_settings(app)
     # Ingestion opens a short-lived session per batch flush.
     session_maker = get_app_db_config(app).create_session_maker()
+
+    # Hand-built test apps in the lifespan suites are bare stand-ins with no
+    # `.plugins` registry at all; real apps always carry ChannelsPlugin
+    # (registered in server/plugins.py), so a genuine lookup miss there would
+    # be a wiring bug worth surfacing, not swallowing.
+    channels: ChannelsPlugin | None = None
+    plugins = getattr(app, "plugins", None)
+    if plugins is not None:
+        try:
+            channels = plugins.get(ChannelsPlugin)
+        except KeyError:
+            channels = None
 
     hostnames = settings.logparser.resolved_hostnames()
     parsers = [
@@ -279,6 +293,7 @@ async def ingestion_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
         batch_size=settings.logparser.batch_size,
         commit_interval=settings.logparser.commit_interval,
         store_debug_lines=settings.logparser.store_debug_lines,
+        channels=channels,
     )
     app.state.ingestion_service = ingestion_service
 

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -257,8 +257,9 @@ async def ingestion_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
 
     # Hand-built test apps in the lifespan suites are bare stand-ins with no
     # `.plugins` registry at all; real apps always carry ChannelsPlugin
-    # (registered in server/plugins.py), so a genuine lookup miss there would
-    # be a wiring bug worth surfacing, not swallowing.
+    # (registered in server/plugins.py), so a genuine lookup miss there is a
+    # wiring bug: log it loudly and degrade the live feed rather than crash
+    # ingestion over it.
     channels: ChannelsPlugin | None = None
     plugins = getattr(app, "plugins", None)
     if plugins is not None:

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -266,6 +266,7 @@ async def ingestion_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
             channels = plugins.get(ChannelsPlugin)
         except KeyError:
             channels = None
+            logger.warning("live_events channel unavailable: ChannelsPlugin not registered")
 
     hostnames = settings.logparser.resolved_hostnames()
     parsers = [

--- a/geometrikks/server/plugins.py
+++ b/geometrikks/server/plugins.py
@@ -7,12 +7,15 @@ when e.g. the GeoIP database is missing.
 """
 
 from __future__ import annotations
+import asyncio
 import platform
 import shutil
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from litestar.channels import ChannelsPlugin
+from litestar.channels.backends.asyncpg import AsyncPgChannelsBackend
 from litestar.middleware.logging import LoggingMiddlewareConfig
 from litestar.plugins.structlog import StructlogConfig, StructlogPlugin
 from litestar.serialization import decode_json, encode_json
@@ -33,10 +36,15 @@ from litestar_vite import ViteConfig, VitePlugin
 from litestar_vite.config import RuntimeConfig, TypeGenConfig, PathConfig
 
 from geometrikks.config.settings import get_settings, Settings
-from geometrikks.server.logging import create_logging_config
+from geometrikks.domain.realtime.events import LIVE_EVENTS_CHANNEL
+from geometrikks.server.logging import get_logger, create_logging_config
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Iterable
+
     from litestar import Litestar
+
+logger = get_logger(__name__)
 
 
 def create_sqlalchemy_config(settings: Settings) -> SQLAlchemyAsyncConfig:
@@ -134,11 +142,75 @@ def create_structlog_plugin(settings: Settings) -> StructlogPlugin:
     )
 
 
+class DegradedTolerantAsyncPgBackend(AsyncPgChannelsBackend):
+    """AsyncPg channels backend that degrades instead of failing startup.
+
+    ChannelsPlugin connects during app startup; an unreachable database must
+    put the app in the existing DB-degraded mode, not crash boot. When
+    degraded, publish and subscribe are no-ops and the event stream stays
+    silent; /ws/live independently gates on db_available and closes 1013.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.degraded = False
+
+    async def on_startup(self) -> None:
+        try:
+            await super().on_startup()
+        except Exception as exc:
+            self.degraded = True
+            logger.warning("Channels backend degraded (DB unreachable): %s", exc)
+
+    async def on_shutdown(self) -> None:
+        if self.degraded:
+            return
+        await super().on_shutdown()
+
+    async def publish(self, data: bytes, channels: Iterable[str]) -> None:
+        if self.degraded:
+            return
+        await super().publish(data, channels)
+
+    async def subscribe(self, channels: Iterable[str]) -> None:
+        if self.degraded:
+            return
+        await super().subscribe(channels)
+
+    async def unsubscribe(self, channels: Iterable[str]) -> None:
+        if self.degraded:
+            return
+        await super().unsubscribe(channels)
+
+    async def stream_events(self) -> AsyncGenerator[tuple[str, bytes], None]:
+        if self.degraded:
+            await asyncio.Event().wait()  # silent forever; plugin task parks here
+        async for item in super().stream_events():
+            yield item
+
+
+def create_channels_plugin(settings: Settings) -> ChannelsPlugin:
+    """Cross-process live-events fan-out over Postgres LISTEN/NOTIFY."""
+    return ChannelsPlugin(
+        backend=DegradedTolerantAsyncPgBackend(dsn=settings.database.asyncpg_dsn),
+        channels=[LIVE_EVENTS_CHANNEL],
+        arbitrary_channels_allowed=False,
+        subscriber_max_backlog=1000,
+        subscriber_backlog_strategy="dropleft",
+    )
+
+
 def create_plugins(
     settings: Settings | None = None,
     db_config: SQLAlchemyAsyncConfig | None = None,
 ) -> list[
-    SQLAlchemyInitPlugin | GeoAlchemyPlugin | GranianPlugin | VitePlugin | CLIPlugin | StructlogPlugin
+    SQLAlchemyInitPlugin
+    | GeoAlchemyPlugin
+    | GranianPlugin
+    | VitePlugin
+    | CLIPlugin
+    | StructlogPlugin
+    | ChannelsPlugin
 ]:
     """Instantiate all app plugins; called once from create_app()."""
     from geometrikks.cli import ImportLogsCLIPlugin
@@ -156,4 +228,5 @@ def create_plugins(
         VitePlugin(config=create_vite_config(settings)),
         ImportLogsCLIPlugin(),
         create_structlog_plugin(settings),
+        create_channels_plugin(settings),
     ]

--- a/geometrikks/server/plugins.py
+++ b/geometrikks/server/plugins.py
@@ -161,6 +161,23 @@ class DegradedTolerantAsyncPgBackend(AsyncPgChannelsBackend):
         except Exception as exc:
             self.degraded = True
             logger.warning("Channels backend degraded (DB unreachable): %s", exc)
+            return
+        self._listener_conn.add_termination_listener(self._on_listener_terminated)
+
+    def _on_listener_terminated(self, connection: Any) -> None:
+        """Surface a dropped LISTEN connection; asyncpg otherwise fails silently.
+
+        No reconnect here (deliberately deferred): the feed is dead on this
+        instance until restart. Must never raise: asyncpg schedules this via
+        call_soon/create_task, and an escaping exception there is unhandled by
+        our code.
+        """
+        try:
+            logger.error(
+                "channels listener connection lost; live feed is dead on this instance until restart"
+            )
+        except Exception:  # pragma: no cover - logging itself must not cascade
+            pass
 
     async def on_shutdown(self) -> None:
         if self.degraded:
@@ -170,7 +187,10 @@ class DegradedTolerantAsyncPgBackend(AsyncPgChannelsBackend):
     async def publish(self, data: bytes, channels: Iterable[str]) -> None:
         if self.degraded:
             return
-        await super().publish(data, channels)
+        try:
+            await super().publish(data, channels)
+        except Exception as exc:
+            logger.warning("live event publish failed; event lost (transient DB failure?): %s", exc)
 
     async def subscribe(self, channels: Iterable[str]) -> None:
         if self.degraded:

--- a/geometrikks/server/plugins.py
+++ b/geometrikks/server/plugins.py
@@ -182,6 +182,15 @@ class DegradedTolerantAsyncPgBackend(AsyncPgChannelsBackend):
     async def on_shutdown(self) -> None:
         if self.degraded:
             return
+        # asyncpg fires termination listeners on a graceful close() too (via
+        # Connection._cleanup()), not just on an unexpected drop. Unregister
+        # first so a normal shutdown doesn't log a false "listener lost"
+        # alarm; remove_termination_listener() uses set.discard() internally
+        # so it is a no-op if the listener was never added.
+        try:
+            self._listener_conn.remove_termination_listener(self._on_listener_terminated)
+        except Exception:  # pragma: no cover - shutdown must not be blocked by this
+            pass
         await super().on_shutdown()
 
     async def publish(self, data: bytes, channels: Iterable[str]) -> None:

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -138,9 +138,6 @@ class LogIngestionService:
         self._channels: "ChannelsPlugin | None" = channels
         self.publish_dropped: int = 0
 
-        # Live-feed fan-out: bounded queues, publish post-commit only.
-        self._subscribers: set[asyncio.Queue[ParsedLogRecord]] = set()
-
         # In-memory cache: geohash -> committed (or pending-commit) GeoLocation id.
         # Ids cached since the last successful commit are tracked so a rollback
         # can evict them (their rows never landed -> FK poison otherwise).
@@ -543,32 +540,11 @@ class LogIngestionService:
             self.last_record_at = datetime.now(timezone.utc)
         await self._flush_batch()
 
-    def subscribe(self, maxsize: int = 1000) -> asyncio.Queue[ParsedLogRecord]:
-        """Register a live-feed subscriber. Caller must unsubscribe()."""
-        queue: asyncio.Queue[ParsedLogRecord] = asyncio.Queue(maxsize=maxsize)
-        self._subscribers.add(queue)
-        return queue
-
-    def unsubscribe(self, queue: asyncio.Queue[ParsedLogRecord]) -> None:
-        self._subscribers.discard(queue)
-
     def _publish(self, records: list[ParsedLogRecord]) -> None:
-        """Fan committed records out to subscribers; drop oldest when full.
+        """Publish committed records to the live_events channel.
 
-        Never blocks and never raises: a slow browser must not backpressure
-        ingestion.
+        Never raises: a publish failure must not backpressure or break ingestion.
         """
-        for queue in self._subscribers:
-            for record in records:
-                try:
-                    queue.put_nowait(record)
-                except asyncio.QueueFull:
-                    try:
-                        queue.get_nowait()
-                        queue.put_nowait(record)
-                    except (asyncio.QueueEmpty, asyncio.QueueFull):
-                        pass
-
         if self._channels is not None:
             for record in records:
                 for event in record_to_events(record):

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -17,6 +17,7 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from geoip2.database import Reader
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -27,11 +28,15 @@ from geometrikks.domain.geo.repositories import GeoLocationRepository, GeoEventR
 from geometrikks.domain.logs.models import AccessLog, AccessLogDebug
 from geometrikks.domain.logs.repositories import AccessLogRepository, AccessLogDebugRepository
 from geometrikks.domain.geo.utils import make_point
+from geometrikks.domain.realtime.events import LIVE_EVENTS_CHANNEL, encode_guard, record_to_events
 from geometrikks.services.logparser.schemas import ParsedLogRecord, ParsedGeoData, ParsedAccessLog
 from geometrikks.services.logparser.constants import ALLOWED_GEOIP_LOCALES, GEOIP_LOCALES_DEFAULT
 from geometrikks.services.logparser.logparser import LogParser
 from geometrikks.lib.utils import wait_for_path
 from geometrikks.server.logging import get_logger
+
+if TYPE_CHECKING:
+    from litestar.channels import ChannelsPlugin
 
 
 logger = get_logger(__name__)
@@ -99,6 +104,7 @@ class LogIngestionService:
         commit_interval: float = 5.0,
         store_debug_lines: bool = False,
         queue_maxsize: int = 10_000,
+        channels: "ChannelsPlugin | None" = None,
     ) -> None:
         """Initialize the log ingestion service.
 
@@ -114,6 +120,9 @@ class LogIngestionService:
             commit_interval: Maximum seconds between commits.
             store_debug_lines: If True, store all raw lines in debug table.
             queue_maxsize: Maximum size of the shared record queue.
+            channels: When set, committed records are additionally published
+                to the live_events channel. None (the importer path) publishes
+                nothing.
         """
         self.parsers: list[LogParser] = parsers
         self.hostname: str = hostname
@@ -126,6 +135,8 @@ class LogIngestionService:
         self.commit_interval: int | float = commit_interval
         self.store_debug_lines: bool = store_debug_lines
         self._queue_maxsize: int = queue_maxsize
+        self._channels: "ChannelsPlugin | None" = channels
+        self.publish_dropped: int = 0
 
         # Live-feed fan-out: bounded queues, publish post-commit only.
         self._subscribers: set[asyncio.Queue[ParsedLogRecord]] = set()
@@ -557,6 +568,21 @@ class LogIngestionService:
                         queue.put_nowait(record)
                     except (asyncio.QueueEmpty, asyncio.QueueFull):
                         pass
+
+        if self._channels is not None:
+            for record in records:
+                for event in record_to_events(record):
+                    if not encode_guard(event):
+                        self.publish_dropped += 1
+                        logger.warning(
+                            "live event dropped: encoded payload over budget (ip=%s)",
+                            record.ip_address,
+                        )
+                        continue
+                    try:
+                        self._channels.publish(event, LIVE_EVENTS_CHANNEL)
+                    except Exception:
+                        logger.exception("live event publish failed; continuing")
 
     def _to_access_log_model(
         self, parsed: ParsedAccessLog, log_format: str | None = None,

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -508,8 +508,6 @@ class LogIngestionService:
 
             try:
                 await session.commit()
-                self._uncommitted_geohashes.clear()
-                self._publish(committed_candidates)
             except Exception as e:
                 logger.error("Batch commit failed (rolling back): %s", e)
                 await session.rollback()
@@ -520,6 +518,9 @@ class LogIngestionService:
                 for record in batch:
                     if record.geo_data:
                         self._location_cache.pop(record.geo_data.geohash, None)
+            else:
+                self._uncommitted_geohashes.clear()
+                self._publish(committed_candidates)
 
         logger.debug(
             "Committed batch of %d records. (Geo: %d | Log: %d | Debug: %d)",
@@ -543,22 +544,27 @@ class LogIngestionService:
     def _publish(self, records: list[ParsedLogRecord]) -> None:
         """Publish committed records to the live_events channel.
 
-        Never raises: a publish failure must not backpressure or break ingestion.
+        Never raises: called after commit, so a publish failure (including
+        one from record_to_events) must not backpressure or break ingestion,
+        and must never be mistaken for a commit failure by the caller.
         """
-        if self._channels is not None:
-            for record in records:
-                for event in record_to_events(record):
-                    if not encode_guard(event):
-                        self.publish_dropped += 1
-                        logger.warning(
-                            "live event dropped: encoded payload over budget (ip=%s)",
-                            record.ip_address,
-                        )
-                        continue
-                    try:
-                        self._channels.publish(event, LIVE_EVENTS_CHANNEL)
-                    except Exception:
-                        logger.exception("live event publish failed; continuing")
+        try:
+            if self._channels is not None:
+                for record in records:
+                    for event in record_to_events(record):
+                        if not encode_guard(event):
+                            self.publish_dropped += 1
+                            logger.warning(
+                                "live event dropped: encoded payload over budget (ip=%s)",
+                                record.ip_address,
+                            )
+                            continue
+                        try:
+                            self._channels.publish(event, LIVE_EVENTS_CHANNEL)
+                        except Exception:
+                            logger.exception("live event publish failed; continuing")
+        except Exception:
+            logger.exception("live publish failed; batch already committed")
 
     def _to_access_log_model(
         self, parsed: ParsedAccessLog, log_format: str | None = None,

--- a/resources/lib/demo-traffic.ts
+++ b/resources/lib/demo-traffic.ts
@@ -117,6 +117,7 @@ export function makeDemoRequests(cursor: number, count: number, now: number): Li
         country_code: origin.countryCode,
         country_name: null,
         city: origin.city,
+        hostname: "demo",
       },
     })
   }

--- a/resources/lib/live-traffic/pairing.test.ts
+++ b/resources/lib/live-traffic/pairing.test.ts
@@ -14,6 +14,7 @@ function geo(ip: string, timestamp = TS): LiveEvent {
       longitude: 10.7389,
       city: "Oslo",
       country_code: "NO",
+      hostname: "vps-1",
     },
   }
 }
@@ -38,6 +39,7 @@ function log(ip: string, status: number, timestamp = TS): LiveEvent {
       country_code: "NO",
       country_name: "Norway",
       city: "Oslo",
+      hostname: "vps-1",
     },
   }
 }

--- a/resources/lib/websocket.ts
+++ b/resources/lib/websocket.ts
@@ -5,7 +5,7 @@
  */
 
 export type LiveEvent =
-  | { type: "geo_event"; data: { timestamp: string; ip_address: string; latitude: number; longitude: number; city: string | null; country_code: string | null } }
+  | { type: "geo_event"; data: { timestamp: string; ip_address: string; latitude: number; longitude: number; city: string | null; country_code: string | null; hostname: string } }
   | {
       type: "access_log"
       data: {
@@ -25,6 +25,7 @@ export type LiveEvent =
         country_code: string | null
         country_name: string | null
         city: string | null
+        hostname: string
       }
     }
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -70,6 +70,16 @@ def it_database_url() -> Iterator[str]:
 
 
 @pytest.fixture(scope="session")
+def it_asyncpg_dsn(it_database_url: str) -> str:
+    """Plain postgresql:// DSN for the scratch DB, for asyncpg-based backends.
+
+    Mirrors DatabaseSettings.asyncpg_dsn: AsyncPgChannelsBackend hands the DSN
+    straight to asyncpg, which does not understand the +asyncpg driver suffix.
+    """
+    return it_database_url.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+@pytest.fixture(scope="session")
 def monkeypatch_session():
     """Session-scoped monkeypatch (pytest's default fixture is function-scoped)."""
     from _pytest.monkeypatch import MonkeyPatch

--- a/tests/integration/test_channels_pg.py
+++ b/tests/integration/test_channels_pg.py
@@ -1,0 +1,53 @@
+"""AsyncPg channels round trip against the real integration database."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from litestar.channels import ChannelsPlugin
+from msgspec import json as msgspec_json
+
+from geometrikks.domain.realtime.events import LIVE_EVENTS_CHANNEL
+from geometrikks.server.plugins import DegradedTolerantAsyncPgBackend
+
+pytestmark = [pytest.mark.integration, pytest.mark.anyio]
+
+
+async def test_publish_subscribe_round_trip(it_asyncpg_dsn) -> None:
+    channels = ChannelsPlugin(
+        backend=DegradedTolerantAsyncPgBackend(dsn=it_asyncpg_dsn),
+        channels=[LIVE_EVENTS_CHANNEL],
+    )
+    async with channels:
+        async with channels.start_subscription(LIVE_EVENTS_CHANNEL) as subscriber:
+            channels.publish({"type": "geo_event", "data": {"hostname": "vps-1"}}, LIVE_EVENTS_CHANNEL)
+
+            async def _first_event() -> dict:
+                async for raw in subscriber.iter_events():
+                    return msgspec_json.decode(raw)
+                raise AssertionError("subscriber closed without an event")
+
+            event = await asyncio.wait_for(_first_event(), timeout=10)
+    assert event["data"]["hostname"] == "vps-1"
+
+
+async def test_two_writers_one_subscriber(it_asyncpg_dsn) -> None:
+    channels = ChannelsPlugin(
+        backend=DegradedTolerantAsyncPgBackend(dsn=it_asyncpg_dsn),
+        channels=[LIVE_EVENTS_CHANNEL],
+    )
+    async with channels:
+        async with channels.start_subscription(LIVE_EVENTS_CHANNEL) as subscriber:
+            for host in ("vps-1", "vps-2"):
+                channels.publish({"type": "geo_event", "data": {"hostname": host}}, LIVE_EVENTS_CHANNEL)
+
+            async def _collect_both() -> set[str]:
+                seen: set[str] = set()
+                async for raw in subscriber.iter_events():
+                    seen.add(msgspec_json.decode(raw)["data"]["hostname"])
+                    if seen == {"vps-1", "vps-2"}:
+                        return seen
+                return seen
+
+            seen = await asyncio.wait_for(_collect_both(), timeout=10)
+    assert seen == {"vps-1", "vps-2"}

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -104,6 +104,13 @@ async def test_domain_validation_error_translates_to_400():
     assert "Invalid IP address" in body["detail"]
 
 
+def test_channels_plugin_registered() -> None:
+    from litestar.channels import ChannelsPlugin
+
+    app = create_app(settings=_hermetic_settings())
+    assert app.plugins.get(ChannelsPlugin) is not None
+
+
 def test_create_plugins_derives_db_config_from_explicit_settings(monkeypatch):
     """create_plugins(settings=...) without a db_config must not fall back to
     the ambient process-cached engine (split-brain configuration)."""

--- a/tests/test_auth_endpoints.py
+++ b/tests/test_auth_endpoints.py
@@ -5,16 +5,17 @@ from typing import Any
 
 import pytest
 from litestar import Litestar, get
+from litestar.channels import ChannelsPlugin
+from litestar.channels.backends.memory import MemoryChannelsBackend
 from litestar.testing import TestClient
 
 from geometrikks.config.settings import Settings
 from geometrikks.domain.auth.controllers import AuthController
 from geometrikks.domain.realtime.controllers import crowdsec_feed, live_feed, logs_feed
+from geometrikks.domain.realtime.events import LIVE_EVENTS_CHANNEL
 from geometrikks.server.auth import build_auth_state, create_session_auth
 from geometrikks.server.dependencies import create_settings_provider
 from geometrikks.server.routes import create_api_v1_router
-
-from tests.test_live_ws import FakeIngestion
 
 
 @get("/api/v1/protected")
@@ -35,6 +36,7 @@ def make_app(**settings_kwargs) -> Litestar:
         **settings_kwargs,
     )
     session_auth = create_session_auth(settings)
+    channels = ChannelsPlugin(backend=MemoryChannelsBackend(), channels=[LIVE_EVENTS_CHANNEL])
     app = Litestar(
         route_handlers=[
             create_api_v1_router([AuthController]),
@@ -42,12 +44,13 @@ def make_app(**settings_kwargs) -> Litestar:
         ],
         dependencies={"settings": create_settings_provider(settings)},
         on_app_init=[session_auth.on_app_init],
+        plugins=[channels],
         logging_config=None,
     )
     app.state.auth_state = build_auth_state(settings)
-    # A working ingestion service so the authenticated branch streams rather
-    # than taking the 1013-close (no-service) path.
-    app.state.ingestion_service = FakeIngestion()
+    # DB "available" so the authenticated branch streams rather than taking
+    # the 1013-close (degraded) path.
+    app.state.db_available = True
     return app
 
 
@@ -125,18 +128,20 @@ def test_ws_live_streams_after_login():
         )
         assert res.status_code == 200
         # Same client -> the session cookie persists onto the WS handshake.
-        ingestion = client.app.state.ingestion_service
+        channels = client.app.plugins.get(ChannelsPlugin)
         with client.websocket_connect("/ws/live") as ws:
-            ingestion.queue.put_nowait(_ws_record())
+            for event in _ws_events():
+                channels.publish(event, LIVE_EVENTS_CHANNEL)
             frame = ws.receive_json(timeout=5)
         assert frame["type"] == "batch"
         assert [e["type"] for e in frame["events"]] == ["geo_event", "access_log"]
 
 
-def _ws_record():
+def _ws_events():
     from tests.test_live_ws import make_record
+    from geometrikks.domain.realtime.events import record_to_events
 
-    return make_record()
+    return record_to_events(make_record())
 
 
 def test_create_app_requires_password_when_auth_enabled(monkeypatch):

--- a/tests/test_channels_backend.py
+++ b/tests/test_channels_backend.py
@@ -35,3 +35,50 @@ async def test_degraded_backend_is_inert() -> None:
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(first_event(), timeout=0.2)
     await backend.on_shutdown()  # no-op, must not raise
+
+
+async def test_publish_survives_transient_failure_when_not_degraded() -> None:
+    """A non-degraded backend must swallow a publish-time DB failure.
+
+    The parent AsyncPgChannelsBackend.publish() only needs self._queue set
+    (not full on_startup) to reach self._connect() -- see the RuntimeError
+    guard at the top of the parent method. Seeding just that attribute lets
+    us force the failure through the make_connection factory without going
+    through on_startup (which would itself call _connect() and flip
+    `degraded`, defeating the point of this test).
+    """
+
+    async def failing_connect() -> None:
+        raise OSError("connection refused")
+
+    backend = DegradedTolerantAsyncPgBackend(make_connection=failing_connect)
+    backend._queue = asyncio.Queue()
+
+    await backend.publish(b"{}", ["live_events"])  # must not raise
+
+    assert backend.degraded is False
+
+
+async def test_on_startup_registers_termination_listener() -> None:
+    """A dropped LISTEN connection must be logged, not silently swallowed."""
+
+    class FakeConnection:
+        def __init__(self) -> None:
+            self.termination_callback = None
+
+        def add_termination_listener(self, callback) -> None:
+            self.termination_callback = callback
+
+    fake_conn = FakeConnection()
+
+    async def make_connection() -> FakeConnection:
+        return fake_conn
+
+    backend = DegradedTolerantAsyncPgBackend(make_connection=make_connection)
+    await backend.on_startup()
+
+    assert backend.degraded is False
+    assert fake_conn.termination_callback is not None
+
+    # The callback itself must be exception-safe -- calling it must not raise.
+    fake_conn.termination_callback(fake_conn)

--- a/tests/test_channels_backend.py
+++ b/tests/test_channels_backend.py
@@ -1,0 +1,37 @@
+"""Channels backend must degrade, not crash, when Postgres is unreachable."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from geometrikks.server.plugins import DegradedTolerantAsyncPgBackend
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_startup_failure_degrades_instead_of_raising() -> None:
+    backend = DegradedTolerantAsyncPgBackend(
+        dsn="postgresql://nobody:wrong@127.0.0.1:1/void"
+    )
+    await backend.on_startup()  # must not raise
+    assert backend.degraded is True
+
+
+async def test_degraded_backend_is_inert() -> None:
+    backend = DegradedTolerantAsyncPgBackend(
+        dsn="postgresql://nobody:wrong@127.0.0.1:1/void"
+    )
+    await backend.on_startup()
+    await backend.publish(b"{}", ["live_events"])  # no-op, must not raise
+    await backend.subscribe(["live_events"])
+    await backend.unsubscribe(["live_events"])
+
+    async def first_event():
+        async for _ in backend.stream_events():
+            return True
+        return False
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(first_event(), timeout=0.2)
+    await backend.on_shutdown()  # no-op, must not raise

--- a/tests/test_channels_backend.py
+++ b/tests/test_channels_backend.py
@@ -59,16 +59,32 @@ async def test_publish_survives_transient_failure_when_not_degraded() -> None:
     assert backend.degraded is False
 
 
+class FakeConnection:
+    """Mirrors the asyncpg.Connection termination-listener behavior we rely
+    on: add/remove use set semantics (remove of an absent callback is a
+    no-op), and close() fires whatever listeners are still registered --
+    asyncpg's real Connection.close() unconditionally calls _cleanup(), which
+    calls _call_termination_listeners(), even on a graceful close."""
+
+    def __init__(self) -> None:
+        self._listeners: set = set()
+        self.close_called = False
+
+    def add_termination_listener(self, callback) -> None:
+        self._listeners.add(callback)
+
+    def remove_termination_listener(self, callback) -> None:
+        self._listeners.discard(callback)
+
+    async def close(self) -> None:
+        self.close_called = True
+        for cb in list(self._listeners):
+            cb(self)
+        self._listeners.clear()
+
+
 async def test_on_startup_registers_termination_listener() -> None:
     """A dropped LISTEN connection must be logged, not silently swallowed."""
-
-    class FakeConnection:
-        def __init__(self) -> None:
-            self.termination_callback = None
-
-        def add_termination_listener(self, callback) -> None:
-            self.termination_callback = callback
-
     fake_conn = FakeConnection()
 
     async def make_connection() -> FakeConnection:
@@ -78,7 +94,49 @@ async def test_on_startup_registers_termination_listener() -> None:
     await backend.on_startup()
 
     assert backend.degraded is False
-    assert fake_conn.termination_callback is not None
+    assert backend._on_listener_terminated in fake_conn._listeners
 
     # The callback itself must be exception-safe -- calling it must not raise.
-    fake_conn.termination_callback(fake_conn)
+    backend._on_listener_terminated(fake_conn)
+
+
+async def test_unexpected_termination_still_logs_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A connection lost while still registered (i.e. before on_shutdown had
+    a chance to unregister it) must still surface as an error."""
+    fake_conn = FakeConnection()
+
+    async def make_connection() -> FakeConnection:
+        return fake_conn
+
+    backend = DegradedTolerantAsyncPgBackend(make_connection=make_connection)
+    await backend.on_startup()
+
+    with caplog.at_level("ERROR"):
+        await fake_conn.close()  # simulates asyncpg firing listeners on drop
+
+    assert any("listener connection lost" in r.getMessage() for r in caplog.records)
+
+
+async def test_graceful_shutdown_does_not_log_false_listener_lost(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """asyncpg fires termination listeners on a graceful close() too, so
+    on_shutdown must unregister the listener first -- otherwise every normal
+    app shutdown/redeploy logs a false "listener connection lost" alarm."""
+    fake_conn = FakeConnection()
+
+    async def make_connection() -> FakeConnection:
+        return fake_conn
+
+    backend = DegradedTolerantAsyncPgBackend(make_connection=make_connection)
+    await backend.on_startup()
+    assert backend._on_listener_terminated in fake_conn._listeners
+
+    with caplog.at_level("ERROR"):
+        await backend.on_shutdown()
+
+    assert fake_conn.close_called is True
+    assert not fake_conn._listeners  # unregistered before close fired anything
+    assert not any("listener connection lost" in r.getMessage() for r in caplog.records)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,10 +50,19 @@ def test_runtime_metadata_defaults_and_overrides(monkeypatch):
 def test_database_settings():
     """Test database configuration."""
     settings = Settings()
-    
+
     assert "postgresql" in settings.database.url
     assert settings.database.pool_size == 5
     assert settings.database.echo is False
+
+
+def test_database_asyncpg_dsn_strips_driver_suffix() -> None:
+    """AsyncPgChannelsBackend needs a plain postgresql:// DSN."""
+    from geometrikks.config.settings import DatabaseSettings
+    settings = DatabaseSettings()
+    assert settings.url.startswith("postgresql+asyncpg://")
+    assert settings.asyncpg_dsn == settings.url.replace("postgresql+asyncpg://", "postgresql://", 1)
+    assert "+asyncpg" not in settings.asyncpg_dsn
 
 
 def test_geoip_settings(tmp_path):

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -738,3 +738,29 @@ async def test_channel_publish_only_after_successful_commit() -> None:
     repos.fail_next_commits = 1
     await service.flush_records([make_parsed_record(TEST_DB_IPS[0])])
     assert channels.publish.call_count == 0
+
+
+async def test_publish_blowup_after_commit_does_not_look_like_commit_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A record_to_events explosion happens strictly after `await
+    session.commit()` succeeds, so it must not be caught by the
+    commit-failure handler: no rollback, no cache eviction, and no
+    misleading "Batch commit failed" log. `_publish` must swallow it instead."""
+    import geometrikks.services.ingestion.service as service_module
+
+    def boom(record: object) -> None:
+        raise RuntimeError("record_to_events blew up")
+
+    monkeypatch.setattr(service_module, "record_to_events", boom)
+
+    channels = _channels_stub()
+    service, repos, sessions = make_service([], channels=channels)
+    with caplog.at_level("ERROR"):
+        await service.flush_records([make_parsed_record(TEST_DB_IPS[0])])
+
+    assert sessions[0].commits == 1
+    assert sessions[0].rollbacks == 0
+    assert service._location_cache  # committed location must still be cached
+    assert not any("Batch commit failed" in r.getMessage() for r in caplog.records)
+    assert any("live publish failed; batch already committed" in r.getMessage() for r in caplog.records)

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -658,41 +658,15 @@ def make_parsed_record(ip: str) -> ParsedLogRecord:
     )
 
 
-async def test_pubsub_subscribers_receive_committed_records() -> None:
-    service, _repos, _sessions = make_service([])
-    q = service.subscribe()
-    records = [make_parsed_record(ip) for ip in TEST_DB_IPS]
-
-    await service.flush_records(records)
-
-    got = [q.get_nowait() for _ in range(len(records))]
-    assert [r.ip_address for r in got] == [r.ip_address for r in records]
-
-
-async def test_pubsub_unsubscribed_queue_gets_nothing() -> None:
-    service, _repos, _sessions = make_service([])
-    q = service.subscribe()
-    service.unsubscribe(q)
-    await service.flush_records([make_parsed_record(TEST_DB_IPS[0])])
-    assert q.empty()
-
-
-async def test_pubsub_failed_commit_publishes_nothing() -> None:
-    service, repos, _sessions = make_service([])
-    repos.fail_next_commits = 1
-    q = service.subscribe()
-    await service.flush_records([make_parsed_record(TEST_DB_IPS[0])])
-    assert q.empty(), "post-commit publish only — rolled-back records must not stream"
-
-
-async def test_pubsub_full_subscriber_drops_oldest_not_ingestion() -> None:
-    service, _repos, _sessions = make_service([])
-    q = service.subscribe(maxsize=1)
-    r1, r2 = (make_parsed_record(ip) for ip in TEST_DB_IPS)
-    await service.flush_records([r1])
-    await service.flush_records([r2])   # must not block or raise
-    assert q.qsize() == 1
-    assert q.get_nowait().ip_address == r2.ip_address
+def test_service_has_no_inprocess_subscriber_api() -> None:
+    """The in-process fan-out (subscribe/unsubscribe/_subscribers) is gone;
+    /ws/live now subscribes to the live_events channel instead. Post-commit
+    delivery is covered by the channel-publish tests below."""
+    service = LogIngestionService(
+        parsers=[], session_maker=cast("Any", None), geoip_path="unused", hostname="myserver",
+    )
+    assert not hasattr(service, "subscribe")
+    assert not hasattr(service, "unsubscribe")
 
 
 def make_full_record(hostname: str) -> ParsedLogRecord:
@@ -754,3 +728,13 @@ def test_publish_never_raises_into_ingestion() -> None:
         hostname="myserver", channels=channels,
     )
     service._publish([make_full_record(hostname="vps-1")])  # must not raise
+
+
+async def test_channel_publish_only_after_successful_commit() -> None:
+    """post-commit publish only — a rolled-back batch must not reach the channel
+    (the same invariant the deleted in-process pubsub tests covered)."""
+    channels = _channels_stub()
+    service, repos, _sessions = make_service([], channels=channels)
+    repos.fail_next_commits = 1
+    await service.flush_records([make_parsed_record(TEST_DB_IPS[0])])
+    assert channels.publish.call_count == 0

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -5,7 +5,7 @@ import asyncio
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from geohash2 import encode
@@ -693,3 +693,64 @@ async def test_pubsub_full_subscriber_drops_oldest_not_ingestion() -> None:
     await service.flush_records([r2])   # must not block or raise
     assert q.qsize() == 1
     assert q.get_nowait().ip_address == r2.ip_address
+
+
+def make_full_record(hostname: str) -> ParsedLogRecord:
+    """A record with both geo_data and access_log (field values mirror
+    tests/test_realtime_events.py's `_record`), stamped with `hostname`."""
+    ts = datetime.now(timezone.utc)
+    return ParsedLogRecord(
+        ip_address="203.0.113.7",
+        geo_data=ParsedGeoData(
+            latitude=51.5, longitude=-0.1, geohash="gcpvj0", country_code="GB",
+            country_name="United Kingdom", timestamp=ts,
+        ),
+        access_log=ParsedAccessLog(
+            timestamp=ts, ip_address="203.0.113.7", remote_user=None, method="GET",
+            url="/index", http_version="HTTP/2.0", status_code=200, bytes_sent=10,
+            referrer=None, user_agent=None, request_time=0.1,
+            upstream_response_time=None, host="example.com",
+            country_code="GB", country_name="United Kingdom", city="London",
+        ),
+        raw_line="raw",
+        hostname=hostname,
+    )
+
+
+def _channels_stub():
+    from unittest.mock import MagicMock
+    return MagicMock()
+
+
+def test_publish_sends_events_to_channel() -> None:
+    from geometrikks.domain.realtime.events import LIVE_EVENTS_CHANNEL
+
+    channels = _channels_stub()
+    service = LogIngestionService(
+        parsers=[], session_maker=cast("Any", None), geoip_path="unused",
+        hostname="myserver", channels=channels,
+    )
+    record = make_full_record(hostname="vps-1")
+    service._publish([record])
+    assert channels.publish.call_count == 2  # geo_event + access_log
+    for call in channels.publish.call_args_list:
+        event, channel = call.args
+        assert channel == LIVE_EVENTS_CHANNEL
+        assert event["data"]["hostname"] == "vps-1"
+
+
+def test_publish_without_channels_is_silent_and_safe() -> None:
+    service = LogIngestionService(
+        parsers=[], session_maker=cast("Any", None), geoip_path="unused", hostname="myserver",
+    )
+    service._publish([make_full_record(hostname="vps-1")])  # must not raise
+
+
+def test_publish_never_raises_into_ingestion() -> None:
+    channels = _channels_stub()
+    channels.publish.side_effect = RuntimeError("backend down")
+    service = LogIngestionService(
+        parsers=[], session_maker=cast("Any", None), geoip_path="unused",
+        hostname="myserver", channels=channels,
+    )
+    service._publish([make_full_record(hostname="vps-1")])  # must not raise

--- a/tests/test_live_ws.py
+++ b/tests/test_live_ws.py
@@ -8,9 +8,12 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 from litestar import Litestar
+from litestar.channels import ChannelsPlugin
+from litestar.channels.backends.memory import MemoryChannelsBackend
 from litestar.exceptions import WebSocketDisconnect
 from litestar.testing import TestClient
 
+from geometrikks.domain.realtime.events import LIVE_EVENTS_CHANNEL, record_to_events
 from geometrikks.services.logparser.schemas import ParsedAccessLog, ParsedGeoData, ParsedLogRecord
 
 if TYPE_CHECKING:
@@ -20,7 +23,7 @@ if TYPE_CHECKING:
 TS = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
 
 
-def make_record(with_geo: bool = True, with_log: bool = True) -> ParsedLogRecord:
+def make_record(with_geo: bool = True, with_log: bool = True, hostname: str = "") -> ParsedLogRecord:
     geo = ParsedGeoData(
         latitude=51.5, longitude=-0.09, geohash="gcpvj", country_code="GB",
         country_name="UK", timestamp=TS, city="London",
@@ -34,40 +37,39 @@ def make_record(with_geo: bool = True, with_log: bool = True) -> ParsedLogRecord
     ) if with_log else None
     return ParsedLogRecord(
         ip_address="81.2.69.142", geo_data=geo, access_log=log, raw_line="x",
+        hostname=hostname,
     )
 
 
-class FakeIngestion:
-    """subscribe/unsubscribe stub the handler can drive."""
-
-    def __init__(self) -> None:
-        self.queue: asyncio.Queue = asyncio.Queue()
-        self.unsubscribed = False
-
-    def subscribe(self, maxsize: int = 1000):
-        return self.queue
-
-    def unsubscribe(self, queue) -> None:
-        self.unsubscribed = True
-
-
-def make_app(ingestion) -> Litestar:
+def _live_app(db_available: bool = True) -> tuple[Litestar, ChannelsPlugin]:
     from geometrikks.domain.realtime.controllers import live_feed
-    app = Litestar(route_handlers=[live_feed])
-    app.state.ingestion_service = ingestion
-    return app
+
+    channels = ChannelsPlugin(backend=MemoryChannelsBackend(), channels=[LIVE_EVENTS_CHANNEL])
+    app = Litestar(route_handlers=[live_feed], plugins=[channels])
+    app.state.db_available = db_available
+    return app, channels
 
 
-def test_ws_streams_batch_frames():
-    ingestion = FakeIngestion()
-    with TestClient(app=make_app(ingestion)) as client:
-        with client.websocket_connect("/ws/live") as ws:
-            ingestion.queue.put_nowait(make_record())
-            frame = ws.receive_json(timeout=5)
+def test_ws_streams_batch_frames_from_channel():
+    app, channels = _live_app()
+    with TestClient(app) as client, client.websocket_connect("/ws/live") as ws:
+        for event in record_to_events(make_record()):
+            channels.publish(event, LIVE_EVENTS_CHANNEL)
+        frame = ws.receive_json(timeout=5)
     assert frame["type"] == "batch"
     assert frame["dropped"] == 0
     assert [e["type"] for e in frame["events"]] == ["geo_event", "access_log"]
-    assert ingestion.unsubscribed is True
+
+
+def test_ws_hostname_arrives_in_frames():
+    """The wire event's hostname (needed for multi-instance ingestion) survives
+    the round trip through the channel unchanged."""
+    app, channels = _live_app()
+    with TestClient(app) as client, client.websocket_connect("/ws/live") as ws:
+        for event in record_to_events(make_record(with_log=False, hostname="vps-1")):
+            channels.publish(event, LIVE_EVENTS_CHANNEL)
+        frame = ws.receive_json(timeout=5)
+    assert frame["events"][0]["data"]["hostname"] == "vps-1"
 
 
 def test_ws_sends_empty_batch_heartbeat_when_idle(monkeypatch):
@@ -76,53 +78,50 @@ def test_ws_sends_empty_batch_heartbeat_when_idle(monkeypatch):
     from geometrikks.domain.realtime import controllers as live_controller
 
     monkeypatch.setattr(live_controller, "HEARTBEAT_INTERVAL", 0.3, raising=False)
-    ingestion = FakeIngestion()
-    with TestClient(app=make_app(ingestion)) as client:
-        with client.websocket_connect("/ws/live") as ws:
-            frame = ws.receive_json(timeout=5)
+    app, _channels = _live_app()
+    with TestClient(app) as client, client.websocket_connect("/ws/live") as ws:
+        frame = ws.receive_json(timeout=5)
     assert frame == {"type": "batch", "events": [], "dropped": 0}
-    assert ingestion.unsubscribed is True
 
 
-def test_ws_closes_when_no_ingestion_service():
+def test_ws_closes_1013_when_db_unavailable():
     """Degraded mode closes with 1013 (try again later) and a usable reason."""
-    with TestClient(app=make_app(None)) as client:
+    app, _channels = _live_app(db_available=False)
+    with TestClient(app) as client:
         with pytest.raises(WebSocketDisconnect) as exc_info:
             with client.websocket_connect("/ws/live") as ws:
                 ws.receive_json(timeout=2)
     assert exc_info.value.code == 1013
-    assert exc_info.value.detail == "ingestion not running"
+    assert exc_info.value.detail == "live feed unavailable (database down)"
 
 
 def test_ws_counts_dropped_events_beyond_frame_cap():
     """Overflow beyond MAX_EVENTS_PER_FRAME is counted, not silently lost."""
-    ingestion = FakeIngestion()
-    # 60 prefilled records -> 120 events; the first flush window drains them
-    # all, keeps 100 and counts 20 dropped.
-    for _ in range(60):
-        ingestion.queue.put_nowait(make_record())
-    with TestClient(app=make_app(ingestion)) as client:
-        with client.websocket_connect("/ws/live") as ws:
-            frame = ws.receive_json(timeout=5)
+    app, channels = _live_app()
+    with TestClient(app) as client, client.websocket_connect("/ws/live") as ws:
+        # 60 records -> 120 events; the first flush window drains them all,
+        # keeps 100 and counts 20 dropped.
+        for _ in range(60):
+            for event in record_to_events(make_record()):
+                channels.publish(event, LIVE_EVENTS_CHANNEL)
+        frame = ws.receive_json(timeout=5)
     assert frame["type"] == "batch"
     assert len(frame["events"]) == 100
     assert frame["dropped"] == 20
-    assert ingestion.unsubscribed is True
 
 
 def test_ws_ignores_unexpected_inbound_frames():
     """Policy: inbound client frames are consumed and ignored; the stream
     keeps flowing on the same connection."""
-    ingestion = FakeIngestion()
-    with TestClient(app=make_app(ingestion)) as client:
-        with client.websocket_connect("/ws/live") as ws:
-            ws.send_text("unexpected")
-            ws.send_json({"also": "unexpected"})
-            ingestion.queue.put_nowait(make_record())
-            frame = ws.receive_json(timeout=5)
+    app, channels = _live_app()
+    with TestClient(app) as client, client.websocket_connect("/ws/live") as ws:
+        ws.send_text("unexpected")
+        ws.send_json({"also": "unexpected"})
+        for event in record_to_events(make_record()):
+            channels.publish(event, LIVE_EVENTS_CHANNEL)
+        frame = ws.receive_json(timeout=5)
     assert frame["type"] == "batch"
     assert len(frame["events"]) == 2
-    assert ingestion.unsubscribed is True
 
 
 class FakeSocket:
@@ -130,8 +129,11 @@ class FakeSocket:
 
     connection_state = "connect"
 
-    def __init__(self, state: SimpleNamespace) -> None:
-        self.app = SimpleNamespace(state=state)
+    def __init__(self, channels: ChannelsPlugin, *, db_available: bool = True) -> None:
+        self.app = SimpleNamespace(
+            state=SimpleNamespace(db_available=db_available),
+            plugins=SimpleNamespace(get=lambda _cls: channels),
+        )
         self.sent: list[dict] = []
 
     async def accept(self) -> None: ...
@@ -154,32 +156,43 @@ class DisconnectingSendSocket(FakeSocket):
 
 
 @pytest.mark.anyio
-async def test_ws_disconnect_during_send_is_suppressed_and_unsubscribes():
+async def test_ws_disconnect_during_send_is_suppressed_and_cleans_up_subscription():
     """A WebSocketDisconnect raised from send_json travels through AnyIO's
     task group as an ExceptionGroup; the handler must suppress it (not let
-    the group escape) and unsubscribe before returning."""
+    the group escape) and clean up its channel subscription before returning.
+
+    There is no more `unsubscribed` flag to assert on (that was the fake
+    ingestion broker's bookkeeping); the observable analogue is that the
+    channel's subscriber set is empty again once the handler returns, same
+    as the log-broadcaster feed's disconnect test below asserts.
+    """
     from geometrikks.domain.realtime.controllers import live_feed
 
-    ingestion = FakeIngestion()
-    ingestion.queue.put_nowait(make_record())
-    socket = DisconnectingSendSocket(SimpleNamespace(ingestion_service=ingestion))
-    await live_feed.fn(socket)  # must not raise
-    assert ingestion.unsubscribed is True
+    channels = ChannelsPlugin(backend=MemoryChannelsBackend(), channels=[LIVE_EVENTS_CHANNEL])
+    async with channels:
+        socket = DisconnectingSendSocket(channels)
+        task = asyncio.create_task(cast("Coroutine[Any, Any, None]", live_feed.fn(socket)))
+        await asyncio.sleep(0.05)  # let the handler subscribe and enter its loop
+        for event in record_to_events(make_record()):
+            channels.publish(event, LIVE_EVENTS_CHANNEL)
+        await asyncio.wait_for(task, timeout=5)  # must not raise
+        assert channels._channels[LIVE_EVENTS_CHANNEL] == set()
 
 
 @pytest.mark.anyio
-async def test_ws_cancellation_still_unsubscribes():
+async def test_ws_cancellation_still_cleans_up_subscription():
     """Server-side cancellation (shutdown) must run the cleanup path."""
     from geometrikks.domain.realtime.controllers import live_feed
 
-    ingestion = FakeIngestion()
-    socket = FakeSocket(SimpleNamespace(ingestion_service=ingestion))
-    task = asyncio.create_task(cast("Coroutine[Any, Any, None]", live_feed.fn(socket)))
-    await asyncio.sleep(0.05)  # let the handler subscribe and enter its loop
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
-    assert ingestion.unsubscribed is True
+    channels = ChannelsPlugin(backend=MemoryChannelsBackend(), channels=[LIVE_EVENTS_CHANNEL])
+    async with channels:
+        socket = FakeSocket(channels)
+        task = asyncio.create_task(cast("Coroutine[Any, Any, None]", live_feed.fn(socket)))
+        await asyncio.sleep(0.05)  # let the handler subscribe and enter its loop
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert channels._channels[LIVE_EVENTS_CHANNEL] == set()
 
 
 class TestLogsFeed:

--- a/tests/test_live_ws.py
+++ b/tests/test_live_ws.py
@@ -195,6 +195,43 @@ async def test_ws_cancellation_still_cleans_up_subscription():
         assert channels._channels[LIVE_EVENTS_CHANNEL] == set()
 
 
+@pytest.mark.anyio
+async def test_pump_drops_oldest_when_local_queue_is_full(monkeypatch):
+    """The pump's relay queue (channel subscriber -> batched_frames) silently
+    drops the oldest queued event when a burst outpaces its capacity — the
+    behavior the deleted in-process `subscribe(maxsize=...)` full-queue test
+    used to cover, now living in pump()'s own `except asyncio.QueueFull`
+    branch. This is distinct from (and invisible to) batched_frames' own
+    counted drop for overflow beyond MAX_EVENTS_PER_FRAME within one flush.
+
+    `LIVE_QUEUE_MAXSIZE` is monkeypatched down to 3 so a small burst can fill
+    it; the burst is published only after the handler has had a chance to
+    subscribe and start pumping (`asyncio.sleep(0.05)`, the same pattern the
+    disconnect/cancellation tests above use), so publishing 10 events lands
+    in the pump loop's `except QueueFull` path deterministically instead of
+    racing a real consumer.
+    """
+    from geometrikks.domain.realtime import controllers as live_controller
+    from geometrikks.domain.realtime.controllers import live_feed
+
+    monkeypatch.setattr(live_controller, "LIVE_QUEUE_MAXSIZE", 3, raising=False)
+    channels = ChannelsPlugin(backend=MemoryChannelsBackend(), channels=[LIVE_EVENTS_CHANNEL])
+    async with channels:
+        socket = FakeSocket(channels)
+        task = asyncio.create_task(cast("Coroutine[Any, Any, None]", live_feed.fn(socket)))
+        await asyncio.sleep(0.05)  # let the handler subscribe and start pumping
+        for i in range(10):
+            channels.publish({"type": "geo_event", "data": {"n": i}}, LIVE_EVENTS_CHANNEL)
+        await asyncio.sleep(0.3)  # let the pump drain the burst and batched_frames flush
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    frame = socket.sent[0]
+    assert [e["data"]["n"] for e in frame["events"]] == [7, 8, 9]
+    assert frame["dropped"] == 0
+
+
 class TestLogsFeed:
     def _make_app(self):
         from geometrikks.domain.realtime.controllers import logs_feed

--- a/tests/test_live_ws.py
+++ b/tests/test_live_ws.py
@@ -37,36 +37,6 @@ def make_record(with_geo: bool = True, with_log: bool = True) -> ParsedLogRecord
     )
 
 
-class TestRecordToEvents:
-    def test_full_record_yields_both_events(self):
-        from geometrikks.domain.realtime.controllers import record_to_events
-        events = record_to_events(make_record())
-        types = [e["type"] for e in events]
-        assert types == ["geo_event", "access_log"]
-        geo = events[0]["data"]
-        assert geo["latitude"] == 51.5 and geo["country_code"] == "GB"
-        log = events[1]["data"]
-        assert log["status_code"] == 200 and log["url"] == "/x"
-        # Wire format carries the full access-log field set.
-        assert set(log) == {
-            "timestamp", "ip_address", "remote_user", "method", "url",
-            "http_version", "status_code", "bytes_sent", "referrer",
-            "user_agent", "request_time", "upstream_response_time", "host",
-            "country_code", "country_name", "city",
-        }
-        assert log["http_version"] == "1.1" and log["user_agent"] == "curl"
-        assert log["host"] == "example.com" and log["country_code"] == "GB"
-
-    def test_geo_only_record(self):
-        from geometrikks.domain.realtime.controllers import record_to_events
-        events = record_to_events(make_record(with_log=False))
-        assert [e["type"] for e in events] == ["geo_event"]
-
-    def test_malformed_record_yields_nothing(self):
-        from geometrikks.domain.realtime.controllers import record_to_events
-        assert record_to_events(make_record(with_geo=False, with_log=False)) == []
-
-
 class FakeIngestion:
     """subscribe/unsubscribe stub the handler can drive."""
 

--- a/tests/test_realtime_events.py
+++ b/tests/test_realtime_events.py
@@ -1,0 +1,119 @@
+"""Wire schema for the live_events channel: hostname, truncation, size guard."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from geometrikks.domain.realtime.events import (
+    PAYLOAD_MAX,
+    REFERRER_MAX,
+    URL_MAX,
+    USER_AGENT_MAX,
+    encode_guard,
+    record_to_events,
+)
+from geometrikks.services.logparser.schemas import (
+    ParsedAccessLog,
+    ParsedGeoData,
+    ParsedLogRecord,
+)
+
+
+def _record(url: str = "/index", referrer: str | None = None, user_agent: str | None = None) -> ParsedLogRecord:
+    ts = datetime.now(timezone.utc)
+    return ParsedLogRecord(
+        ip_address="203.0.113.7",
+        geo_data=ParsedGeoData(
+            latitude=51.5, longitude=-0.1, geohash="gcpvj0", country_code="GB",
+            country_name="United Kingdom", timestamp=ts,
+        ),
+        access_log=ParsedAccessLog(
+            timestamp=ts, ip_address="203.0.113.7", remote_user=None, method="GET",
+            url=url, http_version="HTTP/2.0", status_code=200, bytes_sent=10,
+            referrer=referrer, user_agent=user_agent, request_time=0.1,
+            upstream_response_time=None, host="example.com",
+            country_code="GB", country_name="United Kingdom", city="London",
+        ),
+        raw_line="raw",
+        hostname="vps-1",
+    )
+
+
+def test_both_event_types_carry_hostname() -> None:
+    events = record_to_events(_record())
+    assert [e["type"] for e in events] == ["geo_event", "access_log"]
+    assert all(e["data"]["hostname"] == "vps-1" for e in events)
+
+
+def test_access_log_fields_truncated_at_caps() -> None:
+    events = record_to_events(
+        _record(url="u" * (URL_MAX + 500), referrer="r" * (REFERRER_MAX + 500),
+                user_agent="a" * (USER_AGENT_MAX + 500))
+    )
+    data = events[1]["data"]
+    assert len(data["url"]) == URL_MAX
+    assert len(data["referrer"]) == REFERRER_MAX
+    assert len(data["user_agent"]) == USER_AGENT_MAX
+
+
+def test_none_fields_survive_truncation() -> None:
+    data = record_to_events(_record(referrer=None, user_agent=None))[1]["data"]
+    assert data["referrer"] is None
+    assert data["user_agent"] is None
+
+
+def test_encode_guard_accepts_normal_event() -> None:
+    events = record_to_events(_record())
+    assert all(encode_guard(e) for e in events)
+
+
+def test_encode_guard_rejects_oversize_event() -> None:
+    oversize = {"type": "access_log", "data": {"url": "x" * (PAYLOAD_MAX + 1000)}}
+    assert encode_guard(oversize) is False
+
+
+TS = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+
+
+def _make_record_for_legacy_tests(with_geo: bool = True, with_log: bool = True) -> ParsedLogRecord:
+    """Helper for TestRecordToEvents; provides hostname required by new implementation."""
+    geo = ParsedGeoData(
+        latitude=51.5, longitude=-0.09, geohash="gcpvj", country_code="GB",
+        country_name="UK", timestamp=TS, city="London",
+    ) if with_geo else None
+    log = ParsedAccessLog(
+        timestamp=TS, ip_address="81.2.69.142", remote_user=None, method="GET",
+        url="/x", http_version="1.1", status_code=200, bytes_sent=123,
+        referrer=None, user_agent="curl", request_time=0.01,
+        upstream_response_time=None, host="example.com", country_code="GB",
+        country_name="UK", city="London",
+    ) if with_log else None
+    return ParsedLogRecord(
+        ip_address="81.2.69.142", geo_data=geo, access_log=log, raw_line="x",
+    )
+
+
+class TestRecordToEvents:
+    def test_full_record_yields_both_events(self):
+        events = record_to_events(_make_record_for_legacy_tests())
+        types = [e["type"] for e in events]
+        assert types == ["geo_event", "access_log"]
+        geo = events[0]["data"]
+        assert geo["latitude"] == 51.5 and geo["country_code"] == "GB"
+        log = events[1]["data"]
+        assert log["status_code"] == 200 and log["url"] == "/x"
+        # Wire format carries the full access-log field set.
+        assert set(log) == {
+            "timestamp", "ip_address", "remote_user", "method", "url",
+            "http_version", "status_code", "bytes_sent", "referrer",
+            "user_agent", "request_time", "upstream_response_time", "host",
+            "country_code", "country_name", "city", "hostname",
+        }
+        assert log["http_version"] == "1.1" and log["user_agent"] == "curl"
+        assert log["host"] == "example.com" and log["country_code"] == "GB"
+
+    def test_geo_only_record(self):
+        events = record_to_events(_make_record_for_legacy_tests(with_log=False))
+        assert [e["type"] for e in events] == ["geo_event"]
+
+    def test_malformed_record_yields_nothing(self):
+        assert record_to_events(_make_record_for_legacy_tests(with_geo=False, with_log=False)) == []

--- a/tests/test_realtime_events.py
+++ b/tests/test_realtime_events.py
@@ -75,7 +75,7 @@ TS = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
 
 
 def _make_record_for_legacy_tests(with_geo: bool = True, with_log: bool = True) -> ParsedLogRecord:
-    """Helper for TestRecordToEvents; provides hostname required by new implementation."""
+    """Helper for TestRecordToEvents; stamps a hostname so events carry a real value."""
     geo = ParsedGeoData(
         latitude=51.5, longitude=-0.09, geohash="gcpvj", country_code="GB",
         country_name="UK", timestamp=TS, city="London",
@@ -89,6 +89,7 @@ def _make_record_for_legacy_tests(with_geo: bool = True, with_log: bool = True) 
     ) if with_log else None
     return ParsedLogRecord(
         ip_address="81.2.69.142", geo_data=geo, access_log=log, raw_line="x",
+        hostname="legacy-host",
     )
 
 
@@ -110,6 +111,7 @@ class TestRecordToEvents:
         }
         assert log["http_version"] == "1.1" and log["user_agent"] == "curl"
         assert log["host"] == "example.com" and log["country_code"] == "GB"
+        assert geo["hostname"] == "legacy-host" and log["hostname"] == "legacy-host"
 
     def test_geo_only_record(self):
         events = record_to_events(_make_record_for_legacy_tests(with_log=False))


### PR DESCRIPTION
> **Stacked PR** on #131 (`feat/record-level-hostname`). Review only the 10 commits of this branch; retarget to `develop` once #131 merges.

## What

Phase 2 of multi-source ingestion: `/ws/live` moves from the in-process fan-out inside `LogIngestionService` to PostgreSQL LISTEN/NOTIFY via Litestar's `ChannelsPlugin`, so committed traffic from any writer process reaches the live map.

- New `domain/realtime/events.py` owns the live wire schema: events now carry the source `hostname`, attacker-controlled fields are truncated (url 2000 / referrer 1000 / user-agent 500 chars), and a 7500-byte guard drops any event that would exceed the 8000-byte NOTIFY cap (logged, never raised into ingestion).
- `DegradedTolerantAsyncPgBackend`: the channels backend degrades instead of crashing boot when the DB is unreachable (preserving DB-degraded mode), survives transient publish failures without killing the pub worker, and logs listener-connection loss; graceful shutdowns stay silent.
- Ingestion publishes committed events post-commit; the CLI importer deliberately publishes nothing (backfills no longer have a path to flood the live map cross-process).
- `/ws/live` subscribes via the plugin; the gate is now database availability (1013 otherwise). Frame shapes, heartbeat, and drop accounting are unchanged for clients. The old in-process subscriber machinery is deleted.
- Frontend `LiveEvent` type gains a required `hostname` (not rendered yet; the map UI lands in a later phase).

## Behavior notes

- Single-instance deployments are visibly unchanged, with one documented exception: in geo-degraded mode (GeoLite2 missing, DB up) the live socket now stays open with heartbeats instead of closing 1013.
- No new settings; no schema changes. Postgres connectivity is the only transport requirement.

## Testing

- Full suite 713 passed including new integration tests against TimescaleDB (AsyncPg publish/subscribe round trip; two writers, one subscriber receiving both hostnames); `ty check` clean; `bun run test` and `bun run typecheck` clean.
- New unit coverage: truncation and byte-guard (pathological probe URLs), degraded-backend startup/publish/stream behavior, pump-task failure isolation and drop-oldest path, publish-only-after-commit, graceful-shutdown listener silence.