### PR TITLE
feat: map source filter with hostname-dimensioned location CAGGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instance into a UI head with no local tailing. The live-feed backend now
   reuses a persistent publish connection and reconnects its listener
   automatically.
+- The map can filter by source hostname: a Sources control beside the
+  country/city filters, URL-backed filter state (shareable links), live
+  traffic and vitals restricted to the selected sources, and the source
+  hostname shown on live popups and feed rows.
+- Settings > Status shows generic operator advisories from the health
+  endpoint; the first is a warning when recorded hostnames look like Docker
+  container IDs, with the consolidation command to fix them.
 
 ### Changed
 
@@ -32,6 +39,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   LISTEN/NOTIFY, so committed traffic from any writer process reaches the
   map, and live events carry the source hostname. Batch imports no longer
   feed the live map.
+- The map layer choice and Live toggle now persist across visits.
+- The location aggregates are rebuilt once at startup with a per-hostname
+  dimension so source-filtered maps stay fast. History older than the raw
+  retention window (default 180 days) cannot be rebuilt and is discarded at
+  that upgrade; installs with many container-ID hostnames skip the rebuild
+  until consolidated (see the status page advisory).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dropped instead of wedging the channel worker (and eventually hanging
   shutdown). A dropped LISTEN connection now logs an error instead of
   silently going dead until restart.
+- The hostname-pollution health advisory no longer fires once the location
+  CAGGs already carry the hostname dimension (fresh install or
+  post-consolidation migration), where its "runs unaggregated" and
+  "restart to migrate" copy was false.
 
 ## [0.8.0] - 2026-08-16
 

--- a/geometrikks/domain/geo/controllers/locations.py
+++ b/geometrikks/domain/geo/controllers/locations.py
@@ -86,8 +86,10 @@ class GeoLocationController(Controller):
 
         Returns a GeoJSON FeatureCollection where each feature represents a
         location with its coordinates and properties including the event count.
-        Any IP/hostname filter forces a raw geo_events scan (the location
-        CAGGs carry no IP or hostname dimension), bounded by raw retention.
+        An IP filter always forces a raw geo_events scan, bounded by raw
+        retention. A hostname filter forces the raw scan only until the
+        location CAGGs carry the hostname dimension (pre-upgrade or
+        pollution-skipped installs); once they do, it reads the CAGGs.
         Args:
             from_datetime: Start datetime for filtering events.
             to_datetime: End datetime for filtering events.

--- a/geometrikks/domain/geo/repositories.py
+++ b/geometrikks/domain/geo/repositories.py
@@ -63,6 +63,25 @@ def get_stats_granularity(from_timestamp: datetime, to_timestamp: datetime) -> S
         return StatsGranularity.DAILY
 
 
+def resolve_locations_granularity(
+    from_timestamp: datetime,
+    to_timestamp: datetime,
+    *,
+    has_ip_filter: bool,
+    has_hostname_filter: bool,
+) -> StatsGranularity:
+    """Routing with filters: IP filters always force RAW; hostname filters
+    force RAW only until the location CAGGs carry the hostname dimension."""
+    from geometrikks.server import timescale
+
+    granularity = get_stats_granularity(from_timestamp, to_timestamp)
+    if has_ip_filter:
+        return StatsGranularity.RAW
+    if has_hostname_filter and not timescale.location_caggs_have_hostname():
+        return StatsGranularity.RAW
+    return granularity
+
+
 def use_local_days(
     granularity: StatsGranularity,
     start: datetime,
@@ -211,9 +230,12 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
         - > 24 hours, ≤ 30 days: location_hourly_stats CAGG
         - > 30 days: location_daily_stats CAGG
 
-        Any IP/hostname filter forces the RAW branch regardless of range:
-        the location CAGGs carry no IP or hostname dimension. Such queries
-        are bounded by raw retention (default 180d).
+        An IP filter always forces the RAW branch regardless of range: the
+        location CAGGs carry no IP dimension, and such queries are bounded
+        by raw retention (default 180d). A hostname filter forces RAW only
+        until the location CAGGs carry the hostname dimension (see
+        ``timescale.location_caggs_have_hostname``); once they do, hostname
+        filters read the CAGGs like any other range-only query.
 
         Args:
             from_timestamp: Start datetime for filtering events.
@@ -235,9 +257,12 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
         if not from_timestamp.tzinfo or not to_timestamp.tzinfo:
             raise ValueError("from_timestamp and to_timestamp must be timezone-aware")
 
-        granularity = get_stats_granularity(from_timestamp, to_timestamp)
-        if ip_addresses or ip_addresses_exclude or hostnames:
-            granularity = StatsGranularity.RAW
+        granularity = resolve_locations_granularity(
+            from_timestamp,
+            to_timestamp,
+            has_ip_filter=bool(ip_addresses or ip_addresses_exclude),
+            has_hostname_filter=bool(hostnames),
+        )
 
         logger.debug(
             "get_all_with_event_counts: using %s for range %s to %s",
@@ -254,17 +279,23 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
         if cities:
             filters_sql += " AND gl.city = ANY(:cities)"
             params["cities"] = cities
-        # ge-aliased conditions are safe here: any of these filters forced the
-        # RAW branch above, and only that branch joins geo_events as ge.
+        # ge-aliased IP conditions are safe here: an IP filter always forces
+        # the RAW branch above, and only that branch joins geo_events as ge.
         if ip_addresses:
             filters_sql += " AND ge.ip_address = ANY(CAST(:filter_ips AS inet[]))"
             params["filter_ips"] = list(ip_addresses)
         if ip_addresses_exclude:
             filters_sql += " AND NOT (ge.ip_address = ANY(CAST(:filter_ips_excl AS inet[])))"
             params["filter_ips_excl"] = list(ip_addresses_exclude)
+
+        # Hostname is aliased per branch: ge in RAW, ls in the CAGGs (only
+        # reachable there once the hostname dimension exists).
+        hostname_sql = ""
+        cagg_hostname_sql = ""
         if hostnames:
-            filters_sql += " AND ge.hostname = ANY(:filter_hostnames)"
             params["filter_hostnames"] = list(hostnames)
+            hostname_sql = " AND ge.hostname = ANY(:filter_hostnames)"
+            cagg_hostname_sql = " AND ls.hostname = ANY(:filter_hostnames)"
 
         if granularity == StatsGranularity.RAW:
             # Query raw geo_events table for exact time range granularity
@@ -274,7 +305,7 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
                     CAST(COUNT(ge.id) AS INTEGER) AS event_count
                 FROM geo_locations gl
                 JOIN geo_events ge ON ge.location_id = gl.id
-                WHERE ge.timestamp >= :from_ts AND ge.timestamp < :to_ts{filters_sql}
+                WHERE ge.timestamp >= :from_ts AND ge.timestamp < :to_ts{filters_sql}{hostname_sql}
                 GROUP BY gl.id
                 ORDER BY event_count DESC, gl.id
             """)
@@ -292,7 +323,7 @@ class GeoLocationRepository(SQLAlchemyAsyncRepository[GeoLocation]):
                 FROM geo_locations gl
                 JOIN {table} ls ON ls.location_id = gl.id
                 WHERE ls.bucket >= time_bucket('{bucket_interval}', CAST(:from_ts AS timestamptz))
-                  AND ls.bucket < :to_ts{filters_sql}
+                  AND ls.bucket < :to_ts{filters_sql}{cagg_hostname_sql}
                 GROUP BY gl.id
                 ORDER BY event_count DESC, gl.id
             """)

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -78,7 +78,7 @@ class HealthResponse(msgspec.Struct, rename="camel"):
     schema_wait: str | None = None
     # Additive: generic operator advisories; empty when nothing needs
     # attention. Producers append here rather than growing bespoke fields.
-    advisories: list[Advisory] = []
+    advisories: list[Advisory] = msgspec.field(default_factory=list)
 
 
 class ReadinessResponse(msgspec.Struct, rename="camel"):

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -53,6 +53,17 @@ class CrowdSecHealth(msgspec.Struct, rename="camel"):
     lapi_reachable: bool | None
 
 
+class Advisory(msgspec.Struct, rename="camel"):
+    """One operator-actionable warning; the status page renders a card per
+    advisory, so producers must write user-facing text, not log lines."""
+
+    id: str
+    severity: Literal["warning", "critical"]
+    summary: str
+    detail: str | None = None
+    remedy: str | None = None
+
+
 class HealthResponse(msgspec.Struct, rename="camel"):
     status: Literal["healthy", "degraded"]
     started_at: str | None
@@ -65,6 +76,9 @@ class HealthResponse(msgspec.Struct, rename="camel"):
     # mode, since only agent startup ever sets app.state.schema_wait_result.
     mode: Literal["full", "agent"] = "full"
     schema_wait: str | None = None
+    # Additive: generic operator advisories; empty when nothing needs
+    # attention. Producers append here rather than growing bespoke fields.
+    advisories: list[Advisory] = []
 
 
 class ReadinessResponse(msgspec.Struct, rename="camel"):
@@ -86,6 +100,31 @@ async def _database_reachable(app: Litestar, timeout: float = 2.0) -> bool:
         return True
     except Exception:
         return False
+
+
+def _collect_advisories() -> list[Advisory]:
+    from geometrikks.server import timescale
+
+    advisories: list[Advisory] = []
+    pollution = timescale.get_hostname_pollution()
+    if pollution and pollution.polluted:
+        advisories.append(Advisory(
+            id="hostname-pollution",
+            severity="warning",
+            summary=(
+                f"{pollution.container_id_count} of {pollution.distinct_count} "
+                "recording hostnames look like Docker container IDs; the map "
+                "source filter runs unaggregated until you consolidate."
+            ),
+            detail=(
+                "LOGPARSER_HOST_NAME was unset while running in Docker, so "
+                "rotating container IDs were recorded as hostnames. The "
+                "location-CAGG upgrade is skipped until the history is "
+                "consolidated; restart afterwards to migrate."
+            ),
+            remedy="litestar backfill-hostname <hostname> --consolidate",
+        ))
+    return advisories
 
 
 @get(
@@ -163,6 +202,7 @@ async def health(
             if settings.is_agent
             else None
         ),
+        advisories=_collect_advisories(),
     )
 
 

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -107,7 +107,7 @@ def _collect_advisories() -> list[Advisory]:
 
     advisories: list[Advisory] = []
     pollution = timescale.get_hostname_pollution()
-    if pollution and pollution.polluted:
+    if pollution and pollution.polluted and not timescale.location_caggs_have_hostname():
         advisories.append(Advisory(
             id="hostname-pollution",
             severity="warning",

--- a/geometrikks/server/timescale.py
+++ b/geometrikks/server/timescale.py
@@ -21,6 +21,8 @@ CAGG Structure:
 from __future__ import annotations
 
 import asyncio
+import re
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
@@ -34,6 +36,67 @@ if TYPE_CHECKING:
     from geometrikks.config.settings import AnalyticsSettings
 
 logger = get_logger(__name__)
+
+
+# =============================================================================
+# Hostname Pollution Detection
+# =============================================================================
+
+# Docker stamps the short container ID as hostname when LOGPARSER_HOST_NAME
+# is unset; 12 lowercase hex chars is that exact shape.
+CONTAINER_ID_RE = re.compile(r"^[0-9a-f]{12}$")
+CONTAINER_ID_THRESHOLD = 10
+DISTINCT_HOSTNAME_CEILING = 50
+# +1: fetching one past the ceiling proves it was exceeded without an
+# unbounded DISTINCT over the hypertable.
+_POLLUTION_PROBE_LIMIT = DISTINCT_HOSTNAME_CEILING + 1
+
+
+@dataclass(frozen=True)
+class HostnamePollution:
+    distinct_count: int
+    container_id_count: int
+
+    @property
+    def polluted(self) -> bool:
+        return (
+            self.container_id_count >= CONTAINER_ID_THRESHOLD
+            or self.distinct_count > DISTINCT_HOSTNAME_CEILING
+        )
+
+
+def classify_hostnames(hostnames: list[str]) -> HostnamePollution:
+    """Pure classification so the heuristics are unit-testable without a DB."""
+    return HostnamePollution(
+        distinct_count=len(hostnames),
+        container_id_count=sum(1 for h in hostnames if CONTAINER_ID_RE.match(h)),
+    )
+
+
+async def detect_hostname_pollution(conn: "AsyncConnection") -> HostnamePollution:
+    """Bounded distinct-hostname probe against geo_events.
+
+    GROUP BY + LIMIT streams groups off ix_geo_events_hostname and stops at
+    the cap, so this stays cheap on large hypertables and does not depend on
+    facet-CAGG freshness.
+    """
+    result = await conn.execute(text(
+        "SELECT hostname FROM geo_events GROUP BY hostname ORDER BY hostname LIMIT :cap"
+    ), {"cap": _POLLUTION_PROBE_LIMIT})
+    return classify_hostnames([row.hostname for row in result])
+
+
+_hostname_pollution: HostnamePollution | None = None
+
+
+def get_hostname_pollution() -> HostnamePollution | None:
+    """Result of the startup probe; None before setup_timescaledb ran."""
+    return _hostname_pollution
+
+
+def _set_hostname_pollution(value: HostnamePollution | None) -> None:
+    global _hostname_pollution
+    _hostname_pollution = value
 
 
 # =============================================================================

--- a/geometrikks/server/timescale.py
+++ b/geometrikks/server/timescale.py
@@ -258,9 +258,10 @@ async def _create_location_caggs(conn: "AsyncConnection") -> None:
         SELECT
             time_bucket('1 hour', timestamp) AS bucket,
             location_id,
+            hostname,
             COUNT(*) AS event_count
         FROM geo_events
-        GROUP BY bucket, location_id
+        GROUP BY bucket, location_id, hostname
         WITH NO DATA
     """))
     logger.info("CAGG created/verified: location_hourly_stats")
@@ -271,9 +272,10 @@ async def _create_location_caggs(conn: "AsyncConnection") -> None:
         SELECT
             time_bucket('1 day', timestamp) AS bucket,
             location_id,
+            hostname,
             COUNT(*) AS event_count
         FROM geo_events
-        GROUP BY bucket, location_id
+        GROUP BY bucket, location_id, hostname
         WITH NO DATA
     """))
     logger.info("CAGG created/verified: location_daily_stats")
@@ -288,6 +290,18 @@ async def _create_location_caggs(conn: "AsyncConnection") -> None:
             CREATE INDEX IF NOT EXISTS ix_location_{suffix}_location
             ON location_{suffix}_stats (location_id)
         """))
+        # Pollution-gated skip leaves the pre-hostname view in place: probe
+        # before creating, since a CREATE INDEX on a missing column would
+        # abort the whole setup transaction (not just this statement).
+        has_hostname = (await conn.execute(text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = :table AND column_name = 'hostname' LIMIT 1"
+        ), {"table": f"location_{suffix}_stats"})).scalar()
+        if has_hostname:
+            await conn.execute(text(f"""
+                CREATE INDEX IF NOT EXISTS ix_location_{suffix}_hostname
+                ON location_{suffix}_stats (hostname, bucket DESC)
+            """))
 
 
 async def _create_ip_location_cagg(conn: "AsyncConnection") -> None:
@@ -761,6 +775,36 @@ async def _upgrade_summary_caggs(conn: "AsyncConnection") -> None:
         )
 
 
+LOCATION_CAGGS = ["location_hourly_stats", "location_daily_stats"]
+
+_location_caggs_have_hostname: bool = False
+
+
+def location_caggs_have_hostname() -> bool:
+    """Startup-cached CAGG capability; False means hostname filters go raw."""
+    return _location_caggs_have_hostname
+
+
+def _set_location_caggs_have_hostname(value: bool) -> None:
+    global _location_caggs_have_hostname
+    _location_caggs_have_hostname = value
+
+
+async def _location_caggs_need_upgrade(conn: "AsyncConnection") -> bool:
+    """True when a location CAGG exists in the pre-hostname shape."""
+    has_hostname = (await conn.execute(text("""
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = ANY(:views) AND column_name = 'hostname' LIMIT 1
+    """), {"views": LOCATION_CAGGS})).scalar()
+    if has_hostname:
+        return False
+    exists = (await conn.execute(text("""
+        SELECT 1 FROM information_schema.views
+        WHERE table_name = ANY(:views) LIMIT 1
+    """), {"views": LOCATION_CAGGS})).scalar()
+    return bool(exists)
+
+
 async def setup_timescaledb(
     engine: "AsyncEngine",
     analytics: "AnalyticsSettings",
@@ -785,6 +829,32 @@ async def setup_timescaledb(
         if upgraded:
             await _upgrade_summary_caggs(conn)
 
+        # Upgrade pre-hostname location CAGGs, gated on hostname pollution:
+        # migrating polluted (container-ID) hostnames would make the map's
+        # per-source filter useless, so the old shape is kept until the
+        # deployment consolidates hostnames and restarts.
+        location_upgrade = await _location_caggs_need_upgrade(conn)
+        pollution = await detect_hostname_pollution(conn)
+        _set_hostname_pollution(pollution)
+        if location_upgrade and pollution.polluted:
+            logger.warning(
+                "Skipping the location-CAGG hostname upgrade: %d of %d distinct "
+                "hostnames look like Docker container IDs. Map source filtering "
+                "stays on raw scans. Run `litestar backfill-hostname NAME "
+                "--consolidate`, then restart to migrate.",
+                pollution.container_id_count,
+                pollution.distinct_count,
+            )
+            location_upgrade = False
+        elif location_upgrade:
+            for cagg in LOCATION_CAGGS:
+                await conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {cagg} CASCADE"))
+            logger.warning(
+                "Recreating location CAGGs with a hostname dimension; history "
+                "older than the raw retention window cannot be rebuilt and is "
+                "discarded."
+            )
+
         # Create continuous aggregates
         await _create_summary_caggs(conn)
         await _create_geo_summary_caggs(conn)
@@ -794,6 +864,10 @@ async def setup_timescaledb(
         await _create_url_caggs(conn)
         await _create_user_agent_caggs(conn)
         await _create_host_facet_caggs(conn)
+
+        _set_location_caggs_have_hostname(
+            not await _location_caggs_need_upgrade(conn)
+        )
 
         # Enable real-time aggregation (merges materialized + live data)
         await _enable_realtime_aggregation(conn)
@@ -817,6 +891,14 @@ async def setup_timescaledb(
             start=datetime.now(timezone.utc) - timedelta(days=analytics.raw_retention_days),
             end=datetime.now(timezone.utc),
             caggs=SUMMARY_CAGGS,
+        )
+
+    if location_upgrade:
+        await refresh_caggs_range(
+            engine,
+            start=datetime.now(timezone.utc) - timedelta(days=analytics.raw_retention_days),
+            end=datetime.now(timezone.utc),
+            caggs=LOCATION_CAGGS,
         )
 
     # Repair deployments whose data predates CAGG refresh coverage

--- a/resources/components/map/GeoMap.tsx
+++ b/resources/components/map/GeoMap.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useNavigate, useSearch } from "@tanstack/react-router"
 import Map, {
   Source,
   Layer,
@@ -41,6 +42,8 @@ import { LiveFeedSheet } from "./LiveFeedSheet"
 import { Card, CardContent } from "@/components/ui/card"
 import { AlertTriangle } from "lucide-react"
 import { getDemoTrafficMode } from "@/lib/demo-traffic"
+import { decodeMapSearch, encodeMapSearch } from "@/lib/map-filters"
+import { useUrlFilters } from "@/hooks/use-url-filters"
 import { loadLiveOverlays, saveLiveOverlays, type LiveOverlayPreferences } from "@/lib/live-overlays"
 import { LiveTrafficProvider, useLiveTrafficStore } from "@/lib/live-traffic/context"
 import type { LiveRequest } from "@/lib/live-traffic/types"
@@ -99,11 +102,33 @@ function GeoMapInner({
   const mapRef = useRef<MapRef>(null)
   const { mapStyle } = useMapStyle()
   const isMobile = useIsMobile()
-  const [selectedCountries, setSelectedCountries] = useState<string[]>([])
-  const [selectedCities, setSelectedCities] = useState<string[]>([])
+  const search = useSearch({ from: "/map" })
+  const navigate = useNavigate({ from: "/map" })
+  const { filters, setFilters } = useUrlFilters({
+    search,
+    navigate,
+    decode: decodeMapSearch,
+    encode: encodeMapSearch,
+  })
+  const selectedSources = filters.sources
+  const selectedCountries = filters.countryCodes
+  const selectedCities = filters.cities
+  const onSourcesChange = useCallback(
+    (values: string[]) => setFilters((prev) => ({ ...prev, sources: values })),
+    [setFilters],
+  )
+  const onCountriesChange = useCallback(
+    (values: string[]) => setFilters((prev) => ({ ...prev, countryCodes: values })),
+    [setFilters],
+  )
+  const onCitiesChange = useCallback(
+    (values: string[]) => setFilters((prev) => ({ ...prev, cities: values })),
+    [setFilters],
+  )
   const { data: geojson, isLoading: isLoadingGeoJSON, isError, error } = useGeoJSON({
     countryCodes: selectedCountries,
     cities: selectedCities,
+    hostnames: selectedSources,
   })
   const { data: globalTopIPs, isLoading: isLoadingTopIPs } = useGlobalTopIPs()
   const { data: runtimeSettings } = useRuntimeSettings()
@@ -202,7 +227,12 @@ function GeoMapInner({
     countryLabels: {},
   })
   const filterOptions = useMemo(() => {
-    if (geojson && selectedCountries.length === 0 && selectedCities.length === 0) {
+    if (
+      geojson &&
+      selectedCountries.length === 0 &&
+      selectedCities.length === 0 &&
+      selectedSources.length === 0
+    ) {
       const countryLabels: Record<string, string> = {}
       const cities = new Set<string>()
       for (const f of geojson.features) {
@@ -226,7 +256,7 @@ function GeoMapInner({
       }
     }
     return optionsRef.current
-  }, [geojson, selectedCountries, selectedCities])
+  }, [geojson, selectedCountries, selectedCities, selectedSources])
 
   // Handle view state changes
   const onMove = useCallback((evt: ViewStateChangeEvent) => {
@@ -571,8 +601,10 @@ function GeoMapInner({
         cityOptions={filterOptions.cities}
         selectedCountries={selectedCountries}
         selectedCities={selectedCities}
-        onCountriesChange={setSelectedCountries}
-        onCitiesChange={setSelectedCities}
+        onCountriesChange={onCountriesChange}
+        onCitiesChange={onCitiesChange}
+        selectedSources={selectedSources}
+        onSourcesChange={onSourcesChange}
       />
 
     </div>

--- a/resources/components/map/GeoMap.tsx
+++ b/resources/components/map/GeoMap.tsx
@@ -46,6 +46,12 @@ import { getDemoTrafficMode } from "@/lib/demo-traffic"
 import { decodeMapSearch, encodeMapSearch } from "@/lib/map-filters"
 import { useUrlFilters } from "@/hooks/use-url-filters"
 import { loadLiveOverlays, saveLiveOverlays, type LiveOverlayPreferences } from "@/lib/live-overlays"
+import {
+  loadLayerPreference,
+  loadLivePreference,
+  saveLayerPreference,
+  saveLivePreference,
+} from "@/lib/map-preferences"
 import { LiveTrafficProvider, useLiveTrafficStore } from "@/lib/live-traffic/context"
 import type { LiveRequest } from "@/lib/live-traffic/types"
 import { useIsMobile } from "@/hooks/use-mobile"
@@ -146,7 +152,7 @@ function GeoMapInner({
   const isLoading = isLoadingGeoJSON || isLoadingTopIPs
 
   const [viewState, setViewState] = useState(INITIAL_VIEW_STATE)
-  const [activeLayer, setActiveLayer] = useState<LayerType>("markers")
+  const [activeLayer, setActiveLayer] = useState<LayerType>(loadLayerPreference)
   const [projection, setProjection] = useState<MapProjection>(loadMapProjectionPreference)
   const [routeEffectsEnabled, setRouteEffectsEnabled] = useState(loadRouteEffectsPreference)
   const [homeMarkerEnabled, setHomeMarkerEnabled] = useState(loadHomeMarkerPreference)
@@ -206,6 +212,10 @@ function GeoMapInner({
   useEffect(() => {
     saveLiveOverlays(liveOverlays)
   }, [liveOverlays])
+
+  useEffect(() => {
+    saveLayerPreference(activeLayer)
+  }, [activeLayer])
 
   // Live off tears down the store; any live-only UI referencing it must go
   // too, or a popup stays pinned to the map after the request it describes
@@ -619,7 +629,13 @@ function GeoMapInner({
 export default function GeoMap() {
   const search = useSearch({ from: "/map" })
   const sources = search.sources ?? []
-  const [liveMode, setLiveMode] = useState(getDemoTrafficMode() !== "off")
+  const [liveMode, setLiveModeState] = useState(
+    () => (getDemoTrafficMode() !== "off" ? true : loadLivePreference()),
+  )
+  const setLiveMode = (enabled: boolean) => {
+    setLiveModeState(enabled)
+    saveLivePreference(enabled)
+  }
 
   return (
     <LiveTrafficProvider enabled={liveMode} sources={sources}>

--- a/resources/components/map/GeoMap.tsx
+++ b/resources/components/map/GeoMap.tsx
@@ -21,6 +21,7 @@ import {
   useRuntimeSettings,
   useBannedLocations,
   useCrowdsecStatus,
+  useGeoEventFacets,
 } from "@/lib/queries"
 import { useMapStyle } from "./hooks/useMapStyle"
 import {
@@ -130,6 +131,8 @@ function GeoMapInner({
     cities: selectedCities,
     hostnames: selectedSources,
   })
+  const { data: facets, isLoading: facetsLoading } = useGeoEventFacets()
+  const sourceOptions = facets?.hostnames ?? []
   const { data: globalTopIPs, isLoading: isLoadingTopIPs } = useGlobalTopIPs()
   const { data: runtimeSettings } = useRuntimeSettings()
   const homeDestination = useMemo<[number, number] | null>(() => {
@@ -603,8 +606,10 @@ function GeoMapInner({
         selectedCities={selectedCities}
         onCountriesChange={onCountriesChange}
         onCitiesChange={onCitiesChange}
+        sourceOptions={sourceOptions}
         selectedSources={selectedSources}
         onSourcesChange={onSourcesChange}
+        sourcesLoading={facetsLoading}
       />
 
     </div>

--- a/resources/components/map/GeoMap.tsx
+++ b/resources/components/map/GeoMap.tsx
@@ -230,46 +230,25 @@ function GeoMapInner({
   // Filter options come from the last UNFILTERED result (a second query just
   // for options would be wasteful), held in a ref so the option lists don't
   // shrink to the filtered subset while a filter is active.
-  const optionsRef = useRef<{
-    countries: string[]
-    cities: string[]
-    countryLabels: Record<string, string>
-  }>({
-    countries: [],
-    cities: [],
-    countryLabels: {},
-  })
+  // Options come from the facets endpoint, not the geojson payload: with
+  // URL-restored filters the first geojson response is already filtered, so
+  // deriving options from it would leave the comboboxes empty after reload.
   const filterOptions = useMemo(() => {
-    if (
-      geojson &&
-      selectedCountries.length === 0 &&
-      selectedCities.length === 0 &&
-      selectedSources.length === 0
-    ) {
-      const countryLabels: Record<string, string> = {}
-      const cities = new Set<string>()
-      for (const f of geojson.features) {
-        const code = f.properties.countryCode
-        if (code) {
-          // Display "<name> (<code>)" but keep the code as the option value,
-          // since the value feeds useGeoJSON({ countryCodes }).
-          countryLabels[code] = f.properties.countryName
-            ? `${f.properties.countryName} (${code})`
-            : code
-        }
-        if (f.properties.city) cities.add(f.properties.city)
-      }
-      optionsRef.current = {
-        // Sort country codes by their display label.
-        countries: Object.keys(countryLabels).sort((a, b) =>
-          countryLabels[a].localeCompare(countryLabels[b]),
-        ),
-        cities: [...cities].sort(),
-        countryLabels,
-      }
+    const countryLabels: Record<string, string> = {}
+    for (const c of facets?.countries ?? []) {
+      // Display "<name> (<code>)" but keep the code as the option value,
+      // since the value feeds useGeoJSON({ countryCodes }).
+      countryLabels[c.code] = c.name ? `${c.name} (${c.code})` : c.code
     }
-    return optionsRef.current
-  }, [geojson, selectedCountries, selectedCities, selectedSources])
+    return {
+      // Sort country codes by their display label.
+      countries: Object.keys(countryLabels).sort((a, b) =>
+        countryLabels[a].localeCompare(countryLabels[b]),
+      ),
+      cities: [...(facets?.cities ?? [])].sort(),
+      countryLabels,
+    }
+  }, [facets])
 
   // Handle view state changes
   const onMove = useCallback((evt: ViewStateChangeEvent) => {

--- a/resources/components/map/GeoMap.tsx
+++ b/resources/components/map/GeoMap.tsx
@@ -617,10 +617,12 @@ function GeoMapInner({
 }
 
 export default function GeoMap() {
+  const search = useSearch({ from: "/map" })
+  const sources = search.sources ?? []
   const [liveMode, setLiveMode] = useState(getDemoTrafficMode() !== "off")
 
   return (
-    <LiveTrafficProvider enabled={liveMode}>
+    <LiveTrafficProvider enabled={liveMode} sources={sources}>
       <GeoMapInner liveMode={liveMode} onLiveModeChange={setLiveMode} />
     </LiveTrafficProvider>
   )

--- a/resources/components/map/LiveFeedList.tsx
+++ b/resources/components/map/LiveFeedList.tsx
@@ -123,6 +123,7 @@ export function LiveFeedList({
                   )}
                 >
                   {[request.city, request.countryCode].filter(Boolean).join(", ") || request.ip}
+                  {request.hostname ? ` · ${request.hostname}` : ""}
                 </span>
               </button>
             )

--- a/resources/components/map/LiveRequestPopup.tsx
+++ b/resources/components/map/LiveRequestPopup.tsx
@@ -91,6 +91,7 @@ function LiveRequestDetail({
       </div>
 
       <Row label="IP" value={request.ip} />
+      {request.hostname && <Row label="Source" value={request.hostname} />}
       <Row label="Location" value={[request.city, request.countryCode].filter(Boolean).join(", ") || "Unknown"} />
       {!request.coordinates && <Row label="Geo" value="No GeoIP match" />}
       {log && <Row label="Host" value={log.host ?? "-"} />}

--- a/resources/components/map/MapControls.tsx
+++ b/resources/components/map/MapControls.tsx
@@ -79,9 +79,10 @@ interface MapControlsProps {
   selectedCities: string[]
   onCountriesChange: (values: string[]) => void
   onCitiesChange: (values: string[]) => void
-  /** Source hostname filter; wired through for the Sources combobox. */
-  selectedSources?: string[]
-  onSourcesChange?: (values: string[]) => void
+  sourceOptions: string[]
+  selectedSources: string[]
+  onSourcesChange: (values: string[]) => void
+  sourcesLoading?: boolean
 }
 
 export function MapControls({
@@ -117,6 +118,10 @@ export function MapControls({
   selectedCities,
   onCountriesChange,
   onCitiesChange,
+  sourceOptions,
+  selectedSources,
+  onSourcesChange,
+  sourcesLoading = false,
 }: MapControlsProps) {
   const { events, countries, cities, locations } = featureStats
   const [isExpanded, setIsExpanded] = useState(true)
@@ -340,6 +345,17 @@ export function MapControls({
           onChange={onCitiesChange}
           forceInline={isMobile}
         />
+        {(sourceOptions.length >= 2 || selectedSources.length > 0) && (
+          <FilterCombobox
+            label="Source"
+            options={sourceOptions}
+            selected={selectedSources}
+            onChange={onSourcesChange}
+            loading={sourcesLoading}
+            emptyText="No sources recorded"
+            forceInline={isMobile}
+          />
+        )}
       </Card>
 
       {/* Fit Bounds / Go Home Buttons */}

--- a/resources/components/map/MapControls.tsx
+++ b/resources/components/map/MapControls.tsx
@@ -79,6 +79,9 @@ interface MapControlsProps {
   selectedCities: string[]
   onCountriesChange: (values: string[]) => void
   onCitiesChange: (values: string[]) => void
+  /** Source hostname filter; wired through for the Sources combobox. */
+  selectedSources?: string[]
+  onSourcesChange?: (values: string[]) => void
 }
 
 export function MapControls({

--- a/resources/components/settings/status-logic.test.ts
+++ b/resources/components/settings/status-logic.test.ts
@@ -9,6 +9,7 @@ import type {
 import type { LogRecord } from "@/lib/logstream"
 import {
   accessLogFiles,
+  advisoryCards,
   authState,
   compressionSummary,
   crowdsecState,
@@ -362,5 +363,24 @@ describe("authState", () => {
       "Built-in authentication is turned off (APP_AUTH_DISABLED=true). Anyone who can reach this app has full access.",
     )
     expect(state.detail).not.toMatch(/proxy/i)
+  })
+})
+
+describe("advisoryCards", () => {
+  it("is empty when health is missing or clean", () => {
+    expect(advisoryCards(undefined)).toEqual([])
+    expect(advisoryCards(makeHealth())).toEqual([])
+  })
+  it("maps severities to tones", () => {
+    const health = makeHealth({
+      advisories: [
+        { id: "hostname-pollution", severity: "warning", summary: "s", remedy: "cmd" },
+        { id: "other", severity: "critical", summary: "c" },
+      ],
+    })
+    const cards = advisoryCards(health)
+    expect(cards).toHaveLength(2)
+    expect(cards[0]).toMatchObject({ tone: "amber", label: "s", remedy: "cmd" })
+    expect(cards[1]).toMatchObject({ tone: "red", label: "c" })
   })
 })

--- a/resources/components/settings/status-logic.ts
+++ b/resources/components/settings/status-logic.ts
@@ -17,6 +17,14 @@ export interface CardState {
   detail?: string
 }
 
+export interface AdvisoryCard {
+  id: string
+  tone: LedTone
+  label: string
+  detail?: string
+  remedy?: string
+}
+
 export function overallState(health: HealthResponse | undefined, isError: boolean): CardState {
   if (isError) {
     return { tone: "red", label: "Unreachable", detail: "The API did not answer the health probe." }
@@ -25,6 +33,17 @@ export function overallState(health: HealthResponse | undefined, isError: boolea
   return health.status === "healthy"
     ? { tone: "emerald", label: "Healthy", detail: "All components operational." }
     : { tone: "amber", label: "Degraded", detail: "One or more components are not operational." }
+}
+
+/** Generic operator advisories from health; one status-page card each. */
+export function advisoryCards(health: HealthResponse | undefined): AdvisoryCard[] {
+  return (health?.advisories ?? []).map((a) => ({
+    id: a.id,
+    tone: a.severity === "critical" ? "red" : "amber",
+    label: a.summary,
+    detail: a.detail ?? undefined,
+    remedy: a.remedy ?? undefined,
+  }))
 }
 
 export function ingestionState(health: HealthResponse | undefined, isError: boolean): CardState {

--- a/resources/components/settings/status-overview.tsx
+++ b/resources/components/settings/status-overview.tsx
@@ -21,12 +21,14 @@ import {
   useStats,
 } from "@/lib/queries"
 import { useLiveEvents, useLiveFeedStatus } from "@/lib/live-feed-context"
+import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { MonoChip, StatusLed } from "@/components/settings/status-led"
 import {
   accessLogFiles,
+  advisoryCards,
   authState,
   type CardState,
   compressionSummary,
@@ -117,6 +119,21 @@ export function StatusOverview() {
 
   return (
     <div className="space-y-4">
+      {advisoryCards(health).map((card) => (
+        <Card key={card.id} className={cn("border-l-2", card.tone === "red" ? "border-l-red-500" : "border-l-amber-500")}>
+          <CardContent className="space-y-1 pt-4">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              <StatusLed tone={card.tone} />
+              {card.label}
+            </div>
+            {card.detail && <p className="text-xs text-muted-foreground">{card.detail}</p>}
+            {card.remedy && (
+              <code className="block w-fit rounded bg-muted px-2 py-1 text-xs">{card.remedy}</code>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+
       {/* Overall state and Authentication share the banner row: the subsystem
           grid below holds an even number of cards, so putting Authentication
           there instead would leave a hole in its last row. */}

--- a/resources/generated/api/index.ts
+++ b/resources/generated/api/index.ts
@@ -62,6 +62,7 @@ export type {
   AccessLogDebugEntry,
   AccessLogDebugStats,
   AccessLogFacets,
+  Advisory,
   AlertView,
   AnalyticsSettingsView,
   ApiV1AccessLogDebugListAccessLogDebugData,

--- a/resources/generated/api/schemas.gen.ts
+++ b/resources/generated/api/schemas.gen.ts
@@ -289,6 +289,44 @@ export const AccessLogFacetsSchema = {
   type: "object",
 } as const;
 
+export const AdvisorySchema = {
+  properties: {
+    detail: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    id: {
+      type: "string",
+    },
+    remedy: {
+      oneOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
+    },
+    severity: {
+      enum: ["warning", "critical"],
+      type: "string",
+    },
+    summary: {
+      type: "string",
+    },
+  },
+  required: ["id", "severity", "summary"],
+  title: "Advisory",
+  type: "object",
+} as const;
+
 export const AlertViewSchema = {
   properties: {
     asName: {
@@ -1397,6 +1435,12 @@ export const GlobalTopIPsResponseSchema = {
 
 export const HealthResponseSchema = {
   properties: {
+    advisories: {
+      items: {
+        $ref: "#/components/schemas/Advisory",
+      },
+      type: "array",
+    },
     crowdsec: {
       $ref: "#/components/schemas/CrowdSecHealth",
     },

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -78,6 +78,17 @@ export type AccessLogFacets = {
 };
 
 /**
+ * Advisory
+ */
+export type Advisory = {
+  detail?: string | null;
+  id: string;
+  remedy?: string | null;
+  severity: "warning" | "critical";
+  summary: string;
+};
+
+/**
  * AlertView
  */
 export type AlertView = {
@@ -422,6 +433,7 @@ export type GlobalTopIpsResponse = {
  * HealthResponse
  */
 export type HealthResponse = {
+  advisories?: Array<Advisory>;
   crowdsec: CrowdSecHealth;
   database: DatabaseHealth;
   geoip: GeoIpHealth;

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -307,6 +307,50 @@
         "title": "AccessLogFacets",
         "type": "object"
       },
+      "Advisory": {
+        "properties": {
+          "detail": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "remedy": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "severity": {
+            "enum": [
+              "warning",
+              "critical"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "severity",
+          "summary"
+        ],
+        "title": "Advisory",
+        "type": "object"
+      },
       "AlertView": {
         "properties": {
           "asName": {
@@ -1469,6 +1513,12 @@
       },
       "HealthResponse": {
         "properties": {
+          "advisories": {
+            "items": {
+              "$ref": "#/components/schemas/Advisory"
+            },
+            "type": "array"
+          },
           "crowdsec": {
             "$ref": "#/components/schemas/CrowdSecHealth"
           },

--- a/resources/lib/api.ts
+++ b/resources/lib/api.ts
@@ -411,7 +411,9 @@ export interface GeoJSONParams {
   ips?: string[]
   /** Exact IPs to exclude; forces a raw geo_events scan on the backend. */
   ipsExclude?: string[]
-  /** Recording hostnames; forces a raw geo_events scan on the backend. */
+  /** Recording hostnames; reads the hostname-dimensioned location CAGGs,
+   * falling back to a raw geo_events scan on installs that have not
+   * migrated. */
   hostnames?: string[]
 }
 

--- a/resources/lib/api.ts
+++ b/resources/lib/api.ts
@@ -109,6 +109,15 @@ export interface HealthIngestionStatus {
   status?: "running" | "degraded" | "disabled"
 }
 
+export interface Advisory {
+  /** Stable slug, e.g. "hostname-pollution". */
+  id: string
+  severity: "warning" | "critical"
+  summary: string
+  detail?: string | null
+  remedy?: string | null
+}
+
 export interface HealthResponse {
   status: "healthy" | "degraded"
   /** App start time; null in test harnesses without lifecycle startup. */
@@ -119,6 +128,8 @@ export interface HealthResponse {
   geoip: { available: boolean; dbBuildDate: string | null }
   crowdsec: { enabled: boolean; lapiReachable: boolean | null }
   timestamp: string
+  /** Operator-actionable warnings; empty when nothing needs attention. */
+  advisories?: Advisory[]
 }
 
 export type RuntimeSettings = SafeSettingsResponse

--- a/resources/lib/demo-traffic.ts
+++ b/resources/lib/demo-traffic.ts
@@ -97,6 +97,7 @@ export function makeDemoRequests(cursor: number, count: number, now: number): Li
       coordinates: origin.coordinates,
       city: origin.city,
       countryCode: origin.countryCode,
+      hostname: "demo",
       statusClass: status,
       banned,
       threat: isThreat(code, banned),

--- a/resources/lib/live-traffic/context.tsx
+++ b/resources/lib/live-traffic/context.tsx
@@ -10,7 +10,7 @@ import { createContext, useContext, useEffect, useMemo, useRef, useState } from 
 import { useLiveEvents, useLiveFeedStatus } from "@/lib/live-feed-context"
 import { useBannedIps } from "@/lib/queries"
 import { getDemoTrafficMode, makeDemoRequests } from "@/lib/demo-traffic"
-import { pairLiveEvents } from "./pairing"
+import { matchesSources, pairLiveEvents } from "./pairing"
 import { LiveTrafficStore } from "./store"
 import { EMPTY_SUMMARY, summarize, type LiveSummary } from "./summary"
 import type { LiveRequest, Vitals } from "./types"
@@ -41,9 +41,11 @@ const SNAPSHOT_INTERVAL_MS = 1000
 
 export function LiveTrafficProvider({
   enabled,
+  sources = [],
   children,
 }: {
   enabled: boolean
+  sources?: string[]
   children: React.ReactNode
 }) {
   const store = useMemo(() => new LiveTrafficStore(), [])
@@ -58,10 +60,19 @@ export function LiveTrafficProvider({
   const feedState: LiveFeedState =
     demoMode !== "off" || socketStatus === "connected" ? "connected" : "reconnecting"
 
+  // Read through a ref so a changed selection does not resubscribe the socket;
+  // the reset effect below is what actually applies a new filter to the window.
+  const sourcesRef = useRef<string[]>(sources)
+  sourcesRef.current = sources
+  const sourcesJoined = sources.join(" ")
+
   useLiveEvents(
     (events, dropped) => {
       const now = Date.now()
-      store.ingest(pairLiveEvents(events, bannedRef.current, now), dropped, now)
+      const paired = pairLiveEvents(events, bannedRef.current, now).filter((request) =>
+        matchesSources(request, sourcesRef.current),
+      )
+      store.ingest(paired, dropped, now)
     },
     enabled && demoMode === "off",
   )
@@ -72,7 +83,10 @@ export function LiveTrafficProvider({
     const emit = () => {
       const now = Date.now()
       const count = demoMode === "burst" ? 4 : 1
-      store.ingest(makeDemoRequests(cursor, count, now), 0, now)
+      const requests = makeDemoRequests(cursor, count, now).filter((request) =>
+        matchesSources(request, sourcesRef.current),
+      )
+      store.ingest(requests, 0, now)
       cursor += count
     }
     const kickoff = window.setTimeout(emit, 250)
@@ -86,6 +100,13 @@ export function LiveTrafficProvider({
   useEffect(() => {
     if (!enabled) store.clear()
   }, [enabled, store])
+
+  // Drop the window whenever the selection changes so stale unfiltered
+  // requests do not linger next to newly-filtered ones.
+  useEffect(() => {
+    store.reset()
+    // sourcesJoined is the stable identity for the sources array; see above.
+  }, [sourcesJoined, store])
 
   return (
     <StoreContext.Provider value={store}>

--- a/resources/lib/live-traffic/context.tsx
+++ b/resources/lib/live-traffic/context.tsx
@@ -64,7 +64,9 @@ export function LiveTrafficProvider({
   // the reset effect below is what actually applies a new filter to the window.
   const sourcesRef = useRef<string[]>(sources)
   sourcesRef.current = sources
-  const sourcesJoined = sources.join(" ")
+  // JSON.stringify (not join(" ")) so a hostname containing a space can't
+  // alias a distinct selection into the same dependency identity.
+  const sourcesKey = JSON.stringify(sources)
 
   useLiveEvents(
     (events, dropped) => {
@@ -105,8 +107,8 @@ export function LiveTrafficProvider({
   // requests do not linger next to newly-filtered ones.
   useEffect(() => {
     store.reset()
-    // sourcesJoined is the stable identity for the sources array; see above.
-  }, [sourcesJoined, store])
+    // sourcesKey is the stable identity for the sources array; see above.
+  }, [sourcesKey, store])
 
   return (
     <StoreContext.Provider value={store}>

--- a/resources/lib/live-traffic/pairing.test.ts
+++ b/resources/lib/live-traffic/pairing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import type { LiveEvent } from "@/lib/websocket"
-import { pairLiveEvents } from "./pairing"
+import { matchesSources, pairLiveEvents } from "./pairing"
+import type { LiveRequest } from "./types"
 
 const TS = "2026-07-22T19:57:54+02:00"
 
@@ -145,5 +146,46 @@ describe("pairLiveEvents", () => {
 
   it("returns nothing for an empty heartbeat frame", () => {
     expect(pairLiveEvents([], new Set(), 1000)).toEqual([])
+  })
+
+  it("carries the recording hostname from either event kind", () => {
+    const geoOnly = pairLiveEvents([geo("1.1.1.1")], new Set(), 1000)
+    const logOnly = pairLiveEvents([log("2.2.2.2", 200)], new Set(), 1000)
+
+    expect(geoOnly[0].hostname).toBe("vps-1")
+    expect(logOnly[0].hostname).toBe("vps-1")
+  })
+})
+
+function requestWithHostname(hostname: string | null): LiveRequest {
+  return {
+    id: "r",
+    timestamp: TS,
+    receivedAt: 0,
+    ip: "1.1.1.1",
+    coordinates: null,
+    city: null,
+    countryCode: null,
+    log: null,
+    statusClass: "unknown",
+    banned: false,
+    threat: false,
+    hostname,
+  }
+}
+
+describe("matchesSources", () => {
+  it("passes everything when no sources are selected", () => {
+    expect(matchesSources(requestWithHostname("nginx-01"), [])).toBe(true)
+    expect(matchesSources(requestWithHostname(null), [])).toBe(true)
+  })
+
+  it("filters by exact hostname", () => {
+    expect(matchesSources(requestWithHostname("nginx-01"), ["nginx-01"])).toBe(true)
+    expect(matchesSources(requestWithHostname("nginx-01"), ["traefik-01"])).toBe(false)
+  })
+
+  it("drops hostname-less requests when a filter is active", () => {
+    expect(matchesSources(requestWithHostname(null), ["nginx-01"])).toBe(false)
   })
 })

--- a/resources/lib/live-traffic/pairing.ts
+++ b/resources/lib/live-traffic/pairing.ts
@@ -31,10 +31,17 @@ function build(
     city: geo?.city ?? log?.city ?? null,
     countryCode: geo?.country_code ?? log?.country_code ?? null,
     log,
+    hostname: geo?.hostname ?? log?.hostname ?? null,
     statusClass: status,
     banned,
     threat: isThreat(log?.status_code, banned),
   }
+}
+
+/** Exact-match source filter; empty selection means unfiltered. */
+export function matchesSources(request: LiveRequest, sources: string[]): boolean {
+  if (sources.length === 0) return true
+  return request.hostname !== null && sources.includes(request.hostname)
 }
 
 export function pairLiveEvents(

--- a/resources/lib/live-traffic/store.test.ts
+++ b/resources/lib/live-traffic/store.test.ts
@@ -15,6 +15,7 @@ function request(overrides: Partial<LiveRequest> = {}): LiveRequest {
     statusClass: "2xx",
     banned: false,
     threat: false,
+    hostname: null,
     ...overrides,
   }
 }
@@ -234,6 +235,19 @@ describe("LiveTrafficStore", () => {
     const vitals = store.getVitals(1000)
     expect(vitals.dropped).toBe(0)
     expect(vitals.droppedRecently).toBe(false)
+  })
+
+  it("reset clears requests and buckets and notifies subscribers", () => {
+    const store = new LiveTrafficStore()
+    const seen = vi.fn()
+    store.ingest([request({ id: "a", receivedAt: 1000 }), request({ id: "b", receivedAt: 1000 })], 0, 1000)
+    store.onRequests(seen)
+
+    store.reset()
+
+    expect(store.getRequests()).toHaveLength(0)
+    expect(store.getBuckets(1000).every((bucket) => bucket.total === 0)).toBe(true)
+    expect(seen).toHaveBeenCalledTimes(1)
   })
 
   it("prunes stale requests on read when idle for longer than the window", () => {

--- a/resources/lib/live-traffic/store.ts
+++ b/resources/lib/live-traffic/store.ts
@@ -138,6 +138,15 @@ export class LiveTrafficStore {
     this.droppedTotal = 0
     this.lastDropAt = null
   }
+
+  /** Drop the whole window (used when the source filter changes so stale
+   *  unfiltered requests cannot linger on screen). Buckets and vitals are
+   *  derived from `requests` on read, so clearing it is enough. */
+  reset(): void {
+    this.requests = []
+    this.byId.clear()
+    this.listeners.forEach((listener) => listener([]))
+  }
 }
 
 export type { StatusClass }

--- a/resources/lib/live-traffic/summary.test.ts
+++ b/resources/lib/live-traffic/summary.test.ts
@@ -12,6 +12,7 @@ function request(overrides: Partial<LiveRequest> = {}): LiveRequest {
     city: "Oslo",
     countryCode: "NO",
     log: null,
+    hostname: null,
     statusClass: "2xx",
     banned: false,
     threat: false,

--- a/resources/lib/live-traffic/types.ts
+++ b/resources/lib/live-traffic/types.ts
@@ -26,6 +26,9 @@ export interface LiveRequest {
   countryCode: string | null
   /** Null for a geo event with no paired access_log. */
   log: AccessLogData | null
+  /** Recording hostname (which instance/agent parsed it); null only for
+   *  pre-upgrade events still in flight. */
+  hostname: string | null
   statusClass: StatusClass
   banned: boolean
   threat: boolean

--- a/resources/lib/map-filters.ts
+++ b/resources/lib/map-filters.ts
@@ -1,0 +1,33 @@
+/** URL codec for the map's data filters (sources/countries/cities). Pure
+ *  module: vitest runs without a DOM, so no router imports here. */
+import { arrayParam } from "@/lib/url-filters"
+
+export interface MapFilterState {
+  sources: string[]
+  countryCodes: string[]
+  cities: string[]
+}
+
+export interface MapSearch {
+  sources?: string[]
+  countries?: string[]
+  cities?: string[]
+  /** Dev-only demo traffic mode; preserved so navigation never strips it. */
+  demoTraffic?: string
+}
+
+export function decodeMapSearch(search: MapSearch): MapFilterState {
+  return {
+    sources: search.sources ?? [],
+    countryCodes: search.countries ?? [],
+    cities: search.cities ?? [],
+  }
+}
+
+export function encodeMapSearch(filters: MapFilterState): Partial<MapSearch> {
+  return {
+    sources: arrayParam(filters.sources),
+    countries: arrayParam(filters.countryCodes),
+    cities: arrayParam(filters.cities),
+  }
+}

--- a/resources/lib/map-preferences.test.ts
+++ b/resources/lib/map-preferences.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  loadLayerPreference,
+  loadLivePreference,
+  saveLayerPreference,
+  saveLivePreference,
+} from "@/lib/map-preferences"
+
+function stubStorage(initial: Record<string, string> = {}) {
+  const data = new Map(Object.entries(initial))
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => data.get(k) ?? null,
+    setItem: (k: string, v: string) => void data.set(k, v),
+  })
+  return data
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe("map preferences", () => {
+  it("defaults to markers and live off", () => {
+    stubStorage()
+    expect(loadLayerPreference()).toBe("markers")
+    expect(loadLivePreference()).toBe(false)
+  })
+  it("round-trips explicit choices", () => {
+    const data = stubStorage()
+    saveLayerPreference("heatmap")
+    saveLivePreference(true)
+    expect(data.get("geometrikks-map-layer")).toBe("heatmap")
+    expect(loadLayerPreference()).toBe("heatmap")
+    expect(loadLivePreference()).toBe(true)
+  })
+  it("survives a missing localStorage", () => {
+    // no stub at all: loaders must return defaults, savers must not throw
+    expect(loadLayerPreference()).toBe("markers")
+    expect(() => saveLivePreference(true)).not.toThrow()
+  })
+})

--- a/resources/lib/map-preferences.ts
+++ b/resources/lib/map-preferences.ts
@@ -1,0 +1,38 @@
+/** localStorage persistence for the map's layer choice and Live toggle.
+ *  Defaults preserve pre-persistence behavior: markers, live off. */
+export const MAP_LAYER_STORAGE_KEY = "geometrikks-map-layer"
+export const MAP_LIVE_STORAGE_KEY = "geometrikks-map-live"
+
+export type MapLayer = "heatmap" | "markers"
+
+export function loadLayerPreference(): MapLayer {
+  try {
+    return localStorage.getItem(MAP_LAYER_STORAGE_KEY) === "heatmap" ? "heatmap" : "markers"
+  } catch {
+    return "markers"
+  }
+}
+
+export function saveLayerPreference(layer: MapLayer): void {
+  try {
+    localStorage.setItem(MAP_LAYER_STORAGE_KEY, layer)
+  } catch {
+    // Storage may be blocked; keep the in-memory preference for this session.
+  }
+}
+
+export function loadLivePreference(): boolean {
+  try {
+    return localStorage.getItem(MAP_LIVE_STORAGE_KEY) === "true"
+  } catch {
+    return false
+  }
+}
+
+export function saveLivePreference(enabled: boolean): void {
+  try {
+    localStorage.setItem(MAP_LIVE_STORAGE_KEY, String(enabled))
+  } catch {
+    // Storage may be blocked; keep the in-memory preference for this session.
+  }
+}

--- a/resources/lib/queries.ts
+++ b/resources/lib/queries.ts
@@ -511,6 +511,8 @@ export interface UseGeoJSONOptions {
   countryCodes?: string[]
   /** Filter to these city names */
   cities?: string[]
+  /** Filter to these source hostnames */
+  hostnames?: string[]
 }
 
 /**
@@ -518,12 +520,15 @@ export interface UseGeoJSONOptions {
  * Uses TimeRangeContext for time filtering.
  */
 export function useGeoJSON(options: UseGeoJSONOptions = {}) {
-  const { enabled = true, countryCodes, cities } = options
+  const { enabled = true, countryCodes, cities, hostnames } = options
   const { range, customRange, pollInterval, lastRefresh } = useTimeRange()
 
   return useQuery({
     // Query key uses lastRefresh for cache invalidation on manual refresh
-    queryKey: queryKeys.geo.geojson({ range, customRange, countryCodes, cities }, lastRefresh),
+    queryKey: queryKeys.geo.geojson(
+      { range, customRange, countryCodes, cities, hostnames },
+      lastRefresh,
+    ),
     // Compute date range at fetch time so polls get fresh data
     queryFn: () => {
       const { startDate, endDate } = parseTimeRange(range, Date.now(), customRange)
@@ -532,6 +537,7 @@ export function useGeoJSON(options: UseGeoJSONOptions = {}) {
         toTimestamp: endDate,
         countryCodes,
         cities,
+        hostnames,
       })
     },
     enabled,

--- a/resources/routes/map-filters.test.ts
+++ b/resources/routes/map-filters.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest"
+import { decodeMapSearch, encodeMapSearch } from "@/lib/map-filters"
+
+describe("map filter codec", () => {
+  it("decodes absent params to empty arrays", () => {
+    expect(decodeMapSearch({})).toEqual({ sources: [], countryCodes: [], cities: [] })
+  })
+  it("round-trips selections and drops empties from the URL", () => {
+    const filters = { sources: ["nginx-01"], countryCodes: ["NO", "DE"], cities: [] }
+    const encoded = encodeMapSearch(filters)
+    expect(encoded).toEqual({ sources: ["nginx-01"], countries: ["NO", "DE"], cities: undefined })
+    expect(decodeMapSearch(encoded)).toEqual(filters)
+  })
+})

--- a/resources/routes/map.tsx
+++ b/resources/routes/map.tsx
@@ -1,14 +1,27 @@
 /**
  * Map route - Interactive geo-location visualization.
+ *
+ * Data filters (sources/countries/cities) live in the URL search params so
+ * filtered map views are shareable links; see resources/lib/map-filters.ts
+ * for the codec.
  */
 
 import { createFileRoute } from "@tanstack/react-router"
 import { lazy, Suspense } from "react"
+import { z } from "zod"
 import { MapSkeleton } from "@/components/map/MapSkeleton"
 
 const GeoMap = lazy(() => import("@/components/map/GeoMap"))
 
+const mapSearchSchema = z.object({
+  sources: z.array(z.string()).optional().catch(undefined),
+  countries: z.array(z.string()).optional().catch(undefined),
+  cities: z.array(z.string()).optional().catch(undefined),
+  demoTraffic: z.string().optional().catch(undefined),
+})
+
 export const Route = createFileRoute("/map")({
+  validateSearch: (search: Record<string, unknown>) => mapSearchSchema.parse(search),
   component: MapPage,
 })
 

--- a/tests/integration/test_location_source_caggs.py
+++ b/tests/integration/test_location_source_caggs.py
@@ -139,3 +139,22 @@ async def test_pollution_gate_keeps_old_shape(pg_engine, pg_session_maker, clean
         ))}
     assert "hostname" in cols
     assert timescale.location_caggs_have_hostname() is True
+
+
+async def test_repository_hostname_filter_reads_cagg(pg_engine, pg_session_maker, clean_tables):
+    """7-day range + hostname filter goes through the CAGG and matches raw."""
+    from geometrikks.domain.geo.repositories import GeoLocationRepository
+
+    await _seed_geo_events(pg_session_maker, ["nginx-01", "traefik-01"], per_host=5)
+    await refresh_caggs_range(
+        pg_engine, start=NOW - timedelta(days=3), end=NOW,
+        caggs=["location_hourly_stats"],
+    )
+    async with pg_session_maker() as session:
+        repo = GeoLocationRepository(session=session)
+        rows = await repo.get_all_with_event_counts(
+            from_timestamp=NOW - timedelta(days=7),
+            to_timestamp=NOW + timedelta(hours=1),
+            hostnames=["nginx-01"],
+        )
+    assert sum(r.event_count for r in rows) == 5

--- a/tests/integration/test_location_source_caggs.py
+++ b/tests/integration/test_location_source_caggs.py
@@ -1,0 +1,141 @@
+"""Location CAGGs with hostname: shape, correctness, and the pollution gate."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+
+from geometrikks.config.settings import get_settings
+from geometrikks.server import timescale
+from geometrikks.server.timescale import refresh_caggs_range, setup_timescaledb
+
+pytestmark = pytest.mark.anyio
+
+NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+
+
+async def _seed_geo_events(session_maker, hostnames: list[str], per_host: int = 5) -> None:
+    """per_host events for each hostname, 2 days back (CAGG range, not raw-only)."""
+    async with session_maker() as session:
+        loc = (await session.execute(text(
+            "INSERT INTO geo_locations (latitude, longitude, geohash, geographic_point, "
+            "country_code, country_name, city, created_at, updated_at) "
+            "VALUES (59.9, 10.7, 'u4xsx', ST_SetSRID(ST_MakePoint(10.7, 59.9), 4326), "
+            "'NO', 'Norway', 'Oslo', now(), now()) RETURNING id"
+        ))).scalar_one()
+        for host in hostnames:
+            for i in range(per_host):
+                await session.execute(text(
+                    "INSERT INTO geo_events (timestamp, ip_address, hostname, location_id) "
+                    "VALUES (:ts, '203.0.113.7', :host, :loc)"
+                ), {"ts": NOW - timedelta(days=2, minutes=i), "host": host, "loc": loc})
+        await session.commit()
+
+
+async def test_location_caggs_carry_hostname_column(pg_engine):
+    async with pg_engine.connect() as conn:
+        rows = await conn.execute(text(
+            "SELECT table_name, column_name FROM information_schema.columns "
+            "WHERE table_name IN ('location_hourly_stats', 'location_daily_stats')"
+        ))
+        cols = {(r.table_name, r.column_name) for r in rows}
+    for view in ("location_hourly_stats", "location_daily_stats"):
+        assert (view, "hostname") in cols
+
+
+async def test_filtered_cagg_counts_match_raw(pg_engine, pg_session_maker, clean_tables):
+    await _seed_geo_events(pg_session_maker, ["nginx-01", "traefik-01"], per_host=5)
+    await refresh_caggs_range(
+        pg_engine, start=NOW - timedelta(days=3), end=NOW,
+        caggs=["location_hourly_stats"],
+    )
+    async with pg_engine.connect() as conn:
+        filtered = (await conn.execute(text(
+            "SELECT COALESCE(SUM(event_count), 0) FROM location_hourly_stats "
+            "WHERE hostname = 'nginx-01'"
+        ))).scalar_one()
+        unfiltered = (await conn.execute(text(
+            "SELECT COALESCE(SUM(event_count), 0) FROM location_hourly_stats"
+        ))).scalar_one()
+    assert filtered == 5
+    assert unfiltered == 10
+
+
+async def test_upgrade_replaces_old_shape(pg_engine, clean_tables):
+    """Drop to the pre-hostname shape, rerun setup, assert the new shape."""
+    async with pg_engine.begin() as conn:
+        for cagg in ("location_hourly_stats", "location_daily_stats"):
+            await conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {cagg} CASCADE"))
+        await conn.execute(text(
+            "CREATE MATERIALIZED VIEW location_hourly_stats "
+            "WITH (timescaledb.continuous) AS "
+            "SELECT time_bucket('1 hour', timestamp) AS bucket, location_id, "
+            "COUNT(*) AS event_count FROM geo_events "
+            "GROUP BY bucket, location_id WITH NO DATA"
+        ))
+        await conn.execute(text(
+            "CREATE MATERIALIZED VIEW location_daily_stats "
+            "WITH (timescaledb.continuous) AS "
+            "SELECT time_bucket('1 day', timestamp) AS bucket, location_id, "
+            "COUNT(*) AS event_count FROM geo_events "
+            "GROUP BY bucket, location_id WITH NO DATA"
+        ))
+    await setup_timescaledb(pg_engine, get_settings().analytics)
+    async with pg_engine.connect() as conn:
+        cols = {r.column_name for r in await conn.execute(text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = 'location_hourly_stats'"
+        ))}
+    assert "hostname" in cols
+    assert timescale.location_caggs_have_hostname() is True
+
+
+async def test_pollution_gate_keeps_old_shape(pg_engine, pg_session_maker, clean_tables):
+    """Container-ID hostnames present: setup must NOT migrate, and the flag
+    plus cached pollution report must say so; consolidating then heals."""
+    from geometrikks.server.timescale import CONTAINER_ID_THRESHOLD
+
+    ids = [f"{i:012x}" for i in range(CONTAINER_ID_THRESHOLD)]
+    await _seed_geo_events(pg_session_maker, ids, per_host=1)
+    async with pg_engine.begin() as conn:
+        for cagg in ("location_hourly_stats", "location_daily_stats"):
+            await conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {cagg} CASCADE"))
+        await conn.execute(text(
+            "CREATE MATERIALIZED VIEW location_hourly_stats "
+            "WITH (timescaledb.continuous) AS "
+            "SELECT time_bucket('1 hour', timestamp) AS bucket, location_id, "
+            "COUNT(*) AS event_count FROM geo_events "
+            "GROUP BY bucket, location_id WITH NO DATA"
+        ))
+        await conn.execute(text(
+            "CREATE MATERIALIZED VIEW location_daily_stats "
+            "WITH (timescaledb.continuous) AS "
+            "SELECT time_bucket('1 day', timestamp) AS bucket, location_id, "
+            "COUNT(*) AS event_count FROM geo_events "
+            "GROUP BY bucket, location_id WITH NO DATA"
+        ))
+
+    await setup_timescaledb(pg_engine, get_settings().analytics)
+    async with pg_engine.connect() as conn:
+        cols = {r.column_name for r in await conn.execute(text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = 'location_hourly_stats'"
+        ))}
+    assert "hostname" not in cols
+    assert timescale.location_caggs_have_hostname() is False
+    pollution = timescale.get_hostname_pollution()
+    assert pollution is not None
+    assert pollution.polluted is True
+
+    # Consolidate (the remedy) and rerun setup: migration happens.
+    async with pg_engine.begin() as conn:
+        await conn.execute(text("UPDATE geo_events SET hostname = 'geometrikks'"))
+    await setup_timescaledb(pg_engine, get_settings().analytics)
+    async with pg_engine.connect() as conn:
+        cols = {r.column_name for r in await conn.execute(text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = 'location_hourly_stats'"
+        ))}
+    assert "hostname" in cols
+    assert timescale.location_caggs_have_hostname() is True

--- a/tests/test_geo_routing.py
+++ b/tests/test_geo_routing.py
@@ -6,9 +6,10 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 
-from geometrikks.domain.geo.repositories import StatsGranularity
+from geometrikks.domain.geo.repositories import GeoLocationRepository, StatsGranularity
 from geometrikks.domain.geo.schemas import GeoEventFilters
 from geometrikks.domain.geo.services import GeoEventService
+from geometrikks.server import timescale
 
 import pytest
 
@@ -110,3 +111,41 @@ async def test_stitched_sql_binds_bounds_as_params():
     sql = session.statements[0]
     assert "bounds" not in sql
     assert ":a_start" in sql and ":a_end" in sql
+
+
+def _location_repo(session: _RecordingSession) -> GeoLocationRepository:
+    return GeoLocationRepository(session=cast("AsyncSession", session))
+
+
+async def test_hostname_filter_uses_cagg_when_capable(monkeypatch):
+    monkeypatch.setattr(timescale, "_location_caggs_have_hostname", True)
+    session = _RecordingSession()
+    await _location_repo(session).get_all_with_event_counts(
+        WEEK_START, NOW, hostnames=["nginx-01"]
+    )
+    sql = session.statements[0]
+    assert "location_hourly_stats" in sql
+    assert "ls.hostname = ANY(:filter_hostnames)" in sql
+
+
+async def test_hostname_filter_forces_raw_without_capability(monkeypatch):
+    monkeypatch.setattr(timescale, "_location_caggs_have_hostname", False)
+    session = _RecordingSession()
+    await _location_repo(session).get_all_with_event_counts(
+        WEEK_START, NOW, hostnames=["nginx-01"]
+    )
+    sql = session.statements[0]
+    assert "location_hourly_stats" not in sql
+    assert "JOIN geo_events" in sql
+    assert "ge.hostname = ANY(:filter_hostnames)" in sql
+
+
+async def test_ip_filter_always_forces_raw(monkeypatch):
+    monkeypatch.setattr(timescale, "_location_caggs_have_hostname", True)
+    session = _RecordingSession()
+    await _location_repo(session).get_all_with_event_counts(
+        WEEK_START, NOW, ip_addresses=["1.1.1.1"], hostnames=["nginx-01"]
+    )
+    sql = session.statements[0]
+    assert "location_hourly_stats" not in sql
+    assert "JOIN geo_events" in sql

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -217,6 +217,42 @@ def test_health_agent_mode_reports_schema_wait(monkeypatch):
     assert body["schemaWait"] == "ready"
 
 
+def test_health_has_no_advisories_when_clean(monkeypatch):
+    async def db_up(app, timeout: float = 2.0) -> bool:
+        return True
+    monkeypatch.setattr(health_module, "_database_reachable", db_up)
+
+    from geometrikks.server import timescale
+    monkeypatch.setattr(timescale, "_hostname_pollution", None)
+
+    with TestClient(app=make_app()) as client:
+        body = client.get("/health").json()
+    assert body["advisories"] == []
+
+
+def test_health_reports_hostname_pollution_advisory(monkeypatch):
+    async def db_up(app, timeout: float = 2.0) -> bool:
+        return True
+    monkeypatch.setattr(health_module, "_database_reachable", db_up)
+
+    from geometrikks.server import timescale
+    from geometrikks.server.timescale import HostnamePollution
+    monkeypatch.setattr(
+        timescale, "_hostname_pollution",
+        HostnamePollution(distinct_count=40, container_id_count=38),
+    )
+
+    with TestClient(app=make_app()) as client:
+        body = client.get("/health").json()
+    data = body["advisories"]
+    assert len(data) == 1
+    a = data[0]
+    assert a["id"] == "hostname-pollution"
+    assert a["severity"] == "warning"
+    assert "38" in a["summary"] and "40" in a["summary"]
+    assert "backfill-hostname" in a["remedy"]
+
+
 def test_health_publish_dropped_present(monkeypatch):
     """publish_dropped surfaces the ingestion service's counter, defaulting
     to 0 when there is no service."""

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -241,6 +241,7 @@ def test_health_reports_hostname_pollution_advisory(monkeypatch):
         timescale, "_hostname_pollution",
         HostnamePollution(distinct_count=40, container_id_count=38),
     )
+    monkeypatch.setattr(timescale, "_location_caggs_have_hostname", False)
 
     with TestClient(app=make_app()) as client:
         body = client.get("/health").json()
@@ -251,6 +252,49 @@ def test_health_reports_hostname_pollution_advisory(monkeypatch):
     assert a["severity"] == "warning"
     assert "38" in a["summary"] and "40" in a["summary"]
     assert "backfill-hostname" in a["remedy"]
+
+
+def test_health_no_pollution_advisory_when_caggs_already_have_hostname(monkeypatch):
+    """Polluted history is moot once the location CAGGs already carry the
+    hostname dimension (fresh install / post-consolidation migration): the
+    filter is not unaggregated and no migration is pending, so the advisory
+    must not fire."""
+    async def db_up(app, timeout: float = 2.0) -> bool:
+        return True
+    monkeypatch.setattr(health_module, "_database_reachable", db_up)
+
+    from geometrikks.server import timescale
+    from geometrikks.server.timescale import HostnamePollution
+    monkeypatch.setattr(
+        timescale, "_hostname_pollution",
+        HostnamePollution(distinct_count=40, container_id_count=38),
+    )
+    monkeypatch.setattr(timescale, "_location_caggs_have_hostname", True)
+
+    with TestClient(app=make_app()) as client:
+        body = client.get("/health").json()
+    assert body["advisories"] == []
+
+
+def test_health_no_pollution_advisory_when_not_polluted(monkeypatch):
+    """A cached, non-None HostnamePollution that is not actually `polluted`
+    (few container-ID-looking hostnames) must not raise the advisory,
+    regardless of the CAGG capability flag."""
+    async def db_up(app, timeout: float = 2.0) -> bool:
+        return True
+    monkeypatch.setattr(health_module, "_database_reachable", db_up)
+
+    from geometrikks.server import timescale
+    from geometrikks.server.timescale import HostnamePollution
+    monkeypatch.setattr(
+        timescale, "_hostname_pollution",
+        HostnamePollution(distinct_count=3, container_id_count=0),
+    )
+    monkeypatch.setattr(timescale, "_location_caggs_have_hostname", False)
+
+    with TestClient(app=make_app()) as client:
+        body = client.get("/health").json()
+    assert body["advisories"] == []
 
 
 def test_health_publish_dropped_present(monkeypatch):

--- a/tests/test_hostname_pollution.py
+++ b/tests/test_hostname_pollution.py
@@ -1,0 +1,42 @@
+"""Hostname-pollution probe: container-ID heuristics behind the CAGG gate."""
+from __future__ import annotations
+
+from geometrikks.server.timescale import (
+    CONTAINER_ID_THRESHOLD,
+    DISTINCT_HOSTNAME_CEILING,
+    classify_hostnames,
+)
+
+
+def test_clean_homelab_hostnames_are_not_polluted():
+    result = classify_hostnames(["nginx-01", "traefik-01", "vps-9"])
+    assert result.distinct_count == 3
+    assert result.container_id_count == 0
+    assert result.polluted is False
+
+
+def test_container_id_shapes_trip_the_threshold():
+    ids = [f"{i:012x}" for i in range(CONTAINER_ID_THRESHOLD)]
+    result = classify_hostnames(ids + ["nginx-01"])
+    assert result.container_id_count == CONTAINER_ID_THRESHOLD
+    assert result.polluted is True
+
+
+def test_below_threshold_container_ids_are_tolerated():
+    ids = [f"{i:012x}" for i in range(CONTAINER_ID_THRESHOLD - 1)]
+    assert classify_hostnames(ids + ["nginx-01"]).polluted is False
+
+
+def test_cardinality_ceiling_trips_without_container_ids():
+    many = [f"host-{i}" for i in range(DISTINCT_HOSTNAME_CEILING + 1)]
+    assert classify_hostnames(many).polluted is True
+
+
+def test_non_hex_twelve_char_names_are_not_container_ids():
+    # 'geometrikks1' is 12 chars but not pure hex
+    assert classify_hostnames(["geometrikks1"]).container_id_count == 0
+
+
+def test_empty_database_is_clean():
+    result = classify_hostnames([])
+    assert result.polluted is False


### PR DESCRIPTION
Phase 4 of multi-source ingestion, stacked on #134.

## What

- **Location CAGGs carry a hostname dimension.** `location_{hourly,daily}_stats` now group by `(bucket, location_id, hostname)` with a `(hostname, bucket DESC)` index. Pure additive counts, so every unfiltered reader is bit-identical. Existing installs upgrade at startup via the proven shape-probe drop-and-recreate (percentile-upgrade pattern) with a one-time backfill refresh over the raw retention window; history older than raw retention cannot be rebuilt and is discarded at that upgrade (changelog states it).
- **Pollution gate.** A bounded probe over `geo_events` counts Docker-container-ID-shaped hostnames; a polluted database skips the migration entirely (WARN with the `backfill-hostname --consolidate` remedy every startup), keeps today's raw-scan behavior, and migrates automatically on the first clean startup.
- **Repository routing.** Hostname filters read the CAGGs when a startup-cached capability flag says the dimension exists; IP filters still force raw; ranges under 24h stay raw-exact.
- **Generic health advisories.** `advisories: []` on `/health` (additive) with a status-page card list; hostname pollution is the first producer, and it only fires while the migration is actually pending.
- **Map filter UX.** URL-backed `sources`/`countries`/`cities` on `/map` (geo-logs `useUrlFilters` pattern, `demoTraffic` preserved), a Sources combobox fed by the facets endpoint (hidden below two hostnames), live traffic filtered at ingest so pulses, feed, vitals, and second-buckets all match the selection, hostname shown on live popups (`Source` row) and feed rows, and layer/Live choices persisted to localStorage.

## Testing

- Unit: pollution classification, routing (capability on/off, IP precedence), advisories, URL codec, live filter predicate, store reset, preferences.
- Integration (real TimescaleDB): CAGG shape, filtered-vs-raw count equality, old-shape upgrade, pollution gate + consolidate-then-heal cycle, end-to-end repository hostname filter.
- Full sweep green: pytest 770, integration 140, vitest 177, ty, tsc, vite build, config-docs freshness.

Manual verification steps for multi-source behavior are in the PR discussion below.