### PR TITLE
feat: backfill-asn CLI for historical rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   retroactively.
 - The Top URLs and Top user agents tables now sit side by side on wide
   screens to save page height.
+- `litestar backfill-asn`: retroactively stamp ASN data onto rows ingested
+  before the ASN feature (or while the database was missing), with a
+  confirmation prompt, decompress-first handling for compressed history,
+  and an ASN CAGG refresh so the Top ASNs view picks up the backfilled
+  range.
 
 - `LOGPARSER_HOST_NAME` accepts a JSON list matched positionally to
   `LOGPARSER_LOG_PATHS`, so one instance tailing logs shipped from several

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   before the ASN feature (or while the database was missing), with a
   confirmation prompt, decompress-first handling for compressed history,
   and an ASN CAGG refresh so the Top ASNs view picks up the backfilled
-  range.
+  range. IPs are resolved and written in bounded chunks, and a failed
+  aggregate refresh exits non-zero rather than reporting a clean run.
 
 - `LOGPARSER_HOST_NAME` accepts a JSON list matched positionally to
   `LOGPARSER_LOG_PATHS`, so one instance tailing logs shipped from several

--- a/README.md
+++ b/README.md
@@ -653,6 +653,10 @@ compression policy recompresses them) and refreshes the ASN continuous
 aggregates afterwards so the Top ASNs view picks up the history. May run
 for minutes on a large database.
 
+If the aggregate refresh fails the command exits non-zero and says which
+aggregates are stale: the rows are stamped, but the Top ASNs view will not
+show the backfilled range until they refresh. Rerunning is safe.
+
 Note that today's ASN database describes today's network ownership;
 stamping years-old traffic with it is a best-effort approximation.
 

--- a/README.md
+++ b/README.md
@@ -634,6 +634,28 @@ grows temporarily until the compression policy recompresses them. It then
 refreshes the affected continuous aggregates so the filter dropdowns
 update. May run for minutes on a large database.
 
+### backfill-asn: fill in ASN data for historical rows
+
+Rows ingested before the ASN feature (or while the ASN database was
+missing) have no ASN data. `backfill-asn` resolves their IPs against the
+local GeoLite2 ASN database and stamps them retroactively:
+
+```bash
+docker compose exec -u geometrikks app litestar backfill-asn
+```
+
+It fills **only** rows with no ASN data - it is idempotent and cannot
+overwrite stamped values - and asks for confirmation after reporting how
+many rows and distinct IPs are affected (`--yes` skips the prompt). IPs
+the database cannot resolve stay empty. Like `backfill-hostname`, it
+decompresses compressed history chunks first (disk usage grows until the
+compression policy recompresses them) and refreshes the ASN continuous
+aggregates afterwards so the Top ASNs view picks up the history. May run
+for minutes on a large database.
+
+Note that today's ASN database describes today's network ownership;
+stamping years-old traffic with it is a best-effort approximation.
+
 ## Configuration
 
 `.env.example` covers the short list most installs need to touch (admin

--- a/geometrikks/cli.py
+++ b/geometrikks/cli.py
@@ -426,18 +426,31 @@ async def _run_backfill_asn(*, yes: bool) -> None:
                 "SELECT MIN(timestamp), MAX(timestamp) FROM access_logs "
                 "WHERE autonomous_system_number IS NULL"
             ))).one()
+            # Materialized deliberately: distinct-IP cardinality stays small
+            # relative to rows (tens of thousands on multi-million-row DBs),
+            # so a streamed server-side cursor interleaved with the temp-table
+            # writes is not worth the transaction plumbing.
             ips = [row[0] for row in (await conn.execute(text(
                 "SELECT DISTINCT host(ip_address) FROM access_logs "
                 "WHERE autonomous_system_number IS NULL"
             ))).all()]
 
+        from geoip2.errors import AddressNotFoundError
+
         mapping: list[dict] = []
-        unresolved = 0
+        not_found = 0
+        failed = 0
         for ip in ips:
             try:
                 asn = reader.asn(ip)
+            except AddressNotFoundError:
+                not_found += 1
+                continue
             except Exception:
-                unresolved += 1
+                # Corrupt reader state or decode errors must not abort the
+                # run, but they are not "not in the database" either.
+                failed += 1
+                logger.debug("ASN lookup failed for %s during backfill", ip, exc_info=True)
                 continue
             org = asn.autonomous_system_organization
             mapping.append({
@@ -445,7 +458,10 @@ async def _run_backfill_asn(*, yes: bool) -> None:
                 "asn": asn.autonomous_system_number,
                 "org": org[:255] if org else None,
             })
-        click.echo(f"Resolved {len(mapping):,} IPs ({unresolved:,} not in the ASN database).")
+        click.echo(
+            f"Resolved {len(mapping):,} IPs "
+            f"({not_found:,} not in the ASN database, {failed:,} lookup failures)."
+        )
 
         if not mapping:
             click.echo("No resolvable IPs; nothing written.")
@@ -482,7 +498,8 @@ async def _run_backfill_asn(*, yes: bool) -> None:
             "asn_backfill_completed",
             rows_updated=updated,
             ips_resolved=len(mapping),
-            ips_unresolved=unresolved,
+            ips_not_found=not_found,
+            ips_lookup_failed=failed,
         )
     finally:
         reader.close()

--- a/geometrikks/cli.py
+++ b/geometrikks/cli.py
@@ -1,4 +1,4 @@
-"""Litestar CLI plugin: `litestar import-logs <paths...>`, `litestar backfill-hostname NAME`.
+"""Litestar CLI plugin: `litestar import-logs <paths...>`, `litestar backfill-hostname NAME`, `litestar backfill-asn`.
 
 Import-time safe: settings, engine, reader are constructed inside the
 command callback, never at module import.
@@ -324,9 +324,173 @@ async def _run_backfill_hostname(name: str, *, consolidate: bool, yes: bool) -> 
         await engine.dispose()
 
 
+@click.command(name="backfill-asn")
+@click.option("--yes", is_flag=True, help="Skip the confirmation prompt.")
+def backfill_asn_command(yes: bool) -> None:
+    """Stamp ASN data onto historical rows from the current ASN database.
+
+    Fills only access_logs rows with NULL autonomous_system_number
+    (idempotent, cannot overwrite stamped values) by resolving each
+    distinct IP through the local GeoLite2-ASN database. IPs the database
+    cannot resolve stay NULL. Refreshes the ASN continuous aggregates for
+    the affected range when rows changed. Compressed hypertable chunks are
+    decompressed first (a full-table UPDATE would trip the TimescaleDB
+    tuple decompression limit); the compression policy recompresses them
+    later. May run for minutes on large databases.
+    """
+    asyncio.run(_run_backfill_asn(yes=yes))
+
+
+async def _apply_asn_mapping(engine, mapping: list[dict]) -> int:
+    """Apply an ip -> (asn, org) mapping to NULL-ASN access_logs rows.
+
+    One transaction: temp mapping table, batched inserts, a single join
+    UPDATE. Returns the UPDATE rowcount. Factored out so the temp-table SQL
+    is integration-testable against a real database.
+    """
+    from sqlalchemy import text
+
+    async with engine.begin() as conn:
+        await conn.execute(text(
+            "CREATE TEMPORARY TABLE tmp_asn_map "
+            "(ip inet PRIMARY KEY, asn bigint NOT NULL, org varchar(255)) "
+            "ON COMMIT DROP"
+        ))
+        insert = text("INSERT INTO tmp_asn_map (ip, asn, org) VALUES (:ip, :asn, :org)")
+        for i in range(0, len(mapping), 5000):
+            await conn.execute(insert, mapping[i : i + 5000])
+        return (await conn.execute(text(
+            "UPDATE access_logs al "
+            "SET autonomous_system_number = m.asn, "
+            "    autonomous_system_organization = m.org "
+            "FROM tmp_asn_map m "
+            "WHERE al.autonomous_system_number IS NULL AND al.ip_address = m.ip"
+        ))).rowcount
+
+
+async def _run_backfill_asn(*, yes: bool) -> None:
+    from sqlalchemy import text
+
+    from geometrikks.config.settings import get_settings
+    from geometrikks.server.logging import get_logger
+    from geometrikks.server.plugins import get_sqlalchemy_config
+    from geometrikks.server.timescale import refresh_caggs_range
+    from geometrikks.services.ingestion.service import create_reader
+
+    logger = get_logger(__name__)
+    settings = get_settings()
+    reader = create_reader(settings.geoip.asn_db_path)
+    if reader is None:
+        raise click.ClickException(
+            f"No GeoLite2 ASN database at {settings.geoip.asn_db_path} - cannot "
+            "backfill. Start the app once with MaxMind credentials to "
+            "auto-download it, or provide the mmdb manually."
+        )
+
+    config = get_sqlalchemy_config()
+    engine = config.get_engine()
+    try:
+        # Cheap EXISTS probe (the ASN column is indexed) so a rerun with
+        # nothing left to fill exits before the expensive scans below.
+        async with engine.connect() as conn:
+            needs_fill = bool((await conn.execute(text(
+                "SELECT EXISTS (SELECT 1 FROM access_logs "
+                "WHERE autonomous_system_number IS NULL)"
+            ))).scalar())
+            timescale = bool((await conn.execute(text(
+                "SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb')"
+            ))).scalar())
+
+        if not needs_fill:
+            click.echo("Nothing to do: no rows without ASN data.")
+            return
+
+        click.echo("Scanning rows without ASN data ...")
+        async with engine.connect() as conn:
+            null_rows, distinct_ips = (await conn.execute(text(
+                "SELECT COUNT(*), COUNT(DISTINCT ip_address) FROM access_logs "
+                "WHERE autonomous_system_number IS NULL"
+            ))).one()
+
+        click.echo(f"{null_rows:,} rows across {distinct_ips:,} distinct IPs lack ASN data.")
+        if not yes and not click.confirm("Backfill them from the local ASN database?"):
+            click.echo("Aborted.")
+            return
+
+        # Bounds before the update: after it, the NULL set shrinks and the
+        # refresh range for the changed rows would be lost.
+        async with engine.connect() as conn:
+            bounds = (await conn.execute(text(
+                "SELECT MIN(timestamp), MAX(timestamp) FROM access_logs "
+                "WHERE autonomous_system_number IS NULL"
+            ))).one()
+            ips = [row[0] for row in (await conn.execute(text(
+                "SELECT DISTINCT host(ip_address) FROM access_logs "
+                "WHERE autonomous_system_number IS NULL"
+            ))).all()]
+
+        mapping: list[dict] = []
+        unresolved = 0
+        for ip in ips:
+            try:
+                asn = reader.asn(ip)
+            except Exception:
+                unresolved += 1
+                continue
+            org = asn.autonomous_system_organization
+            mapping.append({
+                "ip": ip,
+                "asn": asn.autonomous_system_number,
+                "org": org[:255] if org else None,
+            })
+        click.echo(f"Resolved {len(mapping):,} IPs ({unresolved:,} not in the ASN database).")
+
+        if not mapping:
+            click.echo("No resolvable IPs; nothing written.")
+            return
+
+        # Full-table UPDATEs on compressed hypertable chunks trip
+        # timescaledb.max_tuples_decompressed_per_dml_transaction; decompress
+        # first, same pattern as backfill-hostname. The compression policy
+        # recompresses on its own schedule.
+        if timescale:
+            click.echo("Decompressing compressed access_logs chunks ...")
+            async with engine.begin() as conn:
+                await conn.execute(text(
+                    "SELECT decompress_chunk(format('%I.%I', chunk_schema, chunk_name)::regclass, true) "
+                    "FROM timescaledb_information.chunks "
+                    "WHERE hypertable_name = 'access_logs' AND is_compressed"
+                ))
+
+        updated = await _apply_asn_mapping(engine, mapping)
+        click.echo(f"access_logs rows updated: {updated:,}")
+
+        # The ASN CAGGs exclude NULL-ASN rows, so backfilled history is
+        # invisible to /top-asns until the affected range is re-refreshed.
+        if updated and bounds[0] is not None:
+            click.echo("Refreshing ASN CAGGs ...")
+            await refresh_caggs_range(
+                engine,
+                start=bounds[0],
+                end=bounds[1] + timedelta(microseconds=1),
+                caggs=["asn_hourly_stats", "asn_daily_stats"],
+            )
+
+        logger.info(
+            "asn_backfill_completed",
+            rows_updated=updated,
+            ips_resolved=len(mapping),
+            ips_unresolved=unresolved,
+        )
+    finally:
+        reader.close()
+        await engine.dispose()
+
+
 class ImportLogsCLIPlugin(CLIPlugin):
-    """Registers import-logs and backfill-hostname on the litestar CLI group."""
+    """Registers import-logs, backfill-hostname, and backfill-asn on the litestar CLI group."""
 
     def on_cli_init(self, cli: click.Group) -> None:
         cli.add_command(import_logs_command)
         cli.add_command(backfill_hostname_command)
+        cli.add_command(backfill_asn_command)

--- a/geometrikks/cli.py
+++ b/geometrikks/cli.py
@@ -343,14 +343,55 @@ def backfill_asn_command(yes: bool) -> None:
     asyncio.run(_run_backfill_asn(yes=yes))
 
 
-async def _apply_asn_mapping(engine, mapping: list[dict]) -> int:
-    """Apply an ip -> (asn, org) mapping to NULL-ASN access_logs rows.
+ASN_BACKFILL_CHUNK_SIZE = 10_000
 
-    One transaction: temp mapping table, batched inserts, a single join
-    UPDATE. Returns the UPDATE rowcount. Factored out so the temp-table SQL
+
+async def _iter_null_asn_ips(engine, *, chunk_size: int = ASN_BACKFILL_CHUNK_SIZE):
+    """Yield distinct NULL-ASN client IPs in bounded, keyset-paginated chunks.
+
+    Keyset pagination on the inet column (not OFFSET, which rescans) keeps
+    peak memory at one chunk regardless of distinct-IP cardinality: an
+    internet-facing install can approach row cardinality, where materializing
+    the whole set would be a real memory spike.
+    """
+    from sqlalchemy import text
+
+    last: str | None = None
+    while True:
+        where = "autonomous_system_number IS NULL"
+        params: dict = {"lim": chunk_size}
+        if last is not None:
+            where += " AND ip_address > CAST(:last AS inet)"
+            params["last"] = last
+        async with engine.connect() as conn:
+            rows = (await conn.execute(text(
+                f"SELECT DISTINCT ip_address, host(ip_address) AS ip_text "
+                f"FROM access_logs WHERE {where} "
+                f"ORDER BY ip_address LIMIT :lim"
+            ), params)).all()
+        if not rows:
+            return
+        yield [row.ip_text for row in rows]
+        last = rows[-1].ip_text
+
+
+async def _apply_asn_mapping(engine, chunks) -> int:
+    """Stream ip -> (asn, org) chunks into a temp table, then one join UPDATE.
+
+    One transaction so the ON COMMIT DROP temp table spans every chunk;
+    memory stays bounded because only the chunk in flight is held. Returns
+    the UPDATE rowcount. ``chunks`` may be a plain list of mapping dicts (one
+    chunk) or an async iterable of them. Factored out so the temp-table SQL
     is integration-testable against a real database.
     """
     from sqlalchemy import text
+
+    if isinstance(chunks, list):
+        # Bound as a default: reassigning `chunks` below would otherwise make
+        # the closure yield the generator itself.
+        async def _single(only=chunks):
+            yield only
+        chunks = _single()
 
     async with engine.begin() as conn:
         await conn.execute(text(
@@ -359,8 +400,14 @@ async def _apply_asn_mapping(engine, mapping: list[dict]) -> int:
             "ON COMMIT DROP"
         ))
         insert = text("INSERT INTO tmp_asn_map (ip, asn, org) VALUES (:ip, :asn, :org)")
-        for i in range(0, len(mapping), 5000):
-            await conn.execute(insert, mapping[i : i + 5000])
+        mapped = 0
+        async for chunk in chunks:
+            if not chunk:
+                continue
+            await conn.execute(insert, chunk)
+            mapped += len(chunk)
+        if not mapped:
+            return 0
         return (await conn.execute(text(
             "UPDATE access_logs al "
             "SET autonomous_system_number = m.asn, "
@@ -426,51 +473,12 @@ async def _run_backfill_asn(*, yes: bool) -> None:
                 "SELECT MIN(timestamp), MAX(timestamp) FROM access_logs "
                 "WHERE autonomous_system_number IS NULL"
             ))).one()
-            # Materialized deliberately: distinct-IP cardinality stays small
-            # relative to rows (tens of thousands on multi-million-row DBs),
-            # so a streamed server-side cursor interleaved with the temp-table
-            # writes is not worth the transaction plumbing.
-            ips = [row[0] for row in (await conn.execute(text(
-                "SELECT DISTINCT host(ip_address) FROM access_logs "
-                "WHERE autonomous_system_number IS NULL"
-            ))).all()]
 
-        from geoip2.errors import AddressNotFoundError
-
-        mapping: list[dict] = []
-        not_found = 0
-        failed = 0
-        for ip in ips:
-            try:
-                asn = reader.asn(ip)
-            except AddressNotFoundError:
-                not_found += 1
-                continue
-            except Exception:
-                # Corrupt reader state or decode errors must not abort the
-                # run, but they are not "not in the database" either.
-                failed += 1
-                logger.debug("ASN lookup failed for %s during backfill", ip, exc_info=True)
-                continue
-            org = asn.autonomous_system_organization
-            mapping.append({
-                "ip": ip,
-                "asn": asn.autonomous_system_number,
-                "org": org[:255] if org else None,
-            })
-        click.echo(
-            f"Resolved {len(mapping):,} IPs "
-            f"({not_found:,} not in the ASN database, {failed:,} lookup failures)."
-        )
-
-        if not mapping:
-            click.echo("No resolvable IPs; nothing written.")
-            return
-
-        # Full-table UPDATEs on compressed hypertable chunks trip
-        # timescaledb.max_tuples_decompressed_per_dml_transaction; decompress
-        # first, same pattern as backfill-hostname. The compression policy
-        # recompresses on its own schedule.
+        # Decompression precedes the write: the UPDATE inside
+        # _apply_asn_mapping would otherwise trip
+        # timescaledb.max_tuples_decompressed_per_dml_transaction. Same
+        # pattern as backfill-hostname; the compression policy recompresses
+        # on its own schedule.
         if timescale:
             click.echo("Decompressing compressed access_logs chunks ...")
             async with engine.begin() as conn:
@@ -480,14 +488,56 @@ async def _run_backfill_asn(*, yes: bool) -> None:
                     "WHERE hypertable_name = 'access_logs' AND is_compressed"
                 ))
 
-        updated = await _apply_asn_mapping(engine, mapping)
+        from geoip2.errors import AddressNotFoundError
+
+        stats = {"resolved": 0, "not_found": 0, "failed": 0}
+
+        async def _resolved_chunks():
+            """Resolve each IP chunk as it arrives; only one is ever held."""
+            async for ips in _iter_null_asn_ips(engine):
+                mapping: list[dict] = []
+                for ip in ips:
+                    try:
+                        asn = reader.asn(ip)
+                    except AddressNotFoundError:
+                        stats["not_found"] += 1
+                        continue
+                    except Exception:
+                        # Corrupt reader state or decode errors must not abort
+                        # the run, but they are not "not in the database" either.
+                        stats["failed"] += 1
+                        logger.debug(
+                            "ASN lookup failed for %s during backfill", ip, exc_info=True
+                        )
+                        continue
+                    org = asn.autonomous_system_organization
+                    mapping.append({
+                        "ip": ip,
+                        "asn": asn.autonomous_system_number,
+                        "org": org[:255] if org else None,
+                    })
+                stats["resolved"] += len(mapping)
+                click.echo(f"  resolved {stats['resolved']:,} IPs ...")
+                yield mapping
+
+        click.echo("Resolving IPs against the ASN database ...")
+        updated = await _apply_asn_mapping(engine, _resolved_chunks())
+        click.echo(
+            f"Resolved {stats['resolved']:,} IPs "
+            f"({stats['not_found']:,} not in the ASN database, "
+            f"{stats['failed']:,} lookup failures)."
+        )
         click.echo(f"access_logs rows updated: {updated:,}")
 
         # The ASN CAGGs exclude NULL-ASN rows, so backfilled history is
         # invisible to /top-asns until the affected range is re-refreshed.
+        # A failed refresh is not cosmetic: ranges outside the refresh
+        # policy's window may never be retried automatically, so it must not
+        # be reported as a clean run.
+        refresh_failed: list[str] = []
         if updated and bounds[0] is not None:
             click.echo("Refreshing ASN CAGGs ...")
-            await refresh_caggs_range(
+            refresh_failed = await refresh_caggs_range(
                 engine,
                 start=bounds[0],
                 end=bounds[1] + timedelta(microseconds=1),
@@ -497,10 +547,19 @@ async def _run_backfill_asn(*, yes: bool) -> None:
         logger.info(
             "asn_backfill_completed",
             rows_updated=updated,
-            ips_resolved=len(mapping),
-            ips_not_found=not_found,
-            ips_lookup_failed=failed,
+            ips_resolved=stats["resolved"],
+            ips_not_found=stats["not_found"],
+            ips_lookup_failed=stats["failed"],
+            cagg_refresh_failed=refresh_failed,
         )
+
+        if refresh_failed:
+            raise click.ClickException(
+                f"Rows were stamped, but refreshing {', '.join(refresh_failed)} failed; "
+                "the Top ASNs view will not show the backfilled range until they "
+                "refresh. Check the app log, then rerun this command (it is "
+                "idempotent) or refresh those aggregates manually."
+            )
     finally:
         reader.close()
         await engine.dispose()

--- a/geometrikks/server/timescale.py
+++ b/geometrikks/server/timescale.py
@@ -961,11 +961,17 @@ async def refresh_caggs_range(
     start: datetime,
     end: datetime,
     caggs: list[str] | None = None,
-) -> None:
+) -> list[str]:
     """Refresh CAGGs for a specific time range (used after historical imports).
 
     Timestamps are bound as asyncpg parameters. CAGG names cannot be bound
     (identifiers), so they are validated against the ALL_CAGGS allowlist.
+
+    Never raises on a refresh failure (startup and the scheduler must survive
+    one), but returns the CAGGs that could not be refreshed so callers whose
+    correctness depends on it - the backfill commands, whose written rows stay
+    invisible to analytics until the aggregates catch up - can report or exit
+    nonzero. An empty list means every requested CAGG refreshed.
 
     Args:
         engine: Async engine (raw asyncpg connection is used: CALL cannot
@@ -973,6 +979,9 @@ async def refresh_caggs_range(
         start: Range start (inclusive), timezone-aware.
         end: Range end (exclusive), timezone-aware.
         caggs: Optional subset of CAGGs (defaults to all).
+
+    Returns:
+        Names of CAGGs whose refresh failed; empty when all succeeded.
     """
     if not start or not end:
         raise ValueError("Both start and end must be provided")
@@ -982,6 +991,7 @@ async def refresh_caggs_range(
     if unknown:
         raise ValueError(f"Unknown CAGG name(s): {sorted(unknown)}")
 
+    failed: list[str] = []
     for cagg in target_caggs:
         # A background refresh-policy job on an overlapping window makes
         # refresh_continuous_aggregate raise "concurrent refresh"; without a
@@ -1006,7 +1016,9 @@ async def refresh_caggs_range(
                     await asyncio.sleep(0.5 * (attempt + 1))
                     continue
                 logger.warning("CAGG refresh failed: %s (%s → %s): %s", cagg, start, end, e)
+                failed.append(cagg)
                 break
+    return failed
 
 
 # CAGG -> raw source hypertable (all use a "timestamp" time column)

--- a/tests/integration/test_analytics_endpoints.py
+++ b/tests/integration/test_analytics_endpoints.py
@@ -356,3 +356,25 @@ async def test_request_totals_count_unenriched_rows(pg_session_maker, clean_tabl
     assert sum(r.hits for r in asn_rows) == 1, "ASN queries only see tagged rows"
     assert total_requests == 4, "totals must include the unenriched rows"
     assert total_bytes == 500
+
+
+async def test_iter_null_asn_ips_pages_without_gaps_or_repeats(pg_engine, pg_session_maker, clean_tables):
+    """Keyset pagination must cover every distinct NULL-ASN IP exactly once."""
+    from geometrikks.cli import _iter_null_asn_ips
+
+    ts = NOW - timedelta(hours=1)
+    ips = [f"10.0.0.{i}" for i in range(1, 8)]
+    async with pg_session_maker() as session:
+        for ip in ips:
+            for _ in range(2):  # duplicates must collapse
+                await _insert_log(session, ts=ts, url="/a", user_agent="x", ip=ip)
+        # A stamped row's IP must not appear: it needs no backfill.
+        await _insert_asn_log(session, ts=ts, asn=24940, asn_org="Hetzner Online GmbH")
+        await session.commit()
+
+    pages = [page async for page in _iter_null_asn_ips(pg_engine, chunk_size=3)]
+
+    assert len(pages) > 1, "chunk_size=3 over 7 IPs must paginate"
+    seen = [ip for page in pages for ip in page]
+    assert sorted(seen) == sorted(ips)
+    assert len(seen) == len(set(seen))

--- a/tests/integration/test_analytics_endpoints.py
+++ b/tests/integration/test_analytics_endpoints.py
@@ -300,3 +300,33 @@ async def test_top_asns_ordering_and_org(pg_session_maker, clean_tables):
         (24940, "Hetzner Online GmbH", 3, 600),
         (2119, "Telenor Norge AS", 1, 100),
     ]
+
+
+async def test_apply_asn_mapping_fills_only_null_rows(pg_engine, pg_session_maker, clean_tables):
+    from geometrikks.cli import _apply_asn_mapping
+
+    ts = NOW - timedelta(hours=1)
+    async with pg_session_maker() as session:
+        # Two NULL-ASN rows for 10.0.0.1, one already-stamped row that must
+        # not be overwritten, and one NULL row whose IP is not in the mapping.
+        await _insert_log(session, ts=ts, url="/a", user_agent="x")
+        await _insert_log(session, ts=ts, url="/b", user_agent="x")
+        await _insert_asn_log(session, ts=ts, asn=999, asn_org="Stamped Org")
+        await _insert_log(session, ts=ts, url="/c", user_agent="x", ip="10.9.9.9")
+        await session.commit()
+
+    updated = await _apply_asn_mapping(pg_engine, [
+        {"ip": "10.0.0.1", "asn": 24940, "org": "Hetzner Online GmbH"},
+    ])
+    assert updated == 2
+
+    async with pg_session_maker() as session:
+        rows = (await session.execute(text(
+            "SELECT host(ip_address), autonomous_system_number, autonomous_system_organization "
+            "FROM access_logs ORDER BY url"
+        ))).all()
+
+    by_row = {(r[0], r[1], r[2]) for r in rows}
+    assert ("10.0.0.1", 24940, "Hetzner Online GmbH") in by_row
+    assert ("10.0.0.1", 999, "Stamped Org") in by_row
+    assert ("10.9.9.9", None, None) in by_row

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -398,6 +398,7 @@ def test_backfill_asn_stamps_and_refreshes(monkeypatch) -> None:
     assert result.exit_code == 0, result.output
     assert "rows updated: 7" in result.output
     refresh.assert_awaited_once()
+    assert refresh.await_args is not None
     assert refresh.await_args.kwargs["caggs"] == ["asn_hourly_stats", "asn_daily_stats"]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """CLI plugin registration and command surface."""
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 from click.testing import CliRunner
@@ -321,10 +322,13 @@ def _make_asn_engine(
     """Engine for the backfill-asn flow, dispatching on SQL substrings.
 
     connect() answers the EXISTS probe, the count/bounds scan, and the
-    distinct-IP stream; begin() serves the temp-table writes and reports
-    ``rowcount`` on the join UPDATE.
+    keyset-paginated distinct-IP stream (one page, then empty, so the
+    pagination loop terminates); begin() serves the temp-table writes and
+    reports ``rowcount`` on the join UPDATE.
     """
     from datetime import datetime, timezone
+
+    ip_pages = [[SimpleNamespace(ip_text=ip) for ip in distinct_ips], []]
 
     def _result_for(sql: str) -> MagicMock:
         result = MagicMock()
@@ -340,8 +344,8 @@ def _make_asn_engine(
                 datetime(2026, 1, 1, tzinfo=timezone.utc),
                 datetime(2026, 1, 2, tzinfo=timezone.utc),
             )
-        elif "DISTINCT host(ip_address)" in sql:
-            result.all.return_value = [(ip,) for ip in distinct_ips]
+        elif "DISTINCT ip_address" in sql:
+            result.all.return_value = ip_pages.pop(0) if ip_pages else []
         return result
 
     async def _execute(stmt, params=None):
@@ -391,7 +395,7 @@ def _invoke_backfill_asn(
 def test_backfill_asn_stamps_and_refreshes(monkeypatch) -> None:
     """1.128.0.0 resolves via the test db; the run updates and refreshes."""
     engine = _make_asn_engine(null_rows=7, distinct_ips=["1.128.0.0"], rowcount=7)
-    refresh = AsyncMock()
+    refresh = AsyncMock(return_value=[])
 
     result = _invoke_backfill_asn(monkeypatch, engine, ["--yes"], refresh)
 
@@ -404,7 +408,7 @@ def test_backfill_asn_stamps_and_refreshes(monkeypatch) -> None:
 
 def test_backfill_asn_nothing_to_do(monkeypatch) -> None:
     engine = _make_asn_engine(null_rows=0, distinct_ips=[], rowcount=0)
-    refresh = AsyncMock()
+    refresh = AsyncMock(return_value=[])
 
     result = _invoke_backfill_asn(monkeypatch, engine, ["--yes"], refresh)
 
@@ -417,7 +421,7 @@ def test_backfill_asn_aborts_without_confirmation(monkeypatch) -> None:
     """Default (no --yes, input 'n'): no write transaction, no refresh."""
     engine = _make_asn_engine(null_rows=7, distinct_ips=["1.128.0.0"], rowcount=7)
     engine.begin = MagicMock(side_effect=AssertionError("begin() must not run when aborted"))
-    refresh = AsyncMock()
+    refresh = AsyncMock(return_value=[])
 
     result = _invoke_backfill_asn(monkeypatch, engine, [], refresh, cli_input="n\n")
 
@@ -428,7 +432,7 @@ def test_backfill_asn_aborts_without_confirmation(monkeypatch) -> None:
 
 def test_backfill_asn_fails_without_asn_database(monkeypatch) -> None:
     engine = _make_asn_engine(null_rows=7, distinct_ips=["1.128.0.0"], rowcount=7)
-    refresh = AsyncMock()
+    refresh = AsyncMock(return_value=[])
 
     result = _invoke_backfill_asn(
         monkeypatch, engine, ["--yes"], refresh,
@@ -437,3 +441,16 @@ def test_backfill_asn_fails_without_asn_database(monkeypatch) -> None:
 
     assert result.exit_code != 0
     assert "No GeoLite2 ASN database" in result.output
+
+
+def test_backfill_asn_exits_nonzero_when_cagg_refresh_fails(monkeypatch) -> None:
+    """Rows are stamped but the aggregates stayed stale: the run must not
+    report success, or long-range analytics silently miss the backfill."""
+    engine = _make_asn_engine(null_rows=7, distinct_ips=["1.128.0.0"], rowcount=7)
+    refresh = AsyncMock(return_value=["asn_daily_stats"])
+
+    result = _invoke_backfill_asn(monkeypatch, engine, ["--yes"], refresh)
+
+    assert result.exit_code != 0
+    assert "rows updated: 7" in result.output
+    assert "asn_daily_stats" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -302,3 +302,137 @@ def test_backfill_hostname_consolidate_prompts(monkeypatch) -> None:
     assert "Aborted." in result.output
     engine.begin.assert_not_called()
     engine.dispose.assert_awaited_once()
+
+
+def test_cli_plugin_registers_backfill_asn() -> None:
+    import click
+    from geometrikks.cli import ImportLogsCLIPlugin
+
+    @click.group()
+    def cli() -> None: ...
+
+    ImportLogsCLIPlugin().on_cli_init(cli)
+    assert "backfill-asn" in cli.commands
+
+
+def _make_asn_engine(
+    *, null_rows: int, distinct_ips: list[str], rowcount: int
+) -> MagicMock:
+    """Engine for the backfill-asn flow, dispatching on SQL substrings.
+
+    connect() answers the EXISTS probe, the count/bounds scan, and the
+    distinct-IP stream; begin() serves the temp-table writes and reports
+    ``rowcount`` on the join UPDATE.
+    """
+    from datetime import datetime, timezone
+
+    def _result_for(sql: str) -> MagicMock:
+        result = MagicMock()
+        result.rowcount = rowcount
+        if "EXISTS" in sql and "pg_extension" in sql:
+            result.scalar.return_value = False  # no timescale: skip decompress
+        elif "EXISTS" in sql:
+            result.scalar.return_value = null_rows > 0
+        elif "COUNT(DISTINCT" in sql:
+            result.one.return_value = (null_rows, len(distinct_ips))
+        elif "MIN(timestamp)" in sql:
+            result.one.return_value = (
+                datetime(2026, 1, 1, tzinfo=timezone.utc),
+                datetime(2026, 1, 2, tzinfo=timezone.utc),
+            )
+        elif "DISTINCT host(ip_address)" in sql:
+            result.all.return_value = [(ip,) for ip in distinct_ips]
+        return result
+
+    async def _execute(stmt, params=None):
+        return _result_for(str(stmt))
+
+    conn = MagicMock()
+    conn.execute = AsyncMock(side_effect=_execute)
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=False)
+
+    engine = MagicMock()
+    engine.connect = MagicMock(return_value=conn)
+    engine.begin = MagicMock(return_value=conn)
+    engine.dispose = AsyncMock()
+    return engine
+
+
+def _invoke_backfill_asn(
+    monkeypatch, engine: MagicMock, args: list[str], refresh: AsyncMock,
+    *, asn_db_path: str = "tests/GeoLite2-ASN-Test.mmdb", cli_input: str | None = None,
+):
+    """Run backfill-asn against a mocked engine, real ASN test db, mocked refresh."""
+    import click
+
+    import geometrikks.server.plugins as plugins_module
+    import geometrikks.server.timescale as timescale_module
+    from geometrikks.cli import ImportLogsCLIPlugin
+    from geometrikks.config.settings import get_settings
+
+    config = MagicMock()
+    config.get_engine.return_value = engine
+    monkeypatch.setattr(plugins_module, "get_sqlalchemy_config", lambda: config)
+    monkeypatch.setattr(timescale_module, "refresh_caggs_range", refresh)
+    monkeypatch.setenv("GEOIP_ASN_DB_PATH", asn_db_path)
+    get_settings.cache_clear()
+
+    @click.group()
+    def cli() -> None: ...
+
+    ImportLogsCLIPlugin().on_cli_init(cli)
+    try:
+        return CliRunner().invoke(cli, ["backfill-asn", *args], input=cli_input)
+    finally:
+        get_settings.cache_clear()
+
+
+def test_backfill_asn_stamps_and_refreshes(monkeypatch) -> None:
+    """1.128.0.0 resolves via the test db; the run updates and refreshes."""
+    engine = _make_asn_engine(null_rows=7, distinct_ips=["1.128.0.0"], rowcount=7)
+    refresh = AsyncMock()
+
+    result = _invoke_backfill_asn(monkeypatch, engine, ["--yes"], refresh)
+
+    assert result.exit_code == 0, result.output
+    assert "rows updated: 7" in result.output
+    refresh.assert_awaited_once()
+    assert refresh.await_args.kwargs["caggs"] == ["asn_hourly_stats", "asn_daily_stats"]
+
+
+def test_backfill_asn_nothing_to_do(monkeypatch) -> None:
+    engine = _make_asn_engine(null_rows=0, distinct_ips=[], rowcount=0)
+    refresh = AsyncMock()
+
+    result = _invoke_backfill_asn(monkeypatch, engine, ["--yes"], refresh)
+
+    assert result.exit_code == 0, result.output
+    assert "Nothing to do" in result.output
+    refresh.assert_not_awaited()
+
+
+def test_backfill_asn_aborts_without_confirmation(monkeypatch) -> None:
+    """Default (no --yes, input 'n'): no write transaction, no refresh."""
+    engine = _make_asn_engine(null_rows=7, distinct_ips=["1.128.0.0"], rowcount=7)
+    engine.begin = MagicMock(side_effect=AssertionError("begin() must not run when aborted"))
+    refresh = AsyncMock()
+
+    result = _invoke_backfill_asn(monkeypatch, engine, [], refresh, cli_input="n\n")
+
+    assert result.exit_code == 0, result.output
+    assert "Aborted" in result.output
+    refresh.assert_not_awaited()
+
+
+def test_backfill_asn_fails_without_asn_database(monkeypatch) -> None:
+    engine = _make_asn_engine(null_rows=7, distinct_ips=["1.128.0.0"], rowcount=7)
+    refresh = AsyncMock()
+
+    result = _invoke_backfill_asn(
+        monkeypatch, engine, ["--yes"], refresh,
+        asn_db_path="/nonexistent/GeoLite2-ASN.mmdb",
+    )
+
+    assert result.exit_code != 0
+    assert "No GeoLite2 ASN database" in result.output


### PR DESCRIPTION
## What

Phase 3 of the ASN feature, stacked on #145 (layer 3 of the stack): the explicit opt-in path for history.

`litestar backfill-asn` resolves the distinct IPs of all `access_logs` rows with NULL ASN data against the local GeoLite2 ASN database and stamps them retroactively:

- Idempotent by construction: fills only NULL rows, can never overwrite stamped values; unresolvable IPs stay NULL.
- Reports row/IP counts and asks for confirmation before touching anything (`--yes` skips); cheap EXISTS probe makes reruns with nothing to do exit early.
- Decompresses compressed hypertable chunks first (same pattern as `backfill-hostname`; the compression policy recompresses later) and applies the mapping through a temp table joined into one UPDATE rather than per-IP statements.
- Refreshes `asn_{hourly,daily}_stats` over the affected time range afterwards, so the Top ASNs view picks up the backfilled history; the run is audit-logged (`asn_backfill_completed`).
- Documented in the README CLI section, including the caveat that today's ASN database describes today's network ownership.

## Testing

- `uv run ty check geometrikks tests` clean
- 838 unit tests passing (registration, stamp-and-refresh flow, nothing-to-do early exit, declined confirmation runs no write transaction, hard error without an ASN database)
- 153 integration tests passing, including a real-database test that the temp-table apply fills only NULL rows and leaves stamped values and unmapped IPs untouched