### PR TITLE
feat: Traffic origin KPIs on the Summary dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   retroactively.
 - The Top URLs and Top user agents tables now sit side by side on wide
   screens to save page height.
+- The Summary dashboard gains a Traffic origin section: the datacenter share
+  of classified traffic and the busiest network for the selected range. It
+  is hidden entirely when no requests in range carry ASN data.
 - `litestar backfill-asn`: retroactively stamp ASN data onto rows ingested
   before the ASN feature (or while the database was missing), with a
   confirmation prompt, decompress-first handling for compressed history,

--- a/resources/components/analytics/traffic-origin-card.tsx
+++ b/resources/components/analytics/traffic-origin-card.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/table"
 import { Skeleton } from "@/components/ui/skeleton"
 import { formatBytes, formatNumber } from "@/lib/api"
+import { asnCoverage } from "@/lib/asn-coverage"
 import { useTopAsns } from "@/lib/queries"
 import { CategoryBadge } from "./top-asns-table"
 
@@ -17,16 +18,13 @@ export function TrafficOriginCard() {
 
   const datacenter = data?.categories.find((c) => c.category === "datacenter")
   const other = data?.categories.find((c) => c.category === "other")
-  // Two denominators, deliberately: the share is of CLASSIFIED traffic (the
-  // only traffic whose origin is known), while coverage is judged against
-  // every request in the range. Dividing by the classified total alone would
-  // report "100% datacenter" on an install whose history predates ASN
-  // enrichment.
-  const classified = (datacenter?.hits ?? 0) + (other?.hits ?? 0)
   const totalRequests = data?.totalRequests ?? 0
-  const unenriched = Math.max(0, totalRequests - classified)
-  const share = classified > 0 ? ((datacenter?.hits ?? 0) / classified) * 100 : 0
-  const coverage = totalRequests > 0 ? (classified / totalRequests) * 100 : 0
+  // See asn-coverage.ts for why the share and the coverage use different
+  // denominators.
+  const { classified, unenriched, datacenterShare: share, coverage } = asnCoverage(
+    data?.categories,
+    totalRequests,
+  )
 
   return (
     <Card>

--- a/resources/components/dashboard/section-header.tsx
+++ b/resources/components/dashboard/section-header.tsx
@@ -1,0 +1,11 @@
+/** Dashboard section divider: small caps label plus a hairline rule. */
+export function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-3">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {children}
+      </h2>
+      <div className="flex-1 h-px bg-border/50" />
+    </div>
+  )
+}

--- a/resources/components/dashboard/summary.tsx
+++ b/resources/components/dashboard/summary.tsx
@@ -28,17 +28,8 @@ import { useTimeRange } from "@/lib/time-range-context"
 import { cn } from "@/lib/utils"
 import { StatCard, StatCardSkeleton } from "@/components/dashboard/statcard"
 import { DateTimeRange } from "@/components/dashboard/date-time-range"
-
-function SectionHeader({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="flex items-center gap-3">
-      <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-        {children}
-      </h2>
-      <div className="flex-1 h-px bg-border/50" />
-    </div>
-  )
-}
+import { SectionHeader } from "@/components/dashboard/section-header"
+import { TrafficOriginStats } from "@/components/dashboard/traffic-origin-stats"
 
 export function Summary() {
   const { range } = useTimeRange()
@@ -273,6 +264,9 @@ export function Summary() {
                 icon={ArrowRightLeft}
               />
             </div>
+
+            {/* Section 4: Traffic Origin (renders nothing without ASN data) */}
+            <TrafficOriginStats />
           </div>
         )}
       </div>

--- a/resources/components/dashboard/traffic-origin-stats.tsx
+++ b/resources/components/dashboard/traffic-origin-stats.tsx
@@ -12,6 +12,7 @@
  */
 import { Network, Server } from "lucide-react"
 
+import { Card, CardContent } from "@/components/ui/card"
 import { SectionHeader } from "@/components/dashboard/section-header"
 import { StatCard } from "@/components/dashboard/statcard"
 import { formatNumber } from "@/lib/api"
@@ -21,12 +22,32 @@ import { useTopAsns } from "@/lib/queries"
 export function TrafficOriginStats() {
   // limit=1: only the leading organization is shown here. Category totals are
   // computed server-side across every ASN, so they stay exact regardless.
-  const { data } = useTopAsns({ limit: 1 })
+  const { data, isError, error } = useTopAsns({ limit: 1 })
 
   const { classified, datacenterShare, coverage, hasData } = asnCoverage(
     data?.categories,
     data?.totalRequests ?? 0,
   )
+
+  // A failed request must not look like "you have no ASN data": without this
+  // the section would vanish while the rest of Summary renders normally, and
+  // nothing would say the query broke. Only when there is no usable data at
+  // all - a background refetch failure still has the last good values, and
+  // stale KPIs beat an error card.
+  if (isError && !data) {
+    return (
+      <>
+        <SectionHeader>Traffic Origin</SectionHeader>
+        <Card className="border-destructive/50 bg-destructive/10">
+          <CardContent className="py-4">
+            <p className="text-sm text-destructive">
+              Failed to load ASN statistics: {error?.message ?? "Unknown error"}
+            </p>
+          </CardContent>
+        </Card>
+      </>
+    )
+  }
 
   // Nothing enriched yet (fresh install, ASN disabled, history predating the
   // feature): stay silent rather than parking an explanatory card on a

--- a/resources/components/dashboard/traffic-origin-stats.tsx
+++ b/resources/components/dashboard/traffic-origin-stats.tsx
@@ -1,0 +1,63 @@
+/**
+ * Dashboard "Traffic origin" KPIs, fed by the analytics /top-asns endpoint.
+ *
+ * Owns its own query rather than riding /summary: the summary CAGGs carry no
+ * ASN dimension (adding one means drop+recreate, which discards history older
+ * than raw retention), and /summary runs twice per load for its
+ * previous-period comparison. TanStack shares this fetch with the analytics
+ * page whenever the selected range matches.
+ *
+ * The hook depends on AnalyticsFiltersContext, whose default is EMPTY_FILTERS
+ * precisely so dashboard-shared hooks work outside the analytics provider.
+ */
+import { Network, Server } from "lucide-react"
+
+import { SectionHeader } from "@/components/dashboard/section-header"
+import { StatCard } from "@/components/dashboard/statcard"
+import { formatNumber } from "@/lib/api"
+import { asnCoverage } from "@/lib/asn-coverage"
+import { useTopAsns } from "@/lib/queries"
+
+export function TrafficOriginStats() {
+  // limit=1: only the leading organization is shown here. Category totals are
+  // computed server-side across every ASN, so they stay exact regardless.
+  const { data } = useTopAsns({ limit: 1 })
+
+  const { classified, datacenterShare, coverage, hasData } = asnCoverage(
+    data?.categories,
+    data?.totalRequests ?? 0,
+  )
+
+  // Nothing enriched yet (fresh install, ASN disabled, history predating the
+  // feature): stay silent rather than parking an explanatory card on a
+  // glanceable KPI page. The analytics page explains it and names the
+  // backfill command.
+  if (!data || !hasData) return null
+
+  const top = data.items[0]
+
+  return (
+    <>
+      <SectionHeader>Traffic Origin</SectionHeader>
+      <div className="grid gap-4 md:grid-cols-2">
+        <StatCard
+          title="Datacenter Traffic"
+          value={`${datacenterShare.toFixed(1)}%`}
+          subtitle={
+            coverage < 99.5
+              ? `of ${formatNumber(classified)} classified requests (${coverage.toFixed(0)}% of range)`
+              : `of ${formatNumber(classified)} requests`
+          }
+          icon={Server}
+        />
+        <StatCard
+          title="Top Network"
+          value={top?.organization ?? `AS${top?.asn ?? "-"}`}
+          valueClassName="truncate text-xl"
+          subtitle={top ? `AS${top.asn} - ${formatNumber(top.hits)} requests` : "No ASN data"}
+          icon={Network}
+        />
+      </div>
+    </>
+  )
+}

--- a/resources/lib/asn-coverage.test.ts
+++ b/resources/lib/asn-coverage.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+import { asnCoverage } from "./asn-coverage"
+
+const cats = (datacenter: number, other: number) => [
+  { category: "datacenter" as const, hits: datacenter },
+  { category: "other" as const, hits: other },
+]
+
+describe("asnCoverage", () => {
+  it("reports the share of classified traffic, not of the whole range", () => {
+    // 100 classified out of 1000 requests: the range is mostly pre-enrichment
+    // history. Regression: dividing by the category sum alone read as
+    // "100% of 100 requests" while 900 rows were invisible.
+    const c = asnCoverage(cats(90, 10), 1000)
+    expect(c.classified).toBe(100)
+    expect(c.unenriched).toBe(900)
+    expect(c.datacenterShare).toBeCloseTo(90)
+    expect(c.coverage).toBeCloseTo(10)
+    expect(c.hasData).toBe(true)
+  })
+
+  it("reports full coverage when every request is enriched", () => {
+    const c = asnCoverage(cats(63, 37), 100)
+    expect(c.unenriched).toBe(0)
+    expect(c.coverage).toBeCloseTo(100)
+    expect(c.datacenterShare).toBeCloseTo(63)
+  })
+
+  it("has no data when nothing in the range is classified", () => {
+    const c = asnCoverage(cats(0, 0), 5000)
+    expect(c.hasData).toBe(false)
+    expect(c.datacenterShare).toBe(0)
+    expect(c.unenriched).toBe(5000)
+  })
+
+  it("treats missing categories as zero rather than NaN", () => {
+    const c = asnCoverage(undefined, 0)
+    expect(c.hasData).toBe(false)
+    expect(c.datacenterShare).toBe(0)
+    expect(c.coverage).toBe(0)
+  })
+
+  it("never reports negative unenriched when totals race the aggregates", () => {
+    // Live ingestion between the two reads can leave classified > total.
+    const c = asnCoverage(cats(60, 45), 100)
+    expect(c.unenriched).toBe(0)
+  })
+})

--- a/resources/lib/asn-coverage.test.ts
+++ b/resources/lib/asn-coverage.test.ts
@@ -40,9 +40,11 @@ describe("asnCoverage", () => {
     expect(c.coverage).toBe(0)
   })
 
-  it("never reports negative unenriched when totals race the aggregates", () => {
-    // Live ingestion between the two reads can leave classified > total.
+  it("clamps both derived figures when totals race the aggregates", () => {
+    // Live ingestion between the two reads can leave classified > total;
+    // neither "-5 unenriched" nor "105% of range" may reach the UI.
     const c = asnCoverage(cats(60, 45), 100)
     expect(c.unenriched).toBe(0)
+    expect(c.coverage).toBe(100)
   })
 })

--- a/resources/lib/asn-coverage.ts
+++ b/resources/lib/asn-coverage.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared math for the ASN origin split, used by the analytics Traffic origin
+ * card and the dashboard KPI cards.
+ *
+ * Two denominators, deliberately. The datacenter share is of CLASSIFIED
+ * traffic, the only traffic whose origin is known; coverage is against every
+ * request in the range. The ASN aggregates exclude rows with no ASN data
+ * (history predating enrichment, enrichment disabled, unresolvable IPs), so
+ * dividing by the category sum alone reports "100% datacenter" on a database
+ * that is mostly unenriched.
+ */
+
+export interface AsnCategoryTotal {
+  category: "datacenter" | "other"
+  hits: number
+}
+
+export interface AsnCoverage {
+  /** Requests carrying ASN data (datacenter + other). */
+  classified: number
+  /** Requests in range with no ASN data at all. */
+  unenriched: number
+  /** Datacenter percentage OF CLASSIFIED traffic. */
+  datacenterShare: number
+  /** Percentage of the range's requests that carry ASN data. */
+  coverage: number
+  /** False when nothing in the range is classified: callers show an empty state. */
+  hasData: boolean
+}
+
+export function asnCoverage(
+  categories: readonly AsnCategoryTotal[] | undefined,
+  totalRequests: number,
+): AsnCoverage {
+  const datacenter = categories?.find((c) => c.category === "datacenter")?.hits ?? 0
+  const other = categories?.find((c) => c.category === "other")?.hits ?? 0
+  const classified = datacenter + other
+  // max(0): a range whose totals and ASN aggregates were read microseconds
+  // apart can disagree by a row or two under live ingestion.
+  const unenriched = Math.max(0, totalRequests - classified)
+  return {
+    classified,
+    unenriched,
+    datacenterShare: classified > 0 ? (datacenter / classified) * 100 : 0,
+    coverage: totalRequests > 0 ? (classified / totalRequests) * 100 : 0,
+    hasData: classified > 0,
+  }
+}

--- a/resources/lib/asn-coverage.ts
+++ b/resources/lib/asn-coverage.ts
@@ -35,14 +35,16 @@ export function asnCoverage(
   const datacenter = categories?.find((c) => c.category === "datacenter")?.hits ?? 0
   const other = categories?.find((c) => c.category === "other")?.hits ?? 0
   const classified = datacenter + other
-  // max(0): a range whose totals and ASN aggregates were read microseconds
-  // apart can disagree by a row or two under live ingestion.
+  // The totals and the ASN aggregates are two separate reads, so live
+  // ingestion between them can leave classified marginally ahead of the
+  // range total. Both derived figures are clamped to their physical range so
+  // no caller can render "-12 unenriched" or "105% of range".
   const unenriched = Math.max(0, totalRequests - classified)
   return {
     classified,
     unenriched,
     datacenterShare: classified > 0 ? (datacenter / classified) * 100 : 0,
-    coverage: totalRequests > 0 ? (classified / totalRequests) * 100 : 0,
+    coverage: totalRequests > 0 ? Math.min(100, (classified / totalRequests) * 100) : 0,
     hasData: classified > 0,
   }
 }


### PR DESCRIPTION
## What

Layer 4 of the ASN stack, on top of #146: two dashboard KPI cards for the selected range.

- **Datacenter Traffic** - the datacenter share of classified traffic, with coverage in the subtitle ("of 108,987 classified requests (62% of range)") so a partially-enriched database cannot read as "100% datacenter".
- **Top Network** - the busiest organization, with its AS number and request count.

The section hides itself entirely (header included) when no request in the range carries ASN data, rather than parking an explanatory card on a glanceable KPI page; the analytics page keeps the explanation and names the backfill command.

## Why not extend /summary

The summary CAGGs carry no ASN dimension, and adding one is a one-way door: changing their definition means drop and recreate, which permanently discards daily history older than raw retention (the caveat already documented on `_upgrade_summary_caggs`). Materializing the datacenter split would also freeze classification at materialization time, losing the read-time property that lets an improved hosting-ASN list reclassify existing history for free. Merging the ASN queries into the `/summary` *endpoint* was possible but rejected: it runs twice per load for the previous-period comparison, and it would couple the dashboard's core numbers to the ASN feature. `asn_daily_stats` is already the right aggregate, and TanStack shares the fetch with the analytics page when ranges match.

Frontend only: no API, schema, or aggregate changes.

## Notable

- The share/coverage math moved into `resources/lib/asn-coverage.ts`, shared by this card and the analytics Traffic origin card (previously duplicated), with unit tests pinning the regression Sol caught: 100 classified out of 1000 requests must read as 90% datacenter at 10% coverage, not 100% of 100.
- `SectionHeader` extracted from `summary.tsx` so the new section can hide its own header.
- `useTopAsns` works outside `AnalyticsFiltersProvider` by the existing `EMPTY_FILTERS` context default, which the context documents as a contract for dashboard-shared hooks. `limit: 1` keeps the payload minimal; category totals stay exact because they are computed server-side across every ASN.

## Testing

- `bun run typecheck` clean, 191 vitest tests passing (5 new)
- `uv run ty check geometrikks tests` clean, 842 Python tests passing (unchanged: no backend edits)