### PR TITLE
fix(compose): give the app a 20s stop grace period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ... out of background workers" warnings when the aggregate refresh
   policies all fire at once. Existing installs: copy the `command:` block
   from `docker-compose.yml` onto the database service and recreate it.
+- `docker-compose.yml` sets `stop_grace_period: 20s` on the app service, as
+  the deployment docs already prescribed. Docker's default 10s stop timeout
+  raced Granian's 15s worker-kill timeout, so `docker stop` could SIGKILL
+  the container mid-teardown and lose the ingestion batch still in flight.
+  Existing installs: add the same line to your app (and agent) services.
 
 ## [0.8.0] - 2026-08-16
 

--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ services:
   agent:
     image: ghcr.io/gilbn/geometrikks:0.9.0   # same tag as the full instance
     restart: unless-stopped
+    stop_grace_period: 20s
     environment:
       APP_MODE: agent
       DB_HOST: timescale.example.internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,10 @@ services:
     depends_on:
       timescale_db:
         condition: service_healthy
+    # Granian is started with --workers-kill-timeout 15; the default 10s
+    # stop timeout SIGKILLs the container mid-teardown and drops the
+    # ingestion batch still in flight.
+    stop_grace_period: 20s
 
 volumes:
   timescale_data:


### PR DESCRIPTION
The image runs Granian with `--workers-kill-timeout 15`, so Docker's default 10s stop timeout SIGKILLs the container mid-teardown and drops the ingestion batch still in flight.

`docs/deployment.md` already prescribed `stop_grace_period: 20s` and `dev/docker-compose.agents.yml` already set it. The user-facing `docker-compose.yml` and the README's agent snippet never did, so every install following the quickstart had the race.

- `docker-compose.yml`: `stop_grace_period: 20s` on the app service, with a comment on why the number is what it is.
- `README.md`: same line in the agent-mode snippet, since agents drain ingestion too.
- `CHANGELOG.md`: Fixed entry with an "existing installs" note, matching the shape of the neighbouring worker-pool entry.

Config only, no code paths touched.