### PR TITLE
fix(tables): persist the Columns picker selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   range. IPs are resolved and written in bounded chunks, and a failed
   aggregate refresh exits non-zero rather than reporting a clean run.
 
+### Fixed
+
+- The Columns picker on the Access Logs, Geo Logs, and Debug Logs tables
+  now remembers its selection across reloads (per browser). Only columns
+  you toggled are stored, so defaults still apply to the rest and columns
+  added in later releases show up as intended. A "Reset to defaults" item
+  clears the saved selection.
+
 ## [0.9.0] - 2026-08-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now remembers its selection across reloads (per browser). Only columns
   you toggled are stored, so defaults still apply to the rest and columns
   added in later releases show up as intended. A "Reset to defaults" item
-  clears the saved selection.
+  clears the saved selection. The picker is also wide enough for its
+  labels instead of wrapping them at the width of the Columns button.
 
 ## [0.9.0] - 2026-08-20
 

--- a/resources/components/access-logs/access-logs-table.tsx
+++ b/resources/components/access-logs/access-logs-table.tsx
@@ -6,7 +6,6 @@
  * (search, IP, host, hostname, source format, status, method, country and
  * city live in access-logs-filter-bar.tsx). Pairs with GET /api/v1/access-logs/.
  */
-import { useMemo, useState } from "react"
 import { ArrowDown, ArrowUp, ChevronsUpDown, Columns3 } from "lucide-react"
 import {
   Table,
@@ -22,6 +21,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
+  DropdownMenuItem,
   DropdownMenuContent,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -37,7 +37,8 @@ import {
   type AccessLogSortField,
   type SortOrder,
 } from "@/lib/api"
-import { cn, isMobileViewport } from "@/lib/utils"
+import { cn } from "@/lib/utils"
+import { useColumnVisibility } from "@/lib/column-visibility"
 import { useAccessLogFilters } from "@/lib/access-log-filters-context"
 
 export const ACCESS_LOGS_PAGE_SIZES = [10, 20, 50, 100, 200, 500, 1000] as const
@@ -265,14 +266,8 @@ export function AccessLogsTable({
   const { filters } = useAccessLogFilters()
   useCrowdsecLiveUpdates()
 
-  // Column visibility.
-  const [visible, setVisible] = useState<Set<string>>(() => {
-    const mobile = isMobileViewport()
-    return new Set(
-      COLUMNS.filter((c) => c.defaultVisible && !(mobile && c.mobileHidden)).map((c) => c.key),
-    )
-  })
-  const shownColumns = useMemo(() => COLUMNS.filter((c) => visible.has(c.key)), [visible])
+  const { visible, shownColumns, toggleColumn, resetColumns, hasOverrides } =
+    useColumnVisibility("geometrikks-columns-access-logs", COLUMNS)
 
   const { data, isLoading, isError, isPlaceholderData } = useAccessLogs({
     currentPage: page,
@@ -306,15 +301,6 @@ export function AccessLogsTable({
     }
   }
 
-  function toggleColumn(key: string) {
-    setVisible((prev) => {
-      const next = new Set(prev)
-      if (next.has(key)) next.delete(key)
-      else next.add(key)
-      return next
-    })
-  }
-
   const columnsMenu = (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -336,6 +322,10 @@ export function AccessLogsTable({
             {c.label}
           </DropdownMenuCheckboxItem>
         ))}
+      <DropdownMenuSeparator />
+      <DropdownMenuItem disabled={!hasOverrides} onSelect={resetColumns}>
+        Reset to defaults
+      </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/resources/components/access-logs/access-logs-table.tsx
+++ b/resources/components/access-logs/access-logs-table.tsx
@@ -308,7 +308,7 @@ export function AccessLogsTable({
           <Columns3 className="mr-1 h-3.5 w-3.5" /> Columns
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="max-h-80 overflow-y-auto">
+      <DropdownMenuContent align="end" className="max-h-80 w-auto min-w-44 overflow-y-auto">
         <DropdownMenuLabel>Visible columns</DropdownMenuLabel>
         <DropdownMenuSeparator />
         {COLUMNS.map((c) => (

--- a/resources/components/debug-logs/debug-logs-table.tsx
+++ b/resources/components/debug-logs/debug-logs-table.tsx
@@ -4,7 +4,7 @@
  * city, malformed tri-state. Clicking a row opens the raw-line detail
  * dialog. Pairs with GET /api/v1/access-log-debug/.
  */
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useState } from "react"
 import {
   ArrowDown,
   ArrowUp,
@@ -27,6 +27,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
+  DropdownMenuItem,
   DropdownMenuContent,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -49,7 +50,8 @@ import { useDebouncedValue } from "@/hooks/use-debounced-value"
 import { isValidIp } from "@/lib/crowdsec"
 import { useIsMobile } from "@/hooks/use-mobile"
 import type { AccessLogDebugEntry, AccessLogDebugSortField, SortOrder } from "@/lib/api"
-import { cn, isMobileViewport } from "@/lib/utils"
+import { cn } from "@/lib/utils"
+import { useColumnVisibility } from "@/lib/column-visibility"
 
 const PAGE_SIZES = [10, 20, 50, 100, 200, 500, 1000] as const
 
@@ -234,14 +236,8 @@ export function DebugLogsTable() {
   const [sortField, setSortField] = useState<AccessLogDebugSortField>("createdAt")
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc")
 
-  // Column visibility.
-  const [visible, setVisible] = useState<Set<string>>(() => {
-    const mobile = isMobileViewport()
-    return new Set(
-      COLUMNS.filter((c) => c.defaultVisible && !(mobile && c.mobileHidden)).map((c) => c.key),
-    )
-  })
-  const shownColumns = useMemo(() => COLUMNS.filter((c) => visible.has(c.key)), [visible])
+  const { visible, shownColumns, toggleColumn, resetColumns, hasOverrides } =
+    useColumnVisibility("geometrikks-columns-debug-logs", COLUMNS)
 
   // Detail dialog.
   const [selected, setSelected] = useState<AccessLogDebugEntry | null>(null)
@@ -280,15 +276,6 @@ export function DebugLogsTable() {
       setSortField(field)
       setSortOrder("desc")
     }
-  }
-
-  function toggleColumn(key: string) {
-    setVisible((prev) => {
-      const next = new Set(prev)
-      if (next.has(key)) next.delete(key)
-      else next.add(key)
-      return next
-    })
   }
 
   const activeFilterCount =
@@ -396,6 +383,10 @@ export function DebugLogsTable() {
             {c.label}
           </DropdownMenuCheckboxItem>
         ))}
+      <DropdownMenuSeparator />
+      <DropdownMenuItem disabled={!hasOverrides} onSelect={resetColumns}>
+        Reset to defaults
+      </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/resources/components/debug-logs/debug-logs-table.tsx
+++ b/resources/components/debug-logs/debug-logs-table.tsx
@@ -369,7 +369,7 @@ export function DebugLogsTable() {
           <Columns3 className="mr-1 h-3.5 w-3.5" /> Columns
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="max-h-80 overflow-y-auto">
+      <DropdownMenuContent align="end" className="max-h-80 w-auto min-w-44 overflow-y-auto">
         <DropdownMenuLabel>Visible columns</DropdownMenuLabel>
         <DropdownMenuSeparator />
         {COLUMNS.map((c) => (

--- a/resources/components/geo-logs/geo-logs-table.tsx
+++ b/resources/components/geo-logs/geo-logs-table.tsx
@@ -5,7 +5,6 @@
  * arrives here as props; the filter set comes from GeoLogFiltersContext like
  * everything else on the page.
  */
-import { useMemo, useState } from "react"
 import {
   ArrowDown,
   ArrowUp,
@@ -25,6 +24,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
+  DropdownMenuItem,
   DropdownMenuContent,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -35,7 +35,8 @@ import type { GeoLogEntry } from "@/generated/api/types.gen"
 import { formatNumber, type GeoLogSortField, type GeoLogSortOrder } from "@/lib/api"
 import { IpBanControls } from "@/components/crowdsec/ip-ban-controls"
 import { useGeoLogs } from "@/lib/queries"
-import { cn, isMobileViewport } from "@/lib/utils"
+import { cn } from "@/lib/utils"
+import { useColumnVisibility } from "@/lib/column-visibility"
 
 export const GEO_LOGS_PAGE_SIZES = [10, 20, 50, 100, 200, 500] as const
 
@@ -168,13 +169,8 @@ export function GeoLogsTable({
   onPageSizeChange: (pageSize: number) => void
   onSortChange: (sortField: GeoLogSortField, sortOrder: GeoLogSortOrder) => void
 }) {
-  const [visible, setVisible] = useState<Set<string>>(() => {
-    const mobile = isMobileViewport()
-    return new Set(
-      COLUMNS.filter((c) => c.defaultVisible && !(mobile && c.mobileHidden)).map((c) => c.key),
-    )
-  })
-  const shownColumns = useMemo(() => COLUMNS.filter((c) => visible.has(c.key)), [visible])
+  const { visible, shownColumns, toggleColumn, resetColumns, hasOverrides } =
+    useColumnVisibility("geometrikks-columns-geo-logs", COLUMNS)
 
   const { data, isLoading, isError, isPlaceholderData } = useGeoLogs({
     currentPage: page,
@@ -194,15 +190,6 @@ export function GeoLogsTable({
     } else {
       onSortChange(field, "desc")
     }
-  }
-
-  function toggleColumn(key: string) {
-    setVisible((prev) => {
-      const next = new Set(prev)
-      if (next.has(key)) next.delete(key)
-      else next.add(key)
-      return next
-    })
   }
 
   if (isError) {
@@ -237,6 +224,10 @@ export function GeoLogsTable({
                 {c.label}
               </DropdownMenuCheckboxItem>
             ))}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem disabled={!hasOverrides} onSelect={resetColumns}>
+            Reset to defaults
+          </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/resources/components/geo-logs/geo-logs-table.tsx
+++ b/resources/components/geo-logs/geo-logs-table.tsx
@@ -210,7 +210,7 @@ export function GeoLogsTable({
               <Columns3 className="mr-1 h-3.5 w-3.5" /> Columns
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="max-h-80 overflow-y-auto">
+          <DropdownMenuContent align="end" className="max-h-80 w-auto min-w-44 overflow-y-auto">
             <DropdownMenuLabel>Visible columns</DropdownMenuLabel>
             <DropdownMenuSeparator />
             {COLUMNS.map((c) => (

--- a/resources/lib/column-visibility.test.ts
+++ b/resources/lib/column-visibility.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  loadColumnOverrides,
+  resolveVisibleColumns,
+  saveColumnOverrides,
+} from "./column-visibility"
+
+const COLUMNS = [
+  { key: "time", defaultVisible: true },
+  { key: "ip", defaultVisible: true, mobileHidden: true },
+  { key: "referrer", defaultVisible: false },
+]
+
+describe("resolveVisibleColumns", () => {
+  it("applies defaults when nothing is overridden", () => {
+    expect([...resolveVisibleColumns(COLUMNS, {}, false)]).toEqual(["time", "ip"])
+  })
+
+  it("hides mobileHidden columns on mobile unless overridden", () => {
+    expect([...resolveVisibleColumns(COLUMNS, {}, true)]).toEqual(["time"])
+    expect([...resolveVisibleColumns(COLUMNS, { ip: true }, true)]).toEqual(["time", "ip"])
+  })
+
+  it("lets an override hide a default column and show a hidden one", () => {
+    expect([...resolveVisibleColumns(COLUMNS, { time: false, referrer: true }, false)]).toEqual([
+      "ip",
+      "referrer",
+    ])
+  })
+
+  it("ignores overrides for columns that no longer exist", () => {
+    expect([...resolveVisibleColumns(COLUMNS, { gone: true }, false)]).toEqual(["time", "ip"])
+  })
+})
+
+describe("load/save", () => {
+  const store = new Map<string, string>()
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  })
+  afterEach(() => store.clear())
+
+  it("round-trips overrides and removes the key when empty", () => {
+    saveColumnOverrides("k", { ip: false })
+    expect(loadColumnOverrides("k")).toEqual({ ip: false })
+    saveColumnOverrides("k", {})
+    expect(store.has("k")).toBe(false)
+  })
+
+  it("drops non-boolean values and survives junk", () => {
+    store.set("k", JSON.stringify({ ip: false, time: "yes" }))
+    expect(loadColumnOverrides("k")).toEqual({ ip: false })
+    store.set("k", "not json")
+    expect(loadColumnOverrides("k")).toEqual({})
+    store.set("k", "[1,2]")
+    expect(loadColumnOverrides("k")).toEqual({})
+  })
+})

--- a/resources/lib/column-visibility.ts
+++ b/resources/lib/column-visibility.ts
@@ -1,0 +1,101 @@
+/**
+ * Persisted column visibility for the log tables.
+ *
+ * Only the user's overrides are stored, keyed by column, so the defaults
+ * (including the mobile defaults) still decide every column the user has
+ * never touched. A column added in a later release shows per its
+ * defaultVisible instead of staying hidden behind a saved list, and a
+ * removed column's stale override is ignored.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react"
+
+import { isMobileViewport } from "@/lib/utils"
+
+export interface VisibilityColumn {
+  key: string
+  defaultVisible: boolean
+  mobileHidden?: boolean
+}
+
+/** Column key to visible; present only for columns the user toggled. */
+export type ColumnOverrides = Record<string, boolean>
+
+export function loadColumnOverrides(storageKey: string): ColumnOverrides {
+  try {
+    const raw = localStorage.getItem(storageKey)
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {}
+    const overrides: ColumnOverrides = {}
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === "boolean") overrides[key] = value
+    }
+    return overrides
+  } catch {
+    // Storage may be blocked or hold junk; the defaults are always safe.
+    return {}
+  }
+}
+
+export function saveColumnOverrides(storageKey: string, overrides: ColumnOverrides): void {
+  try {
+    if (Object.keys(overrides).length === 0) localStorage.removeItem(storageKey)
+    else localStorage.setItem(storageKey, JSON.stringify(overrides))
+  } catch {
+    // Keep the in-memory choice for this session.
+  }
+}
+
+export function resolveVisibleColumns(
+  columns: readonly VisibilityColumn[],
+  overrides: ColumnOverrides,
+  mobile: boolean,
+): Set<string> {
+  const visible = new Set<string>()
+  for (const c of columns) {
+    const shown =
+      c.key in overrides ? overrides[c.key] : c.defaultVisible && !(mobile && c.mobileHidden)
+    if (shown) visible.add(c.key)
+  }
+  return visible
+}
+
+export function useColumnVisibility<C extends VisibilityColumn>(
+  storageKey: string,
+  columns: readonly C[],
+) {
+  const [overrides, setOverrides] = useState<ColumnOverrides>(() =>
+    loadColumnOverrides(storageKey),
+  )
+  // Sampled once per mount, like the mobile defaults always were.
+  const [mobile] = useState(isMobileViewport)
+
+  useEffect(() => {
+    saveColumnOverrides(storageKey, overrides)
+  }, [storageKey, overrides])
+
+  const visible = useMemo(
+    () => resolveVisibleColumns(columns, overrides, mobile),
+    [columns, overrides, mobile],
+  )
+  const shownColumns = useMemo(() => columns.filter((c) => visible.has(c.key)), [columns, visible])
+
+  const toggleColumn = useCallback(
+    (key: string) => {
+      setOverrides((prev) => ({
+        ...prev,
+        [key]: !resolveVisibleColumns(columns, prev, mobile).has(key),
+      }))
+    },
+    [columns, mobile],
+  )
+  const resetColumns = useCallback(() => setOverrides({}), [])
+
+  return {
+    visible,
+    shownColumns,
+    toggleColumn,
+    resetColumns,
+    hasOverrides: Object.keys(overrides).length > 0,
+  }
+}


### PR DESCRIPTION
The Columns picker on the Access Logs, Geo Logs, and Debug Logs tables remembers its selection across reloads, and its labels no longer wrap.

Closes #143

- One `useColumnVisibility` hook in `resources/lib/column-visibility.ts` replaces the duplicated state in the three tables.
- localStorage stores only the columns the user toggled, as `{ [key]: boolean }` under `geometrikks-columns-<table>`. Untouched columns keep their defaults, so a column added later shows as intended and a stale key for a removed column is ignored.
- "Reset to defaults" at the bottom of each menu clears the stored selection.
- The menus use `w-auto min-w-44` so they size to their labels instead of to the Columns button.

Typecheck clean, vitest 197 passed (6 new). Checked in the browser on all three tables: persistence, reset, the last-column guard, and the menu width.
