### PR TITLE
fix(asn): release review fixes

### DIFF
--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -860,13 +860,13 @@ class SummaryStatsRepository:
                 FROM {table} s
                 WHERE s.bucket >= :a_start AND s.bucket < :a_end
                 UNION ALL
-                SELECT CAST(1 AS BIGINT), COALESCE(al.bytes_sent, 0)
-                FROM access_logs al
-                WHERE al.timestamp >= :start AND al.timestamp < :a_start
+                SELECT COUNT(*), COALESCE(SUM(bytes_sent), 0)
+                FROM access_logs
+                WHERE timestamp >= :start AND timestamp < :a_start
                 UNION ALL
-                SELECT CAST(1 AS BIGINT), COALESCE(al.bytes_sent, 0)
-                FROM access_logs al
-                WHERE al.timestamp >= :a_end AND al.timestamp < :end
+                SELECT COUNT(*), COALESCE(SUM(bytes_sent), 0)
+                FROM access_logs
+                WHERE timestamp >= :a_end AND timestamp < :end
             )
             SELECT CAST(COALESCE(SUM(hits), 0) AS BIGINT) AS hits,
                    CAST(COALESCE(SUM(total_bytes), 0) AS BIGINT) AS total_bytes

--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -832,25 +832,47 @@ class SummaryStatsRepository:
         """(total_requests, total_bytes) for the range, with or without ASN data.
 
         The denominator for /top-asns coverage, since the ASN queries exclude
-        rows without ASN data. Unfiltered ranges read the summary CAGGs via
-        get_summary; filtered ranges scan raw access_logs, like every
-        filtered top list.
+        rows without ASN data. Stitched exactly like get_top_asns (CAGG for
+        whole buckets, raw for the partial edges) so the two sides of the
+        division cover the same window; get_summary's bucket-rounded totals
+        would report bucket slop as unenriched traffic. Filtered ranges scan
+        raw access_logs, like every filtered top list.
         """
         filters = filters or AnalyticsFilters()
-        if not filters.is_active():
-            stats = await self.get_summary(start, end)
-            return (stats.total_log_records, stats.total_bytes) if stats else (0, 0)
-        filter_sql, filter_params = filters.sql_conditions()
+        granularity = get_stats_granularity(start, end)
+        if granularity == StatsGranularity.RAW or filters.is_active():
+            filter_sql, filter_params = filters.sql_conditions()
+            stmt = text(f"""
+                SELECT CAST(COUNT(*) AS BIGINT) AS hits,
+                       CAST(COALESCE(SUM(bytes_sent), 0) AS BIGINT) AS total_bytes
+                FROM access_logs
+                WHERE timestamp >= :start AND timestamp < :end
+                {filter_sql}
+            """)
+            row = (await self.session.execute(
+                stmt, {"start": start, "end": end, **filter_params}
+            )).one()
+            return row.hits, row.total_bytes
+        table = f"summary_{granularity.value}_stats"
         stmt = text(f"""
-            SELECT CAST(COUNT(*) AS BIGINT) AS hits,
-                   CAST(COALESCE(SUM(bytes_sent), 0) AS BIGINT) AS total_bytes
-            FROM access_logs
-            WHERE timestamp >= :start AND timestamp < :end
-            {filter_sql}
+            WITH combined AS (
+                SELECT s.total_requests AS hits, s.total_bytes
+                FROM {table} s
+                WHERE s.bucket >= :a_start AND s.bucket < :a_end
+                UNION ALL
+                SELECT CAST(1 AS BIGINT), COALESCE(al.bytes_sent, 0)
+                FROM access_logs al
+                WHERE al.timestamp >= :start AND al.timestamp < :a_start
+                UNION ALL
+                SELECT CAST(1 AS BIGINT), COALESCE(al.bytes_sent, 0)
+                FROM access_logs al
+                WHERE al.timestamp >= :a_end AND al.timestamp < :end
+            )
+            SELECT CAST(COALESCE(SUM(hits), 0) AS BIGINT) AS hits,
+                   CAST(COALESCE(SUM(total_bytes), 0) AS BIGINT) AS total_bytes
+            FROM combined
         """)
-        row = (await self.session.execute(
-            stmt, {"start": start, "end": end, **filter_params}
-        )).one()
+        row = (await self.session.execute(stmt, _stitch_params(start, end, granularity))).one()
         return row.hits, row.total_bytes
 
     def _log_ip_combined_cte(self, granularity: StatsGranularity) -> str:

--- a/geometrikks/services/geoip/downloader.py
+++ b/geometrikks/services/geoip/downloader.py
@@ -138,7 +138,7 @@ async def ensure_geoip_database(settings: "GeoIPSettings") -> bool:
         return True
 
     if not has_credentials(settings):
-        if settings.db_path.exists():
+        if geoip_info(settings.db_path).available:
             logger.warning(
                 "GeoLite2 database is older than %d days and no MaxMind "
                 "credentials are configured; keeping the stale copy. "
@@ -147,7 +147,7 @@ async def ensure_geoip_database(settings: "GeoIPSettings") -> bool:
             )
             return True
         logger.warning(
-            "No GeoLite2 database at %s and no MaxMind credentials configured. "
+            "No usable GeoLite2 database at %s and no MaxMind credentials configured. "
             "Set MAXMINDDB_USER_ID and MAXMINDDB_LICENSE_KEY (free account: "
             "https://www.maxmind.com/en/geolite2/signup) to enable geo lookups. "
             "Starting in geo-degraded mode.",
@@ -183,7 +183,7 @@ async def ensure_asn_database(settings: "GeoIPSettings") -> bool:
         return True
 
     if not has_credentials(settings):
-        if settings.asn_db_path.exists():
+        if geoip_info(settings.asn_db_path).available:
             logger.warning(
                 "GeoLite2-ASN database is older than %d days and no MaxMind "
                 "credentials are configured; keeping the stale copy.",
@@ -191,7 +191,7 @@ async def ensure_asn_database(settings: "GeoIPSettings") -> bool:
             )
             return True
         logger.warning(
-            "No GeoLite2-ASN database at %s and no MaxMind credentials "
+            "No usable GeoLite2-ASN database at %s and no MaxMind credentials "
             "configured; ASN enrichment is unavailable. Set "
             "GEOIP_ASN_ENABLED=false to silence this.",
             settings.asn_db_path,

--- a/geometrikks/services/geoip/downloader.py
+++ b/geometrikks/services/geoip/downloader.py
@@ -162,12 +162,12 @@ async def ensure_geoip_database(settings: "GeoIPSettings") -> bool:
         return True
     except GeoIPDownloadError as exc:
         logger.error("GeoIP download failed: %s", exc)
-        return settings.db_path.exists()
+        return geoip_info(settings.db_path).available
     except Exception:
         # Startup/scheduler entry point: a full volume, bad mount permissions,
         # or a truncated stream must degrade, never crash the app.
         logger.exception("Unexpected error while refreshing the GeoLite2 database")
-        return settings.db_path.exists()
+        return geoip_info(settings.db_path).available
 
 
 async def ensure_asn_database(settings: "GeoIPSettings") -> bool:
@@ -205,10 +205,10 @@ async def ensure_asn_database(settings: "GeoIPSettings") -> bool:
         return True
     except GeoIPDownloadError as exc:
         logger.error("GeoLite2-ASN download failed: %s", exc)
-        return settings.asn_db_path.exists()
+        return geoip_info(settings.asn_db_path).available
     except Exception:
         logger.exception("Unexpected error while refreshing the GeoLite2-ASN database")
-        return settings.asn_db_path.exists()
+        return geoip_info(settings.asn_db_path).available
 
 
 async def refresh_geoip_databases(settings: "GeoIPSettings") -> None:

--- a/migrations/versions/2026-08-18_access_log_asn_columns_c9d2e4f7a815.py
+++ b/migrations/versions/2026-08-18_access_log_asn_columns_c9d2e4f7a815.py
@@ -67,7 +67,26 @@ def schema_upgrades() -> None:
     """
     op.execute("ALTER TABLE access_logs ADD COLUMN IF NOT EXISTS autonomous_system_number BIGINT")
     op.execute("ALTER TABLE access_logs ADD COLUMN IF NOT EXISTS autonomous_system_organization VARCHAR(255)")
-    op.execute("CREATE INDEX IF NOT EXISTS ix_access_logs_asn ON access_logs (autonomous_system_number)")
+    # On an existing install access_logs is a hypertable with months of
+    # chunks, and a plain CREATE INDEX holds a write lock on all of them for
+    # the whole build, stalling any remote agent mid-insert. Building one
+    # chunk per transaction keeps each lock short. The option needs
+    # autocommit (this block has it) and is rejected on a plain table, which
+    # is what access_logs still is on a fresh install, where hypertable
+    # conversion happens after migrations.
+    bind = op.get_bind()
+    has_timescale = bind.execute(sa.text(
+        "SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb')"
+    )).scalar()
+    is_hypertable = has_timescale and bind.execute(sa.text(
+        "SELECT EXISTS (SELECT 1 FROM timescaledb_information.hypertables "
+        "WHERE hypertable_name = 'access_logs')"
+    )).scalar()
+    with_clause = " WITH (timescaledb.transaction_per_chunk)" if is_hypertable else ""
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_access_logs_asn "
+        f"ON access_logs (autonomous_system_number){with_clause}"
+    )
 
 
 def schema_downgrades() -> None:

--- a/resources/components/analytics/top-asns-table.tsx
+++ b/resources/components/analytics/top-asns-table.tsx
@@ -28,7 +28,7 @@ export function CategoryBadge({ category }: { category: "hosting" | "other" }) {
 }
 
 export function TopAsnsTable() {
-  const { data, isLoading } = useTopAsns({ limit: 25 })
+  const { data, isError, error } = useTopAsns({ limit: 25 })
   const { pageItems, ...pagination } = usePagedRows(data?.items)
 
   return (
@@ -37,7 +37,11 @@ export function TopAsnsTable() {
         <CardTitle className="text-sm font-medium">Top ASNs</CardTitle>
       </CardHeader>
       <CardContent>
-        {isLoading || !data ? (
+        {isError && !data ? (
+          <p className="text-sm text-destructive">
+            Failed to load ASN statistics: {error?.message ?? "Unknown error"}
+          </p>
+        ) : !data ? (
           <Skeleton className="h-48 w-full" />
         ) : (
           <>

--- a/resources/components/analytics/traffic-origin-card.tsx
+++ b/resources/components/analytics/traffic-origin-card.tsx
@@ -15,7 +15,7 @@ import { useTopAsns } from "@/lib/queries"
 import { CategoryBadge } from "./top-asns-table"
 
 export function TrafficOriginCard() {
-  const { data, isLoading } = useTopAsns({ limit: 25 })
+  const { data, isError, error } = useTopAsns({ limit: 25 })
 
   const hosting = data?.categories.find((c) => c.category === "hosting")
   const other = data?.categories.find((c) => c.category === "other")
@@ -36,7 +36,11 @@ export function TrafficOriginCard() {
         </CardTitle>
       </CardHeader>
       <CardContent>
-        {isLoading || !data ? (
+        {isError && !data ? (
+          <p className="text-sm text-destructive">
+            Failed to load ASN statistics: {error?.message ?? "Unknown error"}
+          </p>
+        ) : !data ? (
           <Skeleton className="h-32 w-full" />
         ) : classified === 0 ? (
           <p className="text-sm text-muted-foreground">

--- a/tests/integration/test_analytics_endpoints.py
+++ b/tests/integration/test_analytics_endpoints.py
@@ -358,6 +358,46 @@ async def test_request_totals_count_unenriched_rows(pg_session_maker, clean_tabl
     assert total_bytes == 500
 
 
+async def test_request_totals_match_asn_window_on_misaligned_ranges(
+    pg_engine, pg_session_maker, clean_tables
+):
+    """Totals and ASN hits must cover the same window above 24h.
+
+    Regression: the totals came from get_summary, whose CAGG read floors the
+    start bucket and includes the whole end bucket, while get_top_asns is
+    stitched to the exact range. On a 12:30 -> 12:30 window the totals
+    carried traffic from outside it, which the UI showed as unenriched.
+    """
+    from geometrikks.domain.analytics.repositories import SummaryStatsRepository
+    from geometrikks.server.timescale import refresh_caggs_range
+
+    start = NOW - timedelta(hours=48) + timedelta(minutes=30)
+    end = NOW - timedelta(minutes=30)
+    async with pg_session_maker() as session:
+        # Same hourly bucket as `start`, but before it: must not count.
+        await _insert_asn_log(session, ts=start - timedelta(minutes=10), asn=1, asn_org="Outside")
+        # Same hourly bucket as `end`, but after it: must not count.
+        await _insert_asn_log(session, ts=end + timedelta(minutes=10), asn=1, asn_org="Outside")
+        # Inside the window: one in the partial head bucket, one in a whole bucket.
+        await _insert_asn_log(session, ts=start + timedelta(minutes=5), asn=2, asn_org="Inside")
+        await _insert_asn_log(session, ts=NOW - timedelta(hours=24), asn=2, asn_org="Inside")
+        await session.commit()
+    await refresh_caggs_range(
+        pg_engine,
+        start=NOW - timedelta(hours=50),
+        end=NOW + timedelta(hours=1),
+        caggs=["summary_hourly_stats", "asn_hourly_stats"],
+    )
+
+    async with pg_session_maker() as session:
+        repo = SummaryStatsRepository(session=session)
+        asn_rows = await repo.get_top_asns(start, end)
+        total_requests, _ = await repo.get_request_totals(start, end)
+
+    assert sum(r.hits for r in asn_rows) == 2
+    assert total_requests == 2, "totals must not include the bucket slop outside the window"
+
+
 async def test_iter_null_asn_ips_pages_without_gaps_or_repeats(pg_engine, pg_session_maker, clean_tables):
     """Keyset pagination must cover every distinct NULL-ASN IP exactly once."""
     from geometrikks.cli import _iter_null_asn_ips

--- a/tests/test_geoip_downloader.py
+++ b/tests/test_geoip_downloader.py
@@ -137,12 +137,13 @@ class TestEnsure:
         assert await ensure_geoip_database(settings) is True
 
     async def test_no_credentials_stale_db_keeps_copy_and_returns_true(
-        self, tmp_path, caplog
+        self, tmp_path, caplog, monkeypatch
     ):
-        """Unreadable/old db without credentials: keep it, warn, stay usable."""
+        """Readable but old db without credentials: keep it, warn, stay usable."""
         from geometrikks.services.geoip.downloader import ensure_geoip_database
         settings = make_settings(tmp_path)
-        settings.db_path.write_bytes(b"existing")  # not a valid mmdb -> stale
+        settings.db_path.write_bytes(b"existing")
+        patch_build_epoch(monkeypatch, age_days=30)
         with caplog.at_level("WARNING"):
             assert await ensure_geoip_database(settings) is True
         assert any("keeping the stale copy" in r.message for r in caplog.records)
@@ -186,6 +187,15 @@ class TestEnsure:
         ok = await downloader.ensure_geoip_database(settings)
         assert ok is False, "no db could be written -> degraded"
         assert list(settings.db_path.parent.glob("*.tmp")) == []
+
+    async def test_no_credentials_unreadable_file_returns_false(self, tmp_path, caplog):
+        from geometrikks.services.geoip.downloader import ensure_geoip_database
+
+        settings = make_settings(tmp_path)
+        settings.db_path.write_bytes(b"not an mmdb")
+        with caplog.at_level("WARNING"):
+            assert await ensure_geoip_database(settings) is False
+        assert any("No usable GeoLite2 database" in r.message for r in caplog.records)
 
     async def test_failed_download_keeps_readable_stale_db_and_returns_true(
         self, tmp_path, monkeypatch
@@ -263,6 +273,13 @@ class TestAsnEnsure:
         settings.asn_db_path.write_bytes(b"old")
         patch_build_epoch(monkeypatch, age_days=30)
         assert await ensure_asn_database(settings) is True
+
+    async def test_no_credentials_unreadable_file_returns_false(self, tmp_path):
+        from geometrikks.services.geoip.downloader import ensure_asn_database
+
+        settings = make_settings(tmp_path)
+        settings.asn_db_path.write_bytes(b"not an mmdb")
+        assert await ensure_asn_database(settings) is False
 
     async def test_download_failure_reports_readability_not_existence(
         self, tmp_path, monkeypatch

--- a/tests/test_geoip_downloader.py
+++ b/tests/test_geoip_downloader.py
@@ -187,11 +187,14 @@ class TestEnsure:
         assert ok is False, "no db could be written -> degraded"
         assert list(settings.db_path.parent.glob("*.tmp")) == []
 
-    async def test_failed_download_keeps_existing_db_and_returns_true(self, tmp_path, monkeypatch):
+    async def test_failed_download_keeps_readable_stale_db_and_returns_true(
+        self, tmp_path, monkeypatch
+    ):
         from geometrikks.services.geoip import downloader
 
         settings = make_settings(tmp_path, account_id="1", license_key="k")
-        settings.db_path.write_bytes(b"OLD")  # unreadable mmdb -> stale -> download attempted
+        settings.db_path.write_bytes(b"OLD")
+        patch_build_epoch(monkeypatch, age_days=30)  # readable but stale -> download attempted
 
         async def boom(s, edition):
             raise downloader.GeoIPDownloadError("http 401")
@@ -201,6 +204,20 @@ class TestEnsure:
         ok = await downloader.ensure_geoip_database(settings)
         assert ok is True, "existing (stale) db still usable after failed refresh"
         assert settings.db_path.read_bytes() == b"OLD"
+
+    async def test_failed_download_with_unreadable_file_returns_false(self, tmp_path, monkeypatch):
+        """A file that exists but is not an mmdb must not be reported as usable:
+        ingestion cannot open it, and a True here would silence the advisory."""
+        from geometrikks.services.geoip import downloader
+
+        settings = make_settings(tmp_path, account_id="1", license_key="k")
+        settings.db_path.write_bytes(b"not an mmdb")
+
+        async def boom(s, edition):
+            raise downloader.GeoIPDownloadError("http 401")
+
+        monkeypatch.setattr(downloader, "_fetch_tarball", boom)
+        assert await downloader.ensure_geoip_database(settings) is False
 
 
 class TestAsnEnsure:
@@ -247,7 +264,9 @@ class TestAsnEnsure:
         patch_build_epoch(monkeypatch, age_days=30)
         assert await ensure_asn_database(settings) is True
 
-    async def test_download_failure_reports_existing_file(self, tmp_path, monkeypatch):
+    async def test_download_failure_reports_readability_not_existence(
+        self, tmp_path, monkeypatch
+    ):
         from geometrikks.services.geoip import downloader
 
         async def failing_fetch(settings, edition):
@@ -256,7 +275,10 @@ class TestAsnEnsure:
         monkeypatch.setattr(downloader, "_fetch_tarball", failing_fetch)
         settings = make_settings(tmp_path, account_id="123", license_key="key")
         assert await downloader.ensure_asn_database(settings) is False
+        # Present but not an mmdb: still unusable.
         settings.asn_db_path.write_bytes(b"present")
+        assert await downloader.ensure_asn_database(settings) is False
+        # Readable and merely stale: usable.
         patch_build_epoch(monkeypatch, age_days=30)
         assert await downloader.ensure_asn_database(settings) is True
 


### PR DESCRIPTION
Four fixes to the ASN feature ahead of 0.10.0.

- The Traffic origin card and Top ASNs table show an error message when `/top-asns` fails instead of loading skeletons forever.
- `ensure_asn_database` and `ensure_geoip_database` return whether the mmdb opens after a failed refresh, not whether a file exists. A corrupt file no longer counts as available, so the missing-database advisory fires when ingestion cannot open it.
- `/top-asns` request totals use the same stitched CAGG-plus-raw-edges read as the ASN hits. On misaligned windows above 24h the totals no longer include bucket slop from outside the window, which the Traffic origin card showed as requests without ASN data. Integration test added for a 30-minute-offset 48h window.
- The ASN index migration passes `timescaledb.transaction_per_chunk` when `access_logs` is already a hypertable, so each chunk's write lock is short instead of one lock across the whole build. Fresh installs, where the table is still plain at migration time, keep the ordinary statement.

Verification: ty, 855 unit tests (2 new), 18 integration tests against a fresh TimescaleDB (1 new, and the plain-table migration path), tsc, 197 vitest. The hypertable migration path was run by hand on the dev database: 20 chunks, one chunk index each.
