### PR TITLE
Reload GeoIP readers after the GeoLite2 refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Percent and ratio placeholders render as "-", matching every other empty cell.
 - Stat card trend badges no longer pair a 0.0% label with an up or down arrow; tiny and non-finite deltas render as flat or hidden.
 - Live tail: the Status column is wide enough for its header, which ran into Method.
+- Ingestion reloads its GeoIP readers after the weekly GeoLite2 refresh replaces the database files, so new geo data applies without a restart. This also picks up files replaced outside the app (for example by `geoipupdate`), and a start in geo-degraded mode recovers on its own once a later scheduled download succeeds. Running the refresh job from Settings downloads fresh databases even when the current files are younger than `GEOIP_REFRESH_DAYS`, and applies a file replaced outside the app immediately.
 
 ## [0.10.0] - 2026-08-22
 

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -116,9 +116,10 @@ async def geoip_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
     )
     if not geoip_available:
         logger.warning(
-            "Geo-degraded mode: no usable GeoLite2 database. Ingestion will "
-            "not start until a GeoLite2 database file is present (restart "
-            "after configuring MAXMINDDB_USER_ID/MAXMINDDB_LICENSE_KEY)."
+            "Geo-degraded mode: no usable GeoLite2 database. With MaxMind "
+            "credentials configured, the scheduled refresh retries and starts "
+            "ingestion automatically once a database is downloaded; otherwise "
+            "restart after setting MAXMINDDB_USER_ID/MAXMINDDB_LICENSE_KEY."
         )
     yield
 
@@ -285,7 +286,7 @@ async def scheduler_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
     crowdsec_poller = runtime.get_crowdsec_poller(app)
     kwargs = {"mode": "agent"} if settings.is_agent else {}
     scheduler: AsyncIOScheduler = await create_scheduler(
-        session_maker, settings, crowdsec_poller=crowdsec_poller, **kwargs
+        session_maker, settings, crowdsec_poller=crowdsec_poller, app=app, **kwargs
     )
     # The finally covers start() itself: if it activates the scheduler and
     # then raises, the running scheduler is still shut down.
@@ -388,6 +389,9 @@ async def ingestion_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
     finally:
         service = runtime.get_ingestion_service(app) or ingestion_service
         if service:
+            # A geoip-refresh job mid-flight must not restart the tail tasks
+            # after this stop (the scheduler shuts down after ingestion).
+            service.disable_reloads()
             await service.stop(timeout=5.0)
 
 

--- a/geometrikks/server/scheduler.py
+++ b/geometrikks/server/scheduler.py
@@ -22,6 +22,7 @@ from geometrikks.server.logging import get_logger
 from geometrikks.server.timescale import ALL_CAGGS
 
 if TYPE_CHECKING:
+    from litestar import Litestar
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from geometrikks.config.settings import Settings
@@ -157,11 +158,50 @@ async def refresh_site_home_job(
     await upsert_auto_homes(session_factory, settings.logparser.resolved_hostnames(), home)
 
 
+async def refresh_geoip_job(settings: "Settings", app: "Litestar | None") -> None:
+    """Refresh the GeoLite2 databases, then reload the ingestion readers when
+    a file on disk no longer matches what the readers have open.
+
+    The staleness check (not a download-succeeded flag) also picks up files
+    replaced out-of-band, e.g. by an external geoipupdate against a mounted
+    mmdb. The manual /scheduler/jobs/geoip-refresh/run endpoint executes this
+    same callable, so it doubles as the "pick up my replaced file now" path.
+
+    With app=None the job degrades to refresh-only (hand-built scheduler test
+    doubles that predate the app parameter).
+    """
+    from geometrikks.services.geoip import downloader
+
+    # Module lookup, not a captured reference: tests monkeypatch this.
+    # force: a run of this job (scheduled or the Settings Run button) means
+    # "fetch a fresh copy now"; the staleness gate stays for startup only.
+    await downloader.refresh_geoip_databases(settings.geoip, force=True)
+
+    if app is None:
+        return
+
+    from geometrikks.lib.utils import geoip_info
+    from geometrikks.server import runtime
+
+    # /health and the settings overlay read these; a successful download after
+    # a degraded start must flip them without a restart.
+    app.state.geoip_available = geoip_info(settings.geoip.db_path).available
+    if settings.geoip.asn_enabled:
+        app.state.asn_available = geoip_info(settings.geoip.asn_db_path).available
+
+    service = runtime.get_ingestion_service(app)
+    if service is None or not service.readers_stale():
+        return
+    await service.reload_readers()
+
+
 async def create_scheduler(
     session_factory: "Callable[[], AsyncSession]",
     settings: "Settings",
     crowdsec_poller: "CrowdSecStreamPoller | None" = None,
     mode: str = "full",
+    *,
+    app: "Litestar | None" = None,
 ) -> AsyncIOScheduler:
     """Create and configure the APScheduler instance.
 
@@ -183,6 +223,9 @@ async def create_scheduler(
         session_factory: SQLAlchemy async session factory for creating job sessions.
         settings: Application settings for job configuration.
         mode: "full" or "agent"; controls which jobs are registered.
+        app: The composed app; the geoip-refresh job resolves the ingestion
+            service through it at run time (it does not exist yet at
+            registration). None degrades that job to refresh-only.
 
     Returns:
         Configured AsyncIOScheduler (not yet started).
@@ -225,17 +268,16 @@ async def create_scheduler(
         logger.info("Scheduled full CAGG refresh every 6 hours")
 
     # Weekly GeoLite2 refresh, City + ASN editions in one job (only meaningful
-    # when credentials are set; the ensure functions no-op safely otherwise).
+    # when credentials are set; the ensure functions no-op safely otherwise),
+    # followed by an ingestion reader reload when the files changed.
     # Runs in every mode: an agent still needs its own local databases kept
     # current. One job id: the Settings UI looks up "geoip-refresh" by name.
-    from geometrikks.services.geoip.downloader import refresh_geoip_databases
-
     scheduler.add_job(
-        refresh_geoip_databases,
+        refresh_geoip_job,
         IntervalTrigger(days=settings.geoip.refresh_days),
         id="geoip-refresh",
         name="Refresh GeoLite2 databases from MaxMind",
-        args=[settings.geoip],
+        args=[settings, app],
         replace_existing=True,
     )
     logger.info("Scheduled GeoLite2 refresh every %d day(s)", settings.geoip.refresh_days)

--- a/geometrikks/services/geoip/downloader.py
+++ b/geometrikks/services/geoip/downloader.py
@@ -127,24 +127,33 @@ async def download_database(
     return db_path
 
 
-async def ensure_geoip_database(settings: "GeoIPSettings") -> bool:
+async def ensure_geoip_database(settings: "GeoIPSettings", *, force: bool = False) -> bool:
     """Make the mmdb present-and-fresh if possible. Returns usability.
 
     - fresh db, no creds        -> True (nothing to do)
     - stale/missing db, creds   -> try download; True if a db exists after
     - missing db, no creds      -> False + actionable warning (degraded mode)
+
+    force=True skips the staleness gate (the geoip-refresh job, where a run
+    means "fetch a fresh copy now"); the credentials gate still applies.
     """
-    if not database_is_stale(settings.db_path, settings.refresh_days):
+    if not force and not database_is_stale(settings.db_path, settings.refresh_days):
         return True
 
     if not has_credentials(settings):
         if geoip_info(settings.db_path).available:
-            logger.warning(
-                "GeoLite2 database is older than %d days and no MaxMind "
-                "credentials are configured; keeping the stale copy. "
-                "(GeoLite2 EULA requires refreshing within 30 days.)",
-                settings.refresh_days,
-            )
+            if database_is_stale(settings.db_path, settings.refresh_days):
+                logger.warning(
+                    "GeoLite2 database is older than %d days and no MaxMind "
+                    "credentials are configured; keeping the stale copy. "
+                    "(GeoLite2 EULA requires refreshing within 30 days.)",
+                    settings.refresh_days,
+                )
+            else:
+                logger.warning(
+                    "GeoLite2 refresh requested but no MaxMind credentials "
+                    "are configured; keeping the current database."
+                )
             return True
         logger.warning(
             "No usable GeoLite2 database at %s and no MaxMind credentials configured. "
@@ -170,25 +179,32 @@ async def ensure_geoip_database(settings: "GeoIPSettings") -> bool:
         return geoip_info(settings.db_path).available
 
 
-async def ensure_asn_database(settings: "GeoIPSettings") -> bool:
+async def ensure_asn_database(settings: "GeoIPSettings", *, force: bool = False) -> bool:
     """Download or refresh the GeoLite2-ASN mmdb when possible; never raises.
 
     Unlike ensure_geoip_database, False is not degraded mode, only
     ingestion without ASN data. Disabled returns False without touching the
-    network.
+    network. force=True skips the staleness gate, matching
+    ensure_geoip_database.
     """
     if not settings.asn_enabled:
         return False
-    if not database_is_stale(settings.asn_db_path, settings.refresh_days):
+    if not force and not database_is_stale(settings.asn_db_path, settings.refresh_days):
         return True
 
     if not has_credentials(settings):
         if geoip_info(settings.asn_db_path).available:
-            logger.warning(
-                "GeoLite2-ASN database is older than %d days and no MaxMind "
-                "credentials are configured; keeping the stale copy.",
-                settings.refresh_days,
-            )
+            if database_is_stale(settings.asn_db_path, settings.refresh_days):
+                logger.warning(
+                    "GeoLite2-ASN database is older than %d days and no MaxMind "
+                    "credentials are configured; keeping the stale copy.",
+                    settings.refresh_days,
+                )
+            else:
+                logger.warning(
+                    "GeoLite2-ASN refresh requested but no MaxMind credentials "
+                    "are configured; keeping the current database."
+                )
             return True
         logger.warning(
             "No usable GeoLite2-ASN database at %s and no MaxMind credentials "
@@ -211,7 +227,7 @@ async def ensure_asn_database(settings: "GeoIPSettings") -> bool:
         return geoip_info(settings.asn_db_path).available
 
 
-async def refresh_geoip_databases(settings: "GeoIPSettings") -> None:
+async def refresh_geoip_databases(settings: "GeoIPSettings", *, force: bool = False) -> None:
     """Scheduler entry point: refresh City always, ASN when enabled.
 
     Looked up through the module (not captured references) so tests can
@@ -219,6 +235,6 @@ async def refresh_geoip_databases(settings: "GeoIPSettings") -> None:
     """
     from geometrikks.services.geoip import downloader as _self
 
-    await _self.ensure_geoip_database(settings)
+    await _self.ensure_geoip_database(settings, force=force)
     if settings.asn_enabled:
-        await _self.ensure_asn_database(settings)
+        await _self.ensure_asn_database(settings, force=force)

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -12,6 +12,7 @@ Analytics aggregation is handled automatically by TimescaleDB continuous aggrega
 """
 from __future__ import annotations
 import asyncio
+import os
 import time
 from collections.abc import Callable
 from datetime import datetime, timezone
@@ -59,6 +60,21 @@ class IngestionRepos:
             access_log=AccessLogRepository(session=session),
             access_log_debug=AccessLogDebugRepository(session=session),
         )
+
+
+def _stat_fingerprint(path: Path | str | None) -> tuple[int, int, int] | None:
+    """(st_ino, st_mtime_ns, st_size) of path; None when absent or unreadable.
+
+    The downloader replaces the mmdb atomically (tmp.replace), so a refreshed
+    file always carries a new inode; an out-of-band replacement does too.
+    """
+    if not path:
+        return None
+    try:
+        st = os.stat(path)
+    except OSError:
+        return None
+    return (st.st_ino, st.st_mtime_ns, st.st_size)
 
 
 def create_reader(path: Path|str, locales: list[str] | None = None) -> Reader|None:
@@ -154,6 +170,12 @@ class LogIngestionService:
         # up a refreshed database file).
         self._reader: Reader | None = None
         self._asn_reader: Reader | None = None
+        # What the open readers actually have mmapped; readers_stale() compares
+        # these against the files on disk. None means "no reader open".
+        self._city_fingerprint: tuple[int, int, int] | None = None
+        self._asn_fingerprint: tuple[int, int, int] | None = None
+        self._skip_validation: bool = False
+        self._reloads_enabled: bool = True
         self._stop_event: asyncio.Event | None = None
         self._ingestion_task: asyncio.Task[None] | None = None
         self._queue: asyncio.Queue[ParsedLogRecord] | None = None
@@ -185,11 +207,18 @@ class LogIngestionService:
             logger.warning("Ingestion already running")
             return
 
+        self._skip_validation = skip_validation
+
         if not (reader := create_reader(self.geoip_path, self.locales)):
             logger.error(
                 "Cannot start ingestion: failed to create GeoIP2 reader with database at %s",
                 self.geoip_path,
             )
+            # No reader open: readers_stale() reads a usable file appearing
+            # later as stale, so the geoip-refresh job can start ingestion
+            # without a process restart (geo-degraded recovery).
+            self._city_fingerprint = None
+            self._asn_fingerprint = None
             return
 
         # ASN enrichment is optional: a missing or unreadable database means
@@ -204,6 +233,10 @@ class LogIngestionService:
                 )
         self._reader = reader
         self._asn_reader = asn_reader
+        self._city_fingerprint = _stat_fingerprint(self.geoip_path)
+        self._asn_fingerprint = (
+            _stat_fingerprint(self.asn_db_path) if asn_reader is not None else None
+        )
 
         # Set synchronously (before any `await`/task scheduling) so a second
         # start() called back-to-back sees is_running=True immediately; it
@@ -302,6 +335,40 @@ class LogIngestionService:
         logger.info(
             "Stopped log ingestion service. Total processed: %d", self.total_processed
         )
+
+    def readers_stale(self) -> bool:
+        """True when a database file on disk differs from what the readers opened.
+
+        Covers this process's own download, an out-of-band replacement (e.g.
+        an external geoipupdate), and the recovery case where a reader failed
+        to open but a usable file has since appeared.
+        """
+        if _stat_fingerprint(self.geoip_path) != self._city_fingerprint:
+            return True
+        if self.asn_db_path is None:
+            return False
+        return _stat_fingerprint(self.asn_db_path) != self._asn_fingerprint
+
+    def disable_reloads(self) -> None:
+        """Called by lifecycle teardown before stop(): a mid-flight
+        geoip-refresh job must not restart the tail tasks during shutdown."""
+        self._reloads_enabled = False
+
+    async def reload_readers(self) -> None:
+        """Restart the pipeline so fresh readers (and lookup caches) pick up
+        a replaced database file."""
+        if not self._reloads_enabled:
+            return
+        await self.stop()
+        if not self._reloads_enabled:  # shutdown began while draining
+            return
+        await self.start(skip_validation=self._skip_validation)
+        if self._reader is not None:  # start() logs its own failure path
+            logger.info(
+                "geoip_readers_reloaded",
+                path=str(self.geoip_path),
+                asn_path=str(self.asn_db_path) if self.asn_db_path else None,
+            )
 
     async def _run_ingestion(self) -> None:
         """Consume parsed records from the shared queue, flushing batches to fresh sessions."""

--- a/tests/test_geoip_downloader.py
+++ b/tests/test_geoip_downloader.py
@@ -99,17 +99,27 @@ class TestStaleness:
         assert database_is_stale(p, max_age_days=7) is False
 
     def test_old_build_date_is_stale_despite_fresh_mtime(
-        self, tmp_path, monkeypatch, caplog
+        self, tmp_path, monkeypatch
     ):
         """The bug this check replaced: mtime is fresh (file just written) but
-        the database itself was built 8 days ago -> stale, with a warning."""
+        the database itself was built 8 days ago -> stale, with a warning.
+
+        capture_logs, not caplog: the rendered record only carries the
+        interpolated message once something has configured the structlog
+        pipeline, so a caplog substring check fails when this file runs alone.
+        """
+        from structlog.testing import capture_logs
+
         from geometrikks.services.geoip.downloader import database_is_stale
         p = tmp_path / "db.mmdb"
         p.write_bytes(b"x")  # mtime = now
         patch_build_epoch(monkeypatch, age_days=8)
-        with caplog.at_level("WARNING"):
+        with capture_logs() as logs:
             assert database_is_stale(p, max_age_days=7) is True
-        assert any("older than 7 days" in r.message for r in caplog.records)
+        assert any(
+            "older than %d days" in log["event"] and 7 in log["positional_args"]
+            for log in logs
+        )
 
     def test_build_date_at_max_age_is_not_stale(self, tmp_path, monkeypatch):
         """Staleness is strictly greater-than: exactly max_age_days is kept."""
@@ -306,11 +316,11 @@ class TestRefreshBothEditions:
 
         calls: list[str] = []
 
-        async def fake_city(settings):
+        async def fake_city(settings, *, force=False):
             calls.append("city")
             return True
 
-        async def fake_asn(settings):
+        async def fake_asn(settings, *, force=False):
             calls.append("asn")
             return True
 
@@ -324,11 +334,11 @@ class TestRefreshBothEditions:
 
         calls: list[str] = []
 
-        async def fake_city(settings):
+        async def fake_city(settings, *, force=False):
             calls.append("city")
             return True
 
-        async def fake_asn(settings):
+        async def fake_asn(settings, *, force=False):
             calls.append("asn")
             return True
 
@@ -338,3 +348,82 @@ class TestRefreshBothEditions:
             make_settings(tmp_path, asn_enabled=False)
         )
         assert calls == ["city"]
+
+    async def test_refresh_forwards_force_to_both_editions(self, tmp_path, monkeypatch):
+        from geometrikks.services.geoip import downloader
+
+        forces: dict[str, bool] = {}
+
+        async def fake_city(settings, *, force=False):
+            forces["city"] = force
+            return True
+
+        async def fake_asn(settings, *, force=False):
+            forces["asn"] = force
+            return True
+
+        monkeypatch.setattr(downloader, "ensure_geoip_database", fake_city)
+        monkeypatch.setattr(downloader, "ensure_asn_database", fake_asn)
+        await downloader.refresh_geoip_databases(make_settings(tmp_path), force=True)
+        assert forces == {"city": True, "asn": True}
+
+
+class TestForcedRefresh:
+    """force=True skips the staleness gate (the manual Run path); the
+    credentials gate still applies."""
+
+    def _spy_download(self, monkeypatch) -> list[str]:
+        from geometrikks.services.geoip import downloader
+
+        downloads: list[str] = []
+
+        async def fake_download(settings, *, edition, db_path):
+            downloads.append(edition)
+            return db_path
+
+        monkeypatch.setattr(downloader, "download_database", fake_download)
+        return downloads
+
+    async def test_force_downloads_city_even_when_fresh(self, tmp_path, monkeypatch):
+        from geometrikks.services.geoip import downloader
+
+        settings = make_settings(tmp_path, account_id="123", license_key="key")
+        settings.db_path.write_bytes(b"mmdb")
+        patch_build_epoch(monkeypatch, age_days=1)
+        downloads = self._spy_download(monkeypatch)
+
+        assert await downloader.ensure_geoip_database(settings, force=True) is True
+        assert downloads == [downloader.CITY_EDITION]
+
+    async def test_fresh_db_without_force_skips_download(self, tmp_path, monkeypatch):
+        from geometrikks.services.geoip import downloader
+
+        settings = make_settings(tmp_path, account_id="123", license_key="key")
+        settings.db_path.write_bytes(b"mmdb")
+        patch_build_epoch(monkeypatch, age_days=1)
+        downloads = self._spy_download(monkeypatch)
+
+        assert await downloader.ensure_geoip_database(settings) is True
+        assert downloads == []
+
+    async def test_force_without_credentials_keeps_current_copy(self, tmp_path, monkeypatch):
+        from geometrikks.services.geoip import downloader
+
+        settings = make_settings(tmp_path)
+        settings.db_path.write_bytes(b"mmdb")
+        patch_build_epoch(monkeypatch, age_days=1)
+        downloads = self._spy_download(monkeypatch)
+
+        assert await downloader.ensure_geoip_database(settings, force=True) is True
+        assert downloads == []
+
+    async def test_force_downloads_asn_even_when_fresh(self, tmp_path, monkeypatch):
+        from geometrikks.services.geoip import downloader
+
+        settings = make_settings(tmp_path, account_id="123", license_key="key")
+        settings.asn_db_path.write_bytes(b"mmdb")
+        patch_build_epoch(monkeypatch, age_days=1)
+        downloads = self._spy_download(monkeypatch)
+
+        assert await downloader.ensure_asn_database(settings, force=True) is True
+        assert downloads == [downloader.ASN_EDITION]

--- a/tests/test_geoip_reader_reload.py
+++ b/tests/test_geoip_reader_reload.py
@@ -1,0 +1,270 @@
+"""Reader reload after a GeoLite2 refresh.
+
+Two layers: fingerprints on LogIngestionService (does the file on disk still
+match what the readers opened?) and the scheduler job wrapper that refreshes
+the databases and triggers the reload. The fingerprint check, rather than a
+download-succeeded flag, is what also picks up files replaced out-of-band
+(e.g. an external geoipupdate against a mounted file).
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from geometrikks.services.ingestion.service import LogIngestionService
+
+pytestmark = pytest.mark.anyio
+
+CITY_SRC = Path("tests/GeoLite2-City-Test.mmdb")
+ASN_SRC = Path("tests/GeoLite2-ASN-Test.mmdb")
+
+
+def replace_file(src: Path, dest: Path) -> None:
+    """Copy src over dest via a temp name + replace, giving dest a new inode
+    exactly like the downloader's atomic tmp.replace(dest)."""
+    tmp = dest.with_name(dest.name + ".tmp")
+    shutil.copyfile(src, tmp)
+    tmp.replace(dest)
+
+
+def make_service(
+    city: Path | str, asn: Path | str | None = None
+) -> LogIngestionService:
+    return LogIngestionService(
+        parsers=[],
+        session_maker=cast("Any", None),
+        geoip_path=city,
+        asn_db_path=asn,
+        hostname="test-host",
+    )
+
+
+# ---------------------------------------------------------------------------
+# LogIngestionService fingerprints
+# ---------------------------------------------------------------------------
+
+
+async def test_started_service_is_not_stale(tmp_path: Path) -> None:
+    city = tmp_path / "city.mmdb"
+    shutil.copyfile(CITY_SRC, city)
+    service = make_service(city)
+    await service.start(skip_validation=True)
+    try:
+        assert service.readers_stale() is False
+    finally:
+        await service.stop()
+
+
+async def test_replaced_city_db_is_stale(tmp_path: Path) -> None:
+    city = tmp_path / "city.mmdb"
+    shutil.copyfile(CITY_SRC, city)
+    service = make_service(city)
+    await service.start(skip_validation=True)
+    try:
+        replace_file(CITY_SRC, city)
+        assert service.readers_stale() is True
+    finally:
+        await service.stop()
+
+
+async def test_replaced_asn_db_is_stale(tmp_path: Path) -> None:
+    city = tmp_path / "city.mmdb"
+    asn = tmp_path / "asn.mmdb"
+    shutil.copyfile(CITY_SRC, city)
+    shutil.copyfile(ASN_SRC, asn)
+    service = make_service(city, asn)
+    await service.start(skip_validation=True)
+    try:
+        replace_file(ASN_SRC, asn)
+        assert service.readers_stale() is True
+    finally:
+        await service.stop()
+
+
+async def test_missing_city_db_appearing_later_is_stale(tmp_path: Path) -> None:
+    """Geo-degraded recovery: start() failed to open a reader, then a usable
+    file shows up (a later successful download). That must read as stale so
+    the refresh job starts ingestion without a process restart."""
+    city = tmp_path / "city.mmdb"
+    service = make_service(city)
+    await service.start(skip_validation=True)  # no file: start aborts
+    assert service.is_running is False
+
+    shutil.copyfile(CITY_SRC, city)
+    assert service.readers_stale() is True
+
+
+async def test_absent_asn_db_staying_absent_is_not_stale(tmp_path: Path) -> None:
+    city = tmp_path / "city.mmdb"
+    shutil.copyfile(CITY_SRC, city)
+    service = make_service(city, tmp_path / "never-downloaded.mmdb")
+    await service.start(skip_validation=True)
+    try:
+        assert service.readers_stale() is False
+    finally:
+        await service.stop()
+
+
+async def test_reload_reopens_and_clears_staleness(tmp_path: Path) -> None:
+    city = tmp_path / "city.mmdb"
+    shutil.copyfile(CITY_SRC, city)
+    service = make_service(city)
+    await service.start(skip_validation=True)
+    try:
+        replace_file(CITY_SRC, city)
+        assert service.readers_stale() is True
+        await service.reload_readers()
+        assert service.readers_stale() is False
+    finally:
+        await service.stop()
+
+
+async def test_reload_reuses_the_original_skip_validation(tmp_path: Path) -> None:
+    city = tmp_path / "city.mmdb"
+    shutil.copyfile(CITY_SRC, city)
+    service = make_service(city)
+    await service.start(skip_validation=True)
+
+    restart = AsyncMock()
+    service.start = restart  # type: ignore[method-assign]
+    await service.reload_readers()
+    restart.assert_awaited_once_with(skip_validation=True)
+
+
+async def test_disable_reloads_makes_reload_inert(tmp_path: Path) -> None:
+    """Teardown stops ingestion before the scheduler shuts down; a mid-flight
+    refresh job must not resurrect the tail tasks."""
+    city = tmp_path / "city.mmdb"
+    shutil.copyfile(CITY_SRC, city)
+    service = make_service(city)
+    await service.start(skip_validation=True)
+    try:
+        service.disable_reloads()
+        restart = AsyncMock()
+        service.start = restart  # type: ignore[method-assign]
+        await service.reload_readers()
+        restart.assert_not_awaited()
+    finally:
+        await service.stop()
+
+
+# ---------------------------------------------------------------------------
+# refresh_geoip_job wrapper
+# ---------------------------------------------------------------------------
+
+
+def _fake_app(service: MagicMock | None = None) -> SimpleNamespace:
+    state = SimpleNamespace()
+    if service is not None:
+        state.ingestion_service = service
+    return SimpleNamespace(state=state)
+
+
+def _fake_ingestion(*, stale: bool) -> MagicMock:
+    service = MagicMock()
+    service.readers_stale = MagicMock(return_value=stale)
+    service.reload_readers = AsyncMock()
+    return service
+
+
+@pytest.fixture
+def refresh(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    from geometrikks.services.geoip import downloader
+
+    mock = AsyncMock()
+    monkeypatch.setattr(downloader, "refresh_geoip_databases", mock)
+    return mock
+
+
+async def test_job_reloads_stale_readers(refresh: AsyncMock) -> None:
+    from geometrikks.config.settings import Settings
+    from geometrikks.server.scheduler import refresh_geoip_job
+
+    settings = Settings()
+    service = _fake_ingestion(stale=True)
+    await refresh_geoip_job(settings, cast("Any", _fake_app(service)))
+
+    # force=True: a run of this job (scheduled or the Settings Run button)
+    # means "fetch a fresh copy now", not "download only if stale".
+    refresh.assert_awaited_once_with(settings.geoip, force=True)
+    service.reload_readers.assert_awaited_once()
+
+
+async def test_job_skips_reload_when_readers_fresh(refresh: AsyncMock) -> None:
+    from geometrikks.config.settings import Settings
+    from geometrikks.server.scheduler import refresh_geoip_job
+
+    service = _fake_ingestion(stale=False)
+    await refresh_geoip_job(Settings(), cast("Any", _fake_app(service)))
+
+    service.reload_readers.assert_not_awaited()
+
+
+async def test_job_without_ingestion_service_only_refreshes(refresh: AsyncMock) -> None:
+    """A UI head (LOGPARSER_ENABLED=false) never constructs the service; the
+    job must still refresh the files without raising."""
+    from geometrikks.config.settings import Settings
+    from geometrikks.server.scheduler import refresh_geoip_job
+
+    await refresh_geoip_job(Settings(), cast("Any", _fake_app()))
+
+    refresh.assert_awaited_once()
+
+
+async def test_job_with_app_none_degrades_to_refresh_only(refresh: AsyncMock) -> None:
+    from geometrikks.config.settings import Settings
+    from geometrikks.server.scheduler import refresh_geoip_job
+
+    await refresh_geoip_job(Settings(), None)
+
+    refresh.assert_awaited_once()
+
+
+async def test_job_updates_availability_flags(
+    refresh: AsyncMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """/health reads these; a successful download after a degraded start must
+    flip them without a restart."""
+    from geometrikks.config.settings import Settings
+    from geometrikks.server.scheduler import refresh_geoip_job
+
+    monkeypatch.setenv("GEOIP_DB_PATH", str(CITY_SRC))
+    monkeypatch.setenv("GEOIP_ASN_ENABLED", "true")
+    monkeypatch.setenv("GEOIP_ASN_DB_PATH", str(ASN_SRC))
+    app = _fake_app()
+    await refresh_geoip_job(Settings(), cast("Any", app))
+
+    assert app.state.geoip_available is True
+    assert app.state.asn_available is True
+
+
+async def test_job_reports_unavailable_databases(
+    refresh: AsyncMock, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from geometrikks.config.settings import Settings
+    from geometrikks.server.scheduler import refresh_geoip_job
+
+    monkeypatch.setenv("GEOIP_DB_PATH", str(tmp_path / "missing.mmdb"))
+    app = _fake_app()
+    await refresh_geoip_job(Settings(), cast("Any", app))
+
+    assert app.state.geoip_available is False
+
+
+async def test_create_scheduler_wires_the_wrapper_with_app() -> None:
+    from geometrikks.config.settings import Settings
+    from geometrikks.server.scheduler import create_scheduler, refresh_geoip_job
+
+    settings = Settings()
+    app = cast("Any", _fake_app())
+    scheduler = await create_scheduler(MagicMock(), settings, app=app)
+    job = scheduler.get_job("geoip-refresh")
+    assert job is not None
+    assert job.func is refresh_geoip_job
+    assert job.args[0] is settings
+    assert job.args[1] is app

--- a/tests/test_lifecycle_geoip.py
+++ b/tests/test_lifecycle_geoip.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -113,16 +114,53 @@ async def test_asn_failure_does_not_flip_geoip_available(monkeypatch):
     assert app.state.asn_available is False
 
 
+async def test_scheduler_receives_the_app_for_reader_reloads(monkeypatch):
+    """The geoip-refresh job resolves the ingestion service through the app
+    at run time; the lifecycle must hand the app to create_scheduler."""
+    from geometrikks.server import lifecycle as lc
+
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=True, ensure=AsyncMock(return_value=True)
+    )
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    async with enter_lifespan(app):
+        pass
+
+    call = cast("AsyncMock", lc.create_scheduler).await_args
+    assert call is not None
+    assert call.kwargs["app"] is app
+
+
+async def test_teardown_disables_reloads_before_stopping_ingestion(monkeypatch):
+    """A geoip-refresh job mid-flight during shutdown must not restart the
+    tail tasks after the lifecycle stopped them."""
+    from geometrikks.server import lifecycle as lc
+
+    ingestion, _ = _patch_startup_collaborators(
+        monkeypatch, lc, db_available=True, ensure=AsyncMock(return_value=True)
+    )
+    order: list[str] = []
+    ingestion.disable_reloads = MagicMock(side_effect=lambda: order.append("disable"))
+    ingestion.stop = AsyncMock(side_effect=lambda timeout=None: order.append("stop"))
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    async with enter_lifespan(app):
+        pass
+
+    assert order == ["disable", "stop"]
+
+
 async def test_geoip_refresh_job_covers_both_editions(monkeypatch):
-    """The single geoip-refresh job must point at refresh_geoip_databases."""
+    """The single geoip-refresh job must point at the wrapper that refreshes
+    both editions and reloads the ingestion readers."""
     from geometrikks.config.settings import Settings
-    from geometrikks.server.scheduler import create_scheduler
-    from geometrikks.services.geoip.downloader import refresh_geoip_databases
+    from geometrikks.server.scheduler import create_scheduler, refresh_geoip_job
 
     scheduler = await create_scheduler(MagicMock(), Settings())
     job = scheduler.get_job("geoip-refresh")
     assert job is not None
-    assert job.func is refresh_geoip_databases
+    assert job.func is refresh_geoip_job
 
 
 async def test_scheduler_has_geoip_refresh_job(monkeypatch):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -224,7 +224,7 @@ async def test_lifespan_migrates_before_timescale(monkeypatch) -> None:
     async def fake_timescale(engine, analytics) -> None:
         order.append("timescale")
 
-    async def fake_create_scheduler(session_maker, settings, crowdsec_poller=None):
+    async def fake_create_scheduler(session_maker, settings, crowdsec_poller=None, app=None):
         scheduler = MagicMock()
         scheduler.start = MagicMock()
         return scheduler


### PR DESCRIPTION
The weekly GeoLite2 refresh replaces the mmdb files on disk, but the ingestion pipeline kept serving lookups from the old copies until the process restarted. The readers are captured inside the tail generators' cached lookup closures, so nothing short of a restart picked up a new file. Closes #149.

## Ingestion service

- `start()` records an inode/mtime/size fingerprint per database file when it opens readers. `readers_stale()` compares the files on disk against those fingerprints, which also catches files replaced outside the app, such as an external `geoipupdate` run against a mounted mmdb.
- `reload_readers()` restarts the pipeline with the original `skip_validation`, reopening both readers and rebuilding the lookup caches, and logs `geoip_readers_reloaded`.
- A start without a usable database leaves no fingerprint, so a later successful download reads as stale and starts ingestion. Geo-degraded mode recovers without a restart, and the job flips the `/health` availability flags to match.
- Teardown stops ingestion before the scheduler, so the lifecycle latches reloads off (`disable_reloads()`) before stopping. A refresh job mid-flight during shutdown cannot restart the tail tasks.

## Scheduler

- The `geoip-refresh` job is now a wrapper: refresh both editions, update `app.state.geoip_available`/`asn_available`, reload when stale. It keeps the job id the Settings UI looks up and registers in both modes, since agents refresh their own databases.
- Downloads pass `force=True`. A run of this job means "fetch a fresh copy now", so the manual Run button downloads even when the files are younger than `GEOIP_REFRESH_DAYS`. Startup keeps the staleness gate, so boots never re-download, and the credentials gate still applies; a forced run without credentials logs that it kept the current database.
- `create_scheduler` takes a keyword-only `app`. The job resolves the ingestion service through it at run time because the service does not exist yet at registration.

The reload seeks to the end of the tailed files, so lines written during the sub-second stop/start gap are skipped once per refresh, and `/health` reports ingestion down for that blip.

## Tests

Fingerprint staleness against real mmdb replacement (City, ASN, missing-then-present, absent ASN), reload semantics (reopen, `skip_validation` reuse, the shutdown latch), wrapper behavior (reload only when stale, no service, no app, availability flags), force propagation and the force/credentials matrix, scheduler wiring, and the lifecycle app pass-through and teardown order.

Also fixes an order-dependent staleness test: caplog only sees the interpolated message once something has configured the structlog pipeline, so the test captures via `structlog.testing.capture_logs` instead.

ty and pytest (unit and integration) pass. No API or settings changes. Verified manually: Run from Settings downloads both editions and logs stop, start, `geoip_readers_reloaded`.
