### PR TITLE
feat(brand): combined map backdrop, sharp on hi-dpi screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Login, the error page, 404 and the Settings backdrop use the brand map scene (graticule, relief, markers, routes), and the map page shows it while the map loads. Backdrops render at the screen's native resolution, so they stay sharp on hi-dpi displays.
 - Settings > Status: each site home shows the last day its source recorded traffic, and a retired source's auto-detected home can be removed so its beacon leaves the map. Homes pinned by `MAP_HOME_LOCATIONS` stay read-only. Backed by `DELETE /api/v1/geo-locations/site-homes/{hostname}` and a `lastEventDay` field on the site-homes response.
 - Filters on Access logs, Geo logs, Debug logs and Analytics share one layout: text inputs on one row, selects on the next, include and exclude for the same field (IP, host, hostname) as one joined control, and a Clear button that shows how many filter groups are active. Geo logs and Analytics get the mobile filter drawer Access logs already had.
 - Access logs: selecting a row opens the full record in a side panel, with ASN, recording hostname, source format and the ban controls. Enter and Space open rows too.

--- a/resources/components/brand/backdrops.tsx
+++ b/resources/components/brand/backdrops.tsx
@@ -1,8 +1,9 @@
 /**
- * Full-bleed backdrops for BrandScreen, the same two pictures as the README
- * banners: routes converging on the mark, and relief contours. Both read
- * their colors from the theme tokens, so they follow the accent and the
- * color mode. Deterministic: no Math.random, every load draws the same scene.
+ * Full-bleed backdrops for BrandScreen and the settings pages: routes
+ * converging on the mark, relief contours, and the combined map scene the
+ * brand banner uses (graticule, relief, markers, routes). All read their
+ * colors from the theme tokens, so they follow the accent and the color
+ * mode. Deterministic: no Math.random, every load draws the same scene.
  */
 import { useEffect, useRef } from "react"
 
@@ -61,29 +62,47 @@ const SEGMENTS: Record<number, string> = {
   9: "tb", 10: "tr,lb", 11: "tr", 12: "lr", 13: "br", 14: "lb",
 }
 
-// The canvas renders once at a fixed size and CSS covers the screen with
-// it, so layout changes (the sidebar opening, a window resize) never
-// trigger a redraw. Contours stretch by at most the aspect difference,
-// which is invisible at hairline weight.
-const CANVAS_W = 1280
-const CANVAS_H = 800
+// The canvas renders once at its element's size times devicePixelRatio
+// (capped, so a huge window cannot demand an absurd bitmap), so hairlines
+// stay crisp on hi-dpi screens. Layout changes after that (the sidebar
+// opening, a window resize) never trigger a redraw; CSS stretches the
+// existing bitmap, which is invisible at hairline weight. Feature sizes
+// scale with the height so the scene reads the same at every resolution;
+// 800 is the reference height the constants were tuned at.
+const REF_H = 800
+const MAX_DIM = 4096
+
+function sizeToElement(canvas: HTMLCanvasElement): { w: number; h: number; s: number } {
+  const rect = canvas.getBoundingClientRect()
+  const dpr = window.devicePixelRatio || 1
+  // A hidden or unlaid-out element measures 0; fall back to the reference frame.
+  const w = (canvas.width = Math.min(Math.round(rect.width * dpr), MAX_DIM) || 1280)
+  const h = (canvas.height = Math.min(Math.round(rect.height * dpr), MAX_DIM) || REF_H)
+  return { w, h, s: h / REF_H }
+}
+
+type DrawFn = (canvas: HTMLCanvasElement, accent: string, line: string, strength: number) => void
 
 function drawRelief(canvas: HTMLCanvasElement, accent: string, line: string, strength = 1) {
   const ctx = canvas.getContext("2d")
   if (!ctx) return
-  const w = (canvas.width = CANVAS_W)
-  const h = (canvas.height = CANVAS_H)
+  const { w, h, s } = sizeToElement(canvas)
   ctx.clearRect(0, 0, w, h)
+  drawContours(ctx, w, h, s, accent, line, strength)
+}
 
+function drawContours(ctx: CanvasRenderingContext2D, w: number, h: number, s: number, accent: string, line: string, strength: number) {
   // Sample the field once on the grid; every level then reads the cache
   // instead of re-evaluating three octaves of noise per corner.
-  const step = 8
+  const step = 8 * s
   const cols = Math.ceil(w / step) + 1
   const rows = Math.ceil(h / step) + 1
   const grid = new Float32Array(cols * rows)
   for (let j = 0; j < rows; j++) {
     for (let i = 0; i < cols; i++) {
-      const x = i * step, y = j * step
+      // Sample in the reference frame so the terrain is the same shapes at
+      // every resolution, only sharper.
+      const x = (i * step) / s, y = (j * step) / s
       grid[j * cols + i] =
         noise(x / 260, y / 260) * 0.6 +
         noise(x / 90, y / 90) * 0.3 +
@@ -98,7 +117,7 @@ function drawRelief(canvas: HTMLCanvasElement, accent: string, line: string, str
     const accented = l % 4 === 0
     ctx.strokeStyle = accented ? accent : line
     ctx.globalAlpha = (accented ? 0.4 : 0.24) * strength
-    ctx.lineWidth = accented ? 1.2 : 0.8
+    ctx.lineWidth = (accented ? 1.2 : 0.8) * s
     ctx.beginPath()
     for (let j = 0; j < rows - 1; j++) {
       for (let i = 0; i < cols - 1; i++) {
@@ -124,6 +143,89 @@ function drawRelief(canvas: HTMLCanvasElement, accent: string, line: string, str
   ctx.globalAlpha = 1
 }
 
+
+/** The brand banner's scene: graticule and contours as ground, a hashed
+ *  scatter of markers with halo rings on the hot ones, and route arcs with
+ *  lit packets converging on the mark. */
+function drawMap(canvas: HTMLCanvasElement, accent: string, line: string, strength = 1) {
+  const ctx = canvas.getContext("2d")
+  if (!ctx) return
+  const { w, h, s } = sizeToElement(canvas)
+  ctx.clearRect(0, 0, w, h)
+
+  // Where the routes converge: the reference frame's HOME, scaled.
+  const home: [number, number] = [w / 2, HOME[1] * s]
+  // Markers and routes stay out of this box so the card (or the page
+  // title) sits on calm ground; it brackets the centered card.
+  const band = { l: home[0] - 220 * s, r: home[0] + 220 * s, t: home[1] - 150 * s, b: home[1] + 160 * s }
+
+  ctx.strokeStyle = line
+  ctx.globalAlpha = 0.18 * strength
+  ctx.lineWidth = 0.6 * s
+  ctx.beginPath()
+  for (let x = 0; x <= w; x += 80 * s) { ctx.moveTo(x, 0); ctx.lineTo(x, h) }
+  for (let y = 0; y <= h; y += 80 * s) { ctx.moveTo(0, y); ctx.lineTo(w, y) }
+  ctx.stroke()
+  ctx.globalAlpha = 1
+
+  // Contours quieter than the plain relief backdrop: here they are ground
+  // under the markers and routes, not the picture itself.
+  drawContours(ctx, w, h, s, accent, line, 0.6 * strength)
+
+  // Marker count follows the visible area so density stays constant on
+  // ultrawide screens; the hash keyed by index keeps it deterministic.
+  const count = Math.round(140 * ((w / s) * (h / s)) / (1280 * REF_H))
+  const markers: Array<[number, number, number]> = []
+  for (let i = 0; i < count; i++) {
+    const x = seed(i, 7) * w, y = seed(i, 13) * h
+    if (x > band.l && x < band.r && y > band.t && y < band.b) continue
+    markers.push([x, y, seed(i, 29)])
+  }
+  for (const [x, y, wgt] of markers) {
+    const hot = wgt > 0.8
+    const rad = (hot ? 3.2 : 1.6 + wgt * 1.4) * s
+    if (hot) {
+      ctx.strokeStyle = accent
+      ctx.globalAlpha = 0.22 * strength
+      ctx.lineWidth = 1 * s
+      ctx.beginPath()
+      ctx.arc(x, y, rad + (6 + wgt * 8) * s, 0, Math.PI * 2)
+      ctx.stroke()
+    }
+    ctx.fillStyle = hot ? accent : line
+    ctx.globalAlpha = (hot ? 0.9 : 0.3) * strength
+    ctx.beginPath()
+    ctx.arc(x, y, rad, 0, Math.PI * 2)
+    ctx.fill()
+  }
+
+  markers.filter(([, , wgt]) => wgt > 0.8).slice(0, 14).forEach(([x, y], i) => {
+    const cx = (x + home[0]) / 2 + (i % 2 ? 1 : -1) * 80 * s
+    const cy = (y + home[1]) / 2 + (y < home[1] ? -60 : 60) * s
+    const strong = i % 3 === 0
+    ctx.strokeStyle = accent
+    ctx.globalAlpha = (strong ? 0.45 : 0.18) * strength
+    ctx.lineWidth = (strong ? 1.3 : 0.9) * s
+    ctx.beginPath()
+    ctx.moveTo(x, y)
+    ctx.quadraticCurveTo(cx, cy, home[0], home[1])
+    ctx.stroke()
+    const u = 0.3 + ((i * 0.11) % 0.45)
+    const px = (1 - u) ** 2 * x + 2 * (1 - u) * u * cx + u * u * home[0]
+    const py = (1 - u) ** 2 * y + 2 * (1 - u) * u * cy + u * u * home[1]
+    ctx.save()
+    ctx.shadowColor = accent
+    ctx.shadowBlur = 8 * s
+    ctx.fillStyle = accent
+    ctx.globalAlpha = 0.9 * strength
+    ctx.beginPath()
+    ctx.arc(px, py, 2.8 * s, 0, Math.PI * 2)
+    ctx.fill()
+    ctx.restore()
+  })
+  ctx.globalAlpha = 1
+}
+
 /**
  * Contour lines from a noise field, drawn once and redrawn on theme change.
  * `fill` covers the nearest positioned ancestor (a screen-sized shell).
@@ -131,14 +233,26 @@ function drawRelief(canvas: HTMLCanvasElement, accent: string, line: string, str
  * long pages that scroll past it: a zero-height sticky wrapper stays at the
  * top of the scroller while the canvas hangs below it one viewport tall.
  */
-export function ReliefBackdrop({
-  mode = "fill",
-  tone = "full",
-}: {
+export function ReliefBackdrop(props: CanvasBackdropProps) {
+  return <CanvasBackdrop draw={drawRelief} {...props} />
+}
+
+/** The brand banner's combined scene, as a page backdrop. */
+export function MapBackdrop(props: CanvasBackdropProps) {
+  return <CanvasBackdrop draw={drawMap} {...props} />
+}
+
+interface CanvasBackdropProps {
   mode?: "fill" | "viewport"
   /** `quiet` halves the line strength for pages with content on top. */
   tone?: "full" | "quiet"
-}) {
+}
+
+function CanvasBackdrop({
+  draw: drawScene,
+  mode = "fill",
+  tone = "full",
+}: CanvasBackdropProps & { draw: DrawFn }) {
   const ref = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
@@ -151,7 +265,7 @@ export function ReliefBackdrop({
       cancelAnimationFrame(frame)
       frame = requestAnimationFrame(() => {
         const style = getComputedStyle(canvas)
-        drawRelief(canvas, style.color, style.borderColor, tone === "quiet" ? 0.5 : 1)
+        drawScene(canvas, style.color, style.borderColor, tone === "quiet" ? 0.5 : 1)
       })
     }
     draw()
@@ -161,7 +275,7 @@ export function ReliefBackdrop({
       cancelAnimationFrame(frame)
       mo.disconnect()
     }
-  }, [tone])
+  }, [drawScene, tone])
 
   const canvas = (
     <canvas

--- a/resources/components/brand/brand-screen.tsx
+++ b/resources/components/brand/brand-screen.tsx
@@ -1,4 +1,4 @@
-import { ReliefBackdrop, RoutesBackdrop } from "@/components/brand/backdrops"
+import { MapBackdrop, ReliefBackdrop, RoutesBackdrop } from "@/components/brand/backdrops"
 import { BrandMark } from "@/components/brand/brand-mark"
 import { Wordmark } from "@/components/brand/wordmark"
 import { cn } from "@/lib/utils"
@@ -8,8 +8,8 @@ import { cn } from "@/lib/utils"
  * root error boundary and the 404 page. One card on the aurora backdrop;
  * the card's header carries the mark, wordmark, the page's H1 and a line of
  * context, the body carries `children`. `backdrop` picks the picture behind
- * the card: routes converging on the mark, or relief contours; both sit on
- * the aurora glow.
+ * the card: routes converging on the mark, relief contours, or the map that
+ * combines them; all sit on the aurora glow.
  */
 export function BrandScreen({
   title,
@@ -20,7 +20,7 @@ export function BrandScreen({
 }: {
   title: string
   description?: string
-  backdrop?: "routes" | "relief"
+  backdrop?: "routes" | "relief" | "map"
   children: React.ReactNode
   className?: string
 }) {
@@ -35,13 +35,13 @@ export function BrandScreen({
             "radial-gradient(640px 420px at 18% -8%, var(--primary-glow), transparent 70%), radial-gradient(720px 520px at 108% 108%, var(--primary-glow), transparent 70%)",
         }}
       />
-      {backdrop === "routes" ? <RoutesBackdrop /> : <ReliefBackdrop />}
+      {backdrop === "routes" ? <RoutesBackdrop /> : backdrop === "relief" ? <ReliefBackdrop /> : <MapBackdrop />}
       <section
         aria-labelledby="brand-screen-title"
         className={cn(
           "relative w-full max-w-sm overflow-hidden rounded-xl bg-background/55 text-card-foreground ring-1 ring-border shadow-[var(--shadow-card)]",
           // Hairline contours dissolve under the full 8px blur; the arcs do not.
-          backdrop === "relief" ? "backdrop-blur-[5px]" : "backdrop-blur",
+          backdrop === "routes" ? "backdrop-blur" : "backdrop-blur-[5px]",
           className,
         )}
       >

--- a/resources/components/map/MapSkeleton.tsx
+++ b/resources/components/map/MapSkeleton.tsx
@@ -1,14 +1,15 @@
 /**
- * Loading skeleton for the map component.
+ * Loading skeleton for the map component: the brand map scene as a stand-in
+ * for the real one, with the controls placeholder and a loading pill on top.
  */
 
 import { Skeleton } from "@/components/ui/skeleton"
+import { MapBackdrop } from "@/components/brand/backdrops"
 
 export function MapSkeleton() {
   return (
     <div className="h-full w-full relative bg-background">
-      {/* Map placeholder */}
-      <Skeleton className="h-full w-full rounded-none" />
+      <MapBackdrop tone="quiet" />
 
       {/* Controls placeholder */}
       <div className="absolute top-4 right-4 z-10 flex flex-col gap-2">

--- a/resources/routes/__root.tsx
+++ b/resources/routes/__root.tsx
@@ -175,7 +175,7 @@ function RootErrorComponent({ error, reset }: { error: Error; reset: () => void 
       <BrandScreen
         title="Something went wrong"
         description="Try again, or go back to the overview."
-        backdrop="relief"
+        backdrop="map"
         className="max-w-lg"
       >
         <div className="space-y-4">
@@ -202,7 +202,7 @@ function NotFoundComponent() {
       <BrandScreen
         title="Page not found"
         description="Nothing lives at this address, or it has moved."
-        backdrop="relief"
+        backdrop="map"
       >
         <div className="flex justify-center">
           <Button variant="default" asChild>

--- a/resources/routes/login.tsx
+++ b/resources/routes/login.tsx
@@ -33,6 +33,7 @@ export const Route = createFileRoute("/login")({
 function LoginPagePending() {
   return (
     <BrandScreen
+      backdrop="map"
       title="Sign in"
       description="Enter the administrator credentials configured for this installation."
     >
@@ -74,6 +75,7 @@ function LoginPage() {
 
   return (
     <BrandScreen
+      backdrop="map"
       title="Sign in"
       description="Enter the administrator credentials configured for this installation."
     >

--- a/resources/routes/settings.tsx
+++ b/resources/routes/settings.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, Outlet, useRouterState } from "@tanstack/react-router"
-import { ReliefBackdrop } from "@/components/brand/backdrops"
+import { MapBackdrop } from "@/components/brand/backdrops"
 
 import {
   Select,
@@ -36,7 +36,7 @@ function SettingsLayout() {
 
   return (
     <div className="relative min-h-full min-w-0">
-      <ReliefBackdrop mode="viewport" />
+      <MapBackdrop mode="viewport"  />
       {/* Glass cards, scoped to Settings: the relief shows through them
           softly instead of only between them. */}
       <div className="relative min-w-0 p-4 md:grid md:grid-cols-[11rem_minmax(0,1fr)] md:gap-8 md:p-6 [&_[data-slot=card]]:bg-card/55 [&_[data-slot=card]]:backdrop-blur-[2px]">

--- a/resources/routes/settings.tsx
+++ b/resources/routes/settings.tsx
@@ -36,8 +36,8 @@ function SettingsLayout() {
 
   return (
     <div className="relative min-h-full min-w-0">
-      <MapBackdrop mode="viewport"  />
-      {/* Glass cards, scoped to Settings: the relief shows through them
+      <MapBackdrop mode="viewport" />
+      {/* Glass cards, scoped to Settings: the backdrop shows through them
           softly instead of only between them. */}
       <div className="relative min-w-0 p-4 md:grid md:grid-cols-[11rem_minmax(0,1fr)] md:gap-8 md:p-6 [&_[data-slot=card]]:bg-card/55 [&_[data-slot=card]]:backdrop-blur-[2px]">
       <Select value={activeTab.to} onValueChange={handleTabChange}>


### PR DESCRIPTION
## What

Adds a `MapBackdrop` that draws the brand banner scene (relief contours, graticule, request markers, route arcs into a home point) on a canvas, and uses it on the login page, the error and 404 pages, the settings pages, and the map's loading skeleton. The existing routes and relief backdrops are untouched; this is a third variant.

The canvas now renders at the element's actual pixel size times `devicePixelRatio` (capped at 4096px per side), so the backdrop stays sharp on hi-dpi screens instead of upscaling a fixed 1280x800 buffer. All geometry is scaled from a reference height, so the scene composition is the same at every size.

## Details

- `backdrops.tsx`: `drawMap` composes the graticule, contours, hashed markers (hot ones get halo rings) and 14 route arcs converging on a home point, with a cleared band around the center so foreground cards sit on calm ground. Marker count scales with canvas area.
- `BrandScreen` accepts `backdrop="map"`; login, `__root`'s error/404 boundaries and the settings layout use it.
- `MapSkeleton` swaps the full-page gray skeleton for the quiet-tone backdrop while MapLibre loads.
- Redraws on theme and accent changes via the existing MutationObserver plumbing; nothing new there.

## Testing

- `bun run test`, `bun run typecheck`, `bun run build` pass.
- Checked in the browser on login, 404, settings and the map loading state, in both themes, at devicePixelRatio 1 and 2.
