### PR TITLE
feat(logparser): geometrikks-json, a keyed JSON access-log format for nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Map controls are one panel with labeled sections (Visualization, Live, Filters, Summary, Top IPs). Toggles are switch rows so the panel fits a laptop screen without scrolling, the map filters get a Clear, fit and home moved into the panel header, and the collapsed button shows a dot while filters are active. The live feed scrolls inside a bounded card instead of stretching to the map's height.
 - Settings > Appearance: theme (System, Light, Dark) and accent (teal, green, copper) side by side with previews. System follows the device's color scheme live, not only at page load. The accent is also switchable from the header, persists per browser and is applied before first paint.
 - Open Graph and Twitter card tags on the app shell.
-- `geometrikks-json`, a keyed JSON access-log format for nginx (`log_format ... escape=json`) and the recommended nginx setup. Lines decode against a fixed schema instead of a positional regex, so a rearranged format is rejected rather than mapped to the wrong columns. Works with live tailing, `LOGPARSER_LOG_FORMATS` and `import-logs --format geometrikks-json`. The existing nginx format keeps working.
+- `geometrikks-json`, a keyed JSON access-log format for nginx (`log_format ... escape=json`) and the recommended nginx setup. Lines decode against a fixed schema instead of a positional regex, so a broken or mistyped format is rejected rather than mapped to the wrong columns. Works with live tailing, `LOGPARSER_LOG_FORMATS` and `import-logs --format geometrikks-json`. The existing nginx format keeps working.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Map controls are one panel with labeled sections (Visualization, Live, Filters, Summary, Top IPs). Toggles are switch rows so the panel fits a laptop screen without scrolling, the map filters get a Clear, fit and home moved into the panel header, and the collapsed button shows a dot while filters are active. The live feed scrolls inside a bounded card instead of stretching to the map's height.
 - Settings > Appearance: theme (System, Light, Dark) and accent (teal, green, copper) side by side with previews. System follows the device's color scheme live, not only at page load. The accent is also switchable from the header, persists per browser and is applied before first paint.
 - Open Graph and Twitter card tags on the app shell.
+- `geometrikks-json`, a keyed JSON access-log format for nginx (`log_format ... escape=json`) and the recommended nginx setup. Lines decode against a fixed schema instead of a positional regex, so a rearranged format is rejected rather than mapped to the wrong columns. Works with live tailing, `LOGPARSER_LOG_FORMATS` and `import-logs --format geometrikks-json`. The existing nginx format keeps working.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,53 @@ file(s) as seen inside the container, under `/var/log/access/`.
 
 ## Nginx setup
 
-GeoMetrikks parses a specific nginx `log_format`. Add it to the `http` block
-in your `nginx.conf`:
+GeoMetrikks reads a keyed JSON access log. Add this `log_format` to the
+`http` block in your `nginx.conf` (nginx 1.11.8 or later for `escape=json`):
+
+```nginx
+log_format geometrikks_json escape=json
+  '{'
+    '"client_ip":"$remote_addr",'
+    '"timestamp":"$time_iso8601",'
+    '"method":"$request_method",'
+    '"path":"$request_uri",'
+    '"protocol":"$server_protocol",'
+    '"status":"$status",'
+    '"bytes":"$body_bytes_sent",'
+    '"host":"$host",'
+    '"referrer":"$http_referer",'
+    '"user_agent":"$http_user_agent",'
+    '"remote_user":"$remote_user",'
+    '"request_time":"$request_time",'
+    '"upstream_time":"$upstream_response_time",'
+    '"request_raw":"$request"'
+  '}';
+```
+
+Then use it on the access log you want GeoMetrikks to tail:
+
+```nginx
+access_log /config/log/nginx/access.log geometrikks_json;
+```
+
+Keep every value quoted, including the numbers: nginx has no typed output,
+and an unquoted empty variable breaks the line. `escape=json` is required;
+without it a quote inside a user agent produces invalid JSON, and the line
+is skipped and counted as unparseable. `client_ip` and `timestamp` are the
+only required keys. Drop any other key and the feature it feeds goes empty
+(`host` feeds the host filter, `request_time` and `upstream_time` feed the
+response-time analytics). Add your own keys freely; GeoMetrikks ignores
+the ones it does not know.
+
+`LOGPARSER_LOG_FORMATS=geometrikks-json` pins the parser to this format
+instead of detecting it per file.
+
+### Legacy nginx format
+
+Earlier versions documented this positional format. It keeps working for
+both live tailing and `import-logs`, so an existing install needs no
+change, and archives already written in it import as before. Use the JSON
+format above for new setups.
 
 ```nginx
 log_format custom '$remote_addr - $remote_user [$time_local] '
@@ -140,11 +185,40 @@ log_format custom '$remote_addr - $remote_user [$time_local] '
         '"$request_time" "$upstream_response_time"';
 ```
 
-Then use it on the access log you want GeoMetrikks to tail:
+The parser matches this format on position and quoting rather than on
+field names, so a rearranged format can land values in the wrong columns
+instead of failing outright. Four rules:
 
-```nginx
-access_log /config/log/nginx/access.log custom;
-```
+- Use `$time_local`. `$time_iso8601` does not match at all, and a file that
+  uses it produces no rows.
+- Keep `$host` unquoted and between `"$http_referer"` and
+  `"$http_user_agent"`. Writing `"$host"` still parses, but the hostname
+  ends up in the user-agent column and `host` comes out empty.
+- Keep `$request_time` and `$upstream_response_time` quoted. Unquoted, both
+  are dropped and read as 0.
+- Append extra fields only after both timing fields. The parser fills the
+  two timing slots by quoting alone, so on a format without them an extra
+  quoted field lands in `$request_time`. A non-numeric value such as
+  `"$http_x_forwarded_for"` is discarded, but a numeric one is recorded and
+  charted as a response time.
+
+`LOGPARSER_LOG_FORMATS=nginx` pins the parser to this format.
+
+#### Backfilling logs written in another format
+
+Lines in nginx's built-in `combined` format also parse, so you can import
+archives you have on disk without having changed your nginx config first.
+Three fields are absent from those lines and cannot be recovered after the
+fact:
+
+| Missing field | What it costs you |
+| --- | --- |
+| `$host` | The host filter on the access-log and analytics pages has nothing to list |
+| `$request_time` | Response-time average and percentiles read 0.00s |
+| `$upstream_response_time` | Upstream timing stays empty in the access-log detail view |
+
+The map, geo analytics, status codes, URLs, referrers, user agents and bytes
+are unaffected.
 
 ### Multiple log files
 
@@ -616,7 +690,8 @@ It reuses the live ingestion pipeline (same parsing, GeoIP lookup and DB
 writes), uses the timestamps in each log line rather than wall-clock time,
 and refreshes the continuous aggregates for the imported range when done.
 The log format is auto-detected per file, as with live tailing; pass
-`--format nginx` or `--format traefik-json` to pin it. You can pass several
+`--format geometrikks-json`, `--format nginx` or `--format traefik-json`
+to pin it. You can pass several
 files in one invocation. Paths are **container** paths, and the import runs
 as the non-root `geometrikks` user (`PUID`:`PGID`, default 1000:1000), so
 host files must be readable by it (`-u geometrikks` keeps `exec` from
@@ -639,6 +714,11 @@ docker compose run --rm app litestar import-logs /var/log/access/access.log.1.gz
   delete rows written by the earlier import.
 - A file that matches no supported log format is rejected up front, before
   anything is written.
+- Without `--format`, the format is detected per file. If detection can only
+  match the relaxed IP-and-timestamp pattern, the file imports as map events
+  with no access-log rows. Pin the format (`--format geometrikks-json` or
+  `--format nginx`) to require a full parse; lines that do not match then
+  show up in the skipped count instead.
 - The TimescaleDB retention policy drops rows older than the raw retention
   window (`ANALYTICS_RAW_RETENTION_DAYS`, default 180 days), so history
   beyond that window will not persist. Raise the retention setting before
@@ -812,9 +892,10 @@ Yes. The GHCR image is a multi-arch manifest for `linux/amd64` and
 Check three things in order: (1) the geo-degraded banner; if it shows,
 MaxMind credentials or the GeoLite2 database are missing; (2) that
 `LOGPARSER_LOG_PATHS` points at a file receiving traffic in a supported
-format (the nginx `log_format` above, or Traefik JSON); (3) that some time
-has passed since you last restarted. The map only shows events ingested
-after startup unless you have run a batch import.
+format (the nginx JSON `log_format` above, the legacy nginx format, or
+Traefik JSON); (3) that some time
+has passed since you last restarted. The map only shows
+events ingested after startup unless you have run a batch import.
 
 **What does the "geo-degraded" banner mean?**
 The app started without a usable GeoLite2 database: either

--- a/README.md
+++ b/README.md
@@ -162,11 +162,13 @@ access_log /config/log/nginx/access.log geometrikks_json;
 Keep every value quoted, including the numbers: nginx has no typed output,
 and an unquoted empty variable breaks the line. `escape=json` is required;
 without it a quote inside a user agent produces invalid JSON, and the line
-is skipped and counted as unparseable. `client_ip` and `timestamp` are the
-only required keys. Drop any other key and the feature it feeds goes empty
-(`host` feeds the host filter, `request_time` and `upstream_time` feed the
-response-time analytics). Add your own keys freely; GeoMetrikks ignores
-the ones it does not know.
+is skipped and counted as unparseable. `escape=json` leaves bytes above
+0x7f raw, so a probe line can carry undecodable bytes; GeoMetrikks
+replaces them with U+FFFD and still classifies the line. `client_ip` and
+`timestamp` are the only required keys. Drop any other key and the feature
+it feeds goes empty (`host` feeds the host filter, `request_time` and
+`upstream_time` feed the response-time analytics). Add your own keys
+freely; GeoMetrikks ignores the ones it does not know.
 
 `LOGPARSER_LOG_FORMATS=geometrikks-json` pins the parser to this format
 instead of detecting it per file.
@@ -226,8 +228,8 @@ are unaffected.
 to more than one file and GeoMetrikks tails all of them:
 
 ```nginx
-access_log /config/log/nginx/somepage/access.log custom;
-access_log /config/log/nginx/access.log custom;
+access_log /config/log/nginx/somepage/access.log geometrikks_json;
+access_log /config/log/nginx/access.log geometrikks_json;
 ```
 
 ```bash
@@ -893,9 +895,9 @@ Check three things in order: (1) the geo-degraded banner; if it shows,
 MaxMind credentials or the GeoLite2 database are missing; (2) that
 `LOGPARSER_LOG_PATHS` points at a file receiving traffic in a supported
 format (the nginx JSON `log_format` above, the legacy nginx format, or
-Traefik JSON); (3) that some time
-has passed since you last restarted. The map only shows
-events ingested after startup unless you have run a batch import.
+Traefik JSON); (3) that some time has passed since you last restarted. The
+map only shows events ingested after startup unless you have run a batch
+import.
 
 **What does the "geo-degraded" banner mean?**
 The app started without a usable GeoLite2 database: either

--- a/dev/docker-compose.agents.yml
+++ b/dev/docker-compose.agents.yml
@@ -195,6 +195,39 @@ services:
       timescale_agent_db:
         condition: service_healthy
 
+  agent-json:
+    container_name: geometrikks_agent_json
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: geometrikks:agent-mode
+    restart: unless-stopped
+    hostname: agent-json
+    stop_grace_period: 20s
+    environment:
+      APP_MODE: agent
+      MAP_HOME_REFRESH_HOURS: 1
+      LOGPARSER_HOST_NAME: json-01
+      LOGPARSER_LOG_PATHS: /var/log/access/nginx-json.log
+      LOGPARSER_LOG_FORMATS: geometrikks-json
+      MAXMINDDB_USER_ID: ${MAXMINDDB_USER_ID:-}
+      MAXMINDDB_LICENSE_KEY: ${MAXMINDDB_LICENSE_KEY:-}
+      DB_HOST: timescale_agent_db
+      DB_PORT: 5432
+      DB_USER: geouser
+      DB_PASSWORD: geopass
+      DB_DATABASE: geometrikks
+    ports:
+      - "8003:8000"
+    volumes:
+      - ../nginx_logs:/var/log/access:ro
+      - ../data/geoip:/app/data/geoip
+    networks:
+      - geometrikks_agent_net
+    depends_on:
+      timescale_agent_db:
+        condition: service_healthy
+
   # ===========================================================================
   # Synthetic traffic: runs dev/inject-logs.sh for the stack's lifetime, so
   # `up` starts the inserts and `down` ends them. Reuses the app image for

--- a/dev/docker-compose.agents.yml
+++ b/dev/docker-compose.agents.yml
@@ -34,15 +34,16 @@
 #     services; the entrypoint chowns it, and rw lets the agents' weekly
 #     geoip-refresh job work. Fine for a test stack, one-volume-per-agent
 #     in real deployments.
-#   - Site homes (Phase 5): both agents share this machine's public IP, so
-#     their auto-detected homes coincide. The head below pins three US
-#     cities so routes and beacons visibly split: its own home in Chicago
-#     (MAP_HOME_LATITUDE/LONGITUDE, the default beacon), nginx-01 in New
-#     York and traefik-01 in Los Angeles (MAP_HOME_LOCATIONS). Only the
-#     agents ingest, so only their two beacons draw routes; Chicago is the
+#   - Site homes (Phase 5): all three agents share this machine's public IP,
+#     so their auto-detected homes coincide. The head below pins two of them
+#     so routes and beacons visibly split: nginx-01 in New York and traefik-01
+#     in Los Angeles (MAP_HOME_LOCATIONS), plus its own home in Chicago
+#     (MAP_HOME_LATITUDE/LONGITUDE, the default beacon). json-01 is left
+#     unpinned, so its beacon is the auto-detected home instead. Only the
+#     agents ingest, so only their three beacons draw routes; Chicago is the
 #     head. Edit or remove the overrides to test the pure-auto path (the
-#     override row is deleted at the next head restart, and the agent's
-#     next write restores it as auto). Inspect the table:
+#     override rows are deleted at the next head restart, and each pinned
+#     agent's next write restores it as auto). Inspect the table:
 #       docker exec timescale_agent_db psql -U geouser -d geometrikks \
 #         -c "SELECT hostname, latitude, longitude, source FROM site_homes;"
 

--- a/dev/docker-compose.agents.yml
+++ b/dev/docker-compose.agents.yml
@@ -5,8 +5,9 @@
 #                       UI/API/WS, runs migrations, no tailing of its own
 #   agent-nginx         APP_MODE=agent tailing nginx_logs/nginx.log
 #   agent-traefik       APP_MODE=agent tailing nginx_logs/traefik.log
+#   agent-json          APP_MODE=agent tailing nginx_logs/nginx-json.log
 #
-# All three app services build the production Dockerfile locally and share
+# All four app services build the production Dockerfile locally and share
 # one image tag, so compose builds it once.
 #
 # Usage, from the repo root (--env-file: the compose project directory is
@@ -29,7 +30,7 @@
 #     flag above only feeds the ${...} interpolations below (admin login,
 #     MaxMind creds, and the CrowdSec LAPI settings on the head, which stay
 #     empty and therefore disabled when .env has none).
-#   - ./data/geoip (the dev mmdb) is bind-mounted rw into all three
+#   - ./data/geoip (the dev mmdb) is bind-mounted rw into all four
 #     services; the entrypoint chowns it, and rw lets the agents' weekly
 #     geoip-refresh job work. Fine for a test stack, one-volume-per-agent
 #     in real deployments.

--- a/dev/inject-logs.sh
+++ b/dev/inject-logs.sh
@@ -25,6 +25,24 @@ PATHS=(/ /api/v1/status /login /wp-login.php /assets/app.js /images/logo.png /fe
 METHODS=(GET GET GET GET POST GET HEAD GET)
 STATUSES=(200 200 200 301 404 200 403 200 500 204)
 AGENTS=("Mozilla/5.0 (X11; Linux x86_64) Firefox/141.0" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/152.0.0.0" "curl/8.9.1")
+REFERRERS=("" "" "https://yourdomain.com/" "https://www.google.com/" "https://duckduckgo.com/" "https://t.co/x8f2kq")
+USERS=("" "" "" "" "" "alice" "bob" "svc-backup")
+
+# Sets rt/ut (seconds, three decimals; ut empty when nginx served the
+# request itself) and rtms/utms (milliseconds) for one request. Static
+# paths never reach an upstream; every 25th dynamic request is a slow
+# outlier so the response-time percentiles have a tail.
+timings() {
+  case "$1" in
+    /assets/*|/images/*|/robots.txt|/health)
+      rtms=$((RANDOM % 6)); utms=0 ;;
+    *)
+      if [ $((RANDOM % 25)) -eq 0 ]; then rtms=$((3000 + RANDOM % 5000)); else rtms=$((20 + RANDOM % 2480)); fi
+      utms=$((rtms - 1 - RANDOM % 40)); [ "$utms" -lt 1 ] && utms=1 ;;
+  esac
+  rt=$(printf '%d.%03d' $((rtms / 1000)) $((rtms % 1000)))
+  ut=""; [ "$utms" -gt 0 ] && ut=$(printf '%d.%03d' $((utms / 1000)) $((utms % 1000)))
+}
 
 i=0
 while [ ! -f "$STOPFILE" ] && { [ "$MAX_SECONDS" -eq 0 ] || [ "$i" -lt "$MAX_SECONDS" ]; }; do
@@ -33,28 +51,47 @@ while [ ! -f "$STOPFILE" ] && { [ "$MAX_SECONDS" -eq 0 ] || [ "$i" -lt "$MAX_SEC
   method=${METHODS[$((RANDOM % ${#METHODS[@]}))]}
   status=${STATUSES[$((RANDOM % ${#STATUSES[@]}))]}
   agent=${AGENTS[$((RANDOM % ${#AGENTS[@]}))]}
+  ref=${REFERRERS[$((RANDOM % ${#REFERRERS[@]}))]}
+  user=${USERS[$((RANDOM % ${#USERS[@]}))]}
   bytes=$((RANDOM % 5000 + 100))
+  timings "$path"
   nts=$(date +"%d/%b/%Y:%H:%M:%S %z")
-  printf '%s - - [%s]"%s %s HTTP/2.0" %s %s"-" yourdomain.com "-""0.0%02d" "0.001""-" "-"\n' \
-    "$ip" "$nts" "$method" "$path" "$status" "$bytes" "$((RANDOM % 90))" >> "$REPO/nginx_logs/nginx.log"
-
-  ip=${IPS[$((RANDOM % ${#IPS[@]}))]}
-  path=${PATHS[$((RANDOM % ${#PATHS[@]}))]}
-  method=${METHODS[$((RANDOM % ${#METHODS[@]}))]}
-  status=${STATUSES[$((RANDOM % ${#STATUSES[@]}))]}
-  tts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  ttsn=$(date -u +"%Y-%m-%dT%H:%M:%S.%NZ")
-  printf '{"ClientAddr":"%s:%s","ClientHost":"%s","ClientPort":"%s","ClientUsername":"-","DownstreamContentSize":%s,"DownstreamStatus":%s,"Duration":%s,"OriginContentSize":%s,"OriginDuration":0,"OriginStatus":%s,"Overhead":1200,"RequestAddr":"traefik.example.com","RequestContentSize":0,"RequestCount":%s,"RequestHost":"traefik.example.com","RequestMethod":"%s","RequestPath":"%s","RequestPort":"-","RequestProtocol":"HTTP/2.0","RequestScheme":"https","RetryAttempts":0,"StartLocal":"%s","StartUTC":"%s","TLSCipher":"TLS_AES_128_GCM_SHA256","TLSVersion":"1.3","entryPointName":"https","level":"info","msg":"","request_User-Agent":"%s","time":"%s"}\n' \
-    "$ip" "$((RANDOM % 50000 + 1024))" "$ip" "$((RANDOM % 50000 + 1024))" "$bytes" "$status" "$((RANDOM % 90000 + 500))" "$bytes" "$status" "$((i + 1))" "$method" "$path" "$ttsn" "$ttsn" "$agent" "$tts" >> "$REPO/nginx_logs/traefik.log"
+  printf '%s - %s [%s]"%s %s HTTP/2.0" %s %s"%s" yourdomain.com "%s""%s" "%s""-" "-"\n' \
+    "$ip" "${user:--}" "$nts" "$method" "$path" "$status" "$bytes" "${ref:--}" "$agent" "$rt" "${ut:--}" >> "$REPO/nginx_logs/nginx.log"
 
   ip=${IPS[$((RANDOM % ${#IPS[@]}))]}
   path=${PATHS[$((RANDOM % ${#PATHS[@]}))]}
   method=${METHODS[$((RANDOM % ${#METHODS[@]}))]}
   status=${STATUSES[$((RANDOM % ${#STATUSES[@]}))]}
   agent=${AGENTS[$((RANDOM % ${#AGENTS[@]}))]}
+  ref=${REFERRERS[$((RANDOM % ${#REFERRERS[@]}))]}
+  user=${USERS[$((RANDOM % ${#USERS[@]}))]}
+  bytes=$((RANDOM % 5000 + 100))
+  timings "$path"
+  # Traefik keeps Referer only when present, so the key is omitted for
+  # a direct hit; durations are nanoseconds, OriginStatus is 0 without
+  # an upstream.
+  tref=""; [ -n "$ref" ] && tref=",\"request_Referer\":\"$ref\""
+  dur=$((rtms * 1000000 + RANDOM % 1000 + 500))
+  orig=$((utms * 1000000))
+  ostat=0; [ "$utms" -gt 0 ] && ostat=$status
+  tts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  ttsn=$(date -u +"%Y-%m-%dT%H:%M:%S.%NZ")
+  printf '{"ClientAddr":"%s:%s","ClientHost":"%s","ClientPort":"%s","ClientUsername":"%s","DownstreamContentSize":%s,"DownstreamStatus":%s,"Duration":%s,"OriginContentSize":%s,"OriginDuration":%s,"OriginStatus":%s,"Overhead":%s,"RequestAddr":"traefik.example.com","RequestContentSize":0,"RequestCount":%s,"RequestHost":"traefik.example.com","RequestMethod":"%s","RequestPath":"%s","RequestPort":"-","RequestProtocol":"HTTP/2.0","RequestScheme":"https","RetryAttempts":0,"StartLocal":"%s","StartUTC":"%s","TLSCipher":"TLS_AES_128_GCM_SHA256","TLSVersion":"1.3","entryPointName":"https","level":"info","msg":"","request_User-Agent":"%s"%s,"time":"%s"}\n' \
+    "$ip" "$((RANDOM % 50000 + 1024))" "$ip" "$((RANDOM % 50000 + 1024))" "${user:--}" "$bytes" "$status" "$dur" "$bytes" "$orig" "$ostat" "$((dur - orig))" "$((i + 1))" "$method" "$path" "$ttsn" "$ttsn" "$agent" "$tref" "$tts" >> "$REPO/nginx_logs/traefik.log"
+
+  ip=${IPS[$((RANDOM % ${#IPS[@]}))]}
+  path=${PATHS[$((RANDOM % ${#PATHS[@]}))]}
+  method=${METHODS[$((RANDOM % ${#METHODS[@]}))]}
+  status=${STATUSES[$((RANDOM % ${#STATUSES[@]}))]}
+  agent=${AGENTS[$((RANDOM % ${#AGENTS[@]}))]}
+  ref=${REFERRERS[$((RANDOM % ${#REFERRERS[@]}))]}
+  user=${USERS[$((RANDOM % ${#USERS[@]}))]}
+  bytes=$((RANDOM % 5000 + 100))
+  timings "$path"
   jts=$(date +"%Y-%m-%dT%H:%M:%S%:z")
-  printf '{"client_ip":"%s","timestamp":"%s","method":"%s","path":"%s","protocol":"HTTP/2.0","status":"%s","bytes":"%s","host":"json.example.com","referrer":"","user_agent":"%s","remote_user":"","request_time":"0.0%02d","upstream_time":"0.001","request_raw":"%s %s HTTP/2.0"}\n' \
-    "$ip" "$jts" "$method" "$path" "$status" "$bytes" "$agent" "$((RANDOM % 90))" "$method" "$path" >> "$REPO/nginx_logs/nginx-json.log"
+  printf '{"client_ip":"%s","timestamp":"%s","method":"%s","path":"%s","protocol":"HTTP/2.0","status":"%s","bytes":"%s","host":"json.example.com","referrer":"%s","user_agent":"%s","remote_user":"%s","request_time":"%s","upstream_time":"%s","request_raw":"%s %s HTTP/2.0"}\n' \
+    "$ip" "$jts" "$method" "$path" "$status" "$bytes" "$ref" "$agent" "$user" "$rt" "$ut" "$method" "$path" >> "$REPO/nginx_logs/nginx-json.log"
 
   # Every tenth line is one the parser cannot fully use, so the Debug logs
   # page has parse failures to show: a TLS probe on the plain port, a line

--- a/dev/inject-logs.sh
+++ b/dev/inject-logs.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# Appends one synthetic nginx line and one traefik JSON line per second to
-# nginx_logs/, with fresh timestamps and a rotating pool of real public IPs,
-# so the agents compose stack (dev/docker-compose.agents.yml) has live
-# traffic to ingest.
+# Appends one synthetic nginx line, one traefik JSON line and one
+# geometrikks-json line per second to nginx_logs/, with fresh timestamps
+# and a rotating pool of real public IPs, so the agents compose stack
+# (dev/docker-compose.agents.yml) has live traffic to ingest.
 #
 # Runs automatically as the compose stack's log-injector service (for the
 # stack's lifetime; `down` stops it). Standalone usage, from the repo root:
@@ -15,6 +15,9 @@ STOPFILE="$REPO/dev/inject-logs.stop"
 MAX_SECONDS=${INJECT_MAX_SECONDS:-1800}
 
 rm -f "$STOPFILE"
+# nginx_logs/ is gitignored; create the tailed files so the agents find
+# them on first start instead of waiting for the first line.
+touch "$REPO/nginx_logs/nginx.log" "$REPO/nginx_logs/traefik.log" "$REPO/nginx_logs/nginx-json.log"
 trap 'echo "injector stopped by signal after $i iterations"; exit 0' TERM INT
 
 IPS=(8.8.8.8 1.1.1.1 81.2.69.142 91.198.174.192 185.60.216.35 34.71.167.225 104.28.42.7 197.248.21.8 133.242.187.207 200.160.2.3 77.88.55.242 129.226.3.47)
@@ -44,16 +47,31 @@ while [ ! -f "$STOPFILE" ] && { [ "$MAX_SECONDS" -eq 0 ] || [ "$i" -lt "$MAX_SEC
   printf '{"ClientAddr":"%s:%s","ClientHost":"%s","ClientPort":"%s","ClientUsername":"-","DownstreamContentSize":%s,"DownstreamStatus":%s,"Duration":%s,"OriginContentSize":%s,"OriginDuration":0,"OriginStatus":%s,"Overhead":1200,"RequestAddr":"traefik.example.com","RequestContentSize":0,"RequestCount":%s,"RequestHost":"traefik.example.com","RequestMethod":"%s","RequestPath":"%s","RequestPort":"-","RequestProtocol":"HTTP/2.0","RequestScheme":"https","RetryAttempts":0,"StartLocal":"%s","StartUTC":"%s","TLSCipher":"TLS_AES_128_GCM_SHA256","TLSVersion":"1.3","entryPointName":"https","level":"info","msg":"","request_User-Agent":"%s","time":"%s"}\n' \
     "$ip" "$((RANDOM % 50000 + 1024))" "$ip" "$((RANDOM % 50000 + 1024))" "$bytes" "$status" "$((RANDOM % 90000 + 500))" "$bytes" "$status" "$((i + 1))" "$method" "$path" "$ttsn" "$ttsn" "$agent" "$tts" >> "$REPO/nginx_logs/traefik.log"
 
-  # Every tenth nginx line is one the parser cannot fully use, so the Debug
-  # logs page has parse failures to show: a TLS probe on the plain port, a
-  # line cut off mid-request by a rotation, and a request with no method.
-  # Traefik never writes lines like these, so only the nginx file gets them.
+  ip=${IPS[$((RANDOM % ${#IPS[@]}))]}
+  path=${PATHS[$((RANDOM % ${#PATHS[@]}))]}
+  method=${METHODS[$((RANDOM % ${#METHODS[@]}))]}
+  status=${STATUSES[$((RANDOM % ${#STATUSES[@]}))]}
+  agent=${AGENTS[$((RANDOM % ${#AGENTS[@]}))]}
+  jts=$(date +"%Y-%m-%dT%H:%M:%S%:z")
+  printf '{"client_ip":"%s","timestamp":"%s","method":"%s","path":"%s","protocol":"HTTP/2.0","status":"%s","bytes":"%s","host":"json.example.com","referrer":"","user_agent":"%s","remote_user":"","request_time":"0.0%02d","upstream_time":"0.001","request_raw":"%s %s HTTP/2.0"}\n' \
+    "$ip" "$jts" "$method" "$path" "$status" "$bytes" "$agent" "$((RANDOM % 90))" "$method" "$path" >> "$REPO/nginx_logs/nginx-json.log"
+
+  # Every tenth line is one the parser cannot fully use, so the Debug logs
+  # page has parse failures to show: a TLS probe on the plain port, a line
+  # cut off mid-request by a rotation, and a request with no method. The
+  # nginx file gets all three; the JSON file gets the two nginx can express
+  # through escape=json (control bytes arrive as \uXXXX, the method is
+  # empty). Traefik never writes lines like these.
   if [ $((i % 10)) -eq 9 ]; then
     case $((RANDOM % 3)) in
       0) printf '%s - - [%s]"\\x16\\x03\\x01\\x02\\x00\\x01\\x00\\x01\\xfc\\x03\\x03" 400 157"-" yourdomain.com "-""0.000" "-""-" "-"\n' "$ip" "$nts" ;;
       1) printf '%s - - [%s]"GET /assets/app\n' "$ip" "$nts" ;;
       2) printf '%s - - [%s]"/ HTTP/1.1" 400 0"-" yourdomain.com "-""0.000" "-""-" "-"\n' "$ip" "$nts" ;;
     esac >> "$REPO/nginx_logs/nginx.log"
+    case $((RANDOM % 2)) in
+      0) printf '{"client_ip":"%s","timestamp":"%s","method":"","path":"","protocol":"","status":"400","bytes":"157","host":"json.example.com","referrer":"","user_agent":"","remote_user":"","request_time":"0.000","upstream_time":"","request_raw":"\\u0016\\u0003\\u0001\\u0002\\u0000\\u0001\\u0000\\u0001\\u00fc\\u0003\\u0003"}\n' "$ip" "$jts" ;;
+      1) printf '{"client_ip":"%s","timestamp":"%s","method":"","path":"/","protocol":"HTTP/1.1","status":"400","bytes":"0","host":"json.example.com","referrer":"","user_agent":"","remote_user":"","request_time":"0.000","upstream_time":"","request_raw":"/ HTTP/1.1"}\n' "$ip" "$jts" ;;
+    esac >> "$REPO/nginx_logs/nginx-json.log"
   fi
 
   i=$((i + 1))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,7 +92,7 @@ from real environment variables. It is read once at import time.
 |---|---|---|
 | `LOGPARSER_ENABLED` | `true` | Enable log parser ingestion service |
 | `LOGPARSER_LOG_PATHS` | *(computed)* | Access log files to tail. Env accepts a single path or a JSON list of paths. Default: /var/log/access/access.log |
-| `LOGPARSER_LOG_FORMATS` | *(computed)* | Log format per tailed file: 'auto' (default, detected from the file's content), 'nginx', or 'traefik-json'. Env accepts a single value applied to every path, or a JSON list matching LOGPARSER_LOG_PATHS by position. |
+| `LOGPARSER_LOG_FORMATS` | *(computed)* | Log format per tailed file: 'auto' (default, detected from the file's content), 'geometrikks-json', 'nginx', or 'traefik-json'. Env accepts a single value applied to every path, or a JSON list matching LOGPARSER_LOG_PATHS by position. |
 | `LOGPARSER_POLL_INTERVAL` | `1.0` | Interval in seconds to poll the log file for new entries |
 | `LOGPARSER_SEND_LOGS` | `true` | Send parsed logs to the database |
 | `LOGPARSER_HOST_NAME` | *(computed)* | Source hostname stamped on ingested records. Env accepts a single value applied to every tailed file, or a JSON list matching LOGPARSER_LOG_PATHS by position. Default: this machine's hostname. |

--- a/geometrikks/cli.py
+++ b/geometrikks/cli.py
@@ -1,7 +1,8 @@
 """Litestar CLI plugin: `litestar import-logs <paths...>`, `litestar backfill-hostname NAME`, `litestar backfill-asn`.
 
 Import-time safe: settings, engine, reader are constructed inside the
-command callback, never at module import.
+command callback, never at module import. The format registry import
+loads the logparser package but constructs none of those.
 """
 
 from __future__ import annotations
@@ -12,6 +13,8 @@ from pathlib import Path
 
 import click
 from litestar.plugins import CLIPlugin
+
+from geometrikks.services.logparser.formats import FORMATS
 
 
 @click.command(name="import-logs")
@@ -28,7 +31,7 @@ from litestar.plugins import CLIPlugin
     "log_format",
     default="auto",
     show_default=True,
-    type=click.Choice(["auto", "nginx", "traefik-json"]),
+    type=click.Choice(["auto", *FORMATS]),
     help="Log format of the given files (auto = detect per file).",
 )
 @click.option(

--- a/geometrikks/config/settings.py
+++ b/geometrikks/config/settings.py
@@ -258,9 +258,9 @@ class LogParserSettings(BaseSettings):
         default_factory=lambda: ["auto"],
         description=(
             "Log format per tailed file: 'auto' (default, detected from the "
-            "file's content), 'nginx', or 'traefik-json'. Env accepts a single "
-            "value applied to every path, or a JSON list matching "
-            "LOGPARSER_LOG_PATHS by position."
+            "file's content), 'geometrikks-json', 'nginx', or 'traefik-json'. "
+            "Env accepts a single value applied to every path, or a JSON list "
+            "matching LOGPARSER_LOG_PATHS by position."
         ),
     )
     poll_interval: float = Field(

--- a/geometrikks/services/logparser/formats/__init__.py
+++ b/geometrikks/services/logparser/formats/__init__.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 from typing import NamedTuple
 
 from .base import LogLineFormat, NormalizedLine
+from .geometrikks_json import GeometrikksJsonFormat
 from .nginx import NginxFormat
 from .traefik import TraefikJsonFormat
 
-# Sniffing order matters: cheap/most-specific first. traefik-json sits in
-# front of nginx: its '{' prefix check is near-free.
+# Sniffing order: the recommended format first, then the other cheap '{'
+# prefix check, then the regex. The two JSON adapters decline each other's
+# lines on required keys (client_ip vs ClientHost), so order is cost only.
 FORMATS: dict[str, LogLineFormat] = {
+    GeometrikksJsonFormat.name: GeometrikksJsonFormat(),
     TraefikJsonFormat.name: TraefikJsonFormat(),
     NginxFormat.name: NginxFormat(),
 }

--- a/geometrikks/services/logparser/formats/base.py
+++ b/geometrikks/services/logparser/formats/base.py
@@ -87,13 +87,21 @@ def detect_probe(
         (is_malformed, reason) with reason None when the request looks normal.
     """
     request = request_raw or ""
+
+    # TLS handshake sent to HTTP port - starts with \x16\x03 (TLS record header)
+    # Common patterns: \x16\x03\x01 (TLS 1.0), \x16\x03\x03 (TLS 1.2/1.3)
+    # Check both escaped string representation and raw bytes
     if request:
+        # Escaped form in log: \x16\x03 (nginx default escaping, regex format)
         if "\\x16\\x03" in request:
             return True, "TLS handshake sent to HTTP port (escaped)"
+        # Raw bytes form: what the JSON decoder yields for escape=json's \u0016\u0003
         if "\x16\x03" in request:
             return True, "TLS handshake sent to HTTP port (raw)"
+        # SSH probe
         if request.startswith("SSH-") or "\\x53\\x53\\x48" in request:
             return True, "SSH probe sent to HTTP port"
+        # SMB probe - \xFFSMB or escaped \x00...\xFFSMB
         if (
             "\\xffsmb" in request.lower()
             or "\xffSMB" in request
@@ -103,13 +111,17 @@ def detect_probe(
         if "NT LM" in request:
             return True, "SMB dialect negotiation probe"
 
+    # TLS probe: No HTTP method and 400 status (client sent HTTP to HTTPS port)
     if method is None and status_code == 400:
         return True, "TLS probe: HTTP request sent to HTTPS port"
+    # Invalid HTTP method (connection closed before sending valid request)
     if method is None:
         return True, "No HTTP method in request"
+    # Check for non-standard/invalid HTTP methods
     if method.upper() not in VALID_HTTP_METHODS:
         return True, f"Invalid HTTP method: {method}"
 
+    # nginx-specific status codes that indicate connection issues, not normal HTTP errors
     if status_code == 408:
         return True, "Request timeout (408)"
     if status_code == 444:

--- a/geometrikks/services/logparser/formats/base.py
+++ b/geometrikks/services/logparser/formats/base.py
@@ -95,7 +95,7 @@ def detect_probe(
         if request.startswith("SSH-") or "\\x53\\x53\\x48" in request:
             return True, "SSH probe sent to HTTP port"
         if (
-            "\\xffSMB" in request.lower()
+            "\\xffsmb" in request.lower()
             or "\xffSMB" in request
             or "SMBr" in request
         ):

--- a/geometrikks/services/logparser/formats/base.py
+++ b/geometrikks/services/logparser/formats/base.py
@@ -66,3 +66,55 @@ def convert_dash_to_none(value: str | None) -> str | None:
         return None
     stripped = value.strip()
     return stripped if stripped not in ("", "-") else None
+
+
+def detect_probe(
+    request_raw: str | None, method: str | None, status_code: int
+) -> tuple[bool, str | None]:
+    """Classify probe garbage and connection-level statuses; shared by the nginx adapters.
+
+    ``request_raw`` arrives in two escapings. The regex format sees nginx's
+    default escaping as literal text (``\\x16\\x03``); ``escape=json`` writes
+    ``\\u0016\\u0003``, which the JSON decoder turns into raw bytes. Each
+    probe therefore has an escaped-text and a raw-bytes branch.
+
+    Args:
+        request_raw: The raw request line, or None when the format did not log one.
+        method: Normalized HTTP method, None when absent.
+        status_code: Response status.
+
+    Returns:
+        (is_malformed, reason) with reason None when the request looks normal.
+    """
+    request = request_raw or ""
+    if request:
+        if "\\x16\\x03" in request:
+            return True, "TLS handshake sent to HTTP port (escaped)"
+        if "\x16\x03" in request:
+            return True, "TLS handshake sent to HTTP port (raw)"
+        if request.startswith("SSH-") or "\\x53\\x53\\x48" in request:
+            return True, "SSH probe sent to HTTP port"
+        if (
+            "\\xffSMB" in request.lower()
+            or "\xffSMB" in request
+            or "SMBr" in request
+        ):
+            return True, "SMB protocol probe (EternalBlue scanner)"
+        if "NT LM" in request:
+            return True, "SMB dialect negotiation probe"
+
+    if method is None and status_code == 400:
+        return True, "TLS probe: HTTP request sent to HTTPS port"
+    if method is None:
+        return True, "No HTTP method in request"
+    if method.upper() not in VALID_HTTP_METHODS:
+        return True, f"Invalid HTTP method: {method}"
+
+    if status_code == 408:
+        return True, "Request timeout (408)"
+    if status_code == 444:
+        return True, "Connection closed without response (nginx 444)"
+    if status_code == 499:
+        return True, "Client closed connection before response (nginx 499)"
+
+    return False, None

--- a/geometrikks/services/logparser/formats/geometrikks_json.py
+++ b/geometrikks/services/logparser/formats/geometrikks_json.py
@@ -112,9 +112,9 @@ class GeometrikksJsonFormat:
             # ValidationError (wrong type for a field) is a DecodeError subclass.
             return None
 
-        ip = (data.client_ip or "").strip()
+        ip = convert_dash_to_none(data.client_ip)
         ts = _parse_timestamp(data.timestamp)
-        if not ip or ts is None:
+        if ip is None or ts is None:
             return None
 
         remote_user = convert_dash_to_none(data.remote_user)
@@ -135,7 +135,7 @@ class GeometrikksJsonFormat:
             request_time=_to_float(data.request_time),
             upstream_response_time=_sum_upstream(data.upstream_time),
             host=convert_dash_to_none(data.host),
-            request_raw=data.request_raw or None,
+            request_raw=convert_dash_to_none(data.request_raw),
         )
 
     def detect_malformed(self, norm: NormalizedLine) -> tuple[bool, str | None]:

--- a/geometrikks/services/logparser/formats/geometrikks_json.py
+++ b/geometrikks/services/logparser/formats/geometrikks_json.py
@@ -1,0 +1,143 @@
+"""Adapter for the GeoMetrikks keyed JSON access-log format.
+
+The recommended nginx setup (README, Nginx setup). nginx has no typed
+output, so every value is a JSON string and this adapter does the number
+parsing; an unquoted empty variable would break the whole line. ``""``,
+``"-"`` and a missing key all mean absent. Only ``client_ip`` and
+``timestamp`` are required. Unknown keys are ignored so users can add
+fields for other consumers of the same file.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+import msgspec
+
+from .base import NormalizedLine, convert_dash_to_none, detect_probe
+
+
+class GeometrikksJsonLine(msgspec.Struct):
+    """One line as written by the documented ``log_format``; all values strings."""
+
+    client_ip: str | None = None
+    timestamp: str | None = None
+    method: str | None = None
+    path: str | None = None
+    protocol: str | None = None
+    status: str | None = None
+    bytes: str | None = None
+    host: str | None = None
+    referrer: str | None = None
+    user_agent: str | None = None
+    remote_user: str | None = None
+    request_time: str | None = None
+    upstream_time: str | None = None
+    request_raw: str | None = None
+
+
+_decoder = msgspec.json.Decoder(GeometrikksJsonLine)
+
+
+def _parse_timestamp(raw: str | None) -> datetime | None:
+    """ISO 8601 with a UTC offset; naive timestamps are rejected, not assumed UTC."""
+    if not raw:
+        return None
+    try:
+        ts = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    return ts if ts.tzinfo is not None else None
+
+
+def _to_int(raw: str | None) -> int:
+    try:
+        return int(raw) if raw else 0
+    except ValueError:
+        return 0
+
+
+def _to_float(raw: str | None) -> float:
+    try:
+        return float(raw) if raw else 0.0
+    except ValueError:
+        return 0.0
+
+
+def _sum_upstream(raw: str | None) -> float | None:
+    """Total time upstream.
+
+    nginx joins per-upstream times with ", " and internal-redirect legs with
+    " : ", and writes "-" for a leg with no upstream. Summing matches what
+    Traefik's OriginDuration measures.
+    """
+    if not raw:
+        return None
+    total = 0.0
+    seen = False
+    for part in raw.replace(":", ",").split(","):
+        part = part.strip()
+        if not part or part == "-":
+            continue
+        try:
+            total += float(part)
+        except ValueError:
+            continue
+        seen = True
+    return total if seen else None
+
+
+class GeometrikksJsonFormat:
+    """Parses one keyed JSON object per line against a fixed schema."""
+
+    name = "geometrikks-json"
+
+    def parse(self, line: str, *, geo_only: bool = False) -> NormalizedLine | None:
+        """Decode one line into a NormalizedLine.
+
+        Args:
+            line: Raw log line (one JSON object).
+            geo_only: Only require the client IP and the timestamp
+                (send_logs=False mode).
+
+        Returns:
+            NormalizedLine on success; None for non-JSON lines, wrong value
+            types, or lines missing the client IP / offset-bearing timestamp.
+        """
+        stripped = line.strip()
+        if not stripped.startswith("{"):
+            return None
+        try:
+            data = _decoder.decode(stripped)
+        except msgspec.DecodeError:
+            # ValidationError (wrong type for a field) is a DecodeError subclass.
+            return None
+
+        ip = (data.client_ip or "").strip()
+        ts = _parse_timestamp(data.timestamp)
+        if not ip or ts is None:
+            return None
+
+        remote_user = convert_dash_to_none(data.remote_user)
+        if geo_only:
+            return NormalizedLine(ip_address=ip, timestamp=ts, remote_user=remote_user)
+
+        return NormalizedLine(
+            ip_address=ip,
+            timestamp=ts,
+            remote_user=remote_user,
+            method=convert_dash_to_none(data.method),
+            path=convert_dash_to_none(data.path),
+            http_version=convert_dash_to_none(data.protocol),
+            status_code=_to_int(data.status),
+            bytes_sent=_to_int(data.bytes),
+            referrer=convert_dash_to_none(data.referrer),
+            user_agent=convert_dash_to_none(data.user_agent),
+            request_time=_to_float(data.request_time),
+            upstream_response_time=_sum_upstream(data.upstream_time),
+            host=convert_dash_to_none(data.host),
+            request_raw=data.request_raw or None,
+        )
+
+    def detect_malformed(self, norm: NormalizedLine) -> tuple[bool, str | None]:
+        """Probe and connection-status classification; see ``detect_probe``."""
+        return detect_probe(norm.request_raw, norm.method, norm.status_code)

--- a/geometrikks/services/logparser/formats/nginx.py
+++ b/geometrikks/services/logparser/formats/nginx.py
@@ -11,7 +11,7 @@ from geometrikks.services.logparser.constants import (
     ipv6_geo_pattern,
     ipv6_pattern,
 )
-from .base import NormalizedLine, VALID_HTTP_METHODS, convert_dash_to_none
+from .base import NormalizedLine, convert_dash_to_none, detect_probe
 
 logger = get_logger(__name__)
 
@@ -94,57 +94,5 @@ class NginxFormat:
         )
 
     def detect_malformed(self, norm: NormalizedLine) -> tuple[bool, str | None]:
-        """Detect malformed requests such as TLS probes and invalid HTTP.
-
-        Args:
-            norm: The normalized line to inspect.
-
-        Returns:
-            tuple of (is_malformed, parse_error_message)
-        """
-        request = norm.request_raw or ""
-        method = norm.method
-        status_code = norm.status_code
-
-        # TLS handshake sent to HTTP port - starts with \x16\x03 (TLS record header)
-        # Common patterns: \x16\x03\x01 (TLS 1.0), \x16\x03\x03 (TLS 1.2/1.3)
-        # Check both escaped string representation and raw bytes
-        if request:
-            # Escaped form in log: \x16\x03
-            if "\\x16\\x03" in request:
-                return True, "TLS handshake sent to HTTP port (escaped)"
-            # Raw bytes form (unlikely but possible)
-            if "\x16\x03" in request:
-                return True, "TLS handshake sent to HTTP port (raw)"
-            # SSH probe
-            if request.startswith("SSH-") or "\\x53\\x53\\x48" in request:
-                return True, "SSH probe sent to HTTP port"
-            # SMB probe - \xFFSMB or escaped \x00...\xFFSMB
-            if (
-                "\\xffSMB" in request.lower()
-                or "\xffSMB" in request
-                or "SMBr" in request
-            ):
-                return True, "SMB protocol probe (EternalBlue scanner)"
-            if "NT LM" in request:
-                return True, "SMB dialect negotiation probe"
-
-        # TLS probe: No HTTP method and 400 status (client sent HTTP to HTTPS port)
-        if method is None and status_code == 400:
-            return True, "TLS probe: HTTP request sent to HTTPS port"
-        # Invalid HTTP method (connection closed before sending valid request)
-        if method is None:
-            return True, "No HTTP method in request"
-        # Check for non-standard/invalid HTTP methods
-        if method.upper() not in VALID_HTTP_METHODS:
-            return True, f"Invalid HTTP method: {method}"
-
-        # nginx-specific status codes that indicate connection issues, not normal HTTP errors
-        if status_code == 408:
-            return True, "Request timeout (408)"
-        if status_code == 444:
-            return True, "Connection closed without response (nginx 444)"
-        if status_code == 499:
-            return True, "Client closed connection before response (nginx 499)"
-
-        return False, None
+        """Probe and connection-status classification; see ``detect_probe``."""
+        return detect_probe(norm.request_raw, norm.method, norm.status_code)

--- a/geometrikks/services/logparser/logparser.py
+++ b/geometrikks/services/logparser/logparser.py
@@ -250,7 +250,7 @@ class LogParser:
         position = LAST_LINE_COUNT + 1
         log_lines_capture: list[str] = []
         lines = []
-        with open(log_path, "r", encoding="utf-8") as f:
+        with open(log_path, "r", encoding="utf-8", errors="replace") as f:
             while len(log_lines_capture) <= LAST_LINE_COUNT:
                 try:
                     f.seek(-position, os.SEEK_END)  # Move to the last line
@@ -594,7 +594,9 @@ class LogParser:
                 continue
             self._mark_file_present()
 
-            async with aiofiles.open(self.log_path, "r", encoding="utf-8") as file:
+            async with aiofiles.open(
+                self.log_path, "r", encoding="utf-8", errors="replace"
+            ) as file:
                 if seek_to_end:
                     await file.seek(stat_result.st_size)
                 # After a rotation we always read the new file from the start

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -233,3 +233,58 @@ async def test_import_file_aborts_on_unrecognized_format(tmp_path, geoip_reader,
             session_maker=session_maker,
         )
     assert service.flush_records.await_count == 0
+
+
+def make_gjson_line(ip: str, day: int = 3) -> str:
+    return (
+        '{"client_ip":"' + ip + f'","timestamp":"2024-08-{day:02d}T13:14:17+02:00","method":"GET",'
+        '"path":"/index.php","protocol":"HTTP/2.0","status":"200","bytes":"1024",'
+        '"host":"example.com","referrer":"","user_agent":"Mozilla/5.0","remote_user":"",'
+        '"request_time":"0.002","upstream_time":"0.001","request_raw":"GET /index.php HTTP/2.0"}'
+    )
+
+
+async def test_import_file_geometrikks_json(tmp_path, geoip_reader, monkeypatch):
+    from geometrikks.services import importer
+
+    log = tmp_path / "old.json.log"
+    log.write_text("".join(make_gjson_line(TEST_IP, day=d) + "\n" for d in (1, 5, 3)))
+
+    service, FakeRepo, session_maker = _import_deps(tmp_path)
+    monkeypatch.setattr(importer, "ImportJobRepository", FakeRepo)
+    parser = LogParser(log_path=log, send_logs=True, log_format="geometrikks-json")
+
+    result = await importer.import_file(
+        log, service=service, parser=parser, reader=geoip_reader,
+        session_maker=session_maker,
+    )
+    assert result.skipped is False
+    assert result.lines_total == 3
+    assert result.lines_skipped == 0
+    assert result.records_written == 3
+    assert result.time_start is not None and result.time_start.day == 1
+    assert result.time_end is not None and result.time_end.day == 5
+
+
+async def test_import_file_traefik_pinned_to_geometrikks_json_is_rejected(tmp_path, geoip_reader, monkeypatch):
+    """Pinning the wrong JSON format aborts before anything is written."""
+    from geometrikks.services import importer
+
+    traefik_line = (
+        '{"ClientAddr":"172.19.0.1:34567","ClientHost":"203.0.113.7","DownstreamStatus":200,'
+        '"Duration":45678900,"RequestMethod":"GET","RequestPath":"/","RequestProtocol":"HTTP/2.0",'
+        '"StartUTC":"2026-08-07T10:34:56.123456789Z","level":"info","msg":""}\n'
+    )
+    log = tmp_path / "traefik.log"
+    log.write_text(traefik_line * 20)
+
+    service, FakeRepo, session_maker = _import_deps(tmp_path)
+    monkeypatch.setattr(importer, "ImportJobRepository", FakeRepo)
+    parser = LogParser(log_path=log, send_logs=True, log_format="geometrikks-json")
+
+    with pytest.raises(importer.UnrecognizedLogFormatError):
+        await importer.import_file(
+            log, service=service, parser=parser, reader=geoip_reader,
+            session_maker=session_maker,
+        )
+    assert service.flush_records.await_count == 0

--- a/tests/test_logparser.py
+++ b/tests/test_logparser.py
@@ -34,6 +34,19 @@ UNPARSEABLE_LOG_PATH = "tests/unparseable_logs.txt"
 NONSTANDARD_LOG_PATH = "tests/nonstandard_logs.txt"
 GEOIP_DB_PATH = "tests/GeoLite2-City-Test.mmdb"
 
+# A geometrikks-json line as nginx's escape=json would actually write a TLS
+# probe: control bytes escaped as JSON \u00XX sequences, but a byte above
+# 0x7f is left raw and, here, not valid UTF-8 on its own (0xfc, an old
+# 5-byte UTF-8 lead byte). Written in binary so the invalid byte lands on
+# disk unchanged; a text-mode write would reject or escape it before the
+# tailer ever sees it.
+GJSON_TLS_PROBE_LINE_BYTES = (
+    b'{"client_ip":"203.0.113.7","timestamp":"2026-08-25T22:00:24+02:00",'
+    b'"method":"","status":"400","request_raw":"\\u0016\\u0003\\u0001'
+    + bytes([0xFC])
+    + b'"}\n'
+)
+
 
 @pytest.fixture
 def load_valid_ipv4_log() -> list[str]:
@@ -230,6 +243,46 @@ def test_validate_log_format_false(tmp_path: Path, log_parser: LogParser) -> Non
     log_parser.send_logs = True
 
     assert log_parser.validate_log_format(log_file) is False
+
+
+def test_validate_log_format_survives_undecodable_bytes(tmp_path: Path) -> None:
+    """A raw non-UTF-8 byte in request_raw must not raise UnicodeDecodeError."""
+    log_file = tmp_path / "access.log"
+    log_file.write_bytes(GJSON_TLS_PROBE_LINE_BYTES * 3)
+    parser = LogParser(log_path=log_file, send_logs=True, log_format="geometrikks-json")
+
+    assert parser.validate_log_format(log_file) is True
+
+
+def test_parse_line_geometrikks_json_survives_undecodable_bytes(geoip_reader: Reader) -> None:
+    """The decoded line still classifies as the raw-bytes TLS probe."""
+    parser = LogParser(log_path=Path("/dev/null"), send_logs=True, log_format="geometrikks-json")
+    lookup = make_cached_city_lookup(geoip_reader)
+    line = GJSON_TLS_PROBE_LINE_BYTES.decode("utf-8", errors="replace")
+
+    record = parser.parse_line(line, lookup)
+
+    assert record is not None
+    assert record.is_malformed is True
+    assert record.parse_error == "TLS handshake sent to HTTP port (raw)"
+
+
+async def test_iter_parsed_records_geometrikks_json_survives_undecodable_bytes(
+    tmp_path: Path, geoip_reader: Reader
+) -> None:
+    """The async tail path also survives a raw non-UTF-8 byte in the file."""
+    log_file = tmp_path / "access.log"
+    log_file.write_bytes(GJSON_TLS_PROBE_LINE_BYTES)
+    parser = LogParser(log_path=log_file, send_logs=True, log_format="geometrikks-json")
+    parser._stop_event = asyncio.Event()
+
+    gen = parser.iter_parsed_records(geoip_reader, skip_validation=True, start_at_end=False)
+    record = await gen.__anext__()
+
+    assert record is not None
+    assert record.ip_address == "203.0.113.7"
+    assert record.is_malformed is True
+    assert record.parse_error == "TLS handshake sent to HTTP port (raw)"
 
 
 async def test_await_valid_log_format_returns_when_stop_requested(

--- a/tests/test_logparser.py
+++ b/tests/test_logparser.py
@@ -806,3 +806,47 @@ class TestAsnEnrichment:
         assert record.access_log is not None
         assert record.access_log.autonomous_system_number == 1221
         assert record.access_log.autonomous_system_organization == "Telstra Pty Ltd"
+
+
+def make_gjson_line(ip: str) -> str:
+    """One geometrikks-json line (the recommended nginx log_format, escape=json)."""
+    return (
+        '{"client_ip":"' + ip + '","timestamp":"2024-08-03T13:14:17+02:00","method":"GET",'
+        '"path":"/index.php","protocol":"HTTP/2.0","status":"200","bytes":"1024",'
+        '"host":"example.com","referrer":"","user_agent":"Mozilla/5.0","remote_user":"",'
+        '"request_time":"0.002","upstream_time":"0.001","request_raw":"GET /index.php HTTP/2.0"}\n'
+    )
+
+
+def test_parse_line_geometrikks_json_end_to_end(tmp_path: Path, geoip_reader: Reader) -> None:
+    """Geo data and the access log are assembled for the JSON format, not just normalized."""
+    ip = "2.125.160.216"  # present in the GeoLite2 test database
+    parser = LogParser(log_path=tmp_path / "access.json.log", send_logs=True, log_format="geometrikks-json")
+    lookup = make_cached_city_lookup(geoip_reader)
+
+    record = parser.parse_line(make_gjson_line(ip), lookup)
+
+    assert record is not None
+    assert record.ip_address == ip
+    assert record.log_format == "geometrikks-json"
+    assert record.is_malformed is False
+    assert record.geo_data is not None
+    assert record.geo_data.country_code == "GB"
+    assert record.access_log is not None
+    assert record.access_log.url == "/index.php"
+    assert record.access_log.host == "example.com"
+    assert record.access_log.status_code == 200
+    assert record.access_log.request_time == pytest.approx(0.002)
+    assert record.access_log.upstream_response_time == pytest.approx(0.001)
+    offset = record.access_log.timestamp.utcoffset()
+    assert offset is not None and offset.total_seconds() == 7200
+    assert parser.parsed_lines == 1
+
+
+def test_parse_line_geometrikks_json_auto_detects(tmp_path: Path, geoip_reader: Reader) -> None:
+    parser = LogParser(log_path=tmp_path / "access.json.log", send_logs=True)
+    lookup = make_cached_city_lookup(geoip_reader)
+    record = parser.parse_line(make_gjson_line("2.125.160.216"), lookup)
+    assert record is not None and record.ip_address == "2.125.160.216"
+    assert parser.format is not None and parser.format.name == "geometrikks-json"
+    assert parser.send_logs is True

--- a/tests/test_logparser_formats.py
+++ b/tests/test_logparser_formats.py
@@ -452,3 +452,72 @@ def test_gjson_websocket_upgrade_logged_at_close() -> None:
     assert norm.request_time == pytest.approx(258.714)
     assert norm.upstream_response_time == pytest.approx(258.576)
     assert GeometrikksJsonFormat().detect_malformed(norm) == (False, None)
+
+
+def test_gjson_detect_malformed_tls_probe_via_json_escapes() -> None:
+    """escape=json writes control bytes as \\uXXXX; the decoder yields raw bytes."""
+    line = (
+        '{"client_ip":"203.0.113.7","timestamp":"2026-08-25T22:00:24+02:00",'
+        '"method":"","status":"400","bytes":"157",'
+        '"request_raw":"\\u0016\\u0003\\u0001\\u0002\\u0000\\u0001\\u0000\\u0001\\u00fc\\u0003\\u0003"}\n'
+    )
+    fmt = GeometrikksJsonFormat()
+    norm = fmt.parse(line)
+    assert norm is not None
+    assert norm.method is None
+    assert norm.request_raw is not None and norm.request_raw.startswith("\x16\x03")
+    is_malformed, reason = fmt.detect_malformed(norm)
+    assert is_malformed is True
+    assert reason == "TLS handshake sent to HTTP port (raw)"
+
+
+def test_gjson_detect_malformed_method_rules() -> None:
+    fmt = GeometrikksJsonFormat()
+    cases = {
+        gjson(method="", status="400", request_raw="/ HTTP/1.1"): "TLS probe: HTTP request sent to HTTPS port",
+        gjson(method="", status="200", request_raw="/ HTTP/1.1"): "No HTTP method in request",
+        gjson(method="PROPFIND", request_raw="PROPFIND / HTTP/1.1"): "Invalid HTTP method: PROPFIND",
+        gjson(method=None, request_raw=None): "No HTTP method in request",
+    }
+    for line, expected in cases.items():
+        norm = fmt.parse(line)
+        assert norm is not None
+        assert fmt.detect_malformed(norm) == (True, expected)
+
+
+def test_gjson_detect_malformed_connection_statuses() -> None:
+    fmt = GeometrikksJsonFormat()
+    for status, fragment in (("444", "444"), ("499", "499"), ("408", "408")):
+        norm = fmt.parse(gjson(status=status))
+        assert norm is not None
+        is_malformed, reason = fmt.detect_malformed(norm)
+        assert is_malformed is True
+        assert reason is not None and fragment in reason
+
+
+def test_gjson_detect_malformed_ok_line() -> None:
+    fmt = GeometrikksJsonFormat()
+    norm = fmt.parse(gjson())
+    assert norm is not None
+    assert fmt.detect_malformed(norm) == (False, None)
+
+
+def test_registry_order() -> None:
+    assert list(FORMATS) == ["geometrikks-json", "traefik-json", "nginx"]
+    assert FORMATS["geometrikks-json"].name == "geometrikks-json"
+
+
+def test_sniff_format_gjson() -> None:
+    sniffed = sniff_format([NGINX_GARBAGE, gjson()])
+    assert sniffed is not None
+    assert sniffed.format.name == "geometrikks-json"
+    assert sniffed.geo_only is False
+
+
+def test_json_adapters_decline_each_others_lines() -> None:
+    assert GeometrikksJsonFormat().parse(TRAEFIK_FULL) is None
+    assert GeometrikksJsonFormat().parse(TRAEFIK_FULL, geo_only=True) is None
+    assert TraefikJsonFormat().parse(gjson()) is None
+    assert TraefikJsonFormat().parse(gjson(), geo_only=True) is None
+    sniffed = sniff_format([TRAEFIK_FULL])
+    assert sniffed is not None and sniffed.format.name == "traefik-json"

--- a/tests/test_logparser_formats.py
+++ b/tests/test_logparser_formats.py
@@ -260,3 +260,37 @@ def test_sniff_format_traefik_before_nginx() -> None:
     assert sniffed is not None
     assert sniffed.format.name == "traefik-json"
     assert sniffed.geo_only is False
+
+
+from geometrikks.services.logparser.formats.base import detect_probe
+
+
+def test_detect_probe_tls_escaped_text() -> None:
+    """The regex format sees nginx's default escaping as literal backslash-x text."""
+    is_malformed, reason = detect_probe("\\x16\\x03\\x01\\x01-\\x01\\x00", None, 400)
+    assert is_malformed is True
+    assert reason == "TLS handshake sent to HTTP port (escaped)"
+
+
+def test_detect_probe_tls_raw_bytes() -> None:
+    """escape=json writes \\u0016\\u0003; the JSON decoder turns that into raw bytes."""
+    is_malformed, reason = detect_probe("\x16\x03\x01\x02\x00\x01", None, 400)
+    assert is_malformed is True
+    assert reason == "TLS handshake sent to HTTP port (raw)"
+
+
+def test_detect_probe_ssh_and_smb() -> None:
+    assert detect_probe("SSH-2.0-OpenSSH_9.6", None, 400) == (True, "SSH probe sent to HTTP port")
+    assert detect_probe("\xffSMBr\x00", None, 400) == (True, "SMB protocol probe (EternalBlue scanner)")
+    assert detect_probe("NT LM 0.12", None, 400) == (True, "SMB dialect negotiation probe")
+
+
+def test_detect_probe_method_and_status_rules() -> None:
+    assert detect_probe("", None, 400) == (True, "TLS probe: HTTP request sent to HTTPS port")
+    assert detect_probe("", None, 200) == (True, "No HTTP method in request")
+    assert detect_probe("", "PROPFIND", 200) == (True, "Invalid HTTP method: PROPFIND")
+    assert detect_probe("GET / HTTP/1.1", "GET", 408) == (True, "Request timeout (408)")
+    assert detect_probe("GET / HTTP/1.1", "GET", 444) == (True, "Connection closed without response (nginx 444)")
+    assert detect_probe("GET / HTTP/1.1", "GET", 499) == (True, "Client closed connection before response (nginx 499)")
+    assert detect_probe("GET / HTTP/1.1", "GET", 200) == (False, None)
+    assert detect_probe(None, "GET", 200) == (False, None)

--- a/tests/test_logparser_formats.py
+++ b/tests/test_logparser_formats.py
@@ -1,10 +1,11 @@
 """Tests for the log line format adapters."""
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
 from geometrikks.services.logparser.formats import FORMATS, sniff_format
+from geometrikks.services.logparser.formats.geometrikks_json import GeometrikksJsonFormat
 from geometrikks.services.logparser.formats.nginx import NginxFormat
 from geometrikks.services.logparser.formats.traefik import TraefikJsonFormat
 
@@ -294,3 +295,160 @@ def test_detect_probe_method_and_status_rules() -> None:
     assert detect_probe("GET / HTTP/1.1", "GET", 499) == (True, "Client closed connection before response (nginx 499)")
     assert detect_probe("GET / HTTP/1.1", "GET", 200) == (False, None)
     assert detect_probe(None, "GET", 200) == (False, None)
+
+
+GJSON_BASE: dict[str, str] = {
+    "client_ip": "203.0.113.7",
+    "timestamp": "2026-08-25T22:00:24+02:00",
+    "method": "GET",
+    "path": "/api/v2/homepage/plex/recent",
+    "protocol": "HTTP/2.0",
+    "status": "200",
+    "bytes": "20580",
+    "host": "app.example.com",
+    "referrer": "https://app.example.com/",
+    "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/151.0.0.0",
+    "remote_user": "",
+    "request_time": "5.670",
+    "upstream_time": "5.586",
+    "request_raw": "GET /api/v2/homepage/plex/recent HTTP/2.0",
+}
+
+
+def gjson(**overrides: str | None) -> str:
+    """One geometrikks-json line; an override of None removes the key."""
+    data = {**GJSON_BASE, **{k: v for k, v in overrides.items() if v is not None}}
+    for key, value in overrides.items():
+        if value is None:
+            data.pop(key, None)
+    return json.dumps(data) + "\n"
+
+
+def test_gjson_parse_full_line() -> None:
+    norm = GeometrikksJsonFormat().parse(gjson())
+    assert norm is not None
+    assert norm.ip_address == "203.0.113.7"
+    assert norm.timestamp == datetime(2026, 8, 25, 22, 0, 24, tzinfo=timezone(timedelta(hours=2)))
+    assert norm.timestamp.astimezone(timezone.utc).hour == 20
+    assert norm.method == "GET"
+    assert norm.path == "/api/v2/homepage/plex/recent"
+    assert norm.http_version == "HTTP/2.0"
+    assert norm.status_code == 200
+    assert norm.bytes_sent == 20580
+    assert norm.host == "app.example.com"
+    assert norm.referrer == "https://app.example.com/"
+    assert norm.user_agent == "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/151.0.0.0"
+    assert norm.remote_user is None                      # "" from escape=json
+    assert norm.request_time == pytest.approx(5.670)
+    assert norm.upstream_response_time == pytest.approx(5.586)
+    assert norm.request_raw == "GET /api/v2/homepage/plex/recent HTTP/2.0"
+
+
+def test_gjson_absent_semantics() -> None:
+    """'' , '-' and a missing key are all None."""
+    fmt = GeometrikksJsonFormat()
+    for line in (
+        gjson(referrer="", host="-", user_agent=None, upstream_time=""),
+        gjson(referrer="-", host="", user_agent="-", upstream_time="-"),
+        gjson(referrer=None, host=None, user_agent=None, upstream_time=None),
+    ):
+        norm = fmt.parse(line)
+        assert norm is not None
+        assert norm.referrer is None
+        assert norm.host is None
+        assert norm.user_agent is None
+        assert norm.upstream_response_time is None
+
+
+def test_gjson_minimal_line_parses() -> None:
+    norm = GeometrikksJsonFormat().parse(
+        json.dumps({"client_ip": "203.0.113.7", "timestamp": "2026-08-25T22:00:24+02:00"})
+    )
+    assert norm is not None
+    assert norm.method is None
+    assert norm.path is None
+    assert norm.status_code == 0
+    assert norm.bytes_sent == 0
+    assert norm.request_time == 0.0
+    assert norm.upstream_response_time is None
+    assert norm.request_raw is None
+
+
+def test_gjson_geo_only() -> None:
+    norm = GeometrikksJsonFormat().parse(gjson(remote_user="alice"), geo_only=True)
+    assert norm is not None
+    assert norm.ip_address == "203.0.113.7"
+    assert norm.timestamp.tzinfo is not None
+    assert norm.remote_user == "alice"
+    assert norm.method is None
+    assert norm.status_code == 0
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "not json at all\n",
+        "[]\n",
+        json.dumps([GJSON_BASE]),
+        gjson(client_ip=None),
+        gjson(client_ip=""),
+        gjson(timestamp=None),
+        gjson(timestamp="2026-08-25T22:00:24"),           # naive
+        gjson(timestamp="25/Aug/2026:22:00:24 +0200"),    # nginx $time_local
+        json.dumps({**GJSON_BASE, "status": 200}),        # number, not string
+    ],
+    ids=["text", "empty-array", "array", "no-ip", "blank-ip", "no-ts", "naive-ts", "time-local", "typed-status"],
+)
+def test_gjson_rejections(line: str) -> None:
+    assert GeometrikksJsonFormat().parse(line) is None
+    assert GeometrikksJsonFormat().parse(line, geo_only=True) is None
+
+
+def test_gjson_numeric_conversion_fallbacks() -> None:
+    norm = GeometrikksJsonFormat().parse(gjson(status="-", bytes="abc", request_time="-"))
+    assert norm is not None
+    assert norm.status_code == 0
+    assert norm.bytes_sent == 0
+    assert norm.request_time == 0.0
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("0.010", 0.010),
+        ("0.010, 0.020", 0.030),
+        ("0.010 : 0.020", 0.030),
+        ("0.010, - : 0.005", 0.015),
+        ("-, -", None),
+        ("0.000", 0.0),
+    ],
+)
+def test_gjson_upstream_time_sums_parts(raw: str, expected: float | None) -> None:
+    norm = GeometrikksJsonFormat().parse(gjson(upstream_time=raw))
+    assert norm is not None
+    if expected is None:
+        assert norm.upstream_response_time is None
+    else:
+        assert norm.upstream_response_time == pytest.approx(expected)
+
+
+def test_gjson_unknown_keys_ignored() -> None:
+    norm = GeometrikksJsonFormat().parse(gjson(scheme="https", request_id="abc123"))
+    assert norm is not None
+    assert norm.ip_address == "203.0.113.7"
+
+
+def test_gjson_websocket_upgrade_logged_at_close() -> None:
+    """Real SWAG line: a 101 upgrade is logged when the socket closes, minutes later."""
+    norm = GeometrikksJsonFormat().parse(gjson(
+        protocol="HTTP/1.1", status="101", bytes="399",
+        path="/prowlarr/signalr/messages?access_token=REDACTED&id=REDACTED",
+        request_time="258.714", upstream_time="258.576",
+        request_raw="GET /prowlarr/signalr/messages?access_token=REDACTED&id=REDACTED HTTP/1.1",
+    ))
+    assert norm is not None
+    assert norm.status_code == 101
+    assert norm.http_version == "HTTP/1.1"
+    assert norm.request_time == pytest.approx(258.714)
+    assert norm.upstream_response_time == pytest.approx(258.576)
+    assert GeometrikksJsonFormat().detect_malformed(norm) == (False, None)

--- a/tests/test_logparser_formats.py
+++ b/tests/test_logparser_formats.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from geometrikks.services.logparser.formats import FORMATS, sniff_format
+from geometrikks.services.logparser.formats.base import detect_probe
 from geometrikks.services.logparser.formats.geometrikks_json import GeometrikksJsonFormat
 from geometrikks.services.logparser.formats.nginx import NginxFormat
 from geometrikks.services.logparser.formats.traefik import TraefikJsonFormat
@@ -263,9 +264,6 @@ def test_sniff_format_traefik_before_nginx() -> None:
     assert sniffed.geo_only is False
 
 
-from geometrikks.services.logparser.formats.base import detect_probe
-
-
 def test_detect_probe_tls_escaped_text() -> None:
     """The regex format sees nginx's default escaping as literal backslash-x text."""
     is_malformed, reason = detect_probe("\\x16\\x03\\x01\\x01-\\x01\\x00", None, 400)
@@ -283,6 +281,7 @@ def test_detect_probe_tls_raw_bytes() -> None:
 def test_detect_probe_ssh_and_smb() -> None:
     assert detect_probe("SSH-2.0-OpenSSH_9.6", None, 400) == (True, "SSH probe sent to HTTP port")
     assert detect_probe("\xffSMBr\x00", None, 400) == (True, "SMB protocol probe (EternalBlue scanner)")
+    assert detect_probe("\\xffSMBr\\x00", None, 400) == (True, "SMB protocol probe (EternalBlue scanner)")
     assert detect_probe("NT LM 0.12", None, 400) == (True, "SMB dialect negotiation probe")
 
 
@@ -344,6 +343,21 @@ def test_gjson_parse_full_line() -> None:
     assert norm.request_raw == "GET /api/v2/homepage/plex/recent HTTP/2.0"
 
 
+def test_gjson_ipv6_client_ip() -> None:
+    norm = GeometrikksJsonFormat().parse(gjson(client_ip="2001:db8::1"))
+    assert norm is not None
+    assert norm.ip_address == "2001:db8::1"
+
+
+def test_gjson_timestamp_z_suffix() -> None:
+    """A 'Z'-suffixed timestamp is a UTC offset of zero, not a naive datetime."""
+    norm = GeometrikksJsonFormat().parse(gjson(timestamp="2026-08-25T20:00:24Z"))
+    assert norm is not None
+    offset = norm.timestamp.utcoffset()
+    assert offset is not None
+    assert offset.total_seconds() == 0
+
+
 def test_gjson_absent_semantics() -> None:
     """'' , '-' and a missing key are all None."""
     fmt = GeometrikksJsonFormat()
@@ -392,12 +406,17 @@ def test_gjson_geo_only() -> None:
         json.dumps([GJSON_BASE]),
         gjson(client_ip=None),
         gjson(client_ip=""),
+        gjson(client_ip="-"),
+        gjson(client_ip="   "),
         gjson(timestamp=None),
         gjson(timestamp="2026-08-25T22:00:24"),           # naive
         gjson(timestamp="25/Aug/2026:22:00:24 +0200"),    # nginx $time_local
         json.dumps({**GJSON_BASE, "status": 200}),        # number, not string
     ],
-    ids=["text", "empty-array", "array", "no-ip", "blank-ip", "no-ts", "naive-ts", "time-local", "typed-status"],
+    ids=[
+        "text", "empty-array", "array", "no-ip", "blank-ip", "dash-ip",
+        "whitespace-ip", "no-ts", "naive-ts", "time-local", "typed-status",
+    ],
 )
 def test_gjson_rejections(line: str) -> None:
     assert GeometrikksJsonFormat().parse(line) is None


### PR DESCRIPTION
## Summary

Adds `geometrikks-json`, a keyed JSON access-log format, and makes it the documented nginx setup. nginx writes the line from a `log_format ... escape=json` block and GeoMetrikks decodes it against a fixed msgspec Struct, so a mistyped or unquoted format is rejected instead of landing values in the wrong columns. The positional regex format stays registered as `nginx` for existing installs and archives.

## What changes

- New adapter `formats/geometrikks_json.py`, registered first in the format registry (`geometrikks-json`, `traefik-json`, `nginx`). Every value is a string and the adapter converts the numbers. `""`, `"-"` and a missing key all mean absent. Only `client_ip` and `timestamp` are required, and the timestamp has to carry a UTC offset. `upstream_time` sums nginx's comma and colon separated lists. Unknown keys are ignored, so users can add their own.
- Probe detection (TLS, SSH, SMB, empty or invalid method) moves from the nginx adapter into `formats/base.py` as `detect_probe`; both adapters call it. Under `escape=json` control bytes arrive as `\uXXXX` and decode to raw bytes, so each check handles both the escaped-text and the raw-bytes form.
- The live tailer opens files with `errors="replace"`, matching the importer. `escape=json` leaves bytes above 0x7f raw; without this, a TLS probe in `$request` raises `UnicodeDecodeError` and ends the tail task.
- `import-logs --format` derives its choices from the registry, `LOGPARSER_LOG_FORMATS` accepts `geometrikks-json`, and `docs/configuration.md` is regenerated.
- README: the JSON block is the nginx setup. The regex format moves under "Legacy nginx format" together with the positional rules it depends on, and the section on importing `combined` archives lists which fields those lines lack.
- Dev stack: the injector writes `nginx_logs/nginx-json.log` and a third agent tails it. Referrers, users and timings are drawn per request across all three formats instead of being constants.

## Verified against real output

The `log_format` block ran on a SWAG server. A 26k-line capture parses in full, zero unparsed lines, with the classifications you would expect from a public proxy: 27 TLS handshakes on the plain port, 6 HTTP-on-HTTPS probes, 10 empty methods, one SMB probe, one SSH banner, one `SSTP_DUPLEX_POST`. The same capture carries a raw `0x8b` byte inside a probe line, which is the case the tailer change exists for.

## Tests

930 unit tests, `ty` clean, config docs fresh, `tsc` clean.
