### PR TITLE
chore(release): 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-27
+
 ### Added
 
 - Login, the error page, 404 and the Settings backdrop use the brand map scene (graticule, relief, markers, routes), and the map page shows it while the map loads. Backdrops render at the screen's native resolution, so they stay sharp on hi-dpi displays.
@@ -900,7 +902,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Settings endpoint no longer exposes the full settings tree (database credentials leaked via `model_dump()`); response is now an explicit whitelist.
 - Timestamps in `CALL refresh_continuous_aggregate` are bound as asyncpg parameters instead of interpolated into SQL.
 
-[Unreleased]: https://github.com/GilbN/geometrikks/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/GilbN/geometrikks/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/GilbN/geometrikks/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/GilbN/geometrikks/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/GilbN/geometrikks/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/GilbN/geometrikks/compare/v0.7.1...v0.8.0

--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ Images are published as `ghcr.io/gilbn/geometrikks`.
 | `latest` | `latest` | The newest stable release. |
 | Exact stable version | `X.Y.Z` | A specific stable release; use this for reproducible deployments. |
 | Major/minor stable version | `X.Y` | The newest stable patch release in a major/minor series. |
-| Exact development version | `0.10.0-dev.1` | A specific prerelease build for testing upcoming changes. |
+| Exact development version | `0.11.0-dev.1` | A specific prerelease build for testing upcoming changes. |
 | `develop` | `develop` | The newest development release; a moving tag. |
 
 Use `latest` to follow stable releases, or pin an exact version:
 
 ```yaml
-image: ghcr.io/gilbn/geometrikks:0.10.0
+image: ghcr.io/gilbn/geometrikks:0.11.0
 ```
 
 `docker-compose.yml` mounts `ACCESS_LOG_DIR` (default `/var/log/nginx`)
@@ -568,7 +568,7 @@ instance, GeoIP credentials, and its own log mount:
 ```yaml
 services:
   agent:
-    image: ghcr.io/gilbn/geometrikks:0.10.0   # same tag as the full instance
+    image: ghcr.io/gilbn/geometrikks:0.11.0   # same tag as the full instance
     restart: unless-stopped
     stop_grace_period: 20s
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geometrikks"
-version = "0.10.0"
+version = "0.11.0"
 description = "Geo metrics ingress service built with Litestar."
 readme = "README.md"
 requires-python = ">=3.13,<3.14"

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -3881,7 +3881,7 @@
   "info": {
     "description": "Real-time GeoIP lookups and traffic analytics API",
     "title": "GeoMetrikks API",
-    "version": "0.10.0"
+    "version": "0.11.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "geometrikks"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy", extra = ["argon2", "cli", "passlib", "pwdlib"] },


### PR DESCRIPTION
Version bump for the 0.11.0 release. #172 merged before this landed.

- `pyproject.toml`, `uv.lock` and `resources/generated/openapi.json` report `0.11.0`.
- `CHANGELOG.md` moves the Unreleased entries under `[0.11.0] - 2026-08-27` and updates the compare links.
- README image tag examples point at `0.11.0`.

No code changes. Tag `v0.11.0` from `main` once this is merged.
