### PR TITLE
feat: store a missing request_time as NULL and show n/a instead of 0.00s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored the Settings pages.
 - Tables, stat cards and data panels use one set of labels, borders and shadows across every page, and each page has a one-line description under its title.
 - Map popups and controls follow the active theme and accent.
-- A missing `request_time` is stored as NULL instead of 0.0, so unmeasured requests stop pulling the response-time average and percentiles toward zero. The summary and URL aggregates gain a count of measured rows; the first start after upgrading adds it in place and refreshes those four aggregates over the raw retention window, which takes minutes on large databases and keeps all history.
+- A missing `request_time` is stored as NULL instead of 0.0, so unmeasured requests stop pulling the response-time average and percentiles toward zero. The summary and URL aggregates gain a count of measured rows; the first start after upgrading adds it in place and refreshes those four aggregates over the raw retention window, which takes minutes on large databases and keeps all history. Buckets older than that window keep their pre-upgrade figures, computed over every row, because the raw rows needed to recount them are gone.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Response-time cards and the latency chart read "n/a" when the selected range has no measured requests, and "From N% of requests" when only some rows carry a timing. Top URLs and the access-log table show "n/a" for rows without one.
-- `litestar backfill-timings` clears the placeholder 0.0 response time on rows imported from `combined`-format nginx archives, optionally narrowed by `--hostname` and `--before`.
+- `litestar backfill-timings` clears the placeholder 0.0 response time on rows imported from `combined`-format nginx archives. `--hostname` and `--before` narrow which rows it touches.
 
 ### Changed
 
-- A missing `request_time` is stored as NULL instead of 0.0, so unmeasured requests stop pulling the response-time average and percentiles toward zero. The summary and URL aggregates gain a count of measured rows; the first start after upgrading adds it in place and refreshes those four aggregates over the raw retention window, which takes minutes on large databases and keeps all history. Buckets older than that window keep their pre-upgrade figures, computed over every row, because the raw rows needed to recount them are gone.
+- A missing `request_time` is now NULL instead of 0.0, so unmeasured requests stop dragging the response-time average and percentiles toward zero. The summary and URL aggregates gain a count of measured rows. The first start after upgrading adds that column in place and refreshes those four aggregates over the raw retention window; on a large database this takes minutes, and no history is lost. Buckets older than the window keep their pre-upgrade figures, which counted every row, because the raw rows needed to recount them are gone.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Response-time cards and the latency chart read "n/a" when the selected range has no measured requests, and "From N% of requests" when only some rows carry a timing. Top URLs and the access-log table show "n/a" for rows without one.
+- `litestar backfill-timings` clears the placeholder 0.0 response time on rows imported from `combined`-format nginx archives, optionally narrowed by `--hostname` and `--before`.
+
+### Changed
+
+- A missing `request_time` is stored as NULL instead of 0.0, so unmeasured requests stop pulling the response-time average and percentiles toward zero. The summary and URL aggregates gain a count of measured rows; the first start after upgrading adds it in place and refreshes those four aggregates over the raw retention window, which takes minutes on large databases and keeps all history. Buckets older than that window keep their pre-upgrade figures, computed over every row, because the raw rows needed to recount them are gone.
+
+### Fixed
+
+- The Overview's Avg and Max Request Time cards formatted seconds as if they were milliseconds, showing a 40 ms average as 40μs.
+
 ## [0.11.0] - 2026-08-27
 
 ### Added
@@ -22,8 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Settings > Appearance: theme (System, Light, Dark) and accent (teal, green, copper) side by side with previews. System follows the device's color scheme live, not only at page load. The accent is also switchable from the header, persists per browser and is applied before first paint.
 - Open Graph and Twitter card tags on the app shell.
 - `geometrikks-json`, a keyed JSON access-log format for nginx (`log_format ... escape=json`) and the recommended nginx setup. Lines decode against a fixed schema instead of a positional regex, so a broken or mistyped format is rejected rather than mapped to the wrong columns. Works with live tailing, `LOGPARSER_LOG_FORMATS` and `import-logs --format geometrikks-json`. The existing nginx format keeps working.
-- Response-time cards and the latency chart read "n/a" when the selected range has no measured requests, and "From N% of requests" when only some rows carry a timing. Top URLs and the access-log table show "n/a" for rows without one.
-- `litestar backfill-timings` clears the placeholder 0.0 response time on rows imported from `combined`-format nginx archives, optionally narrowed by `--hostname` and `--before`.
 
 ### Changed
 
@@ -31,7 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored the Settings pages.
 - Tables, stat cards and data panels use one set of labels, borders and shadows across every page, and each page has a one-line description under its title.
 - Map popups and controls follow the active theme and accent.
-- A missing `request_time` is stored as NULL instead of 0.0, so unmeasured requests stop pulling the response-time average and percentiles toward zero. The summary and URL aggregates gain a count of measured rows; the first start after upgrading adds it in place and refreshes those four aggregates over the raw retention window, which takes minutes on large databases and keeps all history. Buckets older than that window keep their pre-upgrade figures, computed over every row, because the raw rows needed to recount them are gone.
 
 ### Removed
 
@@ -44,7 +54,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stat card trend badges no longer pair a 0.0% label with an up or down arrow; tiny and non-finite deltas render as flat or hidden.
 - Live tail: the Status column is wide enough for its header, which ran into Method.
 - Ingestion reloads its GeoIP readers after the weekly GeoLite2 refresh replaces the database files, so new geo data applies without a restart. This also picks up files replaced outside the app (for example by `geoipupdate`), and a start in geo-degraded mode recovers on its own once a later scheduled download succeeds. Running the refresh job from Settings downloads fresh databases even when the current files are younger than `GEOIP_REFRESH_DAYS`, and applies a file replaced outside the app immediately.
-- The Overview's Avg and Max Request Time cards formatted seconds as if they were milliseconds, showing a 40 ms average as 40μs.
 
 ## [0.10.0] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Settings > Appearance: theme (System, Light, Dark) and accent (teal, green, copper) side by side with previews. System follows the device's color scheme live, not only at page load. The accent is also switchable from the header, persists per browser and is applied before first paint.
 - Open Graph and Twitter card tags on the app shell.
 - `geometrikks-json`, a keyed JSON access-log format for nginx (`log_format ... escape=json`) and the recommended nginx setup. Lines decode against a fixed schema instead of a positional regex, so a broken or mistyped format is rejected rather than mapped to the wrong columns. Works with live tailing, `LOGPARSER_LOG_FORMATS` and `import-logs --format geometrikks-json`. The existing nginx format keeps working.
+- Response-time cards and the latency chart read "n/a" when the selected range has no measured requests, and "From N% of requests" when only some rows carry a timing. Top URLs and the access-log table show "n/a" for rows without one.
+- `litestar backfill-timings` clears the placeholder 0.0 response time on rows imported from `combined`-format nginx archives, optionally narrowed by `--hostname` and `--before`.
 
 ### Changed
 
@@ -29,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored the Settings pages.
 - Tables, stat cards and data panels use one set of labels, borders and shadows across every page, and each page has a one-line description under its title.
 - Map popups and controls follow the active theme and accent.
+- A missing `request_time` is stored as NULL instead of 0.0, so unmeasured requests stop pulling the response-time average and percentiles toward zero. The summary and URL aggregates gain a count of measured rows; the first start after upgrading adds it in place and refreshes those four aggregates over the raw retention window, which takes minutes on large databases and keeps all history.
 
 ### Removed
 
@@ -41,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stat card trend badges no longer pair a 0.0% label with an up or down arrow; tiny and non-finite deltas render as flat or hidden.
 - Live tail: the Status column is wide enough for its header, which ran into Method.
 - Ingestion reloads its GeoIP readers after the weekly GeoLite2 refresh replaces the database files, so new geo data applies without a restart. This also picks up files replaced outside the app (for example by `geoipupdate`), and a start in geo-degraded mode recovers on its own once a later scheduled download succeeds. Running the refresh job from Settings downloads fresh databases even when the current files are younger than `GEOIP_REFRESH_DAYS`, and applies a file replaced outside the app immediately.
+- The Overview's Avg and Max Request Time cards formatted seconds as if they were milliseconds, showing a 40 ms average as 40μs.
 
 ## [0.10.0] - 2026-08-22
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ fact:
 | Missing field | What it costs you |
 | --- | --- |
 | `$host` | The host filter on the access-log and analytics pages has nothing to list |
-| `$request_time` | Response-time average and percentiles read 0.00s |
+| `$request_time` | Response-time cards show n/a for those rows; run `backfill-timings` after importing so the rows stop counting as 0.00s |
 | `$upstream_response_time` | Upstream timing stays empty in the access-log detail view |
 
 The map, geo analytics, status codes, URLs, referrers, user agents and bytes
@@ -785,6 +785,28 @@ the backfilled range until they refresh. Rerunning is safe.
 
 Today's ASN database describes today's network ownership; stamping
 years-old traffic with it is an approximation.
+
+### backfill-timings: clear placeholder response times
+
+Archives in nginx's built-in `combined` format have no `$request_time`.
+Older versions stored those rows with a response time of 0.0, which
+dragged every average and percentile toward zero. Rows ingested by this
+version store no timing at all for such lines; `backfill-timings` does
+the same for the rows that predate it:
+
+```bash
+docker compose exec -u geometrikks app litestar backfill-timings
+```
+
+It only touches rows the legacy nginx format wrote without a host, which is
+how a `combined` line looks after import (the custom format always logs
+`$host`), and whose response time is exactly 0. A genuine sub-millisecond
+timing on a row with a host is left alone. `--hostname NAME` and
+`--before 2026-08-20` narrow the set; the command prints the row count and
+time span and asks for confirmation (`--yes` skips it). Like the other
+backfills it decompresses history chunks first and refreshes the affected
+continuous aggregates afterwards, so it may run for minutes on a large
+database.
 
 ### Large imports and backfills
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ fact:
 | Missing field | What it costs you |
 | --- | --- |
 | `$host` | The host filter on the access-log and analytics pages has nothing to list |
-| `$request_time` | Response-time cards show n/a for those rows; run `backfill-timings` after importing so the rows stop counting as 0.00s |
+| `$request_time` | Response-time cards show n/a for those rows; rows imported by earlier versions carry a placeholder 0.0 that `backfill-timings` clears |
 | `$upstream_response_time` | Upstream timing stays empty in the access-log detail view |
 
 The map, geo analytics, status codes, URLs, referrers, user agents and bytes

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -89,6 +89,18 @@ migration locking), not a tuning knob.
   always configured at startup. That step is idempotent but requires the
   schema to be at head, and it failing is the deliberate signal that the
   external migration step was skipped.
+- The first start on a version that adds a column to a continuous
+  aggregate (the timed-row counts on the summary and URL aggregates, for
+  example) adds it in place and then re-materializes those aggregates over
+  the raw retention window. That refresh runs inside startup, so the head
+  container answers nothing, `/health` included, until it finishes; on a
+  database with tens of millions of rows expect minutes, and watch for
+  `cagg_timed_column_added` followed by `cagg_timed_refresh_done` in the
+  logs. No history is lost, and a container stopped mid-way resumes the
+  refresh on its next start. A TimescaleDB without in-place aggregate
+  columns (the compose images pin a version that has them) falls back to
+  dropping and recreating the aggregate, which discards daily history older
+  than the raw retention window.
 
 ## Health
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -97,10 +97,12 @@ migration locking), not a tuning knob.
   database with tens of millions of rows expect minutes, and watch for
   `cagg_timed_column_added` followed by `cagg_timed_refresh_done` in the
   logs. No history is lost, and a container stopped mid-way resumes the
-  refresh on its next start. A TimescaleDB without in-place aggregate
-  columns (the compose images pin a version that has them) falls back to
-  dropping and recreating the aggregate, which discards daily history older
-  than the raw retention window.
+  refresh on its next start. Buckets older than the raw retention window
+  keep their pre-upgrade figures, computed over every row, because the raw
+  rows needed to recount them are gone. A TimescaleDB without in-place
+  aggregate columns (the compose images pin a version that has them) falls
+  back to dropping and recreating the aggregate, which discards daily
+  history older than the raw retention window.
 
 ## Health
 

--- a/geometrikks/cli.py
+++ b/geometrikks/cli.py
@@ -1,4 +1,4 @@
-"""Litestar CLI plugin: `litestar import-logs <paths...>`, `litestar backfill-hostname NAME`, `litestar backfill-asn`.
+"""Litestar CLI plugin: `litestar import-logs <paths...>`, `litestar backfill-hostname NAME`, `litestar backfill-asn`, `litestar backfill-timings`.
 
 Import-time safe: settings, engine, reader are constructed inside the
 command callback, never at module import. The format registry import
@@ -8,7 +8,7 @@ loads the logparser package but constructs none of those.
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import click
@@ -566,10 +566,130 @@ async def _run_backfill_asn(*, yes: bool) -> None:
         await engine.dispose()
 
 
+@click.command(name="backfill-timings")
+@click.option("--hostname", default=None, help="Only rows recorded by this LOGPARSER_HOST_NAME.")
+@click.option(
+    "--before",
+    default=None,
+    type=click.DateTime(formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M:%S%z"]),
+    help="Only rows older than this date or datetime (UTC when no offset is given).",
+)
+@click.option("--yes", is_flag=True, help="Skip the confirmation prompt.")
+def backfill_timings_command(hostname: str | None, before: datetime | None, yes: bool) -> None:
+    """Clear placeholder response times on rows that never carried one.
+
+    Targets only rows the legacy nginx format wrote from a combined-style
+    line: log_format 'nginx', no host, request_time 0. The custom nginx
+    format always logs $host, so a host-less row had no timing field and
+    its 0.0 was a placeholder, not a measurement. Rows written by the
+    geometrikks-json format already store NULL. No blanket rewrite of
+    zeros is offered: 0.000 is a real sub-millisecond timing.
+
+    Prints the row count and time span first and asks for confirmation.
+    Compressed hypertable chunks are decompressed before the update (a
+    full-table UPDATE would trip the TimescaleDB tuple decompression
+    limit); the compression policy recompresses them later. Refreshes the
+    summary and URL continuous aggregates for the affected span. May run
+    for minutes on large databases.
+    """
+    if before is not None and before.tzinfo is None:
+        before = before.replace(tzinfo=timezone.utc)
+    asyncio.run(_run_backfill_timings(hostname=hostname, before=before, yes=yes))
+
+
+BACKFILL_TIMINGS_CAGGS = [
+    "summary_hourly_stats",
+    "summary_daily_stats",
+    "url_hourly_stats",
+    "url_daily_stats",
+]
+
+
+async def _run_backfill_timings(*, hostname: str | None, before: datetime | None, yes: bool) -> None:
+    from sqlalchemy import text
+
+    from geometrikks.server.logging import get_logger
+    from geometrikks.server.plugins import get_sqlalchemy_config
+    from geometrikks.server.timescale import refresh_caggs_range
+
+    logger = get_logger(__name__)
+    config = get_sqlalchemy_config()
+    engine = config.get_engine()
+
+    where = "log_format = 'nginx' AND host IS NULL AND request_time = 0"
+    params: dict[str, object] = {}
+    if hostname is not None:
+        where += " AND hostname = :hostname"
+        params["hostname"] = hostname
+    if before is not None:
+        where += " AND timestamp < :before"
+        params["before"] = before
+
+    try:
+        async with engine.connect() as conn:
+            count, first, last = (await conn.execute(
+                text(f"SELECT COUNT(*), MIN(timestamp), MAX(timestamp) FROM access_logs WHERE {where}"),
+                params,
+            )).one()
+            timescale = bool((await conn.execute(text(
+                "SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb')"
+            ))).scalar())
+
+        if not count:
+            click.echo("Nothing to do: no placeholder timings match.")
+            return
+
+        click.echo(f"{count:,} rows between {first} and {last} will have request_time set to NULL.")
+        if not yes and not click.confirm("Continue?"):
+            click.echo("Aborted.")
+            return
+
+        # Same reasoning as backfill-hostname: a full-table UPDATE on compressed
+        # chunks trips timescaledb.max_tuples_decompressed_per_dml_transaction.
+        if timescale:
+            click.echo("Decompressing compressed access_logs chunks ...")
+            async with engine.begin() as conn:
+                await conn.execute(text(
+                    "SELECT decompress_chunk(format('%I.%I', chunk_schema, chunk_name)::regclass, true) "
+                    "FROM timescaledb_information.chunks "
+                    "WHERE hypertable_name = 'access_logs' AND is_compressed"
+                ))
+
+        async with engine.begin() as conn:
+            cleared = (await conn.execute(
+                text(f"UPDATE access_logs SET request_time = NULL WHERE {where}"), params
+            )).rowcount
+        click.echo(f"access_logs placeholder timings cleared: {cleared:,}")
+
+        if cleared and first is not None and last is not None:
+            click.echo("Refreshing summary and URL CAGGs ...")
+            failed = await refresh_caggs_range(
+                engine,
+                start=first,
+                end=last + timedelta(microseconds=1),
+                caggs=BACKFILL_TIMINGS_CAGGS,
+                force=True,
+            )
+            if failed:
+                raise click.ClickException(
+                    "Rows were cleared but these aggregates did not refresh: " + ", ".join(failed)
+                )
+
+        logger.info(
+            "backfill_timings_completed",
+            cleared=cleared,
+            hostname=hostname,
+            before=before.isoformat() if before else None,
+        )
+    finally:
+        await engine.dispose()
+
+
 class ImportLogsCLIPlugin(CLIPlugin):
-    """Registers import-logs, backfill-hostname, and backfill-asn on the litestar CLI group."""
+    """Registers import-logs, backfill-hostname, backfill-asn and backfill-timings on the litestar CLI group."""
 
     def on_cli_init(self, cli: click.Group) -> None:
         cli.add_command(import_logs_command)
         cli.add_command(backfill_hostname_command)
         cli.add_command(backfill_asn_command)
+        cli.add_command(backfill_timings_command)

--- a/geometrikks/cli.py
+++ b/geometrikks/cli.py
@@ -661,6 +661,7 @@ async def _run_backfill_timings(*, hostname: str | None, before: datetime | None
             )).rowcount
         click.echo(f"access_logs placeholder timings cleared: {cleared:,}")
 
+        failed: list[str] = []
         if cleared and first is not None and last is not None:
             click.echo("Refreshing summary and URL CAGGs ...")
             failed = await refresh_caggs_range(
@@ -670,17 +671,19 @@ async def _run_backfill_timings(*, hostname: str | None, before: datetime | None
                 caggs=BACKFILL_TIMINGS_CAGGS,
                 force=True,
             )
-            if failed:
-                raise click.ClickException(
-                    "Rows were cleared but these aggregates did not refresh: " + ", ".join(failed)
-                )
 
         logger.info(
             "backfill_timings_completed",
             cleared=cleared,
             hostname=hostname,
             before=before.isoformat() if before else None,
+            cagg_refresh_failed=failed,
         )
+
+        if failed:
+            raise click.ClickException(
+                "Rows were cleared but these aggregates did not refresh: " + ", ".join(failed)
+            )
     finally:
         await engine.dispose()
 

--- a/geometrikks/domain/analytics/controllers.py
+++ b/geometrikks/domain/analytics/controllers.py
@@ -65,6 +65,13 @@ def _calculate_percent_change(current: float, previous: float) -> float | None:
     return ((current - previous) / previous) * 100
 
 
+def _optional_percent_change(current: float | None, previous: float | None) -> float | None:
+    """Percent change for a figure that is None when nothing was measured."""
+    if current is None or previous is None:
+        return None
+    return _calculate_percent_change(current, previous)
+
+
 def _build_filters(
     country_code: list[str] | None,
     city: list[str] | None,
@@ -136,6 +143,7 @@ class AnalyticsController(Controller):
             # Return empty summary if no data
             empty_period = PeriodSummary(
                 total_requests=0,
+                timed_requests=0,
                 total_geo_events=0,
                 unique_ips=0,
                 unique_countries=0,
@@ -145,8 +153,8 @@ class AnalyticsController(Controller):
                 status_3xx=0,
                 status_4xx=0,
                 status_5xx=0,
-                avg_request_time=0.0,
-                max_request_time=0.0,
+                avg_request_time=None,
+                max_request_time=None,
                 malformed_requests=0,
                 error_rate=0.0,
             )
@@ -158,6 +166,7 @@ class AnalyticsController(Controller):
 
         current_period = PeriodSummary(
             total_requests=current_stats.total_log_records,
+            timed_requests=current_stats.timed_requests,
             total_geo_events=current_stats.total_geo_records,
             unique_ips=current_stats.unique_ips,
             unique_countries=current_stats.unique_countries,
@@ -187,6 +196,7 @@ class AnalyticsController(Controller):
             if prev_stats:
                 previous_period = PeriodSummary(
                     total_requests=prev_stats.total_log_records,
+                    timed_requests=prev_stats.timed_requests,
                     total_geo_events=prev_stats.total_geo_records,
                     unique_ips=prev_stats.unique_ips,
                     unique_countries=prev_stats.unique_countries,
@@ -215,7 +225,7 @@ class AnalyticsController(Controller):
                     bytes_sent=_calculate_percent_change(
                         current_stats.total_bytes_sent, prev_stats.total_bytes_sent
                     ),
-                    avg_request_time=_calculate_percent_change(
+                    avg_request_time=_optional_percent_change(
                         current_stats.avg_request_time, prev_stats.avg_request_time
                     ),
                     error_rate=_calculate_percent_change(
@@ -264,6 +274,7 @@ class AnalyticsController(Controller):
             # Return empty summary if no data
             empty_period = PeriodSummary(
                 total_requests=0,
+                timed_requests=0,
                 total_geo_events=0,
                 unique_ips=0,
                 unique_countries=0,
@@ -273,8 +284,8 @@ class AnalyticsController(Controller):
                 status_3xx=0,
                 status_4xx=0,
                 status_5xx=0,
-                avg_request_time=0.0,
-                max_request_time=0.0,
+                avg_request_time=None,
+                max_request_time=None,
                 malformed_requests=0,
                 error_rate=0.0,
             )
@@ -286,6 +297,7 @@ class AnalyticsController(Controller):
 
         current_period = PeriodSummary(
             total_requests=current_stats.total_log_records,
+            timed_requests=current_stats.timed_requests,
             total_geo_events=current_stats.total_geo_records,
             unique_ips=current_stats.unique_ips,
             unique_countries=current_stats.unique_countries,
@@ -315,6 +327,7 @@ class AnalyticsController(Controller):
             if prev_stats:
                 previous_period = PeriodSummary(
                     total_requests=prev_stats.total_log_records,
+                    timed_requests=prev_stats.timed_requests,
                     total_geo_events=prev_stats.total_geo_records,
                     unique_ips=prev_stats.unique_ips,
                     unique_countries=prev_stats.unique_countries,
@@ -343,7 +356,7 @@ class AnalyticsController(Controller):
                     bytes_sent=_calculate_percent_change(
                         current_stats.total_bytes_sent, prev_stats.total_bytes_sent
                     ),
-                    avg_request_time=_calculate_percent_change(
+                    avg_request_time=_optional_percent_change(
                         current_stats.avg_request_time, prev_stats.avg_request_time
                     ),
                     error_rate=_calculate_percent_change(
@@ -457,6 +470,7 @@ class AnalyticsController(Controller):
                     status_4xx=row.status_4xx,
                     status_5xx=row.status_5xx,
                     error_rate=(row.status_4xx + row.status_5xx) / row.total_requests if row.total_requests else 0.0,
+                    timed_requests=row.timed_requests,
                     avg_request_time=row.avg_request_time,
                     p50_request_time=row.p50_request_time,
                     p95_request_time=row.p95_request_time,

--- a/geometrikks/domain/analytics/dtos.py
+++ b/geometrikks/domain/analytics/dtos.py
@@ -28,10 +28,11 @@ class TimeSeriesDataPoint(msgspec.Struct, rename="camel"):
     status_4xx: int = msgspec.field(name="status4xx")
     status_5xx: int = msgspec.field(name="status5xx")
     error_rate: float
-    avg_request_time: float
-    p50_request_time: float
-    p95_request_time: float
-    p99_request_time: float
+    timed_requests: int
+    avg_request_time: float | None
+    p50_request_time: float | None
+    p95_request_time: float | None
+    p99_request_time: float | None
 
 
 class PerformanceDataPoint(msgspec.Struct, rename="camel"):
@@ -41,8 +42,9 @@ class PerformanceDataPoint(msgspec.Struct, rename="camel"):
     """
 
     timestamp: str  # ISO format string
-    avg_request_time: float
-    max_request_time: float
+    timed_requests: int
+    avg_request_time: float | None
+    max_request_time: float | None
 
 
 class BandwidthDataPoint(msgspec.Struct, rename="camel"):
@@ -110,6 +112,7 @@ class PeriodSummary(msgspec.Struct, rename="camel"):
     """Summary statistics for a single period."""
 
     total_requests: int
+    timed_requests: int
     total_geo_events: int
     unique_ips: int
     unique_countries: int
@@ -119,8 +122,8 @@ class PeriodSummary(msgspec.Struct, rename="camel"):
     status_3xx: int = msgspec.field(name="status3xx")
     status_4xx: int = msgspec.field(name="status4xx")
     status_5xx: int = msgspec.field(name="status5xx")
-    avg_request_time: float
-    max_request_time: float
+    avg_request_time: float | None
+    max_request_time: float | None
     malformed_requests: int
     error_rate: float
 
@@ -198,7 +201,8 @@ class TopUrlDTO(msgspec.Struct, rename="camel"):
     hits: int
     error_hits: int
     total_bytes: int
-    avg_request_time: float
+    timed_hits: int
+    avg_request_time: float | None
 
 
 class TopUrlsResponse(msgspec.Struct, rename="camel"):

--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Sequence
+from typing import Sequence, cast
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -92,6 +92,11 @@ def use_local_days(
     )
 
 
+def _optional_float(value: object) -> float | None:
+    """A timing aggregate is None when the range had no measured rows."""
+    return float(cast("float", value)) if value is not None else None
+
+
 def _floor_to_hour(dt: datetime) -> datetime:
     """Truncate datetime to the start of its hour."""
     result = dt.replace(minute=0, second=0, microsecond=0)
@@ -122,11 +127,12 @@ class SummaryStatsRow:
     status_3xx: int
     status_4xx: int
     status_5xx: int
-    avg_request_time: float
-    max_request_time: float
-    p50_request_time: float
-    p95_request_time: float
-    p99_request_time: float
+    avg_request_time: float | None
+    max_request_time: float | None
+    p50_request_time: float | None
+    p95_request_time: float | None
+    p99_request_time: float | None
+    timed_requests: int = 0
 
 
 @dataclass
@@ -141,11 +147,11 @@ class SummaryStats:
     status_3xx: int
     status_4xx: int
     status_5xx: int
-    avg_request_time: float
-    max_request_time: float
-    p50_request_time: float
-    p95_request_time: float
-    p99_request_time: float
+    avg_request_time: float | None
+    max_request_time: float | None
+    p50_request_time: float | None
+    p95_request_time: float | None
+    p99_request_time: float | None
     error_rate: float
 
     # Geo metrics (from HyperLogLog)
@@ -156,6 +162,7 @@ class SummaryStats:
 
     # Optional fields for backwards compatibility
     malformed_requests: int = 0
+    timed_requests: int = 0
 
     @property
     def total_bytes_sent(self) -> int:
@@ -226,11 +233,12 @@ class SummaryStatsRepository:
                 COUNT(*) FILTER (WHERE status_code >= 300 AND status_code < 400) AS status_3xx,
                 COUNT(*) FILTER (WHERE status_code >= 400 AND status_code < 500) AS status_4xx,
                 COUNT(*) FILTER (WHERE status_code >= 500 AND status_code < 600) AS status_5xx,
-                COALESCE(AVG(request_time), 0) AS avg_request_time,
-                COALESCE(MAX(request_time), 0) AS max_request_time,
-                COALESCE(PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY request_time), 0) AS p50_request_time,
-                COALESCE(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY request_time), 0) AS p95_request_time,
-                COALESCE(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY request_time), 0) AS p99_request_time
+                COUNT(request_time) AS timed_requests,
+                AVG(request_time) AS avg_request_time,
+                MAX(request_time) AS max_request_time,
+                PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY request_time) AS p50_request_time,
+                PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY request_time) AS p95_request_time,
+                PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY request_time) AS p99_request_time
             FROM access_logs
             WHERE timestamp >= :start AND timestamp < :end
         """)
@@ -282,11 +290,12 @@ class SummaryStatsRepository:
             status_3xx=access_row.status_3xx if access_row else 0,
             status_4xx=access_row.status_4xx if access_row else 0,
             status_5xx=access_row.status_5xx if access_row else 0,
-            avg_request_time=float(access_row.avg_request_time or 0.0) if access_row else 0.0,
-            max_request_time=float(access_row.max_request_time or 0.0) if access_row else 0.0,
-            p50_request_time=float(access_row.p50_request_time or 0.0) if access_row else 0.0,
-            p95_request_time=float(access_row.p95_request_time or 0.0) if access_row else 0.0,
-            p99_request_time=float(access_row.p99_request_time or 0.0) if access_row else 0.0,
+            timed_requests=int(access_row.timed_requests) if access_row else 0,
+            avg_request_time=_optional_float(access_row.avg_request_time) if access_row else None,
+            max_request_time=_optional_float(access_row.max_request_time) if access_row else None,
+            p50_request_time=_optional_float(access_row.p50_request_time) if access_row else None,
+            p95_request_time=_optional_float(access_row.p95_request_time) if access_row else None,
+            p99_request_time=_optional_float(access_row.p99_request_time) if access_row else None,
             error_rate=error_rate,
             total_geo_records=total_geo_records,
             unique_ips=geo_row.unique_ips if geo_row else 0,
@@ -319,6 +328,7 @@ class SummaryStatsRepository:
                 log.status_3xx,
                 log.status_4xx,
                 log.status_5xx,
+                log.timed_requests,
                 log.avg_request_time,
                 log.max_request_time,
                 log.p50_request_time,
@@ -337,11 +347,12 @@ class SummaryStatsRepository:
                     COALESCE(SUM(status_3xx), 0) AS status_3xx,
                     COALESCE(SUM(status_4xx), 0) AS status_4xx,
                     COALESCE(SUM(status_5xx), 0) AS status_5xx,
-                    COALESCE(AVG(avg_request_time), 0) AS avg_request_time,
-                    COALESCE(MAX(max_request_time), 0) AS max_request_time,
-                    COALESCE(approx_percentile(0.50, rollup(pct_agg)), 0) AS p50_request_time,
-                    COALESCE(approx_percentile(0.95, rollup(pct_agg)), 0) AS p95_request_time,
-                    COALESCE(approx_percentile(0.99, rollup(pct_agg)), 0) AS p99_request_time
+                    COALESCE(SUM(timed_requests), 0) AS timed_requests,
+                    SUM(avg_request_time * timed_requests) / NULLIF(SUM(timed_requests), 0) AS avg_request_time,
+                    MAX(max_request_time) AS max_request_time,
+                    approx_percentile(0.50, rollup(pct_agg)) AS p50_request_time,
+                    approx_percentile(0.95, rollup(pct_agg)) AS p95_request_time,
+                    approx_percentile(0.99, rollup(pct_agg)) AS p99_request_time
                 FROM {summary_table}
                 WHERE bucket >= time_bucket('{bucket_interval}', CAST(:start AS timestamptz))
                 AND bucket < :end
@@ -382,11 +393,12 @@ class SummaryStatsRepository:
             status_3xx=row.status_3xx,
             status_4xx=row.status_4xx,
             status_5xx=row.status_5xx,
-            avg_request_time=float(row.avg_request_time),
-            max_request_time=float(row.max_request_time),
-            p50_request_time=float(row.p50_request_time),
-            p95_request_time=float(row.p95_request_time),
-            p99_request_time=float(row.p99_request_time),
+            timed_requests=int(row.timed_requests),
+            avg_request_time=_optional_float(row.avg_request_time),
+            max_request_time=_optional_float(row.max_request_time),
+            p50_request_time=_optional_float(row.p50_request_time),
+            p95_request_time=_optional_float(row.p95_request_time),
+            p99_request_time=_optional_float(row.p99_request_time),
             error_rate=error_rate,
             total_geo_records=row.total_geo_records,
             unique_ips=row.unique_ips,
@@ -423,10 +435,9 @@ class SummaryStatsRepository:
 
         if use_local_days(granularity, start, end, tz):
             # Local days assembled from hourly buckets: counts sum, sketches
-            # merge via rollup(), and the mean is request-weighted. The CAGG's
-            # AVG skips NULL request_time rows while total_requests counts
-            # them, so the weighted mean drifts slightly when NULLs cluster.
-            # GROUP BY 1: a bare "bucket" would resolve to the source column.
+            # merge via rollup(), and the mean is weighted by the timed rows
+            # of each hour, so hours with unmeasured requests do not dilute
+            # it. GROUP BY 1: a bare "bucket" would resolve to the source column.
             stmt = text("""
                 SELECT
                     time_bucket('1 day', bucket, CAST(:tz AS TEXT)) AS bucket,
@@ -436,8 +447,9 @@ class SummaryStatsRepository:
                     CAST(SUM(status_3xx) AS BIGINT) AS status_3xx,
                     CAST(SUM(status_4xx) AS BIGINT) AS status_4xx,
                     CAST(SUM(status_5xx) AS BIGINT) AS status_5xx,
-                    SUM(avg_request_time * total_requests)
-                        / NULLIF(SUM(total_requests), 0) AS avg_request_time,
+                    CAST(COALESCE(SUM(timed_requests), 0) AS BIGINT) AS timed_requests,
+                    SUM(avg_request_time * timed_requests)
+                        / NULLIF(SUM(timed_requests), 0) AS avg_request_time,
                     MAX(max_request_time) AS max_request_time,
                     approx_percentile(0.50, rollup(pct_agg)) AS p50_request_time,
                     approx_percentile(0.95, rollup(pct_agg)) AS p95_request_time,
@@ -462,6 +474,7 @@ class SummaryStatsRepository:
                     status_3xx,
                     status_4xx,
                     status_5xx,
+                    timed_requests,
                     avg_request_time,
                     max_request_time,
                     approx_percentile(0.50, pct_agg) AS p50_request_time,
@@ -486,11 +499,12 @@ class SummaryStatsRepository:
                 status_3xx=row.status_3xx or 0,
                 status_4xx=row.status_4xx or 0,
                 status_5xx=row.status_5xx or 0,
-                avg_request_time=float(row.avg_request_time or 0.0),
-                max_request_time=float(row.max_request_time or 0.0),
-                p50_request_time=float(row.p50_request_time or 0.0),
-                p95_request_time=float(row.p95_request_time or 0.0),
-                p99_request_time=float(row.p99_request_time or 0.0),
+                timed_requests=int(row.timed_requests or 0),
+                avg_request_time=_optional_float(row.avg_request_time),
+                max_request_time=_optional_float(row.max_request_time),
+                p50_request_time=_optional_float(row.p50_request_time),
+                p95_request_time=_optional_float(row.p95_request_time),
+                p99_request_time=_optional_float(row.p99_request_time),
             )
             for row in rows
         ]
@@ -688,18 +702,18 @@ class SummaryStatsRepository:
         table = f"url_{granularity.value}_stats"
         stmt = text(f"""
             WITH combined AS (
-                SELECT s.url, s.hits, s.error_hits, s.total_bytes, s.total_request_time
+                SELECT s.url, s.hits, s.timed_hits, s.error_hits, s.total_bytes, s.total_request_time
                 FROM {table} s
                 WHERE s.bucket >= :a_start AND s.bucket < :a_end
                 UNION ALL
-                SELECT al.url, CAST(1 AS BIGINT), CAST((al.status_code >= 400)::int AS BIGINT),
-                       al.bytes_sent, al.request_time
+                SELECT al.url, CAST(1 AS BIGINT), CAST((al.request_time IS NOT NULL)::int AS BIGINT),
+                       CAST((al.status_code >= 400)::int AS BIGINT), al.bytes_sent, al.request_time
                 FROM access_logs al
                 WHERE al.timestamp >= :start AND al.timestamp < :a_start
                   AND al.url IS NOT NULL
                 UNION ALL
-                SELECT al.url, CAST(1 AS BIGINT), CAST((al.status_code >= 400)::int AS BIGINT),
-                       al.bytes_sent, al.request_time
+                SELECT al.url, CAST(1 AS BIGINT), CAST((al.request_time IS NOT NULL)::int AS BIGINT),
+                       CAST((al.status_code >= 400)::int AS BIGINT), al.bytes_sent, al.request_time
                 FROM access_logs al
                 WHERE al.timestamp >= :a_end AND al.timestamp < :end
                   AND al.url IS NOT NULL
@@ -707,9 +721,10 @@ class SummaryStatsRepository:
             SELECT
                 url,
                 CAST(SUM(hits) AS BIGINT) AS hits,
+                CAST(SUM(timed_hits) AS BIGINT) AS timed_hits,
                 CAST(SUM(error_hits) AS BIGINT) AS error_hits,
                 CAST(COALESCE(SUM(total_bytes), 0) AS BIGINT) AS total_bytes,
-                COALESCE(SUM(total_request_time) / NULLIF(SUM(hits), 0), 0) AS avg_request_time
+                SUM(total_request_time) / NULLIF(SUM(timed_hits), 0) AS avg_request_time
             FROM combined
             GROUP BY url
             ORDER BY hits DESC, url
@@ -724,7 +739,8 @@ class SummaryStatsRepository:
                 hits=row.hits,
                 error_hits=row.error_hits,
                 total_bytes=row.total_bytes,
-                avg_request_time=float(row.avg_request_time),
+                timed_hits=row.timed_hits,
+                avg_request_time=_optional_float(row.avg_request_time),
             )
             for row in result.fetchall()
         ]
@@ -1008,7 +1024,8 @@ class TopUrlRow:
     hits: int
     error_hits: int
     total_bytes: int
-    avg_request_time: float
+    avg_request_time: float | None
+    timed_hits: int
 
 
 @dataclass
@@ -1170,11 +1187,12 @@ class LiveStatsRepository:
                 COUNT(*) FILTER (WHERE status_code >= 300 AND status_code < 400) AS status_3xx,
                 COUNT(*) FILTER (WHERE status_code >= 400 AND status_code < 500) AS status_4xx,
                 COUNT(*) FILTER (WHERE status_code >= 500 AND status_code < 600) AS status_5xx,
-                COALESCE(AVG(request_time), 0) AS avg_request_time,
-                COALESCE(MAX(request_time), 0) AS max_request_time,
-                COALESCE(PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY request_time), 0) AS p50_request_time,
-                COALESCE(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY request_time), 0) AS p95_request_time,
-                COALESCE(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY request_time), 0) AS p99_request_time
+                COUNT(request_time) AS timed_requests,
+                AVG(request_time) AS avg_request_time,
+                MAX(request_time) AS max_request_time,
+                PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY request_time) AS p50_request_time,
+                PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY request_time) AS p95_request_time,
+                PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY request_time) AS p99_request_time
             FROM access_logs
             WHERE timestamp >= :start AND timestamp < :end
         """)
@@ -1226,11 +1244,12 @@ class LiveStatsRepository:
             status_3xx=access_row.status_3xx if access_row else 0,
             status_4xx=access_row.status_4xx if access_row else 0,
             status_5xx=access_row.status_5xx if access_row else 0,
-            avg_request_time=float(access_row.avg_request_time or 0.0) if access_row else 0.0,
-            max_request_time=float(access_row.max_request_time or 0.0) if access_row else 0.0,
-            p50_request_time=float(access_row.p50_request_time or 0.0) if access_row else 0.0,
-            p95_request_time=float(access_row.p95_request_time or 0.0) if access_row else 0.0,
-            p99_request_time=float(access_row.p99_request_time or 0.0) if access_row else 0.0,
+            timed_requests=int(access_row.timed_requests) if access_row else 0,
+            avg_request_time=_optional_float(access_row.avg_request_time) if access_row else None,
+            max_request_time=_optional_float(access_row.max_request_time) if access_row else None,
+            p50_request_time=_optional_float(access_row.p50_request_time) if access_row else None,
+            p95_request_time=_optional_float(access_row.p95_request_time) if access_row else None,
+            p99_request_time=_optional_float(access_row.p99_request_time) if access_row else None,
             error_rate=error_rate,
             total_geo_records=total_events,
             unique_ips=geo_row.unique_ips if geo_row else 0,
@@ -1275,11 +1294,12 @@ class LiveStatsRepository:
                 COUNT(*) FILTER (WHERE status_code >= 300 AND status_code < 400) AS status_3xx,
                 COUNT(*) FILTER (WHERE status_code >= 400 AND status_code < 500) AS status_4xx,
                 COUNT(*) FILTER (WHERE status_code >= 500 AND status_code < 600) AS status_5xx,
-                COALESCE(AVG(request_time), 0) AS avg_request_time,
-                COALESCE(MAX(request_time), 0) AS max_request_time,
-                COALESCE(PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY request_time), 0) AS p50_request_time,
-                COALESCE(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY request_time), 0) AS p95_request_time,
-                COALESCE(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY request_time), 0) AS p99_request_time
+                COUNT(request_time) AS timed_requests,
+                AVG(request_time) AS avg_request_time,
+                MAX(request_time) AS max_request_time,
+                PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY request_time) AS p50_request_time,
+                PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY request_time) AS p95_request_time,
+                PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY request_time) AS p99_request_time
             FROM access_logs
             WHERE timestamp >= :start AND timestamp < :end
             {filter_sql}
@@ -1298,11 +1318,12 @@ class LiveStatsRepository:
                 status_3xx=row.status_3xx or 0,
                 status_4xx=row.status_4xx or 0,
                 status_5xx=row.status_5xx or 0,
-                avg_request_time=float(row.avg_request_time or 0.0),
-                max_request_time=float(row.max_request_time or 0.0),
-                p50_request_time=float(row.p50_request_time or 0.0),
-                p95_request_time=float(row.p95_request_time or 0.0),
-                p99_request_time=float(row.p99_request_time or 0.0),
+                timed_requests=int(row.timed_requests or 0),
+                avg_request_time=_optional_float(row.avg_request_time),
+                max_request_time=_optional_float(row.max_request_time),
+                p50_request_time=_optional_float(row.p50_request_time),
+                p95_request_time=_optional_float(row.p95_request_time),
+                p99_request_time=_optional_float(row.p99_request_time),
             )
             for row in result.fetchall()
         ]
@@ -1322,7 +1343,8 @@ class LiveStatsRepository:
                 CAST(COUNT(*) AS BIGINT) AS hits,
                 CAST(COUNT(*) FILTER (WHERE status_code >= 400) AS BIGINT) AS error_hits,
                 CAST(COALESCE(SUM(bytes_sent), 0) AS BIGINT) AS total_bytes,
-                COALESCE(AVG(request_time), 0) AS avg_request_time
+                CAST(COUNT(request_time) AS BIGINT) AS timed_hits,
+                AVG(request_time) AS avg_request_time
             FROM access_logs
             WHERE timestamp >= :start AND timestamp < :end AND url IS NOT NULL
             {filter_sql}
@@ -1339,7 +1361,8 @@ class LiveStatsRepository:
                 hits=row.hits,
                 error_hits=row.error_hits,
                 total_bytes=row.total_bytes,
-                avg_request_time=float(row.avg_request_time),
+                timed_hits=row.timed_hits,
+                avg_request_time=_optional_float(row.avg_request_time),
             )
             for row in result.fetchall()
         ]

--- a/geometrikks/domain/analytics/repositories.py
+++ b/geometrikks/domain/analytics/repositories.py
@@ -320,6 +320,10 @@ class SummaryStatsRepository:
 
         # Combined query for access log, geo metrics, and malformed requests
         # Floor start time to bucket boundary for CAGG queries
+        # COALESCE(timed_requests, total_requests): buckets older than the raw
+        # retention window never got a count (the rows needed to recount them
+        # are gone) and their mean was taken over every row, so every row of
+        # theirs counts as timed.
         stmt = text(f"""
             SELECT
                 log.total_log_records,
@@ -347,8 +351,9 @@ class SummaryStatsRepository:
                     COALESCE(SUM(status_3xx), 0) AS status_3xx,
                     COALESCE(SUM(status_4xx), 0) AS status_4xx,
                     COALESCE(SUM(status_5xx), 0) AS status_5xx,
-                    COALESCE(SUM(timed_requests), 0) AS timed_requests,
-                    SUM(avg_request_time * timed_requests) / NULLIF(SUM(timed_requests), 0) AS avg_request_time,
+                    COALESCE(SUM(COALESCE(timed_requests, total_requests)), 0) AS timed_requests,
+                    SUM(avg_request_time * COALESCE(timed_requests, total_requests))
+                        / NULLIF(SUM(COALESCE(timed_requests, total_requests)), 0) AS avg_request_time,
                     MAX(max_request_time) AS max_request_time,
                     approx_percentile(0.50, rollup(pct_agg)) AS p50_request_time,
                     approx_percentile(0.95, rollup(pct_agg)) AS p95_request_time,
@@ -437,7 +442,9 @@ class SummaryStatsRepository:
             # Local days assembled from hourly buckets: counts sum, sketches
             # merge via rollup(), and the mean is weighted by the timed rows
             # of each hour, so hours with unmeasured requests do not dilute
-            # it. GROUP BY 1: a bare "bucket" would resolve to the source column.
+            # it. Buckets predating the count column have no count and were
+            # averaged over every row, so they weigh in with total_requests.
+            # GROUP BY 1: a bare "bucket" would resolve to the source column.
             stmt = text("""
                 SELECT
                     time_bucket('1 day', bucket, CAST(:tz AS TEXT)) AS bucket,
@@ -447,9 +454,9 @@ class SummaryStatsRepository:
                     CAST(SUM(status_3xx) AS BIGINT) AS status_3xx,
                     CAST(SUM(status_4xx) AS BIGINT) AS status_4xx,
                     CAST(SUM(status_5xx) AS BIGINT) AS status_5xx,
-                    CAST(COALESCE(SUM(timed_requests), 0) AS BIGINT) AS timed_requests,
-                    SUM(avg_request_time * timed_requests)
-                        / NULLIF(SUM(timed_requests), 0) AS avg_request_time,
+                    CAST(COALESCE(SUM(COALESCE(timed_requests, total_requests)), 0) AS BIGINT) AS timed_requests,
+                    SUM(avg_request_time * COALESCE(timed_requests, total_requests))
+                        / NULLIF(SUM(COALESCE(timed_requests, total_requests)), 0) AS avg_request_time,
                     MAX(max_request_time) AS max_request_time,
                     approx_percentile(0.50, rollup(pct_agg)) AS p50_request_time,
                     approx_percentile(0.95, rollup(pct_agg)) AS p95_request_time,
@@ -474,7 +481,7 @@ class SummaryStatsRepository:
                     status_3xx,
                     status_4xx,
                     status_5xx,
-                    timed_requests,
+                    COALESCE(timed_requests, total_requests) AS timed_requests,
                     avg_request_time,
                     max_request_time,
                     approx_percentile(0.50, pct_agg) AS p50_request_time,
@@ -700,9 +707,12 @@ class SummaryStatsRepository:
                 start, end, limit, filters=filters
             )
         table = f"url_{granularity.value}_stats"
+        # COALESCE(s.timed_hits, s.hits): buckets older than the raw retention
+        # window never got a count and timed every row they cover.
         stmt = text(f"""
             WITH combined AS (
-                SELECT s.url, s.hits, s.timed_hits, s.error_hits, s.total_bytes, s.total_request_time
+                SELECT s.url, s.hits, COALESCE(s.timed_hits, s.hits) AS timed_hits,
+                       s.error_hits, s.total_bytes, s.total_request_time
                 FROM {table} s
                 WHERE s.bucket >= :a_start AND s.bucket < :a_end
                 UNION ALL
@@ -721,7 +731,7 @@ class SummaryStatsRepository:
             SELECT
                 url,
                 CAST(SUM(hits) AS BIGINT) AS hits,
-                CAST(SUM(timed_hits) AS BIGINT) AS timed_hits,
+                CAST(COALESCE(SUM(timed_hits), 0) AS BIGINT) AS timed_hits,
                 CAST(SUM(error_hits) AS BIGINT) AS error_hits,
                 CAST(COALESCE(SUM(total_bytes), 0) AS BIGINT) AS total_bytes,
                 SUM(total_request_time) / NULLIF(SUM(timed_hits), 0) AS avg_request_time

--- a/geometrikks/domain/logs/controllers/access_logs.py
+++ b/geometrikks/domain/logs/controllers/access_logs.py
@@ -23,6 +23,7 @@ from geometrikks.domain.logs.models import AccessLog
 from geometrikks.domain.logs.schemas import AccessLogFacets
 from geometrikks.domain.logs.services import AccessLogService
 from geometrikks.domain.logs.dtos import AccessLogDTO
+from geometrikks.domain.logs.sorting import nulls_last_for_timings
 from geometrikks.lib.validation import validate_ip_addresses
 
 
@@ -161,7 +162,7 @@ class AccessLogController(Controller):
         in_filters: NamedDependency[SkipValidation[list[FilterTypes]]],
     ) -> OffsetPagination[AccessLog]:
         """List access logs newest-first, with optional search/filter/sort."""
-        all_filters = [*filters, *time_window, *in_filters]
+        all_filters = nulls_last_for_timings([*filters, *time_window, *in_filters])
         results, total = await access_log_service.get_many_and_count(*all_filters)
         return access_log_service.to_schema(results, total, filters=all_filters)
 

--- a/geometrikks/domain/logs/models.py
+++ b/geometrikks/domain/logs/models.py
@@ -56,7 +56,7 @@ class AccessLog(base.BigIntBase):
     user_agent: Mapped[str | None] = mapped_column(Text)
     
     # Performance metrics
-    request_time: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    request_time: Mapped[float | None] = mapped_column(Float, nullable=True)
     upstream_response_time: Mapped[float | None] = mapped_column(Float, nullable=True, default=None)
     
     # Host information (may be missing on malformed lines)

--- a/geometrikks/domain/logs/sorting.py
+++ b/geometrikks/domain/logs/sorting.py
@@ -1,0 +1,43 @@
+"""Sort helpers for the access-log list.
+
+advanced-alchemy's OrderBy emits a bare ASC/DESC. Postgres puts NULLs first
+on DESC, so a "slowest first" sort on the nullable timing columns would lead
+with the rows that have no timing at all.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, cast
+
+from advanced_alchemy.filters import FilterTypes, ModelT, OrderBy, StatementFilter, StatementTypeT
+from sqlalchemy import Select
+
+TIMING_SORT_FIELDS: frozenset[str] = frozenset({"request_time", "upstream_response_time"})
+
+
+@dataclass
+class NullsLastOrderBy(StatementFilter):
+    """ORDER BY <field> <dir> NULLS LAST."""
+
+    field_name: str
+    sort_order: Literal["asc", "desc"] = "asc"
+
+    def append_to_statement(self, statement: StatementTypeT, model: type[ModelT]) -> StatementTypeT:
+        if not isinstance(statement, Select):
+            return statement
+        column = getattr(model, self.field_name)
+        direction = column.desc() if self.sort_order == "desc" else column.asc()
+        return statement.order_by(direction.nulls_last())  # type: ignore[return-value]
+
+
+def nulls_last_for_timings(filters: list[FilterTypes]) -> list[FilterTypes]:
+    """Swap OrderBy on a timing column for the NULLS LAST variant."""
+    return cast(
+        list[FilterTypes],
+        [
+            NullsLastOrderBy(f.field_name, f.sort_order)  # type: ignore[arg-type]
+            if isinstance(f, OrderBy) and isinstance(f.field_name, str) and f.field_name in TIMING_SORT_FIELDS
+            else f
+            for f in filters
+        ],
+    )

--- a/geometrikks/server/timescale.py
+++ b/geometrikks/server/timescale.py
@@ -810,13 +810,25 @@ TIMED_COUNT_COLUMNS: dict[str, str] = {
 }
 
 
-async def _timed_columns_need_upgrade(conn: "AsyncConnection") -> list[str]:
+async def _timed_columns_need_upgrade(
+    conn: "AsyncConnection", *, raw_retention_days: int
+) -> list[str]:
     """Views whose count column is missing or not yet backfilled.
 
     A view that does not exist yet needs nothing: the CREATE includes the
     column. "Any bucket with a NULL count" is the rerun-safe half of the
     probe: a container killed during the forced refresh comes back with the
     column present and history still uncounted, and must refresh again.
+
+    That half is scoped to the raw retention window, the only span the forced
+    refresh can recount. Daily buckets older than it keep a NULL count for
+    good (their raw rows are gone), and an unscoped probe would see those and
+    schedule the full refresh again on every start. Readers fall back to the
+    bucket's total for them.
+
+    Args:
+        conn: Open connection inside the setup transaction.
+        raw_retention_days: Window the forced refresh covers.
     """
     result = await conn.execute(text("""
         SELECT table_name, column_name FROM information_schema.columns
@@ -832,7 +844,11 @@ async def _timed_columns_need_upgrade(conn: "AsyncConnection") -> list[str]:
             pending.append(view)
             continue
         has_null = (await conn.execute(
-            text(f"SELECT 1 FROM {view} WHERE {column} IS NULL LIMIT 1")
+            text(
+                f"SELECT 1 FROM {view} WHERE {column} IS NULL "
+                f"AND bucket >= now() - make_interval(days => :days) LIMIT 1"
+            ),
+            {"days": raw_retention_days},
         )).scalar()
         if has_null:
             pending.append(view)
@@ -862,10 +878,14 @@ async def _add_timed_columns(conn: "AsyncConnection", views: list[str]) -> list[
         if exists:
             continue
         try:
-            await conn.execute(text(
-                f"ALTER MATERIALIZED VIEW {view} ADD COLUMN {column} bigint "
-                f"GENERATED ALWAYS AS (COUNT(request_time)) STORED"
-            ))
+            # Savepoint: a failed DDL poisons the whole setup transaction, so
+            # without one the fallback DROP below would hit "current
+            # transaction is aborted" and take startup down with it.
+            async with conn.begin_nested():
+                await conn.execute(text(
+                    f"ALTER MATERIALIZED VIEW {view} ADD COLUMN {column} bigint "
+                    f"GENERATED ALWAYS AS (COUNT(request_time)) STORED"
+                ))
             logger.info("cagg_timed_column_added", view=view, column=column)
         except Exception as exc:
             logger.warning(
@@ -976,9 +996,13 @@ async def setup_timescaledb(
         # Probed before the CREATE step: CREATE IF NOT EXISTS never alters an
         # existing view. The forced refresh runs after policies, outside the
         # transaction (CALL cannot run inside one).
-        timed_views = await _timed_columns_need_upgrade(conn)
+        timed_views = await _timed_columns_need_upgrade(
+            conn, raw_retention_days=analytics.raw_retention_days
+        )
         if timed_views:
-            await _add_timed_columns(conn, timed_views)
+            recreated = await _add_timed_columns(conn, timed_views)
+            if recreated:
+                logger.info("cagg_timed_views_recreated", views=recreated)
 
         # Upgrade pre-hostname location CAGGs, gated on hostname pollution:
         # migrating polluted (container-ID) hostnames would make the map's
@@ -1064,16 +1088,20 @@ async def setup_timescaledb(
 
     if timed_views:
         started = time.monotonic()
-        await refresh_caggs_range(
+        failed = await refresh_caggs_range(
             engine,
             start=datetime.now(timezone.utc) - timedelta(days=analytics.raw_retention_days),
             end=datetime.now(timezone.utc),
             caggs=timed_views,
             force=True,
         )
+        if failed:
+            # The column is there but those views' history stays uncounted;
+            # the next start finds the NULL counts and refreshes them again.
+            logger.warning("cagg_timed_refresh_failed", views=failed)
         logger.info(
             "cagg_timed_refresh_done",
-            views=timed_views,
+            views=[view for view in timed_views if view not in failed],
             seconds=round(time.monotonic() - started, 1),
         )
 

--- a/geometrikks/server/timescale.py
+++ b/geometrikks/server/timescale.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Literal
@@ -196,6 +197,7 @@ async def _create_summary_caggs(conn: "AsyncConnection") -> None:
             COUNT(*) FILTER (WHERE status_code >= 300 AND status_code < 400) AS status_3xx,
             COUNT(*) FILTER (WHERE status_code >= 400 AND status_code < 500) AS status_4xx,
             COUNT(*) FILTER (WHERE status_code >= 500 AND status_code < 600) AS status_5xx,
+            COUNT(request_time) AS timed_requests,
             AVG(request_time) AS avg_request_time,
             MAX(request_time) AS max_request_time,
             percentile_agg(request_time) AS pct_agg
@@ -216,6 +218,7 @@ async def _create_summary_caggs(conn: "AsyncConnection") -> None:
             COUNT(*) FILTER (WHERE status_code >= 300 AND status_code < 400) AS status_3xx,
             COUNT(*) FILTER (WHERE status_code >= 400 AND status_code < 500) AS status_4xx,
             COUNT(*) FILTER (WHERE status_code >= 500 AND status_code < 600) AS status_5xx,
+            COUNT(request_time) AS timed_requests,
             AVG(request_time) AS avg_request_time,
             MAX(request_time) AS max_request_time,
             percentile_agg(request_time) AS pct_agg
@@ -408,7 +411,8 @@ async def _create_url_caggs(conn: "AsyncConnection") -> None:
     """Create per-URL access-log CAGGs (hourly + daily).
 
     Used for: analytics /top-urls (unfiltered path). total_request_time is a
-    SUM so the rolled-up average is exact (SUM/SUM), never an AVG of AVGs.
+    SUM and timed_hits a COUNT of measured rows, so the rolled-up average is
+    exact (SUM/COUNT of timed rows), never an AVG of AVGs.
     """
     for suffix, interval in (("hourly", "1 hour"), ("daily", "1 day")):
         await conn.execute(text(f"""
@@ -419,6 +423,7 @@ async def _create_url_caggs(conn: "AsyncConnection") -> None:
                 url,
                 COUNT(*) AS hits,
                 COUNT(*) FILTER (WHERE status_code >= 400) AS error_hits,
+                COUNT(request_time) AS timed_hits,
                 COALESCE(SUM(bytes_sent), 0) AS total_bytes,
                 SUM(request_time) AS total_request_time
             FROM access_logs
@@ -795,6 +800,85 @@ async def teardown_timescaledb(conn: "AsyncConnection") -> None:
 
 SUMMARY_CAGGS = ["summary_hourly_stats", "summary_daily_stats"]
 
+# CAGG -> its count-of-measured-rows column. Added to existing views in
+# place by _add_timed_columns; fresh installs get them from the CREATE.
+TIMED_COUNT_COLUMNS: dict[str, str] = {
+    "summary_hourly_stats": "timed_requests",
+    "summary_daily_stats": "timed_requests",
+    "url_hourly_stats": "timed_hits",
+    "url_daily_stats": "timed_hits",
+}
+
+
+async def _timed_columns_need_upgrade(conn: "AsyncConnection") -> list[str]:
+    """Views whose count column is missing or not yet backfilled.
+
+    A view that does not exist yet needs nothing: the CREATE includes the
+    column. "Any bucket with a NULL count" is the rerun-safe half of the
+    probe: a container killed during the forced refresh comes back with the
+    column present and history still uncounted, and must refresh again.
+    """
+    result = await conn.execute(text("""
+        SELECT table_name, column_name FROM information_schema.columns
+        WHERE table_name = ANY(:views)
+    """), {"views": list(TIMED_COUNT_COLUMNS)})
+    columns = {(r.table_name, r.column_name) for r in result}
+    existing_views = {name for name, _ in columns}
+    pending: list[str] = []
+    for view, column in TIMED_COUNT_COLUMNS.items():
+        if view not in existing_views:
+            continue
+        if (view, column) not in columns:
+            pending.append(view)
+            continue
+        has_null = (await conn.execute(
+            text(f"SELECT 1 FROM {view} WHERE {column} IS NULL LIMIT 1")
+        )).scalar()
+        if has_null:
+            pending.append(view)
+    return pending
+
+
+async def _add_timed_columns(conn: "AsyncConnection", views: list[str]) -> list[str]:
+    """Add the count column in place; fall back to drop-and-recreate.
+
+    The in-place ALTER keeps every existing bucket; only the new column is
+    filled by the forced refresh the caller runs afterwards. TimescaleDB
+    versions without in-place CAGG columns raise here, and for those the
+    old percentile-upgrade route applies: drop the view (setup recreates it
+    with the column) and accept that daily history older than raw retention
+    cannot be rebuilt.
+
+    Returns:
+        Views that were dropped and will be recreated by the CREATE step.
+    """
+    dropped: list[str] = []
+    for view in views:
+        column = TIMED_COUNT_COLUMNS[view]
+        exists = (await conn.execute(text("""
+            SELECT 1 FROM information_schema.columns
+            WHERE table_name = :view AND column_name = :column
+        """), {"view": view, "column": column})).scalar()
+        if exists:
+            continue
+        try:
+            await conn.execute(text(
+                f"ALTER MATERIALIZED VIEW {view} ADD COLUMN {column} bigint "
+                f"GENERATED ALWAYS AS (COUNT(request_time)) STORED"
+            ))
+            logger.info("cagg_timed_column_added", view=view, column=column)
+        except Exception as exc:
+            logger.warning(
+                "In-place column add failed on %s (%s); recreating the view. "
+                "History older than the raw retention window cannot be rebuilt "
+                "and is discarded.",
+                view,
+                exc,
+            )
+            await conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {view} CASCADE"))
+            dropped.append(view)
+    return dropped
+
 
 async def _summary_caggs_need_upgrade(conn: "AsyncConnection") -> bool:
     """True when a summary CAGG exists in the pre-percentile_agg shape.
@@ -888,6 +972,14 @@ async def setup_timescaledb(
         if upgraded:
             await _upgrade_summary_caggs(conn)
 
+        # Add the timed-row count columns to pre-existing summary/URL CAGGs.
+        # Probed before the CREATE step: CREATE IF NOT EXISTS never alters an
+        # existing view. The forced refresh runs after policies, outside the
+        # transaction (CALL cannot run inside one).
+        timed_views = await _timed_columns_need_upgrade(conn)
+        if timed_views:
+            await _add_timed_columns(conn, timed_views)
+
         # Upgrade pre-hostname location CAGGs, gated on hostname pollution:
         # migrating polluted (container-ID) hostnames would make the map's
         # per-source filter useless, so the old shape is kept until the
@@ -970,6 +1062,21 @@ async def setup_timescaledb(
             caggs=LOCATION_CAGGS,
         )
 
+    if timed_views:
+        started = time.monotonic()
+        await refresh_caggs_range(
+            engine,
+            start=datetime.now(timezone.utc) - timedelta(days=analytics.raw_retention_days),
+            end=datetime.now(timezone.utc),
+            caggs=timed_views,
+            force=True,
+        )
+        logger.info(
+            "cagg_timed_refresh_done",
+            views=timed_views,
+            seconds=round(time.monotonic() - started, 1),
+        )
+
     # Repair deployments whose data predates CAGG refresh coverage
     # (issue #14: long-range charts truncated while top lists are not).
     await backfill_cagg_gaps(
@@ -987,6 +1094,7 @@ async def refresh_caggs_range(
     start: datetime,
     end: datetime,
     caggs: list[str] | None = None,
+    force: bool = False,
 ) -> list[str]:
     """Refresh CAGGs for a specific time range (used after historical imports).
 
@@ -1005,6 +1113,9 @@ async def refresh_caggs_range(
         start: Range start (inclusive), timezone-aware.
         end: Range end (exclusive), timezone-aware.
         caggs: Optional subset of CAGGs (defaults to all).
+        force: Re-materialize buckets that are already up to date. Needed
+            once after a column is added to an existing view, since a normal
+            refresh skips buckets it considers current.
 
     Returns:
         Names of CAGGs whose refresh failed; empty when all succeeded.
@@ -1030,8 +1141,9 @@ async def refresh_caggs_range(
                     driver_conn = raw_conn.driver_connection
                     if driver_conn is None:
                         raise RuntimeError("No driver connection available for CALL statement")
+                    force_arg = ", force => true" if force else ""
                     await driver_conn.execute(
-                        f"CALL refresh_continuous_aggregate('{cagg}', $1::timestamptz, $2::timestamptz)",
+                        f"CALL refresh_continuous_aggregate('{cagg}', $1::timestamptz, $2::timestamptz{force_arg})",
                         start,
                         end,
                     )

--- a/geometrikks/services/logparser/formats/base.py
+++ b/geometrikks/services/logparser/formats/base.py
@@ -10,6 +10,7 @@ the single place where that gets corrected.
 """
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Protocol, runtime_checkable
@@ -29,7 +30,7 @@ class NormalizedLine:
     bytes_sent: int = 0
     referrer: str | None = None
     user_agent: str | None = None
-    request_time: float = 0.0
+    request_time: float | None = None
     upstream_response_time: float | None = None
     host: str | None = None
     # Raw request-line text ("GET / HTTP/1.1" or probe garbage); nginx only,
@@ -66,6 +67,21 @@ def convert_dash_to_none(value: str | None) -> str | None:
         return None
     stripped = value.strip()
     return stripped if stripped not in ("", "-") else None
+
+
+def parse_seconds(raw: str | None) -> float | None:
+    """A timing in seconds, or None when the line carries no measurement.
+
+    '', '-' and unparseable text are absence. nan and inf parse as floats
+    but are not measurements either.
+    """
+    if not raw or raw.strip() == "-":
+        return None
+    try:
+        value = float(raw)
+    except ValueError:
+        return None
+    return value if math.isfinite(value) else None
 
 
 def detect_probe(

--- a/geometrikks/services/logparser/formats/geometrikks_json.py
+++ b/geometrikks/services/logparser/formats/geometrikks_json.py
@@ -13,7 +13,7 @@ from datetime import datetime
 
 import msgspec
 
-from .base import NormalizedLine, convert_dash_to_none, detect_probe
+from .base import NormalizedLine, convert_dash_to_none, detect_probe, parse_seconds
 
 
 class GeometrikksJsonLine(msgspec.Struct):
@@ -54,13 +54,6 @@ def _to_int(raw: str | None) -> int:
         return int(raw) if raw else 0
     except ValueError:
         return 0
-
-
-def _to_float(raw: str | None) -> float:
-    try:
-        return float(raw) if raw else 0.0
-    except ValueError:
-        return 0.0
 
 
 def _sum_upstream(raw: str | None) -> float | None:
@@ -132,7 +125,7 @@ class GeometrikksJsonFormat:
             bytes_sent=_to_int(data.bytes),
             referrer=convert_dash_to_none(data.referrer),
             user_agent=convert_dash_to_none(data.user_agent),
-            request_time=_to_float(data.request_time),
+            request_time=parse_seconds(data.request_time),
             upstream_response_time=_sum_upstream(data.upstream_time),
             host=convert_dash_to_none(data.host),
             request_raw=convert_dash_to_none(data.request_raw),

--- a/geometrikks/services/logparser/formats/nginx.py
+++ b/geometrikks/services/logparser/formats/nginx.py
@@ -11,7 +11,7 @@ from geometrikks.services.logparser.constants import (
     ipv6_geo_pattern,
     ipv6_pattern,
 )
-from .base import NormalizedLine, convert_dash_to_none, detect_probe
+from .base import NormalizedLine, convert_dash_to_none, detect_probe, parse_seconds
 
 logger = get_logger(__name__)
 
@@ -52,10 +52,7 @@ class NginxFormat:
                 remote_user=convert_dash_to_none(d.get("remote_user")),
             )
 
-        try:
-            request_time = float(d.get("request_time") or 0)
-        except (ValueError, TypeError):
-            request_time = 0.0
+        request_time = parse_seconds(d.get("request_time"))
         upstream_raw = d.get("upstream_response_time")
         try:
             upstream = (

--- a/geometrikks/services/logparser/formats/traefik.py
+++ b/geometrikks/services/logparser/formats/traefik.py
@@ -86,7 +86,7 @@ class TraefikJsonFormat:
 
         duration_ns = data.get("Duration")
         request_time = (
-            duration_ns / 1e9 if isinstance(duration_ns, (int, float)) else 0.0
+            duration_ns / 1e9 if isinstance(duration_ns, (int, float)) else None
         )
         origin_ns = data.get("OriginDuration")
         upstream = (

--- a/geometrikks/services/logparser/schemas.py
+++ b/geometrikks/services/logparser/schemas.py
@@ -36,7 +36,7 @@ class ParsedAccessLog:
     bytes_sent: int
     referrer: str | None
     user_agent: str | None
-    request_time: float
+    request_time: float | None
     upstream_response_time: float | None
     host: str | None
     country_code: str | None

--- a/migrations/versions/2026-08-26_nullable_request_time_d4e8f2a6b913.py
+++ b/migrations/versions/2026-08-26_nullable_request_time_d4e8f2a6b913.py
@@ -1,0 +1,104 @@
+"""request_time nullable: absent timings stop being 0.0
+
+Revision ID: d4e8f2a6b913
+Revises: c9d2e4f7a815
+Create Date: 2026-08-26 00:00:00.000000
+
+"""
+
+import warnings
+
+import sqlalchemy as sa
+from alembic import op
+from advanced_alchemy.types import Bool, EncryptedString, EncryptedText, GUID, JsonB, ORA_JSONB, DateTimeUTC, StoredObject, PasswordHash, FernetBackend, TOTPSecret, OneTimeCode
+from advanced_alchemy.types.encrypted_string import PGCryptoBackend
+from advanced_alchemy.types.password_hash.argon2 import Argon2Hasher
+from advanced_alchemy.types.password_hash.passlib import PasslibHasher
+from advanced_alchemy.types.password_hash.pwdlib import PwdlibHasher
+from sqlalchemy import Text  # noqa: F401
+from sqlalchemy.dialects import postgresql  # noqa: F401
+
+__all__ = ("downgrade", "upgrade", "schema_upgrades", "schema_downgrades", "data_upgrades", "data_downgrades")
+
+sa.GUID = GUID
+sa.Bool = Bool
+sa.DateTimeUTC = DateTimeUTC
+sa.JsonB = JsonB
+sa.ORA_JSONB = ORA_JSONB
+sa.EncryptedString = EncryptedString
+sa.EncryptedText = EncryptedText
+sa.StoredObject = StoredObject
+sa.PasswordHash = PasswordHash
+sa.Argon2Hasher = Argon2Hasher
+sa.PasslibHasher = PasslibHasher
+sa.PwdlibHasher = PwdlibHasher
+sa.FernetBackend = FernetBackend
+sa.PGCryptoBackend = PGCryptoBackend
+sa.TOTPSecret = TOTPSecret
+sa.OneTimeCode = OneTimeCode
+
+# revision identifiers, used by Alembic.
+revision = 'd4e8f2a6b913'
+down_revision = 'c9d2e4f7a815'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        with op.get_context().autocommit_block():
+            schema_upgrades()
+            data_upgrades()
+
+
+def downgrade() -> None:
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        with op.get_context().autocommit_block():
+            data_downgrades()
+            schema_downgrades()
+
+
+def schema_upgrades() -> None:
+    """Both statements are idempotent, so a rerun after a crash is safe.
+
+    Metadata-only on a compressed hypertable: chunks stay compressed.
+    """
+    op.execute("ALTER TABLE access_logs ALTER COLUMN request_time DROP NOT NULL")
+    op.execute("ALTER TABLE access_logs ALTER COLUMN request_time DROP DEFAULT")
+
+
+def schema_downgrades() -> None:
+    """Restore NOT NULL DEFAULT 0.0 after data_downgrades filled the NULLs."""
+    op.execute("ALTER TABLE access_logs ALTER COLUMN request_time SET DEFAULT 0.0")
+    op.execute("ALTER TABLE access_logs ALTER COLUMN request_time SET NOT NULL")
+
+
+def data_upgrades() -> None:
+    """No backfill: existing 0.0 placeholders stay. `litestar backfill-timings`
+    is the explicit opt-in that rewrites the ones it can identify."""
+
+
+def data_downgrades() -> None:
+    """NULL back to 0.0 so SET NOT NULL succeeds.
+
+    On a compressed hypertable an UPDATE over history trips the tuple
+    decompression limit, so compressed chunks are decompressed first, the
+    same pattern as the url/referrer swap revision.
+    """
+    bind = op.get_bind()
+    has_timescale = bind.execute(sa.text(
+        "SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb')"
+    )).scalar()
+    is_hypertable = has_timescale and bind.execute(sa.text(
+        "SELECT EXISTS (SELECT 1 FROM timescaledb_information.hypertables "
+        "WHERE hypertable_name = 'access_logs')"
+    )).scalar()
+    if is_hypertable:
+        op.execute(
+            "SELECT decompress_chunk(format('%I.%I', chunk_schema, chunk_name)::regclass, true) "
+            "FROM timescaledb_information.chunks "
+            "WHERE hypertable_name = 'access_logs' AND is_compressed"
+        )
+    op.execute("UPDATE access_logs SET request_time = 0.0 WHERE request_time IS NULL")

--- a/resources/components/access-logs/access-log-detail-sheet.tsx
+++ b/resources/components/access-logs/access-log-detail-sheet.tsx
@@ -8,6 +8,7 @@ import { IpBanControls } from "@/components/crowdsec/ip-ban-controls"
 import { Badge } from "@/components/ui/badge"
 import { formatBytes, formatDuration, type AccessLog } from "@/lib/api"
 import { statusBadgeClass } from "@/lib/status-badge"
+import { formatDurationOrNa } from "@/lib/timing"
 import { cn } from "@/lib/utils"
 
 export function AccessLogDetailSheet({
@@ -52,7 +53,7 @@ export function AccessLogDetailSheet({
           <DetailField label="Remote user" value={entry.remoteUser} mono />
           <DetailField label="HTTP version" value={entry.httpVersion} mono />
           <DetailField label="Bytes sent" value={formatBytes(entry.bytesSent)} />
-          <DetailField label="Request time" value={formatDuration(entry.requestTime * 1000)} />
+          <DetailField label="Request time" value={formatDurationOrNa(entry.requestTime)} />
           <DetailField
             label="Upstream response"
             value={entry.upstreamResponseTime != null ? formatDuration(entry.upstreamResponseTime * 1000) : null}

--- a/resources/components/access-logs/access-logs-table.tsx
+++ b/resources/components/access-logs/access-logs-table.tsx
@@ -46,6 +46,7 @@ import { cn } from "@/lib/utils"
 import { useColumnVisibility } from "@/lib/column-visibility"
 import { useAccessLogFilters } from "@/lib/access-log-filters-context"
 import { statusBadgeClass } from "@/lib/status-badge"
+import { formatDurationOrNa } from "@/lib/timing"
 
 export const ACCESS_LOGS_PAGE_SIZES = [10, 20, 50, 100, 200, 500, 1000] as const
 
@@ -82,7 +83,7 @@ function renderCell(column: AccessLogColumn, r: AccessLog): React.ReactNode {
     case "bytesSent":
       return <span className="tabular-nums">{formatBytes(r.bytesSent)}</span>
     case "requestTime":
-      return <span className="tabular-nums">{formatDuration(r.requestTime * 1000)}</span>
+      return <span className="tabular-nums">{formatDurationOrNa(r.requestTime)}</span>
     case "remoteUser":
       return <span className="font-mono">{r.remoteUser ?? "-"}</span>
     case "httpVersion":

--- a/resources/components/access-logs/live-tail.tsx
+++ b/resources/components/access-logs/live-tail.tsx
@@ -11,8 +11,9 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { useLiveEvents } from "@/lib/live-feed-context"
-import { formatBytes, formatDuration } from "@/lib/api"
+import { formatBytes } from "@/lib/api"
 import { statusBadgeClass } from "@/lib/status-badge"
+import { formatDurationOrNa } from "@/lib/timing"
 import { cn } from "@/lib/utils"
 import type { AccessLogData } from "@/lib/websocket"
 
@@ -154,7 +155,7 @@ export function LiveTail({ enabled }: { enabled: boolean }) {
                   <span className="w-32 shrink-0 text-muted-foreground">{row.ip_address}</span>
                   <span className="hidden w-16 shrink-0 truncate text-muted-foreground md:block">{row.remote_user ?? "-"}</span>
                   <span className="w-16 shrink-0 text-right tabular-nums">{formatBytes(row.bytes_sent)}</span>
-                  <span className="w-16 shrink-0 text-right tabular-nums">{formatDuration(row.request_time * 1000)}</span>
+                  <span className="w-16 shrink-0 text-right tabular-nums">{formatDurationOrNa(row.request_time)}</span>
                   <span className="hidden w-16 shrink-0 text-muted-foreground md:block">{row.http_version ?? "-"}</span>
                   <span className="w-16 shrink-0 truncate" title={row.country_code ?? undefined}>
                     {row.country_name ?? row.country_code ?? "-"}

--- a/resources/components/analytics/latency-chart.tsx
+++ b/resources/components/analytics/latency-chart.tsx
@@ -17,8 +17,9 @@ export function LatencyChart() {
   const { data, error, isLoading, isError, refetch } = useTimeSeries()
   const points = data?.data ?? []
   const hasTimings = points.some((d) => d.timedRequests > 0)
-  const clipMax = clampedYMax(points.flatMap((d) => SERIES.map((key) => d[key] ?? 0)))
-  const state = dataState(isLoading, isError, hasTimings ? points.length : 0)
+  const noTimings = points.length > 0 && !hasTimings
+  const clipMax = clampedYMax(points.flatMap((d) => SERIES.map((key) => d[key])))
+  const state = dataState(isLoading, isError, noTimings ? 0 : points.length)
 
   return (
     <SignalPanel
@@ -26,7 +27,7 @@ export function LatencyChart() {
       description="Average and percentile response time in the selected range."
       state={state}
       error={error?.message ?? "Failed to load request latency."}
-      empty={`No timing data in this range. ${TIMING_HINT}`}
+      empty={noTimings ? `No timing data in this range. ${TIMING_HINT}` : undefined}
       onRetry={() => void refetch()}
       bodyClassName="min-h-[240px]"
       actions={

--- a/resources/components/analytics/latency-chart.tsx
+++ b/resources/components/analytics/latency-chart.tsx
@@ -2,10 +2,10 @@ import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts"
 import { SignalPanel } from "@/components/data/signal-panel"
 import { dataState } from "@/components/data/types"
 import { ChartContainer, ChartTooltip } from "@/components/ui/chart"
-import { formatDuration } from "@/lib/api"
 import { clampedYMax } from "@/lib/chart-scale"
 import { formatTs } from "@/lib/datetime"
 import { useTimeSeries } from "@/lib/queries"
+import { formatDurationOrNa, TIMING_HINT } from "@/lib/timing"
 import { ChartLegendRow } from "./chart-legend-row"
 import { latencyChartConfig } from "./chart-utils"
 import { GranularityBadge } from "./granularity-badge"
@@ -16,8 +16,9 @@ const SERIES = Object.keys(latencyChartConfig) as (keyof typeof latencyChartConf
 export function LatencyChart() {
   const { data, error, isLoading, isError, refetch } = useTimeSeries()
   const points = data?.data ?? []
-  const clipMax = clampedYMax(points.flatMap((d) => SERIES.map((key) => d[key])))
-  const state = dataState(isLoading, isError, points.length)
+  const hasTimings = points.some((d) => d.timedRequests > 0)
+  const clipMax = clampedYMax(points.flatMap((d) => SERIES.map((key) => d[key] ?? 0)))
+  const state = dataState(isLoading, isError, hasTimings ? points.length : 0)
 
   return (
     <SignalPanel
@@ -25,11 +26,12 @@ export function LatencyChart() {
       description="Average and percentile response time in the selected range."
       state={state}
       error={error?.message ?? "Failed to load request latency."}
+      empty={`No timing data in this range. ${TIMING_HINT}`}
       onRetry={() => void refetch()}
       bodyClassName="min-h-[240px]"
       actions={
         <>
-          {clipMax != null && <span>y-axis clipped at {formatDuration(clipMax * 1000)}</span>}
+          {clipMax != null && <span>y-axis clipped at {formatDurationOrNa(clipMax)}</span>}
           <GranularityBadge granularity={data?.granularity} />
         </>
       }
@@ -49,8 +51,8 @@ export function LatencyChart() {
               tickLine={false}
               axisLine={false}
               width={56}
-              // request_time is seconds; formatDuration takes ms
-              tickFormatter={(v: number) => formatDuration(v * 1000)}
+              // request_time is seconds; formatDurationOrNa takes seconds
+              tickFormatter={(v: number) => formatDurationOrNa(v)}
               domain={clipMax != null ? [0, clipMax] : undefined}
               allowDataOverflow={clipMax != null}
             />
@@ -63,7 +65,9 @@ export function LatencyChart() {
                       <span className="text-muted-foreground">
                         {latencyChartConfig[name as keyof typeof latencyChartConfig]?.label ?? name}
                       </span>
-                      <span className="font-mono tabular-nums">{formatDuration(Number(value) * 1000)}</span>
+                      <span className="font-mono tabular-nums">
+                        {formatDurationOrNa(value == null ? null : Number(value))}
+                      </span>
                     </span>
                   )}
                 />
@@ -77,6 +81,7 @@ export function LatencyChart() {
                 stroke={`var(--color-${key})`}
                 strokeWidth={2}
                 dot={false}
+                connectNulls={false}
               />
             ))}
           </LineChart>

--- a/resources/components/analytics/top-urls-table.tsx
+++ b/resources/components/analytics/top-urls-table.tsx
@@ -8,8 +8,9 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { Skeleton } from "@/components/ui/skeleton"
-import { formatBytes, formatDuration, formatNumber } from "@/lib/api"
+import { formatBytes, formatNumber } from "@/lib/api"
 import { useTopUrls } from "@/lib/queries"
+import { formatDurationOrNa } from "@/lib/timing"
 import { TablePaginationFooter, usePagedRows } from "./table-pagination"
 
 export function TopUrlsTable() {
@@ -43,7 +44,7 @@ export function TopUrlsTable() {
                     <TableCell className="text-right tabular-nums">{formatNumber(row.hits)}</TableCell>
                     <TableCell className="text-right tabular-nums">{formatNumber(row.errorHits)}</TableCell>
                     <TableCell className="text-right tabular-nums">{formatBytes(row.totalBytes)}</TableCell>
-                    <TableCell className="text-right tabular-nums">{formatDuration(row.avgRequestTime * 1000)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{formatDurationOrNa(row.avgRequestTime)}</TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/resources/components/dashboard/summary-sections.tsx
+++ b/resources/components/dashboard/summary-sections.tsx
@@ -23,12 +23,8 @@ import {
 
 import { StatCard, StatCardSkeleton } from "@/components/dashboard/statcard"
 import { SectionHeader } from "@/components/section-header"
-import {
-  formatNumber,
-  formatBytes,
-  formatDuration,
-  type SummaryResponse,
-} from "@/lib/api"
+import { formatNumber, formatBytes, type SummaryResponse } from "@/lib/api"
+import { formatDurationOrNa, timingCoverage, TIMING_HINT } from "@/lib/timing"
 import { cn } from "@/lib/utils"
 
 interface SectionProps {
@@ -186,9 +182,16 @@ export function HttpStatusSection({ summary, isLoading, rangeLabel }: SectionPro
   )
 }
 
+function timingSubtitle(coverage: ReturnType<typeof timingCoverage>, whenFull: string): string {
+  if (coverage.state === "none") return TIMING_HINT
+  if (coverage.state === "partial") return `From ${coverage.percent}% of requests`
+  return whenFull
+}
+
 export function PerformanceSection({ summary, isLoading, rangeLabel }: SectionProps) {
   const cur = summary?.currentPeriod
   const chg = summary?.percentChanges
+  const coverage = cur ? timingCoverage(cur.timedRequests, cur.totalRequests) : timingCoverage(0, 0)
   return (
     <Section
       title="Performance & Bandwidth"
@@ -200,21 +203,20 @@ export function PerformanceSection({ summary, isLoading, rangeLabel }: SectionPr
         <>
           <StatCard
             title="Avg Request Time"
-            value={formatDuration(cur.avgRequestTime)}
-            subtitle={
-              chg?.avgRequestTime != null ? `vs last ${rangeLabel}` : "Response time"
-            }
+            value={formatDurationOrNa(cur.avgRequestTime)}
+            subtitle={timingSubtitle(coverage, chg?.avgRequestTime != null ? `vs last ${rangeLabel}` : "Response time")}
             icon={Clock}
             iconClassName="text-primary/70"
-            trend={{
-              value: chg?.avgRequestTime ?? null,
-              positive: (chg?.avgRequestTime ?? 0) <= 0,
-            }}
+            trend={
+              coverage.state === "none"
+                ? undefined
+                : { value: chg?.avgRequestTime ?? null, positive: (chg?.avgRequestTime ?? 0) <= 0 }
+            }
           />
           <StatCard
             title="Max Request Time"
-            value={formatDuration(cur.maxRequestTime)}
-            subtitle="Peak latency"
+            value={formatDurationOrNa(cur.maxRequestTime)}
+            subtitle={timingSubtitle(coverage, "Peak latency")}
             icon={Zap}
             iconClassName="text-amber-500/70"
             valueClassName="text-amber-500"

--- a/resources/components/dashboard/summary-sections.tsx
+++ b/resources/components/dashboard/summary-sections.tsx
@@ -183,6 +183,7 @@ export function HttpStatusSection({ summary, isLoading, rangeLabel }: SectionPro
 }
 
 function timingSubtitle(coverage: ReturnType<typeof timingCoverage>, whenFull: string): string {
+  if (coverage.state === "empty") return "No requests in this range"
   if (coverage.state === "none") return TIMING_HINT
   if (coverage.state === "partial") return `From ${coverage.percent}% of requests`
   return whenFull
@@ -208,7 +209,7 @@ export function PerformanceSection({ summary, isLoading, rangeLabel }: SectionPr
             icon={Clock}
             iconClassName="text-primary/70"
             trend={
-              coverage.state === "none"
+              coverage.state === "empty" || coverage.state === "none"
                 ? undefined
                 : { value: chg?.avgRequestTime ?? null, positive: (chg?.avgRequestTime ?? 0) <= 0 }
             }

--- a/resources/components/data/signal-panel.tsx
+++ b/resources/components/data/signal-panel.tsx
@@ -20,6 +20,7 @@ export function SignalPanel({
   actions,
   legend,
   error = "The chart data could not be loaded.",
+  empty = "No data for this range.",
   onRetry,
   bodyClassName = "min-h-64",
   children,
@@ -32,6 +33,7 @@ export function SignalPanel({
   actions?: React.ReactNode
   legend?: React.ReactNode
   error?: string
+  empty?: string
   onRetry?: () => void
   bodyClassName?: string
 }) {
@@ -69,7 +71,7 @@ export function SignalPanel({
         )}
         {state === "empty" && (
           <div className="flex h-full min-h-[inherit] items-center justify-center text-center text-sm text-muted-foreground">
-            No data for this range.
+            {empty}
           </div>
         )}
         {state === "ready" && children}

--- a/resources/components/map/LiveRequestPopup.tsx
+++ b/resources/components/map/LiveRequestPopup.tsx
@@ -9,8 +9,9 @@
  * sheet) opened it.
  */
 import { Popup } from "react-map-gl/maplibre"
-import { formatBytes, formatDuration } from "@/lib/api"
+import { formatBytes } from "@/lib/api"
 import { PACKET_COLORS } from "@/lib/live-traffic/classify"
+import { formatDurationOrNa } from "@/lib/timing"
 import { IpBanControls } from "./IpBanControls"
 import type { LiveRequest } from "@/lib/live-traffic/types"
 
@@ -102,7 +103,7 @@ function LiveRequestDetail({
       {!request.coordinates && <Row label="Geo" value="No GeoIP match" />}
       {log && <Row label="Host" value={log.host ?? "-"} />}
       {log && <Row label="Bytes" value={formatBytes(log.bytes_sent)} />}
-      {log && <Row label="Time" value={formatDuration(log.request_time * 1000)} />}
+      {log && <Row label="Time" value={formatDurationOrNa(log.request_time)} />}
       {log?.referrer && <Row label="Referrer" value={log.referrer} />}
       {log?.user_agent && <Row label="Agent" value={log.user_agent} />}
 

--- a/resources/generated/api/schemas.gen.ts
+++ b/resources/generated/api/schemas.gen.ts
@@ -1949,8 +1949,14 @@ export const ListAccessLogsAccessLogResponseBodySchema = {
       type: "string",
     },
     requestTime: {
-      default: 0,
-      type: "number",
+      oneOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     statusCode: {
       type: "integer",
@@ -2532,7 +2538,14 @@ export const PeriodSummarySchema = {
       type: "number",
     },
     avgRequestTime: {
-      type: "number",
+      oneOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     errorRate: {
       type: "number",
@@ -2541,7 +2554,14 @@ export const PeriodSummarySchema = {
       type: "integer",
     },
     maxRequestTime: {
-      type: "number",
+      oneOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     status2xx: {
       type: "integer",
@@ -2553,6 +2573,9 @@ export const PeriodSummarySchema = {
       type: "integer",
     },
     status5xx: {
+      type: "integer",
+    },
+    timedRequests: {
       type: "integer",
     },
     totalBytesSent: {
@@ -2581,6 +2604,7 @@ export const PeriodSummarySchema = {
     "status3xx",
     "status4xx",
     "status5xx",
+    "timedRequests",
     "totalBytesSent",
     "totalGeoEvents",
     "totalRequests",
@@ -3019,19 +3043,47 @@ export const SystemSettingsResponseSchema = {
 export const TimeSeriesDataPointSchema = {
   properties: {
     avgRequestTime: {
-      type: "number",
+      oneOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     errorRate: {
       type: "number",
     },
     p50RequestTime: {
-      type: "number",
+      oneOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     p95RequestTime: {
-      type: "number",
+      oneOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     p99RequestTime: {
-      type: "number",
+      oneOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     status2xx: {
       type: "integer",
@@ -3043,6 +3095,9 @@ export const TimeSeriesDataPointSchema = {
       type: "integer",
     },
     status5xx: {
+      type: "integer",
+    },
+    timedRequests: {
       type: "integer",
     },
     timestamp: {
@@ -3068,6 +3123,7 @@ export const TimeSeriesDataPointSchema = {
     "status3xx",
     "status4xx",
     "status5xx",
+    "timedRequests",
     "timestamp",
     "totalBytesSent",
     "totalGeoEvents",
@@ -3526,12 +3582,22 @@ export const TopIpsResponseSchema = {
 export const TopUrlDTOSchema = {
   properties: {
     avgRequestTime: {
-      type: "number",
+      oneOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
     },
     errorHits: {
       type: "integer",
     },
     hits: {
+      type: "integer",
+    },
+    timedHits: {
       type: "integer",
     },
     totalBytes: {
@@ -3541,7 +3607,14 @@ export const TopUrlDTOSchema = {
       type: "string",
     },
   },
-  required: ["avgRequestTime", "errorHits", "hits", "totalBytes", "url"],
+  required: [
+    "avgRequestTime",
+    "errorHits",
+    "hits",
+    "timedHits",
+    "totalBytes",
+    "url",
+  ],
   title: "TopUrlDTO",
   type: "object",
 } as const;

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -569,7 +569,7 @@ export type ListAccessLogsAccessLogResponseBody = {
   method?: string | null;
   referrer?: string | null;
   remoteUser?: string;
-  requestTime?: number;
+  requestTime?: number | null;
   statusCode: number;
   timestamp: string;
   upstreamResponseTime?: number | null;
@@ -744,14 +744,15 @@ export type PercentChange = {
  */
 export type PeriodSummary = {
   avgBytesPerRequest: number;
-  avgRequestTime: number;
+  avgRequestTime: number | null;
   errorRate: number;
   malformedRequests: number;
-  maxRequestTime: number;
+  maxRequestTime: number | null;
   status2xx: number;
   status3xx: number;
   status4xx: number;
   status5xx: number;
+  timedRequests: number;
   totalBytesSent: number;
   totalGeoEvents: number;
   totalRequests: number;
@@ -902,15 +903,16 @@ export type SystemSettingsResponse = {
  * TimeSeriesDataPoint
  */
 export type TimeSeriesDataPoint = {
-  avgRequestTime: number;
+  avgRequestTime: number | null;
   errorRate: number;
-  p50RequestTime: number;
-  p95RequestTime: number;
-  p99RequestTime: number;
+  p50RequestTime: number | null;
+  p95RequestTime: number | null;
+  p99RequestTime: number | null;
   status2xx: number;
   status3xx: number;
   status4xx: number;
   status5xx: number;
+  timedRequests: number;
   timestamp: string;
   totalBytesSent: number;
   totalGeoEvents: number;
@@ -1089,9 +1091,10 @@ export type TopIpsResponse = {
  * TopUrlDTO
  */
 export type TopUrlDto = {
-  avgRequestTime: number;
+  avgRequestTime: number | null;
   errorHits: number;
   hits: number;
+  timedHits: number;
   totalBytes: number;
   url: string;
 };

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -2062,8 +2062,14 @@
             "type": "string"
           },
           "requestTime": {
-            "default": 0.0,
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "statusCode": {
             "type": "integer"
@@ -2682,7 +2688,14 @@
             "type": "number"
           },
           "avgRequestTime": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "errorRate": {
             "type": "number"
@@ -2691,7 +2704,14 @@
             "type": "integer"
           },
           "maxRequestTime": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "status2xx": {
             "type": "integer"
@@ -2703,6 +2723,9 @@
             "type": "integer"
           },
           "status5xx": {
+            "type": "integer"
+          },
+          "timedRequests": {
             "type": "integer"
           },
           "totalBytesSent": {
@@ -2731,6 +2754,7 @@
           "status3xx",
           "status4xx",
           "status5xx",
+          "timedRequests",
           "totalBytesSent",
           "totalGeoEvents",
           "totalRequests",
@@ -3205,19 +3229,47 @@
       "TimeSeriesDataPoint": {
         "properties": {
           "avgRequestTime": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "errorRate": {
             "type": "number"
           },
           "p50RequestTime": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "p95RequestTime": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "p99RequestTime": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "status2xx": {
             "type": "integer"
@@ -3229,6 +3281,9 @@
             "type": "integer"
           },
           "status5xx": {
+            "type": "integer"
+          },
+          "timedRequests": {
             "type": "integer"
           },
           "timestamp": {
@@ -3254,6 +3309,7 @@
           "status3xx",
           "status4xx",
           "status5xx",
+          "timedRequests",
           "timestamp",
           "totalBytesSent",
           "totalGeoEvents",
@@ -3757,12 +3813,22 @@
       "TopUrlDTO": {
         "properties": {
           "avgRequestTime": {
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "errorHits": {
             "type": "integer"
           },
           "hits": {
+            "type": "integer"
+          },
+          "timedHits": {
             "type": "integer"
           },
           "totalBytes": {
@@ -3776,6 +3842,7 @@
           "avgRequestTime",
           "errorHits",
           "hits",
+          "timedHits",
           "totalBytes",
           "url"
         ],

--- a/resources/lib/api.ts
+++ b/resources/lib/api.ts
@@ -150,6 +150,7 @@ export type RuntimeSettings = SafeSettingsResponse
 
 export interface PeriodSummary {
   totalRequests: number
+  timedRequests: number
   totalGeoEvents: number
   uniqueIps: number
   uniqueCountries: number
@@ -159,8 +160,8 @@ export interface PeriodSummary {
   status3xx: number
   status4xx: number
   status5xx: number
-  avgRequestTime: number
-  maxRequestTime: number
+  avgRequestTime: number | null
+  maxRequestTime: number | null
   malformedRequests: number
   errorRate: number
 }
@@ -897,7 +898,7 @@ export interface AccessLog {
   bytesSent: number
   referrer: string | null
   userAgent: string | null
-  requestTime: number
+  requestTime: number | null
   upstreamResponseTime: number | null
   host: string | null
   hostname: string | null

--- a/resources/lib/timing.test.ts
+++ b/resources/lib/timing.test.ts
@@ -16,9 +16,12 @@ describe("formatDurationOrNa", () => {
 })
 
 describe("timingCoverage", () => {
-  it("is none when nothing was measured, including an empty range", () => {
+  it("is empty when the range has no requests at all", () => {
+    expect(timingCoverage(0, 0)).toEqual({ state: "empty", percent: 0 })
+  })
+
+  it("is none when requests exist but none was measured", () => {
     expect(timingCoverage(0, 10)).toEqual({ state: "none", percent: 0 })
-    expect(timingCoverage(0, 0)).toEqual({ state: "none", percent: 0 })
   })
 
   it("is partial with an integer percent", () => {

--- a/resources/lib/timing.test.ts
+++ b/resources/lib/timing.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { formatDurationOrNa, timingCoverage } from "./timing"
+
+describe("formatDurationOrNa", () => {
+  it("renders n/a for a missing measurement", () => {
+    expect(formatDurationOrNa(null)).toBe("n/a")
+    expect(formatDurationOrNa(undefined)).toBe("n/a")
+  })
+
+  it("takes seconds and formats like formatDuration in milliseconds", () => {
+    expect(formatDurationOrNa(0.0004)).toBe("400μs")
+    expect(formatDurationOrNa(0.04)).toBe("40ms")
+    expect(formatDurationOrNa(5.67)).toBe("5.67s")
+    expect(formatDurationOrNa(0)).toBe("0μs")
+  })
+})
+
+describe("timingCoverage", () => {
+  it("is none when nothing was measured, including an empty range", () => {
+    expect(timingCoverage(0, 10)).toEqual({ state: "none", percent: 0 })
+    expect(timingCoverage(0, 0)).toEqual({ state: "none", percent: 0 })
+  })
+
+  it("is partial with an integer percent", () => {
+    expect(timingCoverage(63, 100)).toEqual({ state: "partial", percent: 63 })
+    expect(timingCoverage(1, 3)).toEqual({ state: "partial", percent: 33 })
+  })
+
+  it("is full when every request was measured", () => {
+    expect(timingCoverage(10, 10)).toEqual({ state: "full", percent: 100 })
+  })
+})

--- a/resources/lib/timing.ts
+++ b/resources/lib/timing.ts
@@ -1,0 +1,19 @@
+import { formatDuration } from "@/lib/api"
+
+/** One sentence, reused wherever a timing is missing. */
+export const TIMING_HINT = "No timing field in the log format."
+
+/** Timings arrive in seconds; formatDuration takes milliseconds. */
+export function formatDurationOrNa(seconds: number | null | undefined): string {
+  if (seconds == null) return "n/a"
+  return formatDuration(seconds * 1000)
+}
+
+export type TimingCoverage = { state: "none" | "partial" | "full"; percent: number }
+
+/** How much of a range's requests carried a timing. */
+export function timingCoverage(timed: number, total: number): TimingCoverage {
+  if (timed <= 0 || total <= 0) return { state: "none", percent: 0 }
+  if (timed >= total) return { state: "full", percent: 100 }
+  return { state: "partial", percent: Math.round((timed / total) * 100) }
+}

--- a/resources/lib/timing.ts
+++ b/resources/lib/timing.ts
@@ -9,11 +9,13 @@ export function formatDurationOrNa(seconds: number | null | undefined): string {
   return formatDuration(seconds * 1000)
 }
 
-export type TimingCoverage = { state: "none" | "partial" | "full"; percent: number }
+export type TimingCoverage = { state: "empty" | "none" | "partial" | "full"; percent: number }
 
-/** How much of a range's requests carried a timing. */
+/** How much of a range's requests carried a timing. "empty" is a range with
+ * no requests at all, which says nothing about the log format. */
 export function timingCoverage(timed: number, total: number): TimingCoverage {
-  if (timed <= 0 || total <= 0) return { state: "none", percent: 0 }
+  if (total <= 0) return { state: "empty", percent: 0 }
+  if (timed <= 0) return { state: "none", percent: 0 }
   if (timed >= total) return { state: "full", percent: 100 }
   return { state: "partial", percent: Math.round((timed / total) * 100) }
 }

--- a/resources/lib/websocket.ts
+++ b/resources/lib/websocket.ts
@@ -25,7 +25,7 @@ export interface AccessLogData {
   bytes_sent: number
   referrer: string | null
   user_agent: string | null
-  request_time: number
+  request_time: number | null
   upstream_response_time: number | null
   host: string | null
   country_code: string | null

--- a/tests/integration/test_analytics_endpoints.py
+++ b/tests/integration/test_analytics_endpoints.py
@@ -54,6 +54,7 @@ async def test_top_urls_ordering_and_math(pg_session_maker, clean_tables):
     assert busy.hits == 6
     assert busy.error_hits == 1
     assert busy.total_bytes == 6 * 200
+    assert busy.avg_request_time is not None
     assert 0.005 < busy.avg_request_time < 0.02
 
 
@@ -418,3 +419,74 @@ async def test_iter_null_asn_ips_pages_without_gaps_or_repeats(pg_engine, pg_ses
     seen = [ip for page in pages for ip in page]
     assert sorted(seen) == sorted(ips)
     assert len(seen) == len(set(seen))
+
+
+async def test_summary_without_timed_rows_reports_none(pg_session_maker, clean_tables):
+    from datetime import datetime, timedelta, timezone
+
+    from geometrikks.domain.analytics.repositories import LiveStatsRepository
+
+    now = datetime.now(timezone.utc)
+    async with pg_session_maker() as session:
+        for _ in range(3):
+            await session.execute(text(
+                "INSERT INTO access_logs (timestamp, ip_address, method, url, status_code, bytes_sent, request_time) "
+                "VALUES (:ts, '10.0.0.1', 'GET', '/x', 200, 100, NULL)"
+            ), {"ts": now - timedelta(minutes=5)})
+        await session.commit()
+        stats = await LiveStatsRepository(session).get_summary(now - timedelta(hours=1), now)
+    assert stats is not None
+    assert stats.total_log_records == 3
+    assert stats.timed_requests == 0
+    assert stats.avg_request_time is None
+    assert stats.max_request_time is None
+    assert stats.p95_request_time is None
+
+
+async def test_summary_mixed_rows_average_only_the_timed_ones(pg_session_maker, clean_tables):
+    from datetime import datetime, timedelta, timezone
+
+    from geometrikks.domain.analytics.repositories import LiveStatsRepository
+
+    now = datetime.now(timezone.utc)
+    async with pg_session_maker() as session:
+        for rt in (0.2, 0.4, None, None):
+            await session.execute(text(
+                "INSERT INTO access_logs (timestamp, ip_address, method, url, status_code, bytes_sent, request_time) "
+                "VALUES (:ts, '10.0.0.1', 'GET', '/x', 200, 100, :rt)"
+            ), {"ts": now - timedelta(minutes=5), "rt": rt})
+        await session.commit()
+        stats = await LiveStatsRepository(session).get_summary(now - timedelta(hours=1), now)
+        urls = await LiveStatsRepository(session).get_top_urls(now - timedelta(hours=1), now)
+    assert stats is not None
+    assert stats.timed_requests == 2
+    assert stats.avg_request_time == pytest.approx(0.3)
+    assert urls[0].hits == 4
+    assert urls[0].timed_hits == 2
+    assert urls[0].avg_request_time == pytest.approx(0.3)
+
+
+async def test_cagg_time_series_carries_timed_requests(pg_engine, pg_session_maker, clean_tables):
+    from datetime import datetime, timedelta, timezone
+
+    from geometrikks.domain.analytics.repositories import StatsGranularity, SummaryStatsRepository
+    from geometrikks.server.timescale import refresh_caggs_range
+
+    now = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    ts = now - timedelta(hours=2)
+    async with pg_session_maker() as session:
+        for rt in (0.1, None):
+            await session.execute(text(
+                "INSERT INTO access_logs (timestamp, ip_address, method, url, status_code, bytes_sent, request_time) "
+                "VALUES (:ts, '10.0.0.1', 'GET', '/x', 200, 100, :rt)"
+            ), {"ts": ts, "rt": rt})
+        await session.commit()
+    await refresh_caggs_range(pg_engine, start=now - timedelta(days=1), end=now + timedelta(hours=1), caggs=["summary_hourly_stats"])
+    async with pg_session_maker() as session:
+        rows = await SummaryStatsRepository(session).get_time_series(
+            now - timedelta(days=1), now, granularity=StatsGranularity.HOURLY
+        )
+    row = next(r for r in rows if r.bucket == ts)
+    assert row.total_requests == 2
+    assert row.timed_requests == 1
+    assert row.avg_request_time == pytest.approx(0.1)

--- a/tests/integration/test_local_day_buckets_pg.py
+++ b/tests/integration/test_local_day_buckets_pg.py
@@ -106,6 +106,7 @@ class TestSummaryTimeSeries:
         assert row.total_bytes == 200
         # Weighted mean of the two in-window hourly buckets (0.01 and 0.03).
         assert row.avg_request_time == pytest.approx(0.02, rel=0.01)
+        assert row.p50_request_time is not None
         assert 0.005 < row.p50_request_time < 0.035
 
     async def test_daily_buckets_stay_utc_without_tz(self, pg_engine, pg_session_maker, clean_tables):

--- a/tests/integration/test_nullable_request_time_pg.py
+++ b/tests/integration/test_nullable_request_time_pg.py
@@ -1,0 +1,34 @@
+"""access_logs.request_time accepts NULL after the nullable-timings revision."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import text
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_request_time_column_is_nullable_without_default(pg_engine) -> None:
+    async with pg_engine.connect() as conn:
+        row = (await conn.execute(text("""
+            SELECT is_nullable, column_default FROM information_schema.columns
+            WHERE table_name = 'access_logs' AND column_name = 'request_time'
+        """))).one()
+    assert row.is_nullable == "YES"
+    assert row.column_default is None
+
+
+async def test_insert_without_request_time_stores_null(pg_session_maker, clean_tables) -> None:
+    ts = datetime.now(timezone.utc)
+    async with pg_session_maker() as session:
+        await session.execute(text(
+            "INSERT INTO access_logs (timestamp, ip_address, method, url, status_code, bytes_sent) "
+            "VALUES (:ts, '10.0.0.1', 'GET', '/x', 200, 100)"
+        ), {"ts": ts})
+        await session.commit()
+        stored = (await session.execute(text(
+            "SELECT request_time FROM access_logs WHERE ip_address = '10.0.0.1'"
+        ))).scalar_one()
+    assert stored is None

--- a/tests/integration/test_percentile_caggs.py
+++ b/tests/integration/test_percentile_caggs.py
@@ -82,9 +82,10 @@ async def test_repo_summary_and_time_series_percentiles(pg_engine, pg_session_ma
         stats = await repo.get_summary(NOW - timedelta(days=3, hours=3), NOW)  # >24h -> CAGG path
         series = await repo.get_time_series(NOW - timedelta(days=3, hours=3), NOW)
 
-    assert stats is not None and 0.005 < stats.p50_request_time < 0.02
+    assert stats is not None and stats.p50_request_time is not None
+    assert 0.005 < stats.p50_request_time < 0.02
     assert len(series) >= 3
-    assert all(p.p50_request_time >= 0 for p in series)
+    assert all(p.p50_request_time is not None and p.p50_request_time >= 0 for p in series)
 
 
 async def test_old_shape_summary_caggs_are_upgraded(pg_engine):

--- a/tests/integration/test_timed_count_columns_pg.py
+++ b/tests/integration/test_timed_count_columns_pg.py
@@ -1,0 +1,122 @@
+"""Summary and URL CAGGs carry a timed-row count; old-shape views upgrade in place."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import text
+
+import pytest
+
+from geometrikks.config.settings import get_settings
+from geometrikks.server import timescale
+from geometrikks.server.timescale import refresh_caggs_range, setup_timescaledb
+
+pytestmark = pytest.mark.anyio
+
+NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+
+OLD_SUMMARY_HOURLY = """
+    CREATE MATERIALIZED VIEW summary_hourly_stats
+    WITH (timescaledb.continuous) AS
+    SELECT
+        time_bucket('1 hour', timestamp) AS bucket,
+        COUNT(*) AS total_requests,
+        COALESCE(SUM(bytes_sent), 0) AS total_bytes,
+        COUNT(*) FILTER (WHERE status_code >= 200 AND status_code < 300) AS status_2xx,
+        COUNT(*) FILTER (WHERE status_code >= 300 AND status_code < 400) AS status_3xx,
+        COUNT(*) FILTER (WHERE status_code >= 400 AND status_code < 500) AS status_4xx,
+        COUNT(*) FILTER (WHERE status_code >= 500 AND status_code < 600) AS status_5xx,
+        AVG(request_time) AS avg_request_time,
+        MAX(request_time) AS max_request_time,
+        percentile_agg(request_time) AS pct_agg
+    FROM access_logs
+    GROUP BY bucket
+    WITH NO DATA
+"""
+
+
+async def _seed(session_maker) -> None:
+    """Two hours: the older one has 3 timed + 2 untimed rows, the newer 4 untimed."""
+    async with session_maker() as session:
+        older = NOW - timedelta(hours=3)
+        newer = NOW - timedelta(hours=2)
+        for rt in (0.01, 0.02, 0.03, None, None):
+            await session.execute(text(
+                "INSERT INTO access_logs (timestamp, ip_address, method, url, status_code, bytes_sent, request_time) "
+                "VALUES (:ts, '10.0.0.1', 'GET', '/x', 200, 100, :rt)"
+            ), {"ts": older, "rt": rt})
+        for _ in range(4):
+            await session.execute(text(
+                "INSERT INTO access_logs (timestamp, ip_address, method, url, status_code, bytes_sent, request_time) "
+                "VALUES (:ts, '10.0.0.2', 'GET', '/y', 200, 100, NULL)"
+            ), {"ts": newer})
+        await session.commit()
+
+
+async def test_fresh_views_have_the_count_columns(pg_engine) -> None:
+    async with pg_engine.connect() as conn:
+        rows = await conn.execute(text("""
+            SELECT table_name, column_name FROM information_schema.columns
+            WHERE table_name IN ('summary_hourly_stats', 'summary_daily_stats', 'url_hourly_stats', 'url_daily_stats')
+        """))
+        cols = {(r.table_name, r.column_name) for r in rows}
+    for view, column in timescale.TIMED_COUNT_COLUMNS.items():
+        assert (view, column) in cols
+
+
+async def test_counts_follow_the_timed_rows(pg_engine, pg_session_maker, clean_tables) -> None:
+    await _seed(pg_session_maker)
+    await refresh_caggs_range(
+        pg_engine, start=NOW - timedelta(days=1), end=NOW + timedelta(hours=1),
+        caggs=["summary_hourly_stats", "url_hourly_stats"],
+    )
+    async with pg_engine.connect() as conn:
+        rows = (await conn.execute(text(
+            "SELECT bucket, total_requests, timed_requests, avg_request_time "
+            "FROM summary_hourly_stats WHERE bucket >= :s ORDER BY bucket"
+        ), {"s": NOW - timedelta(days=1)})).all()
+        url_rows = (await conn.execute(text(
+            "SELECT url, hits, timed_hits, total_request_time FROM url_hourly_stats WHERE bucket >= :s ORDER BY url"
+        ), {"s": NOW - timedelta(days=1)})).all()
+    assert [(r.total_requests, r.timed_requests) for r in rows] == [(5, 3), (4, 0)]
+    assert rows[0].avg_request_time == pytest.approx(0.02)
+    assert rows[1].avg_request_time is None
+    assert [(r.url, r.hits, r.timed_hits) for r in url_rows] == [("/x", 5, 3), ("/y", 4, 0)]
+    assert url_rows[1].total_request_time is None
+
+
+async def test_old_shape_summary_view_upgrades_in_place(pg_engine, pg_session_maker, clean_tables) -> None:
+    """Recreate the pre-count shape, populate it, compress the chunk, run setup.
+
+    The column must appear, old buckets must be counted, the raw chunk must
+    still be compressed, and a second setup must find nothing to upgrade.
+    """
+    await _seed(pg_session_maker)
+    async with pg_engine.begin() as conn:
+        await conn.execute(text("DROP MATERIALIZED VIEW IF EXISTS summary_hourly_stats CASCADE"))
+        await conn.execute(text(OLD_SUMMARY_HOURLY))
+    await refresh_caggs_range(
+        pg_engine, start=NOW - timedelta(days=1), end=NOW + timedelta(hours=1),
+        caggs=["summary_hourly_stats"],
+    )
+    async with pg_engine.begin() as conn:
+        await conn.execute(text(
+            "SELECT compress_chunk(c, true) FROM show_chunks('access_logs', newer_than => INTERVAL '2 days') c"
+        ))
+        needs = await timescale._timed_columns_need_upgrade(conn)
+    assert "summary_hourly_stats" in needs
+
+    await setup_timescaledb(pg_engine, get_settings().analytics)
+
+    async with pg_engine.connect() as conn:
+        rows = (await conn.execute(text(
+            "SELECT total_requests, timed_requests FROM summary_hourly_stats WHERE bucket >= :s ORDER BY bucket"
+        ), {"s": NOW - timedelta(days=1)})).all()
+        compressed = (await conn.execute(text(
+            "SELECT count(*) FILTER (WHERE is_compressed), count(*) FROM timescaledb_information.chunks "
+            "WHERE hypertable_name = 'access_logs'"
+        ))).one()
+        needs_after = await timescale._timed_columns_need_upgrade(conn)
+    assert [(r.total_requests, r.timed_requests) for r in rows] == [(5, 3), (4, 0)]
+    assert compressed[0] == compressed[1] and compressed[1] >= 1
+    assert "summary_hourly_stats" not in needs_after

--- a/tests/integration/test_timed_count_columns_pg.py
+++ b/tests/integration/test_timed_count_columns_pg.py
@@ -14,6 +14,7 @@ from geometrikks.server.timescale import refresh_caggs_range, setup_timescaledb
 pytestmark = pytest.mark.anyio
 
 NOW = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+RETENTION_DAYS = get_settings().analytics.raw_retention_days
 
 OLD_SUMMARY_HOURLY = """
     CREATE MATERIALIZED VIEW summary_hourly_stats
@@ -103,7 +104,9 @@ async def test_old_shape_summary_view_upgrades_in_place(pg_engine, pg_session_ma
         compressed_chunks = (await conn.execute(text(
             "SELECT compress_chunk(c, true) FROM show_chunks('access_logs', newer_than => INTERVAL '2 days') c"
         ))).scalars().all()
-        needs = await timescale._timed_columns_need_upgrade(conn)
+        needs = await timescale._timed_columns_need_upgrade(
+            conn, raw_retention_days=RETENTION_DAYS
+        )
     assert compressed_chunks
     assert "summary_hourly_stats" in needs
 
@@ -117,7 +120,151 @@ async def test_old_shape_summary_view_upgrades_in_place(pg_engine, pg_session_ma
             "SELECT count(*) FROM timescaledb_information.chunks "
             "WHERE is_compressed AND format('%I.%I', chunk_schema, chunk_name) = ANY(:names)"
         ), {"names": compressed_chunks})).scalar_one()
-        needs_after = await timescale._timed_columns_need_upgrade(conn)
+        needs_after = await timescale._timed_columns_need_upgrade(
+            conn, raw_retention_days=RETENTION_DAYS
+        )
     assert [(r.total_requests, r.timed_requests) for r in rows] == [(5, 3), (4, 0)]
     assert still_compressed == len(compressed_chunks)
     assert "summary_hourly_stats" not in needs_after
+
+
+async def _restore_view(pg_engine, view: str) -> None:
+    """Drop a view the test recreated and let setup rebuild it empty.
+
+    A test that refreshes its own window pushes the view's watermark past
+    now, which would hide a later test's rows from the real-time union. A
+    freshly created CAGG has no watermark, so the union covers everything
+    again.
+    """
+    async with pg_engine.begin() as conn:
+        await conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {view} CASCADE"))
+    await setup_timescaledb(pg_engine, get_settings().analytics)
+
+
+ADD_TIMED_REQUESTS = (
+    "ALTER MATERIALIZED VIEW summary_hourly_stats ADD COLUMN timed_requests bigint "
+    "GENERATED ALWAYS AS (COUNT(request_time)) STORED"
+)
+
+OLD_SUMMARY_DAILY = """
+    CREATE MATERIALIZED VIEW summary_daily_stats
+    WITH (timescaledb.continuous) AS
+    SELECT
+        time_bucket('1 day', timestamp) AS bucket,
+        COUNT(*) AS total_requests,
+        COALESCE(SUM(bytes_sent), 0) AS total_bytes,
+        COUNT(*) FILTER (WHERE status_code >= 200 AND status_code < 300) AS status_2xx,
+        COUNT(*) FILTER (WHERE status_code >= 300 AND status_code < 400) AS status_3xx,
+        COUNT(*) FILTER (WHERE status_code >= 400 AND status_code < 500) AS status_4xx,
+        COUNT(*) FILTER (WHERE status_code >= 500 AND status_code < 600) AS status_5xx,
+        AVG(request_time) AS avg_request_time,
+        MAX(request_time) AS max_request_time,
+        percentile_agg(request_time) AS pct_agg
+    FROM access_logs
+    GROUP BY bucket
+    WITH NO DATA
+"""
+
+
+async def _insert(session_maker, ts: datetime, request_time: float | None) -> None:
+    async with session_maker() as session:
+        await session.execute(text(
+            "INSERT INTO access_logs (timestamp, ip_address, method, url, status_code, bytes_sent, request_time) "
+            "VALUES (:ts, '10.0.0.3', 'GET', '/z', 200, 100, :rt)"
+        ), {"ts": ts, "rt": request_time})
+        await session.commit()
+
+
+async def test_present_column_with_null_counts_triggers_the_refresh_only(
+    pg_engine, pg_session_maker, clean_tables
+) -> None:
+    """A start killed mid-refresh leaves the column in place and history NULL.
+
+    The next start must not try to add the column again; it must refresh the
+    buckets that still carry no count.
+    """
+    await _seed(pg_session_maker)
+    async with pg_engine.begin() as conn:
+        await conn.execute(text("DROP MATERIALIZED VIEW IF EXISTS summary_hourly_stats CASCADE"))
+        await conn.execute(text(OLD_SUMMARY_HOURLY))
+    await refresh_caggs_range(
+        pg_engine, start=NOW - timedelta(days=1), end=NOW + timedelta(hours=1),
+        caggs=["summary_hourly_stats"],
+    )
+    async with pg_engine.begin() as conn:
+        await conn.execute(text(ADD_TIMED_REQUESTS))
+        needs = await timescale._timed_columns_need_upgrade(
+            conn, raw_retention_days=RETENTION_DAYS
+        )
+        uncounted = (await conn.execute(text(
+            "SELECT count(*) FROM summary_hourly_stats "
+            "WHERE bucket >= :s AND timed_requests IS NULL"
+        ), {"s": NOW - timedelta(days=1)})).scalar_one()
+    assert uncounted == 2
+    assert "summary_hourly_stats" in needs
+
+    await setup_timescaledb(pg_engine, get_settings().analytics)
+
+    async with pg_engine.connect() as conn:
+        rows = (await conn.execute(text(
+            "SELECT total_requests, timed_requests FROM summary_hourly_stats "
+            "WHERE bucket >= :s ORDER BY bucket"
+        ), {"s": NOW - timedelta(days=1)})).all()
+        needs_after = await timescale._timed_columns_need_upgrade(
+            conn, raw_retention_days=RETENTION_DAYS
+        )
+    assert [(r.total_requests, r.timed_requests) for r in rows] == [(5, 3), (4, 0)]
+    assert needs_after == []
+
+    await _restore_view(pg_engine, "summary_hourly_stats")
+
+
+async def test_buckets_beyond_the_raw_window_keep_their_pre_upgrade_figures(
+    pg_engine, pg_session_maker, clean_tables
+) -> None:
+    """Daily buckets whose raw rows are gone stay uncounted, and stay quiet.
+
+    They cannot be recounted, so the probe must ignore them (otherwise every
+    start reruns the full forced refresh) and the readers must fall back to
+    the bucket's total instead of reporting zero timed requests.
+    """
+    old_ts = NOW - timedelta(days=RETENTION_DAYS + 20)
+    recent_ts = NOW - timedelta(days=2)
+    await _insert(pg_session_maker, old_ts, 0.5)
+    await _insert(pg_session_maker, recent_ts, 0.25)
+    async with pg_engine.begin() as conn:
+        await conn.execute(text("DROP MATERIALIZED VIEW IF EXISTS summary_daily_stats CASCADE"))
+        await conn.execute(text(OLD_SUMMARY_DAILY))
+    await refresh_caggs_range(
+        pg_engine, start=old_ts - timedelta(days=1), end=NOW + timedelta(hours=1),
+        caggs=["summary_daily_stats"],
+    )
+    async with pg_engine.begin() as conn:
+        await conn.execute(text(
+            "SELECT drop_chunks('access_logs', older_than => make_interval(days => :days))"
+        ), {"days": RETENTION_DAYS + 10})
+
+    await setup_timescaledb(pg_engine, get_settings().analytics)
+
+    async with pg_engine.connect() as conn:
+        rows = (await conn.execute(text(
+            "SELECT bucket, total_requests, timed_requests FROM summary_daily_stats "
+            "WHERE bucket >= :s ORDER BY bucket"
+        ), {"s": old_ts - timedelta(days=1)})).all()
+        needs_after = await timescale._timed_columns_need_upgrade(
+            conn, raw_retention_days=RETENTION_DAYS
+        )
+    assert [(r.total_requests, r.timed_requests) for r in rows] == [(1, None), (1, 1)]
+    assert needs_after == [], "an unrecountable bucket must not reschedule the refresh"
+
+    from geometrikks.domain.analytics.repositories import SummaryStatsRepository
+
+    async with pg_session_maker() as session:
+        summary = await SummaryStatsRepository(session=session).get_summary(
+            old_ts - timedelta(days=1), NOW + timedelta(hours=1)
+        )
+    assert summary is not None
+    assert summary.total_log_records == 2
+    assert summary.timed_requests == 2, "the pre-upgrade bucket counts all its rows as timed"
+
+    await _restore_view(pg_engine, "summary_daily_stats")

--- a/tests/integration/test_timed_count_columns_pg.py
+++ b/tests/integration/test_timed_count_columns_pg.py
@@ -100,10 +100,11 @@ async def test_old_shape_summary_view_upgrades_in_place(pg_engine, pg_session_ma
         caggs=["summary_hourly_stats"],
     )
     async with pg_engine.begin() as conn:
-        await conn.execute(text(
+        compressed_chunks = (await conn.execute(text(
             "SELECT compress_chunk(c, true) FROM show_chunks('access_logs', newer_than => INTERVAL '2 days') c"
-        ))
+        ))).scalars().all()
         needs = await timescale._timed_columns_need_upgrade(conn)
+    assert compressed_chunks
     assert "summary_hourly_stats" in needs
 
     await setup_timescaledb(pg_engine, get_settings().analytics)
@@ -112,11 +113,11 @@ async def test_old_shape_summary_view_upgrades_in_place(pg_engine, pg_session_ma
         rows = (await conn.execute(text(
             "SELECT total_requests, timed_requests FROM summary_hourly_stats WHERE bucket >= :s ORDER BY bucket"
         ), {"s": NOW - timedelta(days=1)})).all()
-        compressed = (await conn.execute(text(
-            "SELECT count(*) FILTER (WHERE is_compressed), count(*) FROM timescaledb_information.chunks "
-            "WHERE hypertable_name = 'access_logs'"
-        ))).one()
+        still_compressed = (await conn.execute(text(
+            "SELECT count(*) FROM timescaledb_information.chunks "
+            "WHERE is_compressed AND format('%I.%I', chunk_schema, chunk_name) = ANY(:names)"
+        ), {"names": compressed_chunks})).scalar_one()
         needs_after = await timescale._timed_columns_need_upgrade(conn)
     assert [(r.total_requests, r.timed_requests) for r in rows] == [(5, 3), (4, 0)]
-    assert compressed[0] == compressed[1] and compressed[1] >= 1
+    assert still_compressed == len(compressed_chunks)
     assert "summary_hourly_stats" not in needs_after

--- a/tests/test_access_log_sorting.py
+++ b/tests/test_access_log_sorting.py
@@ -1,0 +1,30 @@
+"""Sorting the access-log list by a nullable timing puts NULLs last both ways."""
+from __future__ import annotations
+
+from typing import cast
+
+from advanced_alchemy.filters import FilterTypes, OrderBy
+from sqlalchemy import select
+from sqlalchemy.dialects import postgresql
+
+from geometrikks.domain.logs.models import AccessLog
+from geometrikks.domain.logs.sorting import NullsLastOrderBy, nulls_last_for_timings
+
+
+def _sql(stmt) -> str:
+    return str(stmt.compile(dialect=postgresql.dialect()))
+
+
+def test_nulls_last_order_by_desc_and_asc() -> None:
+    desc = NullsLastOrderBy("request_time", "desc").append_to_statement(select(AccessLog), AccessLog)
+    asc = NullsLastOrderBy("request_time", "asc").append_to_statement(select(AccessLog), AccessLog)
+    assert "ORDER BY access_logs.request_time DESC NULLS LAST" in _sql(desc)
+    assert "ORDER BY access_logs.request_time ASC NULLS LAST" in _sql(asc)
+
+
+def test_only_timing_sorts_are_rewritten() -> None:
+    filters = cast(list[FilterTypes], [OrderBy("request_time", "desc"), OrderBy("timestamp", "desc")])
+    rewritten = nulls_last_for_timings(filters)
+    assert isinstance(rewritten[0], NullsLastOrderBy)
+    assert rewritten[0].field_name == "request_time" and rewritten[0].sort_order == "desc"
+    assert rewritten[1] is filters[1]

--- a/tests/test_analytics_granularity.py
+++ b/tests/test_analytics_granularity.py
@@ -83,3 +83,12 @@ def test_build_filters_empty_lists_behave_like_none():
     assert filters.country_codes is None
     assert filters.cities is None
     assert filters.ip_addresses is None
+
+
+def test_optional_percent_change_is_none_when_either_side_is_missing():
+    from geometrikks.domain.analytics.controllers import _optional_percent_change
+
+    assert _optional_percent_change(None, 0.5) is None
+    assert _optional_percent_change(0.5, None) is None
+    assert _optional_percent_change(0.5, 0.0) is None
+    assert _optional_percent_change(0.6, 0.5) == pytest.approx(20.0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -552,6 +552,8 @@ def test_backfill_timings_previews_then_updates_and_refreshes(monkeypatch) -> No
 
 
 def test_backfill_timings_narrows_by_hostname_and_before(monkeypatch) -> None:
+    from datetime import datetime, timezone
+
     engine = _make_timings_engine(5, rowcount=5)
     refresh = AsyncMock(return_value=[])
     result = _invoke_backfill_timings(
@@ -562,6 +564,7 @@ def test_backfill_timings_narrows_by_hostname_and_before(monkeypatch) -> None:
     assert "hostname = :hostname" in str(preview_call.args[0])
     assert "timestamp < :before" in str(preview_call.args[0])
     assert preview_call.args[1]["hostname"] == "nginx-01"
+    assert preview_call.args[1]["before"] == datetime(2026, 8, 20, tzinfo=timezone.utc)
 
 
 def test_backfill_timings_aborts_without_confirmation(monkeypatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -578,3 +578,19 @@ def test_backfill_timings_rejects_bad_before_date(monkeypatch) -> None:
     result = _invoke_backfill_timings(monkeypatch, engine, ["--yes", "--before", "yesterday"], AsyncMock())
     assert result.exit_code != 0
     assert "before" in result.output.lower()
+
+
+def test_backfill_timings_logs_audit_before_raising_on_refresh_failure(monkeypatch) -> None:
+    import geometrikks.server.logging as logging_module
+
+    engine = _make_timings_engine(7, rowcount=7)
+    refresh = AsyncMock(return_value=["url_daily_stats"])
+    logger = MagicMock()
+    monkeypatch.setattr(logging_module, "get_logger", lambda name: logger)
+    result = _invoke_backfill_timings(monkeypatch, engine, ["--yes"], refresh)
+    assert result.exit_code != 0
+    assert "url_daily_stats" in result.output
+    logger.info.assert_called_once()
+    assert logger.info.call_args.args[0] == "backfill_timings_completed"
+    assert logger.info.call_args.kwargs["cleared"] == 7
+    assert logger.info.call_args.kwargs["cagg_refresh_failed"] == ["url_daily_stats"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -454,3 +454,127 @@ def test_backfill_asn_exits_nonzero_when_cagg_refresh_fails(monkeypatch) -> None
     assert result.exit_code != 0
     assert "rows updated: 7" in result.output
     assert "asn_daily_stats" in result.output
+
+
+def _make_timings_engine(count: int, *, rowcount: int) -> MagicMock:
+    """Engine for backfill-timings: preview via connect(), UPDATE via begin().
+
+    The preview returns (count, min_ts, max_ts); the EXISTS probe for
+    TimescaleDB returns True; every write reports ``rowcount``.
+    """
+    from datetime import datetime, timezone
+
+    preview = MagicMock()
+    preview.one.return_value = (
+        count,
+        datetime(2026, 1, 1, tzinfo=timezone.utc) if count else None,
+        datetime(2026, 1, 2, tzinfo=timezone.utc) if count else None,
+    )
+    preview.scalar.return_value = True
+
+    write_result = MagicMock()
+    write_result.rowcount = rowcount
+
+    read_conn = MagicMock()
+    read_conn.execute = AsyncMock(return_value=preview)
+    read_conn.__aenter__ = AsyncMock(return_value=read_conn)
+    read_conn.__aexit__ = AsyncMock(return_value=False)
+
+    write_conn = MagicMock()
+    write_conn.execute = AsyncMock(return_value=write_result)
+    write_conn.__aenter__ = AsyncMock(return_value=write_conn)
+    write_conn.__aexit__ = AsyncMock(return_value=False)
+
+    engine = MagicMock()
+    engine.connect = MagicMock(return_value=read_conn)
+    engine.begin = MagicMock(return_value=write_conn)
+    engine.dispose = AsyncMock()
+    return engine
+
+
+def _invoke_backfill_timings(monkeypatch, engine: MagicMock, args: list[str], refresh: AsyncMock, cli_input: str | None = None):
+    import click
+
+    import geometrikks.server.plugins as plugins_module
+    import geometrikks.server.timescale as timescale_module
+    from geometrikks.cli import ImportLogsCLIPlugin
+
+    config = MagicMock()
+    config.get_engine.return_value = engine
+    monkeypatch.setattr(plugins_module, "get_sqlalchemy_config", lambda: config)
+    monkeypatch.setattr(timescale_module, "refresh_caggs_range", refresh)
+
+    @click.group()
+    def cli() -> None: ...
+
+    ImportLogsCLIPlugin().on_cli_init(cli)
+    return CliRunner().invoke(cli, ["backfill-timings", *args], input=cli_input)
+
+
+def test_cli_plugin_registers_backfill_timings() -> None:
+    import click
+
+    from geometrikks.cli import ImportLogsCLIPlugin
+
+    @click.group()
+    def cli() -> None: ...
+
+    ImportLogsCLIPlugin().on_cli_init(cli)
+    assert "backfill-timings" in cli.commands
+
+
+def test_backfill_timings_nothing_to_do_skips_everything(monkeypatch) -> None:
+    engine = _make_timings_engine(0, rowcount=0)
+    refresh = AsyncMock(return_value=[])
+    result = _invoke_backfill_timings(monkeypatch, engine, ["--yes"], refresh)
+    assert result.exit_code == 0, result.output
+    assert "Nothing to do" in result.output
+    engine.begin.assert_not_called()
+    refresh.assert_not_awaited()
+
+
+def test_backfill_timings_previews_then_updates_and_refreshes(monkeypatch) -> None:
+    engine = _make_timings_engine(1200, rowcount=1200)
+    refresh = AsyncMock(return_value=[])
+    result = _invoke_backfill_timings(monkeypatch, engine, ["--yes"], refresh)
+    assert result.exit_code == 0, result.output
+    assert "1,200" in result.output
+    write_sql = [str(c.args[0]) for c in engine.begin.return_value.execute.await_args_list]
+    assert any("decompress_chunk" in s for s in write_sql)
+    update = next(s for s in write_sql if "UPDATE access_logs SET request_time = NULL" in s)
+    assert "log_format = 'nginx'" in update and "host IS NULL" in update and "request_time = 0" in update
+    refresh.assert_awaited()
+    assert refresh.await_args is not None
+    assert refresh.await_args.kwargs["force"] is True
+    assert set(refresh.await_args.kwargs["caggs"]) == {
+        "summary_hourly_stats", "summary_daily_stats", "url_hourly_stats", "url_daily_stats"
+    }
+
+
+def test_backfill_timings_narrows_by_hostname_and_before(monkeypatch) -> None:
+    engine = _make_timings_engine(5, rowcount=5)
+    refresh = AsyncMock(return_value=[])
+    result = _invoke_backfill_timings(
+        monkeypatch, engine, ["--yes", "--hostname", "nginx-01", "--before", "2026-08-20"], refresh
+    )
+    assert result.exit_code == 0, result.output
+    preview_call = engine.connect.return_value.execute.await_args_list[0]
+    assert "hostname = :hostname" in str(preview_call.args[0])
+    assert "timestamp < :before" in str(preview_call.args[0])
+    assert preview_call.args[1]["hostname"] == "nginx-01"
+
+
+def test_backfill_timings_aborts_without_confirmation(monkeypatch) -> None:
+    engine = _make_timings_engine(5, rowcount=5)
+    refresh = AsyncMock(return_value=[])
+    result = _invoke_backfill_timings(monkeypatch, engine, [], refresh, cli_input="n\n")
+    assert result.exit_code == 0, result.output
+    assert "Aborted" in result.output
+    engine.begin.assert_not_called()
+
+
+def test_backfill_timings_rejects_bad_before_date(monkeypatch) -> None:
+    engine = _make_timings_engine(5, rowcount=5)
+    result = _invoke_backfill_timings(monkeypatch, engine, ["--yes", "--before", "yesterday"], AsyncMock())
+    assert result.exit_code != 0
+    assert "before" in result.output.lower()

--- a/tests/test_logparser.py
+++ b/tests/test_logparser.py
@@ -445,7 +445,7 @@ def test_create_access_log_sqlalchemy_success(log_parser: LogParser, geoip_reade
     assert isinstance(access_log, ParsedAccessLog)
     assert access_log.country_code is not None
     assert access_log.bytes_sent >= 0
-    assert access_log.request_time >= 0.0
+    assert access_log.request_time is not None and access_log.request_time >= 0.0
 
 
 def test_create_access_log_sqlalchemy_geoip_failure(log_parser: LogParser, monkeypatch) -> None:

--- a/tests/test_logparser_formats.py
+++ b/tests/test_logparser_formats.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from geometrikks.services.logparser.formats import FORMATS, sniff_format
-from geometrikks.services.logparser.formats.base import detect_probe
+from geometrikks.services.logparser.formats.base import detect_probe, parse_seconds
 from geometrikks.services.logparser.formats.geometrikks_json import GeometrikksJsonFormat
 from geometrikks.services.logparser.formats.nginx import NginxFormat
 from geometrikks.services.logparser.formats.traefik import TraefikJsonFormat
@@ -383,7 +383,7 @@ def test_gjson_minimal_line_parses() -> None:
     assert norm.path is None
     assert norm.status_code == 0
     assert norm.bytes_sent == 0
-    assert norm.request_time == 0.0
+    assert norm.request_time is None
     assert norm.upstream_response_time is None
     assert norm.request_raw is None
 
@@ -428,7 +428,7 @@ def test_gjson_numeric_conversion_fallbacks() -> None:
     assert norm is not None
     assert norm.status_code == 0
     assert norm.bytes_sent == 0
-    assert norm.request_time == 0.0
+    assert norm.request_time is None
 
 
 @pytest.mark.parametrize(
@@ -540,3 +540,62 @@ def test_json_adapters_decline_each_others_lines() -> None:
     assert TraefikJsonFormat().parse(gjson(), geo_only=True) is None
     sniffed = sniff_format([TRAEFIK_FULL])
     assert sniffed is not None and sniffed.format.name == "traefik-json"
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("0.000", 0.0),
+        ("5.670", 5.67),
+        ("", None),
+        ("-", None),
+        ("abc", None),
+        ("nan", None),
+        ("inf", None),
+        ("-inf", None),
+        (None, None),
+    ],
+)
+def test_parse_seconds(raw: str | None, expected: float | None) -> None:
+    assert parse_seconds(raw) == expected
+
+
+def test_gjson_request_time_absent_is_none() -> None:
+    fmt = GeometrikksJsonFormat()
+    for line in (gjson(request_time=None), gjson(request_time=""), gjson(request_time="-"), gjson(request_time="nan")):
+        norm = fmt.parse(line)
+        assert norm is not None
+        assert norm.request_time is None
+
+
+def test_gjson_request_time_zero_is_a_measurement() -> None:
+    norm = GeometrikksJsonFormat().parse(gjson(request_time="0.000"))
+    assert norm is not None
+    assert norm.request_time == 0.0
+
+
+def test_nginx_combined_line_has_no_request_time() -> None:
+    """A combined-format line has no timing groups; that is None, not 0.0."""
+    line = '203.0.113.7 - - [03/Aug/2024:13:14:17 +0200] "GET /a HTTP/1.1" 200 12 "-" "Mozilla/5.0"'
+    norm = NginxFormat().parse(line)
+    assert norm is not None
+    assert norm.request_time is None
+    assert norm.upstream_response_time is None
+
+
+def test_nginx_dash_request_time_is_none() -> None:
+    line = (
+        '203.0.113.7 - - [03/Aug/2024:13:14:17 +0200]"GET /a HTTP/1.1" 200 12'
+        '"-" example.com "Mozilla/5.0""-" "-"'
+    )
+    norm = NginxFormat().parse(line)
+    assert norm is not None
+    assert norm.request_time is None
+
+
+def test_traefik_missing_duration_is_none() -> None:
+    data = json.loads(TRAEFIK_FULL)
+    del data["Duration"]
+    norm = TraefikJsonFormat().parse(json.dumps(data))
+    assert norm is not None
+    assert norm.request_time is None

--- a/tests/test_timescale_refresh.py
+++ b/tests/test_timescale_refresh.py
@@ -131,3 +131,37 @@ async def test_cagg_summary_returned_when_only_geo_events_exist():
     assert stats is not None
     assert stats.total_geo_records == 42
     assert stats.total_log_records == 0
+
+
+async def test_refresh_caggs_range_force_flag_adds_force_argument() -> None:
+    from datetime import datetime, timezone
+    from unittest.mock import AsyncMock, MagicMock
+
+    from geometrikks.server import timescale
+
+    driver = MagicMock()
+    driver.execute = AsyncMock()
+    raw = MagicMock()
+    raw.driver_connection = driver
+    conn = MagicMock()
+    conn.get_raw_connection = AsyncMock(return_value=raw)
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=False)
+    engine = MagicMock()
+    engine.connect = MagicMock(return_value=conn)
+
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    failed = await timescale.refresh_caggs_range(
+        engine, start=start, end=end, caggs=["summary_hourly_stats"], force=True
+    )
+    assert failed == []
+    assert driver.execute.await_args is not None
+    sql = driver.execute.await_args.args[0]
+    assert "force => true" in sql
+    assert "summary_hourly_stats" in sql
+
+    driver.execute.reset_mock()
+    await timescale.refresh_caggs_range(engine, start=start, end=end, caggs=["summary_hourly_stats"])
+    assert driver.execute.await_args is not None
+    assert "force" not in driver.execute.await_args.args[0]

--- a/tests/test_timescale_refresh.py
+++ b/tests/test_timescale_refresh.py
@@ -116,7 +116,7 @@ async def test_cagg_summary_returned_when_only_geo_events_exist():
 
     row = SimpleNamespace(
         total_log_records=0, total_bytes=0, status_2xx=0, status_3xx=0,
-        status_4xx=0, status_5xx=0, avg_request_time=0.0, max_request_time=0.0,
+        status_4xx=0, status_5xx=0, timed_requests=0, avg_request_time=0.0, max_request_time=0.0,
         p50_request_time=0.0, p95_request_time=0.0, p99_request_time=0.0,
         total_geo_records=42, unique_ips=7, unique_countries=3, unique_cities=5,
         malformed_requests=0,

--- a/tests/test_timescale_timed_columns.py
+++ b/tests/test_timescale_timed_columns.py
@@ -1,0 +1,229 @@
+"""Upgrade path for the timed-row count columns on the summary and URL CAGGs."""
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from geometrikks.server import timescale
+
+pytestmark = pytest.mark.anyio
+
+
+class _Scalar:
+    """Minimal stand-in for a Result whose only use is .scalar()."""
+
+    def __init__(self, value: Any = None) -> None:
+        self._value = value
+
+    def scalar(self) -> Any:
+        return self._value
+
+
+class FakeConn:
+    """AsyncConnection double that models an aborted transaction.
+
+    Postgres rejects every statement after a failed DDL until the enclosing
+    (sub)transaction rolls back, so `aborted` stays set until a savepoint
+    exits with an exception.
+    """
+
+    def __init__(self, fail_alter_on: set[str] | None = None) -> None:
+        self.fail_alter_on = fail_alter_on or set()
+        self.statements: list[str] = []
+        self.aborted = False
+        self.savepoints = 0
+
+    async def execute(self, statement: Any, params: Any = None) -> Any:
+        sql = str(statement)
+        self.statements.append(sql)
+        if self.aborted:
+            raise RuntimeError("current transaction is aborted, commands ignored")
+        if "ALTER MATERIALIZED VIEW" in sql and any(v in sql for v in self.fail_alter_on):
+            self.aborted = True
+            raise RuntimeError("cannot add column to a continuous aggregate")
+        return _Scalar(None)
+
+    def begin_nested(self) -> Any:
+        conn = self
+
+        class _Savepoint:
+            async def __aenter__(self) -> Any:
+                conn.savepoints += 1
+                return self
+
+            async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+                if exc_type is not None:
+                    conn.aborted = False  # ROLLBACK TO SAVEPOINT heals the transaction
+                return False
+
+        return _Savepoint()
+
+
+async def test_failed_alter_falls_back_to_drop_in_a_healthy_transaction() -> None:
+    conn = FakeConn(fail_alter_on={"url_hourly_stats"})
+
+    dropped = await timescale._add_timed_columns(
+        cast("Any", conn), ["summary_hourly_stats", "url_hourly_stats"]
+    )
+
+    assert dropped == ["url_hourly_stats"]
+    assert conn.savepoints == 2, "each ALTER must run inside its own savepoint"
+    alter_index = next(
+        i for i, sql in enumerate(conn.statements)
+        if "ALTER MATERIALIZED VIEW url_hourly_stats" in sql
+    )
+    drop_index = next(
+        i for i, sql in enumerate(conn.statements)
+        if "DROP MATERIALIZED VIEW IF EXISTS url_hourly_stats" in sql
+    )
+    assert drop_index > alter_index
+    assert not any(
+        "DROP MATERIALIZED VIEW IF EXISTS summary_hourly_stats" in sql
+        for sql in conn.statements
+    ), "a view whose ALTER succeeded must not be dropped"
+
+
+async def test_probe_scopes_the_null_check_to_the_raw_window() -> None:
+    calls: list[tuple[str, Any]] = []
+
+    class ProbeConn:
+        async def execute(self, statement: Any, params: Any = None) -> Any:
+            sql = str(statement)
+            calls.append((sql, params))
+            if "information_schema.columns" in sql:
+                return [
+                    SimpleNamespace(table_name=view, column_name=column)
+                    for view, column in timescale.TIMED_COUNT_COLUMNS.items()
+                ]
+            return _Scalar(None)
+
+    pending = await timescale._timed_columns_need_upgrade(
+        cast("Any", ProbeConn()), raw_retention_days=180
+    )
+
+    assert pending == []
+    null_probes = [(sql, params) for sql, params in calls if "IS NULL" in sql]
+    assert len(null_probes) == len(timescale.TIMED_COUNT_COLUMNS)
+    for sql, params in null_probes:
+        assert "make_interval(days => :days)" in sql
+        assert "bucket >=" in sql
+        assert params == {"days": 180}
+
+
+async def test_probe_reports_a_view_with_a_null_count_inside_the_window() -> None:
+    class ProbeConn:
+        async def execute(self, statement: Any, params: Any = None) -> Any:
+            sql = str(statement)
+            if "information_schema.columns" in sql:
+                return [
+                    SimpleNamespace(table_name=view, column_name=column)
+                    for view, column in timescale.TIMED_COUNT_COLUMNS.items()
+                ]
+            return _Scalar(1 if "summary_daily_stats" in sql else None)
+
+    pending = await timescale._timed_columns_need_upgrade(
+        cast("Any", ProbeConn()), raw_retention_days=30
+    )
+
+    assert pending == ["summary_daily_stats"]
+
+
+async def _run_setup(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    timed_views: list[str],
+    refresh_failed: list[str],
+    dropped: list[str] | None = None,
+) -> MagicMock:
+    """Run setup_timescaledb with every DDL step stubbed; return its logger."""
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=_Scalar(None))
+    begin_ctx = MagicMock()
+    begin_ctx.__aenter__ = AsyncMock(return_value=conn)
+    begin_ctx.__aexit__ = AsyncMock(return_value=False)
+    engine = MagicMock()
+    engine.begin = MagicMock(return_value=begin_ctx)
+
+    for name in dir(timescale):
+        attr = getattr(timescale, name)
+        if name.startswith(("_create_", "_enable_", "_add_", "_upgrade_")) and inspect.iscoroutinefunction(attr):
+            monkeypatch.setattr(timescale, name, AsyncMock(return_value=None))
+    monkeypatch.setattr(timescale, "_summary_caggs_need_upgrade", AsyncMock(return_value=False))
+    monkeypatch.setattr(timescale, "_location_caggs_need_upgrade", AsyncMock(return_value=False))
+    monkeypatch.setattr(
+        timescale, "detect_hostname_pollution",
+        AsyncMock(return_value=timescale.classify_hostnames(["nginx-01"])),
+    )
+    monkeypatch.setattr(timescale, "_timed_columns_need_upgrade", AsyncMock(return_value=timed_views))
+    monkeypatch.setattr(timescale, "_add_timed_columns", AsyncMock(return_value=dropped or []))
+    monkeypatch.setattr(timescale, "backfill_cagg_gaps", AsyncMock(return_value=None))
+    monkeypatch.setattr(timescale, "refresh_caggs_range", AsyncMock(return_value=refresh_failed))
+    logger = MagicMock()
+    monkeypatch.setattr(timescale, "logger", logger)
+
+    analytics = SimpleNamespace(
+        raw_retention_days=180,
+        debug_retention_days=7,
+        hourly_retention_days=365,
+        compression_after_days=7,
+        cagg_refresh_interval_minutes=5,
+    )
+    await timescale.setup_timescaledb(engine, cast("Any", analytics))
+    return logger
+
+
+def _events(logger_method: Any) -> dict[str, dict]:
+    return {call.args[0]: call.kwargs for call in logger_method.call_args_list if call.args}
+
+
+async def test_setup_logs_the_views_that_failed_and_the_ones_that_refreshed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = await _run_setup(
+        monkeypatch,
+        timed_views=["summary_hourly_stats", "url_daily_stats"],
+        refresh_failed=["url_daily_stats"],
+    )
+
+    warnings = _events(logger.warning)
+    assert warnings["cagg_timed_refresh_failed"]["views"] == ["url_daily_stats"]
+    infos = _events(logger.info)
+    assert infos["cagg_timed_refresh_done"]["views"] == ["summary_hourly_stats"]
+
+
+async def test_setup_logs_only_done_when_every_view_refreshed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = await _run_setup(
+        monkeypatch, timed_views=["summary_hourly_stats"], refresh_failed=[]
+    )
+
+    assert "cagg_timed_refresh_failed" not in _events(logger.warning)
+    assert _events(logger.info)["cagg_timed_refresh_done"]["views"] == ["summary_hourly_stats"]
+
+
+async def test_setup_logs_the_views_the_upgrade_recreated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = await _run_setup(
+        monkeypatch,
+        timed_views=["summary_daily_stats"],
+        refresh_failed=[],
+        dropped=["summary_daily_stats"],
+    )
+
+    assert _events(logger.info)["cagg_timed_views_recreated"]["views"] == ["summary_daily_stats"]
+
+
+async def test_setup_passes_the_raw_retention_window_to_the_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _run_setup(monkeypatch, timed_views=[], refresh_failed=[])
+
+    probe = cast("Any", timescale._timed_columns_need_upgrade)
+    assert probe.await_args is not None
+    assert probe.await_args.kwargs["raw_retention_days"] == 180


### PR DESCRIPTION
## Summary

A request with no timing is stored as NULL instead of 0.0. Until now every `combined`-format nginx line imported through `import-logs`, and every JSON line without a `request_time` key, landed as a 0.0 that counted as an instant response and pulled the average and percentiles toward zero. Absence is a value of its own now, the aggregates carry a count of measured rows, and the UI says so instead of printing a fake 0.00s.

## What changes

- The three log-format adapters share one `parse_seconds`: a missing, empty, `-`, unparseable or non-finite timing is None; `0.000` is a measurement.
- `access_logs.request_time` drops `NOT NULL` and its default (alembic `d4e8f2a6b913`). Existing rows keep their values. The downgrade decompresses hypertable chunks, fills NULLs with 0.0 and restores the constraint.
- The summary and URL continuous aggregates gain `timed_requests` / `timed_hits` (`COUNT(request_time)`). Fresh installs get the column from the CREATE. Existing installs get it at startup: an in-place `ALTER MATERIALIZED VIEW ... ADD COLUMN ... GENERATED ALWAYS AS (COUNT(request_time)) STORED` inside a savepoint, then a forced refresh of those four views over the raw retention window. The probe that decides whether to run is "column missing, or any bucket inside the raw window still uncounted", so a start that is killed mid-refresh resumes on the next one. Buckets older than the raw window cannot be recounted and read as fully timed, which reproduces their pre-upgrade figures. If the ALTER is not supported, the view is dropped and recreated, with the same history-loss warning the percentile upgrade uses. A failed refresh is logged as `cagg_timed_refresh_failed` and startup continues.
- Analytics queries stop coalescing timing figures to zero. `avg`, `max` and the percentiles are `float | None` on `/summary`, `/live-summary`, `/time-series` and `/top-urls`, next to `timedRequests` / `timedHits`. The hourly-to-local-day rollup weights the mean by timed rows, which removes the drift the old comment described. The generated client is regenerated; as a side effect `AccessLog.requestTime` in the client also becomes `number | null`, which it should have been since the column changed.
- The access-log list sorts NULL timings last in both directions on `request_time` and `upstream_response_time`.
- Frontend: the Avg and Max Request Time cards show "n/a" with "No timing field in the log format." when a range has requests but none carries a timing, "From N% of requests" when only some do, and "n/a" with "No requests in this range" when the range is empty. The latency chart shows a timing-specific empty state and leaves gaps for unmeasured hours instead of dropping to zero. Top URLs, the access-log table, the detail sheet, the live tail and the map popup render "n/a" for a missing timing. The cards also passed seconds to a millisecond formatter and showed a 40 ms average as 40μs; that is fixed.
- New `litestar backfill-timings` command for rows imported by earlier versions. It clears the placeholder 0.0 only on rows the legacy nginx format wrote without a host, which is how a `combined` line looks after import, since the custom format always logs `$host`. `--hostname` and `--before` narrow the set, the preview prints the row count and time span and asks for confirmation (`--yes` skips it), compressed chunks are decompressed first, and the four aggregates are force-refreshed for the span. It logs `backfill_timings_completed` before raising on a failed refresh, so a partial run leaves an audit trail.
- README documents the command and the n/a states; `docs/deployment.md` describes the one-off startup refresh, its cost on large databases, and the fallback.

## Verified

- Unit 972, integration 170, `ty`, vitest 263, `tsc`, typegen drift and config-docs freshness all clean.
- On an existing dev database the upgrade ran as designed: four `cagg_timed_column_added` events, one forced refresh over 180 days, `cagg_timed_refresh_done`, and nothing on the next start.
- A real 1,375,237-line `combined` archive from production imported with 0 unparseable lines and every row stored with a NULL timing; the Overview and the latency chart show the n/a states for that week. After manufacturing the old placeholders with an UPDATE, `backfill-timings --hostname combined-prod` previewed the same 1,375,217 rows, cleared them, refreshed the four views and logged the audit event.
- On a production database whose imports all used the custom format, the command correctly finds nothing to do.
