### PR TITLE
fix(logparser): stop treating 408, 444 and 499 as malformed requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - A missing `request_time` is now NULL instead of 0.0, so unmeasured requests stop dragging the response-time average and percentiles toward zero. The summary and URL aggregates gain a count of measured rows. The first start after upgrading adds that column in place and refreshes those four aggregates over the raw retention window; on a large database this takes minutes, and no history is lost. Buckets older than the window keep their pre-upgrade figures, which counted every row, because the raw rows needed to recount them are gone.
+- nginx status 408, 444 and 499 no longer mark a request as malformed. A 444 is usually a block rule and a 499 is a client that hung up, so those lines now land in Access logs like any other request instead of filling the Debug page and the malformed count. Probe detection is unchanged; TLS, SSH and SMB handshakes and requests without a valid HTTP method are still flagged.
 
 ### Fixed
 

--- a/geometrikks/services/logparser/formats/base.py
+++ b/geometrikks/services/logparser/formats/base.py
@@ -87,7 +87,11 @@ def parse_seconds(raw: str | None) -> float | None:
 def detect_probe(
     request_raw: str | None, method: str | None, status_code: int
 ) -> tuple[bool, str | None]:
-    """Classify probe garbage and connection-level statuses; shared by the nginx adapters.
+    """Classify probe garbage; shared by the nginx adapters.
+
+    Status codes are not a signal. 408, 444 and 499 used to mark a line
+    malformed, but a 444 is usually a block rule and a 499 is a client that
+    gave up, both well-formed requests the server chose not to answer.
 
     ``request_raw`` arrives in two escapings. The regex format sees nginx's
     default escaping as literal text (``\\x16\\x03``); ``escape=json`` writes
@@ -136,13 +140,5 @@ def detect_probe(
     # Check for non-standard/invalid HTTP methods
     if method.upper() not in VALID_HTTP_METHODS:
         return True, f"Invalid HTTP method: {method}"
-
-    # nginx-specific status codes that indicate connection issues, not normal HTTP errors
-    if status_code == 408:
-        return True, "Request timeout (408)"
-    if status_code == 444:
-        return True, "Connection closed without response (nginx 444)"
-    if status_code == 499:
-        return True, "Client closed connection before response (nginx 499)"
 
     return False, None

--- a/geometrikks/services/logparser/formats/geometrikks_json.py
+++ b/geometrikks/services/logparser/formats/geometrikks_json.py
@@ -132,5 +132,5 @@ class GeometrikksJsonFormat:
         )
 
     def detect_malformed(self, norm: NormalizedLine) -> tuple[bool, str | None]:
-        """Probe and connection-status classification; see ``detect_probe``."""
+        """Probe classification; see ``detect_probe``."""
         return detect_probe(norm.request_raw, norm.method, norm.status_code)

--- a/geometrikks/services/logparser/formats/nginx.py
+++ b/geometrikks/services/logparser/formats/nginx.py
@@ -91,5 +91,5 @@ class NginxFormat:
         )
 
     def detect_malformed(self, norm: NormalizedLine) -> tuple[bool, str | None]:
-        """Probe and connection-status classification; see ``detect_probe``."""
+        """Probe classification; see ``detect_probe``."""
         return detect_probe(norm.request_raw, norm.method, norm.status_code)

--- a/tests/test_logparser_formats.py
+++ b/tests/test_logparser_formats.py
@@ -74,19 +74,17 @@ def test_nginx_detect_malformed_tls_probe() -> None:
     assert "TLS" in reason
 
 
-def test_nginx_detect_malformed_nginx_statuses() -> None:
+def test_nginx_connection_statuses_are_well_formed() -> None:
+    """A 444 geoblock or a 499 client hang-up is a normal request the server chose not to answer."""
     fmt = NginxFormat()
-    for status, fragment in ((444, "444"), (499, "499"), (408, "408")):
+    for status in (444, 499, 408):
         line = (
             f'203.0.113.7 - - [03/Aug/2024:13:14:17 +0200]"GET / HTTP/1.1" {status} 0"-" '
             f'example.com "-""0.002" "-"'
         )
         norm = fmt.parse(line)
         assert norm is not None
-        is_malformed, reason = fmt.detect_malformed(norm)
-        assert is_malformed is True, f"status {status} should be malformed"
-        assert reason is not None
-        assert fragment in reason
+        assert fmt.detect_malformed(norm) == (False, None), f"status {status} should not be malformed"
 
 
 def test_nginx_detect_malformed_ok_line() -> None:
@@ -249,7 +247,7 @@ def test_traefik_detect_malformed_method_only() -> None:
     assert is_malformed is True
     assert reason is not None
     assert "BOGUS" in reason
-    # nginx-specific status heuristics must NOT apply
+    # a connection-level status is not a malformed line
     data = json.loads(TRAEFIK_FULL)
     data["DownstreamStatus"] = 499
     norm = fmt.parse(json.dumps(data))
@@ -282,6 +280,7 @@ def test_detect_probe_ssh_and_smb() -> None:
     assert detect_probe("SSH-2.0-OpenSSH_9.6", None, 400) == (True, "SSH probe sent to HTTP port")
     assert detect_probe("\xffSMBr\x00", None, 400) == (True, "SMB protocol probe (EternalBlue scanner)")
     assert detect_probe("\\xffSMBr\\x00", None, 400) == (True, "SMB protocol probe (EternalBlue scanner)")
+    assert detect_probe("\\xffSMB\\x25", None, 400) == (True, "SMB protocol probe (EternalBlue scanner)")
     assert detect_probe("NT LM 0.12", None, 400) == (True, "SMB dialect negotiation probe")
 
 
@@ -289,10 +288,9 @@ def test_detect_probe_method_and_status_rules() -> None:
     assert detect_probe("", None, 400) == (True, "TLS probe: HTTP request sent to HTTPS port")
     assert detect_probe("", None, 200) == (True, "No HTTP method in request")
     assert detect_probe("", "PROPFIND", 200) == (True, "Invalid HTTP method: PROPFIND")
-    assert detect_probe("GET / HTTP/1.1", "GET", 408) == (True, "Request timeout (408)")
-    assert detect_probe("GET / HTTP/1.1", "GET", 444) == (True, "Connection closed without response (nginx 444)")
-    assert detect_probe("GET / HTTP/1.1", "GET", 499) == (True, "Client closed connection before response (nginx 499)")
     assert detect_probe("GET / HTTP/1.1", "GET", 200) == (False, None)
+    for status in (408, 444, 499):
+        assert detect_probe("GET / HTTP/1.1", "GET", status) == (False, None)
     assert detect_probe(None, "GET", 200) == (False, None)
 
 
@@ -504,14 +502,12 @@ def test_gjson_detect_malformed_method_rules() -> None:
         assert fmt.detect_malformed(norm) == (True, expected)
 
 
-def test_gjson_detect_malformed_connection_statuses() -> None:
+def test_gjson_connection_statuses_are_well_formed() -> None:
     fmt = GeometrikksJsonFormat()
-    for status, fragment in (("444", "444"), ("499", "499"), ("408", "408")):
+    for status in ("444", "499", "408"):
         norm = fmt.parse(gjson(status=status))
         assert norm is not None
-        is_malformed, reason = fmt.detect_malformed(norm)
-        assert is_malformed is True
-        assert reason is not None and fragment in reason
+        assert fmt.detect_malformed(norm) == (False, None), f"status {status} should not be malformed"
 
 
 def test_gjson_detect_malformed_ok_line() -> None:


### PR DESCRIPTION
## Summary

A 408, 444 or 499 status no longer marks an nginx request as malformed.

`detect_probe` inherited that rule from the regex adapter, and both nginx adapters call it. On a server whose geoblock rule returns 444, 42% of a 26k-line capture was well-formed requests that each wrote an `access_log_debug` row regardless of `LOGPARSER_STORE_DEBUG_LINES`, and the Debug page's malformed count was 99% geoblocks.

## What changes

- `detect_probe` drops the three status checks. The byte-level probes (TLS record header, SSH banner, SMB and NT LM negotiation) and the method checks (none, or not a valid HTTP method) are unchanged.
- The nginx, geometrikks-json and unit-level status tests now assert `(False, None)` for 408, 444 and 499.
- `test_detect_probe_ssh_and_smb` gains the lowercase-needle case `\xffSMB\x25`, which the geometrikks-json PR fixed without a test.

Rows already flagged in `access_log_debug` stay as they are; only new lines are affected.

## Verified

972 unit tests, `ty check geometrikks tests`.

