### PR TITLE
fix(ui): stop prefixing calendar ranges with "Last" on stat cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The Overview's Avg and Max Request Time cards formatted seconds as if they were milliseconds, showing a 40 ms average as 40μs.
+- Stat cards on the Summary, Geo logs and Debug logs pages no longer read "Last Last month" or "Last Today" for calendar presets. Calendar ranges show their own name, and trends on the Summary page read "vs previous period" instead of "vs last Yesterday".
 
 ## [0.11.0] - 2026-08-27
 

--- a/dev/docker-compose.agents.yml
+++ b/dev/docker-compose.agents.yml
@@ -234,7 +234,8 @@ services:
   # Synthetic traffic: runs dev/inject-logs.sh for the stack's lifetime, so
   # `up` starts the inserts and `down` ends them. Reuses the app image for
   # bash + GNU date (the traefik timestamps need date %N) with the app
-  # entrypoint bypassed. Pause from the host with `touch dev/inject-logs.stop`
+  # entrypoint bypassed, and the image's HEALTHCHECK (a GET on :8000/health)
+  # disabled since nothing here listens. Pause from the host with `touch dev/inject-logs.stop`
   # (the container exits; `up -d log-injector` clears the stopfile and
   # resumes). No restart policy for that reason: a restart would wipe a
   # freshly touched stopfile and resume against the operator's intent.
@@ -244,6 +245,8 @@ services:
     image: geometrikks:agent-mode
     user: "${PUID:-1000}:${PGID:-1000}"
     entrypoint: ["bash", "/injector/dev/inject-logs.sh"]
+    healthcheck:
+      disable: true
     environment:
       INJECT_MAX_SECONDS: 0
     volumes:

--- a/resources/components/dashboard/summary-sections.tsx
+++ b/resources/components/dashboard/summary-sections.tsx
@@ -30,8 +30,10 @@ import { cn } from "@/lib/utils"
 interface SectionProps {
   summary: SummaryResponse | undefined
   isLoading: boolean
-  /** Human label of the selected range, e.g. "24 hours". */
-  rangeLabel: string
+  /** Span the values cover, e.g. "Last 24h" or "Last month". */
+  rangeSubtitle: string
+  /** Wording for a trend against the span before, e.g. "vs last 24h". */
+  compareLabel: string
 }
 
 /** Header plus grid; skeletons while loading, nothing on error (the page
@@ -64,7 +66,7 @@ function Section({
 const calcPercent = (part: number, total: number) =>
   total > 0 ? ((part / total) * 100).toFixed(1) : "0"
 
-export function TrafficOverviewSection({ summary, isLoading, rangeLabel }: SectionProps) {
+export function TrafficOverviewSection({ summary, isLoading, rangeSubtitle }: SectionProps) {
   const cur = summary?.currentPeriod
   const chg = summary?.percentChanges
   return (
@@ -79,7 +81,7 @@ export function TrafficOverviewSection({ summary, isLoading, rangeLabel }: Secti
           <StatCard
             title="Access Log Records"
             value={formatNumber(cur.totalRequests)}
-            subtitle={`Last ${rangeLabel}`}
+            subtitle={rangeSubtitle}
             icon={Activity}
             trend={{
               value: chg?.logRecords ?? null,
@@ -89,7 +91,7 @@ export function TrafficOverviewSection({ summary, isLoading, rangeLabel }: Secti
           <StatCard
             title="Geo Event Records"
             value={formatNumber(cur.totalGeoEvents)}
-            subtitle={`Last ${rangeLabel}`}
+            subtitle={rangeSubtitle}
             icon={FileText}
             trend={{
               value: chg?.geoRecords ?? null,
@@ -105,7 +107,7 @@ export function TrafficOverviewSection({ summary, isLoading, rangeLabel }: Secti
           <StatCard
             title="Malformed Requests"
             value={formatNumber(cur.malformedRequests)}
-            subtitle={`Last ${rangeLabel}`}
+            subtitle={rangeSubtitle}
             icon={AlertTriangle}
             trend={{
               value: chg?.malformedRate ?? null,
@@ -118,7 +120,7 @@ export function TrafficOverviewSection({ summary, isLoading, rangeLabel }: Secti
   )
 }
 
-export function HttpStatusSection({ summary, isLoading, rangeLabel }: SectionProps) {
+export function HttpStatusSection({ summary, isLoading, compareLabel }: SectionProps) {
   const cur = summary?.currentPeriod
   const chg = summary?.percentChanges
   return (
@@ -166,7 +168,7 @@ export function HttpStatusSection({ summary, isLoading, rangeLabel }: SectionPro
             title="Unique IPs"
             value={formatNumber(cur.uniqueIps)}
             subtitle={
-              chg?.uniqueIps != null ? `vs last ${rangeLabel}` : "Active visitors"
+              chg?.uniqueIps != null ? compareLabel : "Active visitors"
             }
             icon={Users}
             iconClassName="text-primary/70"
@@ -189,7 +191,7 @@ function timingSubtitle(coverage: ReturnType<typeof timingCoverage>, whenFull: s
   return whenFull
 }
 
-export function PerformanceSection({ summary, isLoading, rangeLabel }: SectionProps) {
+export function PerformanceSection({ summary, isLoading, compareLabel }: SectionProps) {
   const cur = summary?.currentPeriod
   const chg = summary?.percentChanges
   const coverage = cur ? timingCoverage(cur.timedRequests, cur.totalRequests) : timingCoverage(0, 0)
@@ -205,7 +207,7 @@ export function PerformanceSection({ summary, isLoading, rangeLabel }: SectionPr
           <StatCard
             title="Avg Request Time"
             value={formatDurationOrNa(cur.avgRequestTime)}
-            subtitle={timingSubtitle(coverage, chg?.avgRequestTime != null ? `vs last ${rangeLabel}` : "Response time")}
+            subtitle={timingSubtitle(coverage, chg?.avgRequestTime != null ? compareLabel : "Response time")}
             icon={Clock}
             iconClassName="text-primary/70"
             trend={
@@ -226,7 +228,7 @@ export function PerformanceSection({ summary, isLoading, rangeLabel }: SectionPr
             title="Total Bandwidth"
             value={formatBytes(cur.totalBytesSent)}
             subtitle={
-              chg?.bytesSent != null ? `vs last ${rangeLabel}` : "Data transferred"
+              chg?.bytesSent != null ? compareLabel : "Data transferred"
             }
             icon={HardDrive}
             iconClassName="text-primary/70"

--- a/resources/components/dashboard/summary.tsx
+++ b/resources/components/dashboard/summary.tsx
@@ -1,7 +1,7 @@
 import { TooltipProvider } from "@/components/ui/tooltip"
 
 import { useSummary } from "@/lib/queries"
-import { TIME_RANGE_PRESETS } from "@/lib/api"
+import { rangeCompareLabel, rangeSubtitle } from "@/lib/time-range-labels"
 import { useTimeRange } from "@/lib/time-range-context"
 import { DateTimeRange } from "@/components/dashboard/date-time-range"
 import {
@@ -19,9 +19,12 @@ export function Summary() {
     comparePrevious: true,
   })
 
-  const rangeLabel =
-    TIME_RANGE_PRESETS.find((p) => p.value === range)?.label ?? range
-  const section = { summary, isLoading, rangeLabel }
+  const section = {
+    summary,
+    isLoading,
+    rangeSubtitle: rangeSubtitle(range),
+    compareLabel: rangeCompareLabel(range),
+  }
 
   return (
     <TooltipProvider>

--- a/resources/components/debug-logs/debug-logs-stats.tsx
+++ b/resources/components/debug-logs/debug-logs-stats.tsx
@@ -6,15 +6,16 @@
 import { AlertTriangle, Bug, ScrollText } from "lucide-react"
 import { StatCard, StatCardSkeleton } from "@/components/dashboard/statcard"
 import { ErrorBanner } from "@/components/error-banner"
-import { formatNumber, formatPercent, TIME_RANGE_PRESETS } from "@/lib/api"
+import { formatNumber, formatPercent } from "@/lib/api"
 import { useAccessLogDebugStats } from "@/lib/queries"
 import { useTimeRange } from "@/lib/time-range-context"
+import { rangeSubtitle } from "@/lib/time-range-labels"
 
 export function DebugLogsStats() {
   const { range } = useTimeRange()
   const { data, isLoading, isError } = useAccessLogDebugStats()
 
-  const rangeLabel = TIME_RANGE_PRESETS.find((p) => p.value === range)?.label ?? range
+  const subtitle = rangeSubtitle(range)
 
   if (isError) {
     return <ErrorBanner title="Failed to load debug log stats." />
@@ -38,13 +39,13 @@ export function DebugLogsStats() {
       <StatCard
         title="Debug Lines"
         value={formatNumber(data.total)}
-        subtitle={`Last ${rangeLabel}`}
+        subtitle={subtitle}
         icon={ScrollText}
       />
       <StatCard
         title="Malformed"
         value={formatNumber(data.malformed)}
-        subtitle={malformedShare ? `${malformedShare} of total` : `Last ${rangeLabel}`}
+        subtitle={malformedShare ? `${malformedShare} of total` : subtitle}
         icon={AlertTriangle}
         iconClassName="text-amber-500"
       />
@@ -55,7 +56,7 @@ export function DebugLogsStats() {
         subtitle={
           data.topParseError
             ? `${formatNumber(data.topParseError.count)} lines`
-            : `Last ${rangeLabel}`
+            : subtitle
         }
         icon={Bug}
       />

--- a/resources/components/geo-logs/geo-logs-stats.tsx
+++ b/resources/components/geo-logs/geo-logs-stats.tsx
@@ -5,15 +5,16 @@
 import { Activity, Building2, Globe2, Users } from "lucide-react"
 import { StatCard, StatCardSkeleton } from "@/components/dashboard/statcard"
 import { ErrorBanner } from "@/components/error-banner"
-import { formatNumber, TIME_RANGE_PRESETS } from "@/lib/api"
+import { formatNumber } from "@/lib/api"
 import { useGeoLogSummary } from "@/lib/queries"
 import { useTimeRange } from "@/lib/time-range-context"
+import { rangeSubtitle } from "@/lib/time-range-labels"
 
 export function GeoLogsStats() {
   const { range } = useTimeRange()
   const { data: summary, isLoading, isError } = useGeoLogSummary({ comparePrevious: true })
 
-  const rangeLabel = TIME_RANGE_PRESETS.find((p) => p.value === range)?.label ?? range
+  const subtitle = rangeSubtitle(range)
 
   if (isError) {
     return <ErrorBanner title="Failed to load geo event summary." />
@@ -37,28 +38,28 @@ export function GeoLogsStats() {
       <StatCard
         title="Total Events"
         value={formatNumber(summary.currentPeriod.totalEvents)}
-        subtitle={`Last ${rangeLabel}`}
+        subtitle={subtitle}
         icon={Activity}
         trend={{ value: changes?.totalEvents ?? null }}
       />
       <StatCard
         title="Unique IPs"
         value={formatNumber(summary.currentPeriod.uniqueIps)}
-        subtitle={`Last ${rangeLabel}`}
+        subtitle={subtitle}
         icon={Users}
         trend={{ value: changes?.uniqueIps ?? null }}
       />
       <StatCard
         title="Countries"
         value={formatNumber(summary.currentPeriod.uniqueCountries)}
-        subtitle={`Last ${rangeLabel}`}
+        subtitle={subtitle}
         icon={Globe2}
         trend={{ value: changes?.uniqueCountries ?? null }}
       />
       <StatCard
         title="Cities"
         value={formatNumber(summary.currentPeriod.uniqueCities)}
-        subtitle={`Last ${rangeLabel}`}
+        subtitle={subtitle}
         icon={Building2}
         trend={{ value: changes?.uniqueCities ?? null }}
       />

--- a/resources/lib/time-range-labels.test.ts
+++ b/resources/lib/time-range-labels.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import { rangeCompareLabel, rangeSubtitle } from "./time-range-labels"
+
+describe("rangeSubtitle", () => {
+  it("prefixes duration presets with Last", () => {
+    expect(rangeSubtitle("24h")).toBe("Last 24h")
+    expect(rangeSubtitle("7d")).toBe("Last 7d")
+  })
+
+  it("uses calendar preset labels as they are", () => {
+    expect(rangeSubtitle("today")).toBe("Today")
+    expect(rangeSubtitle("yesterday")).toBe("Yesterday")
+    expect(rangeSubtitle("this_week")).toBe("This week")
+    expect(rangeSubtitle("last_week")).toBe("Last week")
+    expect(rangeSubtitle("this_month")).toBe("This month")
+    expect(rangeSubtitle("last_month")).toBe("Last month")
+  })
+
+  it("names a custom range without a Last prefix", () => {
+    expect(rangeSubtitle("custom")).toBe("Custom range")
+  })
+})
+
+describe("rangeCompareLabel", () => {
+  it("compares duration presets against the same span before", () => {
+    expect(rangeCompareLabel("24h")).toBe("vs last 24h")
+  })
+
+  it("compares calendar and custom ranges against the previous period", () => {
+    expect(rangeCompareLabel("last_month")).toBe("vs previous period")
+    expect(rangeCompareLabel("today")).toBe("vs previous period")
+    expect(rangeCompareLabel("custom")).toBe("vs previous period")
+  })
+})

--- a/resources/lib/time-range-labels.ts
+++ b/resources/lib/time-range-labels.ts
@@ -1,0 +1,30 @@
+/**
+ * Stat-card wording for the selected time range.
+ *
+ * Duration presets read as a span ("Last 24h"); calendar presets already
+ * name their span ("Last month", "Today"), so they take no prefix. The
+ * comparison window is always the equal-length span before the range,
+ * which only reads naturally as "last 24h" for a duration.
+ */
+import { TIME_RANGE_PRESETS, type TimeRangeValue } from "@/lib/api"
+
+function isDuration(range: TimeRangeValue): boolean {
+  const preset = TIME_RANGE_PRESETS.find((p) => p.value === range)
+  return preset != null && preset.minutes > 0
+}
+
+function presetLabel(range: TimeRangeValue): string {
+  return TIME_RANGE_PRESETS.find((p) => p.value === range)?.label ?? range
+}
+
+/** Card subtitle naming the span the value covers. */
+export function rangeSubtitle(range: TimeRangeValue): string {
+  if (range === "custom") return "Custom range"
+  const label = presetLabel(range)
+  return isDuration(range) ? `Last ${label}` : label
+}
+
+/** Card subtitle for a value shown against the span before the range. */
+export function rangeCompareLabel(range: TimeRangeValue): string {
+  return isDuration(range) ? `vs last ${presetLabel(range)}` : "vs previous period"
+}


### PR DESCRIPTION
## Summary

Stat cards on Summary, Geo logs and Debug logs read "Last Last month" and "Last Today" when a calendar preset is selected. The Summary trends did the same ("vs last Yesterday"). Also disables the healthcheck the dev log injector inherits from the app image.

## What changes

- New `resources/lib/time-range-labels.ts` with two helpers. `rangeSubtitle` gives "Last 24h" for duration presets, the preset's own name for calendar ones ("Last month", "Today"), and "Custom range" for a custom span. `rangeCompareLabel` gives "vs last 24h" for durations and "vs previous period" otherwise, since the comparison window is the equal-length span before the range and "last Last month" does not describe that.
- `summary.tsx` computes both strings once and passes them to the sections as `rangeSubtitle` and `compareLabel`; the sections stop building strings from `rangeLabel`.
- `geo-logs-stats.tsx` and `debug-logs-stats.tsx` use `rangeSubtitle` for their card subtitles.
- `dev/docker-compose.agents.yml`: `healthcheck: disable: true` on `log-injector`. It reuses the app image, so Docker kept probing `:8000/health` on a container that runs a bash script, and `docker ps` listed it as unhealthy.

## Verified

Vitest cases for both helpers (duration, every calendar preset, custom); 268 tests pass, `tsc -b` clean. Checked in the browser on Summary, Geo logs and Debug logs with "Last month", "Today", "24h" and a custom range. The injector container recreated with the new compose shows no health state.

