### PR TITLE
fix(map): follow the OS colour scheme when the theme is System

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The Overview's Avg and Max Request Time cards formatted seconds as if they were milliseconds, showing a 40 ms average as 40μs.
 - Stat cards on the Summary, Geo logs and Debug logs pages no longer read "Last Last month" or "Last Today" for calendar presets. Calendar ranges show their own name, and trends on the Summary page read "vs previous period" instead of "vs last Yesterday".
+- The map basemap follows the System theme. It stayed dark while the rest of the app switched to light with the OS, and now switches with it, live.
 
 ## [0.11.0] - 2026-08-27
 

--- a/resources/components/map/hooks/useMapStyle.ts
+++ b/resources/components/map/hooks/useMapStyle.ts
@@ -10,13 +10,12 @@ const MAP_STYLES = {
 } as const
 
 export function useMapStyle() {
-  const { theme } = useTheme()
-
-  // Use dark for "dark" and "system" themes (since system defaults to dark in this app)
-  const effectiveTheme = theme === "light" ? "light" : "dark"
+  // resolvedTheme, not theme: "system" has to land on whichever mode the
+  // rest of the page is showing, and it changes live with the OS setting.
+  const { resolvedTheme } = useTheme()
 
   return {
-    mapStyle: MAP_STYLES[effectiveTheme],
-    theme: effectiveTheme,
+    mapStyle: MAP_STYLES[resolvedTheme],
+    theme: resolvedTheme,
   }
 }

--- a/resources/components/theme-provider.tsx
+++ b/resources/components/theme-provider.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useMemo, useState } from "react"
 import { type Accent, accentAttribute, parseAccent } from "@/lib/accent"
-import { type Theme, parseTheme } from "@/lib/theme"
+import { type ResolvedTheme, type Theme, parseTheme, resolveTheme } from "@/lib/theme"
 
 type ThemeProviderProps = {
   children: React.ReactNode
@@ -10,13 +10,20 @@ type ThemeProviderProps = {
 }
 
 type ThemeProviderState = {
+  /** The stored preference, "system" included. */
   theme: Theme
+  /** What the page is showing right now; "system" resolved against the OS. */
+  resolvedTheme: ResolvedTheme
   setTheme: (theme: Theme) => void
   accent: Accent
   setAccent: (accent: Accent) => void
 }
 
 const ThemeProviderContext = createContext<ThemeProviderState | undefined>(undefined)
+
+function prefersDark(): boolean {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+}
 
 function readStorage(key: string): string | null {
   try {
@@ -44,23 +51,25 @@ export function ThemeProvider({
     parseTheme(readStorage(storageKey), defaultTheme),
   )
   const [accent, setAccentState] = useState<Accent>(() => parseAccent(readStorage(accentStorageKey)))
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() =>
+    resolveTheme(theme, prefersDark()),
+  )
 
   useEffect(() => {
-    const root = window.document.documentElement
-    const apply = (dark: boolean) => {
-      root.classList.remove("light", "dark")
-      root.classList.add(dark ? "dark" : "light")
-    }
-    if (theme !== "system") {
-      apply(theme === "dark")
-      return
-    }
+    setResolvedTheme(resolveTheme(theme, prefersDark()))
+    if (theme !== "system") return
     const query = window.matchMedia("(prefers-color-scheme: dark)")
-    apply(query.matches)
-    const onChange = (event: MediaQueryListEvent) => apply(event.matches)
+    const onChange = (event: MediaQueryListEvent) =>
+      setResolvedTheme(resolveTheme(theme, event.matches))
     query.addEventListener("change", onChange)
     return () => query.removeEventListener("change", onChange)
   }, [theme])
+
+  useEffect(() => {
+    const root = window.document.documentElement
+    root.classList.remove("light", "dark")
+    root.classList.add(resolvedTheme)
+  }, [resolvedTheme])
 
   useEffect(() => {
     const root = window.document.documentElement
@@ -72,6 +81,7 @@ export function ThemeProvider({
   const value = useMemo<ThemeProviderState>(
     () => ({
       theme,
+      resolvedTheme,
       setTheme: (next) => {
         writeStorage(storageKey, next)
         setThemeState(next)
@@ -82,7 +92,7 @@ export function ThemeProvider({
         setAccentState(next)
       },
     }),
-    [theme, accent, storageKey, accentStorageKey],
+    [theme, resolvedTheme, accent, storageKey, accentStorageKey],
   )
 
   return <ThemeProviderContext.Provider value={value}>{children}</ThemeProviderContext.Provider>

--- a/resources/lib/theme.test.ts
+++ b/resources/lib/theme.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { THEMES, parseTheme } from "./theme"
+import { THEMES, parseTheme, resolveTheme } from "./theme"
 
 describe("parseTheme", () => {
   it("returns a valid theme unchanged", () => {
@@ -11,5 +11,17 @@ describe("parseTheme", () => {
     expect(parseTheme("solarized")).toBe("system")
     expect(parseTheme(null, "dark")).toBe("dark")
     expect(parseTheme("", "dark")).toBe("dark")
+  })
+})
+
+describe("resolveTheme", () => {
+  it("returns an explicit choice regardless of the OS setting", () => {
+    expect(resolveTheme("dark", false)).toBe("dark")
+    expect(resolveTheme("light", true)).toBe("light")
+  })
+
+  it("follows the OS setting for system", () => {
+    expect(resolveTheme("system", true)).toBe("dark")
+    expect(resolveTheme("system", false)).toBe("light")
   })
 })

--- a/resources/lib/theme.ts
+++ b/resources/lib/theme.ts
@@ -7,3 +7,11 @@ export type Theme = (typeof THEMES)[number]
 export function parseTheme(value: string | null, fallback: Theme = "system"): Theme {
   return (THEMES as readonly string[]).includes(value ?? "") ? (value as Theme) : fallback
 }
+
+export type ResolvedTheme = Exclude<Theme, "system">
+
+/** The mode a preference lands on once "system" is read against the OS setting. */
+export function resolveTheme(theme: Theme, prefersDark: boolean): ResolvedTheme {
+  if (theme === "system") return prefersDark ? "dark" : "light"
+  return theme
+}


### PR DESCRIPTION
## Summary

With the theme set to System and the OS in light mode, the page went light but the map stayed on the dark basemap. Closes #170.

## What changes

- `useMapStyle` mapped everything except an explicit "light" to the dark style, with a comment saying System means dark in this app. That stopped being true when the theme provider started resolving System against `prefers-color-scheme`, but the provider only exposed the stored preference, so the hook had nothing better to read.
- The provider now keeps a `resolvedTheme` ("light" | "dark") next to `theme`. The `prefers-color-scheme` listener it already had updates it, and the `<html>` class is applied from it. `resolveTheme(theme, prefersDark)` in `lib/theme.ts` holds the rule, with tests.
- `useMapStyle` reads `resolvedTheme`. Both the Map page and the Geo logs map go through this hook.

## Verified

270 vitest cases pass, `tsc -b` clean. Checked in the browser: System with a light OS loads the Positron basemap on Map and Geo logs, flipping the OS scheme with the app open swaps the page and the basemap together, and explicit Light and Dark behave as before. The pre-render script in `index.html` resolves System the same way, so first paint matches.

