### PR TITLE
fix(ui): open the IP inspector from a detail sheet

### DIFF
--- a/resources/components/access-logs/access-log-detail-sheet.tsx
+++ b/resources/components/access-logs/access-log-detail-sheet.tsx
@@ -45,9 +45,7 @@ export function AccessLogDetailSheet({
               <span className="inline-flex flex-wrap items-center gap-2 font-mono text-xs">
                 {entry.ipAddress}
                 <IpBanControls ip={entry.ipAddress}>
-                  <span onClickCapture={() => onOpenChange(false)}>
-                    <InspectIpButton ip={entry.ipAddress} />
-                  </span>
+                  <InspectIpButton ip={entry.ipAddress} onOpen={() => onOpenChange(false)} />
                 </IpBanControls>
               </span>
             }

--- a/resources/components/debug-logs/debug-log-detail-sheet.tsx
+++ b/resources/components/debug-logs/debug-log-detail-sheet.tsx
@@ -115,9 +115,7 @@ export function DebugLogDetailSheet({
                       <span className="inline-flex flex-wrap items-center gap-2 font-mono text-xs">
                         {entry.ipAddress}
                         <IpBanControls ip={entry.ipAddress}>
-                          <span onClickCapture={() => onOpenChange(false)}>
-                            <InspectIpButton ip={entry.ipAddress} />
-                          </span>
+                          <InspectIpButton ip={entry.ipAddress} onOpen={() => onOpenChange(false)} />
                         </IpBanControls>
                       </span>
                     ) : null

--- a/resources/components/geo-logs/geo-log-detail-sheet.tsx
+++ b/resources/components/geo-logs/geo-log-detail-sheet.tsx
@@ -35,9 +35,7 @@ export function GeoLogDetailSheet({
               <span className="inline-flex flex-wrap items-center gap-2 font-mono text-xs">
                 {entry.ipAddress}
                 <IpBanControls ip={entry.ipAddress}>
-                  <span onClickCapture={() => onOpenChange(false)}>
-                    <InspectIpButton ip={entry.ipAddress} fromLocationId={entry.locationId} />
-                  </span>
+                  <InspectIpButton ip={entry.ipAddress} fromLocationId={entry.locationId} onOpen={() => onOpenChange(false)} />
                 </IpBanControls>
               </span>
             }

--- a/resources/components/ip-inspector/inspect-ip-button.tsx
+++ b/resources/components/ip-inspector/inspect-ip-button.tsx
@@ -5,15 +5,20 @@ import { useIpInspector } from "@/lib/ip-inspector"
 import { cn } from "@/lib/utils"
 
 /** Opens the IP inspector. Safe inside activatable table rows: it stops
- *  propagation so the row's own detail sheet does not open too. */
+ *  propagation so the row's own detail sheet does not open too. A detail
+ *  sheet that hosts the button closes itself through `onOpen`; closing in
+ *  a capture handler instead unmounts the button before its click runs,
+ *  because React flushes the close between the capture and bubble phases. */
 export function InspectIpButton({
   ip,
   fromLocationId,
   className,
+  onOpen,
 }: {
   ip: string
   fromLocationId?: number
   className?: string
+  onOpen?: () => void
 }) {
   const { open } = useIpInspector()
   return (
@@ -27,6 +32,7 @@ export function InspectIpButton({
       onClick={(event) => {
         event.stopPropagation()
         open(ip, fromLocationId)
+        onOpen?.()
       }}
     >
       <ScanSearch />


### PR DESCRIPTION
The detail sheets closed themselves in a capture-phase click handler around the inspect button. React flushes that state update between the capture and bubble phases, the sheet re-renders with no entry, the button unmounts, and its own click never runs. The button now takes an onOpen callback that the sheet uses to close after the inspector has opened.