### PR TITLE
fix(server): close the live-events channel after ingestion stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Overview's Avg and Max Request Time cards formatted seconds as if they were milliseconds, showing a 40 ms average as 40μs.
 - Stat cards on the Summary, Geo logs and Debug logs pages no longer read "Last Last month" or "Last Today" for calendar presets. Calendar ranges show their own name, and trends on the Summary page read "vs previous period" instead of "vs last Yesterday".
 - The map basemap follows the System theme. It stayed dark while the rest of the app switched to light with the OS, and now switches with it, live.
+- Stopping the app while it was tailing a log logged one `live event publish failed` traceback per row in the final batch. The live-events channel closed before ingestion flushed that batch; it now closes after. The rows were always committed, only their live-map events went missing.
 
 ## [0.11.0] - 2026-08-27
 

--- a/geometrikks/server/core.py
+++ b/geometrikks/server/core.py
@@ -12,7 +12,6 @@ from litestar.config.compression import CompressionConfig
 from geometrikks.config.settings import Settings, get_settings
 from geometrikks.server import plugins
 from geometrikks.server.exceptions import EXCEPTION_HANDLERS
-from geometrikks.server.lifecycle import LIFESPAN
 from geometrikks.server.routes import get_agent_route_handlers, get_route_handlers
 from geometrikks.server.dependencies import create_settings_provider
 
@@ -104,7 +103,6 @@ def create_app(
     app = Litestar(
         debug=settings.debug,
         route_handlers=route_handlers,
-        lifespan=list(LIFESPAN),
         plugins=plugins.create_plugins(
             settings, db_config=db_config, include_vite=not settings.is_agent
         ),

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -1,13 +1,21 @@
 """Application lifecycle as focused lifespan context managers.
 
 Each concern owns both its startup and its cleanup in one async context
-manager. ``create_app()`` passes :data:`LIFESPAN` to Litestar, which enters
-the managers in order on an ``AsyncExitStack`` and exits them in reverse:
+manager. :class:`LifecyclePlugin` registers :data:`LIFESPAN` with Litestar,
+which enters the managers in order on an ``AsyncExitStack`` and exits them
+in reverse:
 
 - teardown order is the exact reverse of startup (ingestion stops first,
   the scheduler second, the CrowdSec client closes after both), and
 - a failure during startup unwinds only the managers that already started,
   so partial startup no longer leaks running services.
+
+The plugin, not the ``lifespan=`` constructor argument, is what puts these
+managers after the ones other plugins register. ChannelsPlugin appends its
+own lifespan during ``on_app_init``; had ours been passed to the
+constructor they would sit ahead of it, exit first, and ingestion's final
+flush would publish into a channels plugin that had already torn down its
+queue.
 
 Degraded modes are decided once: :func:`database_lifespan` records
 ``app.state.db_available`` and the scheduler and ingestion managers no-op
@@ -24,6 +32,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import text
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from litestar.plugins import InitPlugin
 
 from geometrikks.config.settings import get_settings
 from geometrikks.server.logging import get_logger
@@ -48,6 +57,7 @@ if TYPE_CHECKING:
 
     from geometrikks.config.settings import Settings
     from litestar import Litestar
+    from litestar.config.app import AppConfig
 
 logger = get_logger(__name__)
 
@@ -404,3 +414,15 @@ LIFESPAN = [
     scheduler_lifespan,
     ingestion_lifespan,
 ]
+
+
+class LifecyclePlugin(InitPlugin):
+    """Registers :data:`LIFESPAN` after every plugin listed before it.
+
+    Must be the last entry in ``create_plugins()`` so the app's managers
+    nest inside the plugin-owned ones (channels, database engine).
+    """
+
+    def on_app_init(self, app_config: "AppConfig") -> "AppConfig":
+        app_config.lifespan.extend(LIFESPAN)
+        return app_config

--- a/geometrikks/server/plugins.py
+++ b/geometrikks/server/plugins.py
@@ -45,6 +45,8 @@ if TYPE_CHECKING:
 
     from litestar import Litestar
 
+    from geometrikks.server.lifecycle import LifecyclePlugin
+
 logger = get_logger(__name__)
 
 
@@ -371,6 +373,7 @@ def create_plugins(
     | CLIPlugin
     | StructlogPlugin
     | ChannelsPlugin
+    | LifecyclePlugin
 ]:
     """Instantiate all app plugins; called once from create_app().
 
@@ -379,6 +382,7 @@ def create_plugins(
     a headless log-tailing process has no use for.
     """
     from geometrikks.cli import ImportLogsCLIPlugin
+    from geometrikks.server.lifecycle import LifecyclePlugin
 
     if db_config is None:
         # Explicit settings must also govern the SQLAlchemy plugin; only a
@@ -394,6 +398,7 @@ def create_plugins(
         | CLIPlugin
         | StructlogPlugin
         | ChannelsPlugin
+        | LifecyclePlugin
     ] = [
         SQLAlchemyInitPlugin(config=db_config),
         GeoAlchemyPlugin(),  # GeoAlchemy plugin for PostGIS support
@@ -406,6 +411,9 @@ def create_plugins(
             ImportLogsCLIPlugin(),
             create_structlog_plugin(settings),
             create_channels_plugin(settings),
+            # Last on purpose: its lifespan managers must nest inside the
+            # channels plugin's (see lifecycle.LifecyclePlugin).
+            LifecyclePlugin(),
         ]
     )
     return plugin_list

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -154,3 +154,52 @@ def test_create_plugins_derives_db_config_from_explicit_settings(monkeypatch):
     url = str(init_plugin.config[0].get_engine().url)
     assert "127.0.0.1" in url
     assert "ambient.invalid" not in url
+
+
+async def test_lifecycle_managers_nest_inside_channels_plugin(monkeypatch) -> None:
+    """The channels plugin must start before ingestion and stop after it.
+
+    ChannelsPlugin appends itself to the lifespan list during on_app_init;
+    if the app's own managers were registered ahead of it, they would exit
+    first and ingestion's final flush would publish into a torn-down plugin.
+    """
+    from contextlib import asynccontextmanager
+
+    from litestar.channels import ChannelsPlugin
+
+    from geometrikks.server import lifecycle
+
+    events: list[str] = []
+
+    @asynccontextmanager
+    async def recording_lifespan(app):
+        events.append("lifecycle:enter")
+        yield
+        events.append("lifecycle:exit")
+
+    monkeypatch.setattr(lifecycle, "LIFESPAN", [recording_lifespan])
+
+    real_aenter = ChannelsPlugin.__aenter__
+    real_aexit = ChannelsPlugin.__aexit__
+
+    async def aenter(self):
+        events.append("channels:enter")
+        return await real_aenter(self)
+
+    async def aexit(self, exc_type, exc_val, exc_tb):
+        events.append("channels:exit")
+        return await real_aexit(self, exc_type, exc_val, exc_tb)
+
+    monkeypatch.setattr(ChannelsPlugin, "__aenter__", aenter)
+    monkeypatch.setattr(ChannelsPlugin, "__aexit__", aexit)
+
+    app = create_app(settings=_hermetic_settings())
+    async with AsyncTestClient(app=app):
+        pass
+
+    assert events == [
+        "channels:enter",
+        "lifecycle:enter",
+        "lifecycle:exit",
+        "channels:exit",
+    ]


### PR DESCRIPTION
## Summary

Stopping any instance that is tailing a log printed one `live event publish failed` traceback per row in the final batch (`RuntimeError: Plugin not yet initialized. Did you forget to call on_startup?`). The rows were committed; only their live-map events were lost.

`create_app` passed `LIFESPAN` to the Litestar constructor. `ChannelsPlugin` appends its own lifespan during `on_app_init`, so it sat after the app's managers, exited first, and set its publish queue to `None` before ingestion flushed its last batch.

## What changes

- `LifecyclePlugin` (in `server/lifecycle.py`) registers `LIFESPAN` from `on_app_init`. It is the last entry in `create_plugins()`, after `ChannelsPlugin`, so the app's managers nest inside the channels plugin's: channels starts before ingestion and stops after it. The same ordering removes the window at startup where ingestion could begin tailing before the channels queue existed.
- `create_app` no longer passes `lifespan=`.
- `test_lifecycle_managers_nest_inside_channels_plugin` runs a real app lifespan with a recording manager and asserts `channels:enter, lifecycle:enter, lifecycle:exit, channels:exit`.

## Verification

- `uv run ty check geometrikks tests` and `uv run pytest` (1026 passed).
- Rebuilt `dev/docker-compose.agents.yml`, let the injector run until every agent had pending records, then `docker compose stop`. No publish failures or tracebacks on any container; the nginx agent still flushed its final batch (28 processed at stop, 19 parsed a few seconds earlier).
