### PR TITLE
fix(map): point MapLibre 6 at the worker Vite bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The map runs on MapLibre GL JS 6.
+
 ## [0.12.0] - 2026-08-29
 
 ### Added

--- a/resources/components/geo-logs/geo-logs-map.tsx
+++ b/resources/components/geo-logs/geo-logs-map.tsx
@@ -27,6 +27,7 @@ import {
   unclusteredPointLabelLayer,
   unclusteredPointLayer,
 } from "@/components/map/layers"
+import { MAPLIBRE_WORKER_URL } from "@/lib/maplibre-worker"
 import { useGeoLogsGeoJSON } from "@/lib/queries"
 import { cn } from "@/lib/utils"
 
@@ -141,6 +142,7 @@ export default function GeoLogsMap() {
       <div className="absolute inset-0">
         <Map
           ref={mapRef}
+          workerUrl={MAPLIBRE_WORKER_URL}
           {...viewState}
           onMove={onMove}
           onClick={onClick}

--- a/resources/components/map/GeoMap.tsx
+++ b/resources/components/map/GeoMap.tsx
@@ -58,6 +58,7 @@ import {
 import { LiveTrafficProvider, useLiveTrafficStore } from "@/lib/live-traffic/context"
 import type { LiveRequest } from "@/lib/live-traffic/types"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { MAPLIBRE_WORKER_URL } from "@/lib/maplibre-worker"
 
 export type LayerType = "heatmap" | "markers"
 export type MapProjection = "mercator" | "globe"
@@ -492,6 +493,7 @@ function GeoMapInner({
     <div className="h-full w-full relative">
       <Map
         ref={mapRef}
+        workerUrl={MAPLIBRE_WORKER_URL}
         {...viewState}
         onLoad={() => setMapLoaded(true)}
         onMove={onMove}

--- a/resources/lib/maplibre-worker.ts
+++ b/resources/lib/maplibre-worker.ts
@@ -1,0 +1,9 @@
+/**
+ * MapLibre 6 runs tile and GeoJSON processing in a separate worker script and
+ * looks for it next to its own module URL. Inside a Vite bundle that file is
+ * never emitted, so every GL layer (tiles, heatmap, live routes) stays blank
+ * while DOM markers keep working. This is the copy Vite bundles instead.
+ */
+import workerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url"
+
+export const MAPLIBRE_WORKER_URL = workerUrl


### PR DESCRIPTION
MapLibre 6 ships its web worker as a separate file and resolves it next to its own module URL. In the Vite bundle that path was never emitted, so the worker failed to start and everything rendered through it (tiles, heatmap, clusters, live routes) stayed blank while DOM markers kept working.

Import the worker with Vite's ?worker&url and hand the URL to both maps through react-maplibre's workerUrl prop, which calls setWorkerUrl once the library loads.