### PR TITLE
fix(build): clear the vite build warnings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -862,7 +862,7 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001761", "", {}, ""],
+    "caniuse-lite": ["caniuse-lite@1.0.30001810", "", {}, "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 

--- a/resources/main.css
+++ b/resources/main.css
@@ -5,7 +5,7 @@
 
 @font-face {
   font-family: "runr";
-  src: url("/static/fonts/runr-Regular.woff2") format("woff2");
+  src: url("/fonts/runr-Regular.woff2") format("woff2");
   font-style: normal;
   font-weight: 400;
   font-display: swap;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
   build: {
     outDir: "public",
     emptyOutDir: true,
+    // maplibre-gl alone is ~990 kB minified and already ships as its own
+    // lazy chunk behind the map route; the default 500 kB limit only ever
+    // flagged it.
+    chunkSizeWarningLimit: 1100,
   },
   // No server block: Litestar is the single dev origin. litestar-vite runs
   // Vite as a sidecar on an ephemeral localhost port (written to the
@@ -78,7 +82,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "resources"),
+      "@": path.resolve(import.meta.dirname, "resources"),
     },
   },
 });


### PR DESCRIPTION
`bun run build` printed four warnings. This clears all of them without changing the built output.

- `vite.config.ts` uses `import.meta.dirname` instead of `__dirname`, which Vite 8 flags as unsupported by its upcoming native config loader.
- `main.css` references the runr font as `/fonts/runr-Regular.woff2` (publicDir-relative). Vite now resolves it as a public asset and prepends the `/static/` base itself; the emitted CSS still points at `/static/fonts/runr-Regular.woff2`.
- `build.chunkSizeWarningLimit` is 1100 kB. The only chunk over the 500 kB default is maplibre-gl, which is already lazy-loaded behind the map route and cannot be split further.
- `bun.lock` bumps caniuse-lite from 1.0.30001761 (December 2025) to 1.0.30001810, which silences the stale browserslist data warning.

The service-worker precache manifest is identical to a develop build, and the font loads in dev mode as well.
