### PR TITLE
Release 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The map runs on MapLibre GL JS 6.
+
 ## [0.12.0] - 2026-08-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-08-30
+
 ### Changed
 
-- The map runs on MapLibre GL JS 6.
+- The map runs on MapLibre GL JS 6 (6.6.0, up from 5.24.0).
+- The backend's HTTP client is `httpx2` 2.12 instead of `httpx`; the unused `httpx-oauth` dependency is dropped. The container image builds on `oven/bun` 1.4.0.
+- The API reference at `/schema` is rendered by Scalar. The ReDoc, Swagger UI, RapiDoc and Stoplight pages and `/schema/openapi.yaml` are gone; `/schema/openapi.json` is unchanged.
 
 ## [0.12.0] - 2026-08-29
 
@@ -929,7 +933,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Settings endpoint no longer exposes the full settings tree (database credentials leaked via `model_dump()`); response is now an explicit whitelist.
 - Timestamps in `CALL refresh_continuous_aggregate` are bound as asyncpg parameters instead of interpolated into SQL.
 
-[Unreleased]: https://github.com/GilbN/geometrikks/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/GilbN/geometrikks/compare/v0.12.1...develop
+[0.12.1]: https://github.com/GilbN/geometrikks/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/GilbN/geometrikks/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/GilbN/geometrikks/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/GilbN/geometrikks/compare/v0.9.0...v0.10.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # --platform=$BUILDPLATFORM: the vite/tsc output is architecture-independent,
 # so always build it natively instead of under QEMU emulation (bun is slow and
 # flaky when emulated during multi-arch release builds).
-FROM --platform=$BUILDPLATFORM oven/bun:1.3.14-slim@sha256:d56a2534ffd262e92c12fd3249d3924d296d97086da773f821d7d0477435ea04 AS frontend-builder
+FROM --platform=$BUILDPLATFORM oven/bun:1.4.0-slim@sha256:e0ee68d16ccb9927bf02aa7dd8fd4bf3369ee6d46da04faa72b05ce8bfd135f6 AS frontend-builder
 
 WORKDIR /app
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM oven/bun:1.3.14-slim@sha256:d56a2534ffd262e92c12fd3249d3924d296d97086da773f821d7d0477435ea04 AS bun
+FROM oven/bun:1.4.0-slim@sha256:e0ee68d16ccb9927bf02aa7dd8fd4bf3369ee6d46da04faa72b05ce8bfd135f6 AS bun
 
 FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 

--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ Images are published as `ghcr.io/gilbn/geometrikks`.
 | `latest` | `latest` | The newest stable release. |
 | Exact stable version | `X.Y.Z` | A specific stable release; use this for reproducible deployments. |
 | Major/minor stable version | `X.Y` | The newest stable patch release in a major/minor series. |
-| Exact development version | `0.12.0-dev.1` | A specific prerelease build for testing upcoming changes. |
+| Exact development version | `0.12.1-dev.1` | A specific prerelease build for testing upcoming changes. |
 | `develop` | `develop` | The newest development release; a moving tag. |
 
 Use `latest` to follow stable releases, or pin an exact version:
 
 ```yaml
-image: ghcr.io/gilbn/geometrikks:0.12.0
+image: ghcr.io/gilbn/geometrikks:0.12.1
 ```
 
 `docker-compose.yml` mounts `ACCESS_LOG_DIR` (default `/var/log/nginx`)
@@ -571,7 +571,7 @@ instance, GeoIP credentials, and its own log mount:
 ```yaml
 services:
   agent:
-    image: ghcr.io/gilbn/geometrikks:0.12.0   # same tag as the full instance
+    image: ghcr.io/gilbn/geometrikks:0.12.1   # same tag as the full instance
     restart: unless-stopped
     stop_grace_period: 20s
     environment:

--- a/bun.lock
+++ b/bun.lock
@@ -862,7 +862,7 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001761", "", {}, ""],
+    "caniuse-lite": ["caniuse-lite@1.0.30001810", "", {}, "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.34.0",
-        "maplibre-gl": "^5.24.0",
+        "maplibre-gl": "^6.6.0",
         "radix-ui": "^1.6.7",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -398,17 +398,15 @@
 
     "@mapbox/tiny-sdf": ["@mapbox/tiny-sdf@2.2.0", "", {}, "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg=="],
 
-    "@mapbox/unitbezier": ["@mapbox/unitbezier@0.0.1", "", {}, "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw=="],
+    "@mapbox/unitbezier": ["@mapbox/unitbezier@1.0.0", "", {}, "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ=="],
 
-    "@mapbox/vector-tile": ["@mapbox/vector-tile@2.0.5", "", { "dependencies": { "@mapbox/point-geometry": "~1.1.0", "@types/geojson": "^7946.0.16", "pbf": "^4.0.2" } }, "sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw=="],
-
-    "@mapbox/whoots-js": ["@mapbox/whoots-js@3.1.0", "", {}, "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="],
+    "@mapbox/vector-tile": ["@mapbox/vector-tile@3.0.0", "", { "dependencies": { "@mapbox/point-geometry": "~1.1.0", "@types/geojson": "^7946.0.16", "pbf": "^5.0.0" } }, "sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q=="],
 
     "@maplibre/geojson-vt": ["@maplibre/geojson-vt@6.1.1", "", { "dependencies": { "kdbush": "^4.1.0" } }, "sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ=="],
 
-    "@maplibre/maplibre-gl-style-spec": ["@maplibre/maplibre-gl-style-spec@24.10.0", "", { "dependencies": { "@mapbox/jsonlint-lines-primitives": "~2.0.2", "@mapbox/unitbezier": "^1.0.0", "json-stringify-pretty-compact": "^4.0.0", "minimist": "^1.2.8", "quickselect": "^3.0.0", "tinyqueue": "^3.0.0" }, "bin": { "gl-style-format": "dist/gl-style-format.mjs", "gl-style-migrate": "dist/gl-style-migrate.mjs", "gl-style-validate": "dist/gl-style-validate.mjs" } }, "sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw=="],
+    "@maplibre/maplibre-gl-style-spec": ["@maplibre/maplibre-gl-style-spec@26.4.1", "", { "dependencies": { "@mapbox/jsonlint-lines-primitives": "^2.0.3", "@mapbox/unitbezier": "^1.0.0", "json-stringify-pretty-compact": "^4.0.0", "minimist": "^1.2.8", "quickselect": "^3.0.0", "tinyqueue": "^3.0.0" }, "bin": { "gl-style-format": "dist/gl-style-format.mjs", "gl-style-migrate": "dist/gl-style-migrate.mjs", "gl-style-validate": "dist/gl-style-validate.mjs" } }, "sha512-I/qcIKVFHFSg1Meu/eqHrkSTjIez0gCsSaK56TNPutM3TkE61aSq6F1cZ4Kg4KiNs3cpViLtubDjfyRcQCdEJQ=="],
 
-    "@maplibre/mlt": ["@maplibre/mlt@1.1.12", "", { "dependencies": { "@mapbox/point-geometry": "^1.1.0" } }, "sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw=="],
+    "@maplibre/mlt": ["@maplibre/mlt@1.2.0", "", { "dependencies": { "@mapbox/point-geometry": "^1.1.0" } }, "sha512-g45M8gEI4sMO3X9ib4K7n3ZKFf0qQOL+NMkHCnEK51lOrYFHiEssOuZncx1+miIgi1IEE2NcbRMcq8RBkL+QHA=="],
 
     "@maplibre/vt-pbf": ["@maplibre/vt-pbf@4.3.2", "", { "dependencies": { "@mapbox/point-geometry": "^1.1.0", "@types/geojson": "^7946.0.16", "pbf": "^5.1.0" } }, "sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw=="],
 
@@ -1362,7 +1360,7 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, ""],
 
-    "maplibre-gl": ["maplibre-gl@5.24.0", "", { "dependencies": { "@mapbox/jsonlint-lines-primitives": "^2.0.2", "@mapbox/point-geometry": "^1.1.0", "@mapbox/tiny-sdf": "^2.1.0", "@mapbox/unitbezier": "^0.0.1", "@mapbox/vector-tile": "^2.0.4", "@mapbox/whoots-js": "^3.1.0", "@maplibre/geojson-vt": "^6.1.0", "@maplibre/maplibre-gl-style-spec": "^24.8.1", "@maplibre/mlt": "^1.1.8", "@maplibre/vt-pbf": "^4.3.0", "@types/geojson": "^7946.0.16", "earcut": "^3.0.2", "gl-matrix": "^3.4.4", "kdbush": "^4.0.2", "murmurhash-js": "^1.0.0", "pbf": "^4.0.1", "potpack": "^2.1.0", "quickselect": "^3.0.0", "tinyqueue": "^3.0.0" } }, "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A=="],
+    "maplibre-gl": ["maplibre-gl@6.6.0", "", { "dependencies": { "@mapbox/point-geometry": "^1.1.0", "@mapbox/tiny-sdf": "^2.2.0", "@mapbox/unitbezier": "^1.0.0", "@mapbox/vector-tile": "^3.0.0", "@maplibre/geojson-vt": "^6.1.1", "@maplibre/maplibre-gl-style-spec": "^26.3.0", "@maplibre/mlt": "^1.2.0", "@maplibre/vt-pbf": "^4.3.2", "@types/geojson": "^7946.0.16", "earcut": "^3.2.3", "gl-matrix": "^3.4.4", "kdbush": "^4.1.0", "murmurhash-js": "^1.0.0", "pbf": "^5.1.2", "potpack": "^2.1.0", "quickselect": "^3.0.0", "tinyqueue": "^3.0.0" } }, "sha512-EQql6eZYPhbHvJpqY4AwoiuLkUfXFRBHk67S8mDtzNo1F/jAo7xAxunIzO7gJ1vwTcPMgrK9b64dqKHvnkTlDQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, ""],
 
@@ -1450,7 +1448,7 @@
 
     "pathe": ["pathe@2.0.3", "", {}, ""],
 
-    "pbf": ["pbf@4.0.2", "", { "dependencies": { "resolve-protobuf-schema": "^2.1.0" }, "bin": { "pbf": "bin/pbf" } }, "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg=="],
+    "pbf": ["pbf@5.1.2", "", { "dependencies": { "resolve-protobuf-schema": "^2.1.0" }, "bin": { "pbf": "bin/pbf" } }, "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w=="],
 
     "perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
 
@@ -2068,10 +2066,6 @@
 
     "@dotenvx/dotenvx/picomatch": ["picomatch@4.0.3", "", {}, ""],
 
-    "@maplibre/maplibre-gl-style-spec/@mapbox/unitbezier": ["@mapbox/unitbezier@1.0.0", "", {}, "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ=="],
-
-    "@maplibre/vt-pbf/pbf": ["pbf@5.1.2", "", { "dependencies": { "resolve-protobuf-schema": "^2.1.0" }, "bin": { "pbf": "bin/pbf" } }, "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w=="],
-
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
@@ -2371,6 +2365,8 @@
     "@tanstack/router-utils/tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, ""],
 
     "@vis.gl/react-maplibre/@maplibre/maplibre-gl-style-spec/@mapbox/jsonlint-lines-primitives": ["@mapbox/jsonlint-lines-primitives@2.0.2", "", {}, "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ=="],
+
+    "@vis.gl/react-maplibre/@maplibre/maplibre-gl-style-spec/@mapbox/unitbezier": ["@mapbox/unitbezier@0.0.1", "", {}, "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw=="],
 
     "@vis.gl/react-maplibre/@maplibre/maplibre-gl-style-spec/json-stringify-pretty-compact": ["json-stringify-pretty-compact@3.0.0", "", {}, "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA=="],
 

--- a/geometrikks/server/core.py
+++ b/geometrikks/server/core.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from litestar import Litestar
 from litestar.di import Provide
 from litestar.openapi import OpenAPIConfig
+from litestar.openapi.plugins import ScalarRenderPlugin
 from litestar.config.compression import CompressionConfig
 
 from geometrikks.config.settings import Settings, get_settings
@@ -82,6 +83,7 @@ def create_app(
             version=settings.version,
             description=settings.description,
             create_examples=False,
+            render_plugins=[ScalarRenderPlugin()],
         )
 
     compression_config = CompressionConfig(

--- a/geometrikks/services/crowdsec/exceptions.py
+++ b/geometrikks/services/crowdsec/exceptions.py
@@ -1,6 +1,6 @@
 """Domain exceptions for the CrowdSec integration.
 
-The service raises these instead of leaking httpx exceptions; app-level
+The service raises these instead of leaking httpx2 exceptions; app-level
 handlers in server/core.py translate them to HTTP responses.
 """
 from __future__ import annotations

--- a/geometrikks/services/crowdsec/service.py
+++ b/geometrikks/services/crowdsec/service.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-import httpx
+import httpx2
 import msgspec
 
 from geometrikks.config.settings import CrowdSecSettings
@@ -27,7 +27,7 @@ logger = get_logger(__name__)
 class CrowdSecService:
     """Async client for the CrowdSec Local API.
 
-    Owns one ``httpx.AsyncClient`` for the process lifetime; constructed at
+    Owns one ``httpx2.AsyncClient`` for the process lifetime; constructed at
     startup only when the integration is enabled and closed on shutdown.
     """
 
@@ -35,7 +35,7 @@ class CrowdSecService:
         self,
         settings: CrowdSecSettings,
         *,
-        transport: httpx.AsyncBaseTransport | None = None,
+        transport: httpx2.AsyncBaseTransport | None = None,
     ) -> None:
         if settings.lapi_url is None or settings.bouncer_api_key is None:
             raise CrowdSecAuthError(
@@ -43,7 +43,7 @@ class CrowdSecService:
             )
         self._settings = settings
         self._bouncer_headers = {"X-Api-Key": settings.bouncer_api_key.get_secret_value()}
-        self._client = httpx.AsyncClient(
+        self._client = httpx2.AsyncClient(
             base_url=settings.lapi_url,
             timeout=settings.request_timeout,
             verify=settings.verify_tls,
@@ -86,13 +86,13 @@ class CrowdSecService:
                 "/v1/decisions", headers=self._bouncer_headers, params=params
             )
             resp.raise_for_status()
-        except httpx.HTTPStatusError as exc:
+        except httpx2.HTTPStatusError as exc:
             if exc.response.status_code in (401, 403):
                 raise CrowdSecAuthError("LAPI rejected the bouncer API key") from exc
             raise CrowdSecUnavailableError(
                 f"LAPI error: HTTP {exc.response.status_code}"
             ) from exc
-        except httpx.HTTPError as exc:
+        except httpx2.HTTPError as exc:
             raise CrowdSecUnavailableError(f"LAPI unreachable: {exc}") from exc
         # The LAPI returns JSON null when no decisions match.
         return msgspec.convert(resp.json() or [], list[Decision], strict=False)
@@ -117,13 +117,13 @@ class CrowdSecService:
                 "/v1/decisions/stream", headers=self._bouncer_headers, params=params
             )
             resp.raise_for_status()
-        except httpx.HTTPStatusError as exc:
+        except httpx2.HTTPStatusError as exc:
             if exc.response.status_code in (401, 403):
                 raise CrowdSecAuthError("LAPI rejected the bouncer API key") from exc
             raise CrowdSecUnavailableError(
                 f"LAPI error: HTTP {exc.response.status_code}"
             ) from exc
-        except httpx.HTTPError as exc:
+        except httpx2.HTTPError as exc:
             raise CrowdSecUnavailableError(f"LAPI unreachable: {exc}") from exc
         body = resp.json() or {}
         # Both keys are JSON null when nothing changed.
@@ -159,13 +159,13 @@ class CrowdSecService:
             if resp.status_code in (401, 403):
                 raise CrowdSecAuthError("LAPI rejected the machine credentials")
             resp.raise_for_status()
-        except httpx.HTTPError as exc:
+        except httpx2.HTTPError as exc:
             raise CrowdSecUnavailableError(f"LAPI unreachable: {exc}") from exc
         self._machine_token = resp.json()["token"]
         logger.info("Logged in to CrowdSec LAPI as machine %s", self._settings.machine_id)
         return self._machine_token
 
-    async def _machine_request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+    async def _machine_request(self, method: str, url: str, **kwargs: Any) -> httpx2.Response:
         token = self._machine_token or await self._login()
         try:
             resp = await self._client.request(
@@ -181,11 +181,11 @@ class CrowdSecService:
                 raise CrowdSecAuthError("LAPI rejected the machine token")
             resp.raise_for_status()
             return resp
-        except httpx.HTTPStatusError as exc:
+        except httpx2.HTTPStatusError as exc:
             raise CrowdSecUnavailableError(
                 f"LAPI error: HTTP {exc.response.status_code}"
             ) from exc
-        except httpx.HTTPError as exc:
+        except httpx2.HTTPError as exc:
             raise CrowdSecUnavailableError(f"LAPI unreachable: {exc}") from exc
 
     async def ban_ip(

--- a/geometrikks/services/geoip/downloader.py
+++ b/geometrikks/services/geoip/downloader.py
@@ -16,7 +16,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import httpx
+import httpx2
 
 from geometrikks.lib.utils import GeoIPInfoView, geoip_info
 from geometrikks.server.logging import get_logger
@@ -66,7 +66,7 @@ def database_is_stale(db_path: Path, max_age_days: int) -> bool:
 async def _fetch_tarball(settings: "GeoIPSettings", edition: str) -> bytes:
     """GET the tar.gz with basic auth; module-level for test monkeypatching."""
     try:
-        async with httpx.AsyncClient(
+        async with httpx2.AsyncClient(
             auth=(
                 settings.account_id or "",
                 settings.license_key.get_secret_value() if settings.license_key else "",
@@ -80,7 +80,7 @@ async def _fetch_tarball(settings: "GeoIPSettings", edition: str) -> bytes:
             )
             response.raise_for_status()
             return response.content
-    except httpx.HTTPError as exc:
+    except httpx2.HTTPError as exc:
         raise GeoIPDownloadError(f"MaxMind download failed ({edition}): {exc}") from exc
 
 

--- a/geometrikks/services/geoip/home.py
+++ b/geometrikks/services/geoip/home.py
@@ -6,7 +6,7 @@ import ipaddress
 from dataclasses import dataclass
 from typing import Literal
 
-import httpx
+import httpx2
 from geoip2.database import Reader
 from geoip2.errors import GeoIP2Error
 
@@ -27,7 +27,7 @@ class HomeLocation:
     source: HomeLocationSource
 
 
-async def _fetch_public_ip(settings: MapSettings, client: httpx.AsyncClient) -> str:
+async def _fetch_public_ip(settings: MapSettings, client: httpx2.AsyncClient) -> str:
     response = await client.get(settings.public_ip_url)
     response.raise_for_status()
     payload = response.json()
@@ -44,7 +44,7 @@ async def resolve_home_location(
     geoip_settings: GeoIPSettings,
     *,
     geoip_available: bool,
-    client: httpx.AsyncClient | None = None,
+    client: httpx2.AsyncClient | None = None,
 ) -> HomeLocation | None:
     """Resolve configured coordinates or geolocate the server's public IP.
 
@@ -63,8 +63,8 @@ async def resolve_home_location(
 
     try:
         if client is None:
-            timeout = httpx.Timeout(map_settings.public_ip_timeout)
-            async with httpx.AsyncClient(timeout=timeout, follow_redirects=False) as owned_client:
+            timeout = httpx2.Timeout(map_settings.public_ip_timeout)
+            async with httpx2.AsyncClient(timeout=timeout, follow_redirects=False) as owned_client:
                 public_ip = await _fetch_public_ip(map_settings, owned_client)
         else:
             public_ip = await _fetch_public_ip(map_settings, client)
@@ -77,7 +77,7 @@ async def resolve_home_location(
             raise ValueError("GeoIP lookup returned no coordinates")
         logger.info("home_location_resolved", source="external_ip")
         return HomeLocation(latitude=latitude, longitude=longitude, source="external_ip")
-    except (GeoIP2Error, httpx.HTTPError, OSError, ValueError) as exc:
+    except (GeoIP2Error, httpx2.HTTPError, OSError, ValueError) as exc:
         logger.warning(
             "Could not auto-detect map home location: %s. Set MAP_HOME_LATITUDE "
             "and MAP_HOME_LONGITUDE to override it.",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.34.0",
-    "maplibre-gl": "^5.24.0",
+    "maplibre-gl": "^6.6.0",
     "radix-ui": "^1.6.7",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,10 @@ dependencies = [
     "python-dotenv>=1.2.3",
     "pydantic-settings>=2.15.0",
     "asyncpg>=0.31.0",
-    "httpx>=0.28.1",
-    "httpx-oauth>=0.17.0",
     "aiofiles>=25.1.0",
     "geoalchemy2>=0.20.0",
     "apscheduler>=3.11.3,<4.0",
+    "httpx2>=2.12.0",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geometrikks"
-version = "0.12.0"
+version = "0.12.1"
 description = "Geo metrics ingress service built with Litestar."
 readme = "README.md"
 requires-python = ">=3.13,<3.14"

--- a/resources/components/geo-logs/geo-logs-map.tsx
+++ b/resources/components/geo-logs/geo-logs-map.tsx
@@ -27,6 +27,7 @@ import {
   unclusteredPointLabelLayer,
   unclusteredPointLayer,
 } from "@/components/map/layers"
+import { MAPLIBRE_WORKER_URL } from "@/lib/maplibre-worker"
 import { useGeoLogsGeoJSON } from "@/lib/queries"
 import { cn } from "@/lib/utils"
 
@@ -141,6 +142,7 @@ export default function GeoLogsMap() {
       <div className="absolute inset-0">
         <Map
           ref={mapRef}
+          workerUrl={MAPLIBRE_WORKER_URL}
           {...viewState}
           onMove={onMove}
           onClick={onClick}

--- a/resources/components/map/GeoMap.tsx
+++ b/resources/components/map/GeoMap.tsx
@@ -58,6 +58,7 @@ import {
 import { LiveTrafficProvider, useLiveTrafficStore } from "@/lib/live-traffic/context"
 import type { LiveRequest } from "@/lib/live-traffic/types"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { MAPLIBRE_WORKER_URL } from "@/lib/maplibre-worker"
 
 export type LayerType = "heatmap" | "markers"
 export type MapProjection = "mercator" | "globe"
@@ -492,6 +493,7 @@ function GeoMapInner({
     <div className="h-full w-full relative">
       <Map
         ref={mapRef}
+        workerUrl={MAPLIBRE_WORKER_URL}
         {...viewState}
         onLoad={() => setMapLoaded(true)}
         onMove={onMove}

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -4238,7 +4238,7 @@
   "info": {
     "description": "Real-time GeoIP lookups and traffic analytics API",
     "title": "GeoMetrikks API",
-    "version": "0.12.0"
+    "version": "0.12.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/resources/generated/routes.json
+++ b/resources/generated/routes.json
@@ -628,13 +628,6 @@
       ],
       "uri": "/schema/openapi.json"
     },
-    "openapi.yaml": {
-      "method": "get",
-      "methods": [
-        "GET"
-      ],
-      "uri": "/schema/openapi.yaml"
-    },
     "read_settings": {
       "method": "get",
       "methods": [

--- a/resources/generated/routes.ts
+++ b/resources/generated/routes.ts
@@ -69,7 +69,6 @@ export type RouteName =
   | 'lookup_decisions'
   | 'me'
   | 'openapi.json'
-  | 'openapi.yaml'
   | 'read_settings'
   | 'rotate'
   | 'run_scheduler_job'
@@ -139,7 +138,6 @@ export interface RoutePathParams {
   'lookup_decisions': Record<string, never>;
   'me': Record<string, never>;
   'openapi.json': Record<string, never>;
-  'openapi.yaml': Record<string, never>;
   'read_settings': Record<string, never>;
   'rotate': Record<string, never>;
   'run_scheduler_job': {
@@ -424,7 +422,6 @@ export interface RouteQueryParams {
   };
   'me': Record<string, never>;
   'openapi.json': Record<string, never>;
-  'openapi.yaml': Record<string, never>;
   'read_settings': Record<string, never>;
   'rotate': Record<string, never>;
   'run_scheduler_job': Record<string, never>;
@@ -799,13 +796,6 @@ export const routeDefinitions = {
   },
   'openapi.json': {
     path: '/schema/openapi.json',
-    methods: ['GET'] as const,
-    method: 'get',
-    pathParams: [] as const,
-    queryParams: [] as const,
-  },
-  'openapi.yaml': {
-    path: '/schema/openapi.yaml',
     methods: ['GET'] as const,
     method: 'get',
     pathParams: [] as const,

--- a/resources/lib/maplibre-worker.ts
+++ b/resources/lib/maplibre-worker.ts
@@ -1,0 +1,9 @@
+/**
+ * MapLibre 6 runs tile and GeoJSON processing in a separate worker script and
+ * looks for it next to its own module URL. Inside a Vite bundle that file is
+ * never emitted, so every GL layer (tiles, heatmap, live routes) stays blank
+ * while DOM markers keep working. This is the copy Vite bundles instead.
+ */
+import workerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url"
+
+export const MAPLIBRE_WORKER_URL = workerUrl

--- a/resources/main.css
+++ b/resources/main.css
@@ -5,7 +5,7 @@
 
 @font-face {
   font-family: "runr";
-  src: url("/static/fonts/runr-Regular.woff2") format("woff2");
+  src: url("/fonts/runr-Regular.woff2") format("woff2");
   font-style: normal;
   font-weight: 400;
   font-display: swap;

--- a/tests/test_crowdsec_service.py
+++ b/tests/test_crowdsec_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-import httpx
+import httpx2
 import pytest
 
 from geometrikks.config.settings import CrowdSecSettings
@@ -40,13 +40,13 @@ def make_settings(**overrides) -> CrowdSecSettings:
 def make_service(respond, **settings_overrides) -> CrowdSecService:
     return CrowdSecService(
         make_settings(**settings_overrides),
-        transport=httpx.MockTransport(respond),
+        transport=httpx2.MockTransport(respond),
     )
 
 
 async def test_get_decisions_parses_typed_decisions():
-    def respond(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json=[DECISION_JSON])
+    def respond(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, json=[DECISION_JSON])
 
     service = make_service(respond)
     decisions = await service.get_decisions()
@@ -65,9 +65,9 @@ async def test_get_decisions_parses_typed_decisions():
 
 
 async def test_get_decisions_null_body_returns_empty_list():
-    def respond(request: httpx.Request) -> httpx.Response:
+    def respond(request: httpx2.Request) -> httpx2.Response:
         # LAPI returns JSON null when no decisions match
-        return httpx.Response(200, content=b"null", headers={"content-type": "application/json"})
+        return httpx2.Response(200, content=b"null", headers={"content-type": "application/json"})
 
     service = make_service(respond)
     assert await service.get_decisions() == []
@@ -77,10 +77,10 @@ async def test_get_decisions_null_body_returns_empty_list():
 async def test_get_decisions_sends_bouncer_key_and_filters():
     seen: dict = {}
 
-    def respond(request: httpx.Request) -> httpx.Response:
+    def respond(request: httpx2.Request) -> httpx2.Response:
         seen["headers"] = request.headers
         seen["url"] = request.url
-        return httpx.Response(200, json=[])
+        return httpx2.Response(200, json=[])
 
     service = make_service(respond)
     await service.get_decisions(ip="1.2.3.4", origins="cscli,crowdsec")
@@ -94,9 +94,9 @@ async def test_get_decisions_sends_bouncer_key_and_filters():
 async def test_get_decisions_for_ip_filters_on_ip():
     seen: dict = {}
 
-    def respond(request: httpx.Request) -> httpx.Response:
+    def respond(request: httpx2.Request) -> httpx2.Response:
         seen["params"] = request.url.params
-        return httpx.Response(200, json=[])
+        return httpx2.Response(200, json=[])
 
     service = make_service(respond)
     await service.get_decisions_for_ip("10.0.0.1")
@@ -105,8 +105,8 @@ async def test_get_decisions_for_ip_filters_on_ip():
 
 
 async def test_rejected_bouncer_key_raises_auth_error():
-    def respond(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(403, json={"message": "forbidden"})
+    def respond(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(403, json={"message": "forbidden"})
 
     service = make_service(respond)
     with pytest.raises(CrowdSecAuthError):
@@ -115,8 +115,8 @@ async def test_rejected_bouncer_key_raises_auth_error():
 
 
 async def test_lapi_5xx_raises_unavailable_error():
-    def respond(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(502)
+    def respond(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(502)
 
     service = make_service(respond)
     with pytest.raises(CrowdSecUnavailableError):
@@ -125,8 +125,8 @@ async def test_lapi_5xx_raises_unavailable_error():
 
 
 async def test_connection_failure_raises_unavailable_error():
-    def respond(request: httpx.Request) -> httpx.Response:
-        raise httpx.ConnectError("boom")
+    def respond(request: httpx2.Request) -> httpx2.Response:
+        raise httpx2.ConnectError("boom")
 
     service = make_service(respond)
     with pytest.raises(CrowdSecUnavailableError):
@@ -135,11 +135,11 @@ async def test_connection_failure_raises_unavailable_error():
 
 
 async def test_ping_true_when_reachable_false_when_not():
-    def ok(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json=[])
+    def ok(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, json=[])
 
-    def down(request: httpx.Request) -> httpx.Response:
-        raise httpx.ConnectError("boom")
+    def down(request: httpx2.Request) -> httpx2.Response:
+        raise httpx2.ConnectError("boom")
 
     up_service = make_service(ok)
     down_service = make_service(down)
@@ -150,9 +150,9 @@ async def test_ping_true_when_reachable_false_when_not():
 
 
 async def test_unknown_extra_fields_are_ignored():
-    def respond(request: httpx.Request) -> httpx.Response:
+    def respond(request: httpx2.Request) -> httpx2.Response:
         payload = [{**DECISION_JSON, "simulated": False, "until": "2026-01-01T00:00:00Z"}]
-        return httpx.Response(200, content=json.dumps(payload), headers={"content-type": "application/json"})
+        return httpx2.Response(200, content=json.dumps(payload), headers={"content-type": "application/json"})
 
     service = make_service(respond)
     decisions = await service.get_decisions()
@@ -180,23 +180,23 @@ class LapiWriteFake:
         self._login_status = login_status
         self._expire_first_token = expire_first_token
 
-    def __call__(self, request: httpx.Request) -> httpx.Response:
+    def __call__(self, request: httpx2.Request) -> httpx2.Response:
         if request.url.path == "/v1/watchers/login":
             self.login_calls += 1
             if self._login_status != 200:
-                return httpx.Response(self._login_status, json={"message": "denied"})
-            return httpx.Response(200, json={"token": f"jwt-{self.login_calls}", "expire": "2099-01-01T00:00:00Z"})
+                return httpx2.Response(self._login_status, json={"message": "denied"})
+            return httpx2.Response(200, json={"token": f"jwt-{self.login_calls}", "expire": "2099-01-01T00:00:00Z"})
         self.auth_headers.append(request.headers.get("Authorization"))
         # Simulate an expired first token: 401 until re-login issues jwt-2
         if self._expire_first_token and request.headers.get("Authorization") == "Bearer jwt-1":
-            return httpx.Response(401, json={"message": "token expired"})
+            return httpx2.Response(401, json={"message": "token expired"})
         if request.url.path == "/v1/alerts" and request.method == "POST":
             self.alert_payloads.append(json.loads(request.content))
-            return httpx.Response(201, json=["1"])
+            return httpx2.Response(201, json=["1"])
         if request.url.path == "/v1/decisions" and request.method == "DELETE":
             self.delete_params.append(dict(request.url.params))
-            return httpx.Response(200, json={"nbDeleted": "2"})
-        return httpx.Response(404)
+            return httpx2.Response(200, json={"nbDeleted": "2"})
+        return httpx2.Response(404)
 
 
 def write_settings() -> dict:
@@ -290,11 +290,11 @@ ALERT_JSON = {
 
 
 class LapiAlertsFake(LapiWriteFake):
-    def __call__(self, request: httpx.Request) -> httpx.Response:
+    def __call__(self, request: httpx2.Request) -> httpx2.Response:
         if request.url.path == "/v1/alerts" and request.method == "GET":
             self.auth_headers.append(request.headers.get("Authorization"))
             self.alert_params = dict(request.url.params)
-            return httpx.Response(200, json=[ALERT_JSON, {**ALERT_JSON, "id": 8, "decisions": None}])
+            return httpx2.Response(200, json=[ALERT_JSON, {**ALERT_JSON, "id": 8, "decisions": None}])
         return super().__call__(request)
 
 

--- a/tests/test_crowdsec_stream.py
+++ b/tests/test_crowdsec_stream.py
@@ -1,7 +1,7 @@
 """Decision stream: service parsing and the poller's broadcast behavior."""
 from __future__ import annotations
 
-import httpx
+import httpx2
 
 from tests.test_crowdsec_service import DECISION_JSON, make_service
 
@@ -17,9 +17,9 @@ class _StreamResponder:
         self._payloads = payloads
         self.calls: list[dict] = []
 
-    def __call__(self, request: httpx.Request) -> httpx.Response:
+    def __call__(self, request: httpx2.Request) -> httpx2.Response:
         self.calls.append({"params": dict(request.url.params), "headers": request.headers})
-        return httpx.Response(
+        return httpx2.Response(
             200, json=self._payloads[min(len(self.calls) - 1, len(self._payloads) - 1)]
         )
 
@@ -120,8 +120,8 @@ async def test_empty_delta_broadcasts_nothing():
 
 
 async def test_poll_survives_lapi_errors():
-    def respond(request: httpx.Request) -> httpx.Response:
-        raise httpx.ConnectError("boom")
+    def respond(request: httpx2.Request) -> httpx2.Response:
+        raise httpx2.ConnectError("boom")
 
     service = make_service(respond)
     poller = make_poller(service)
@@ -136,11 +136,11 @@ def flaky_responder(failures: int, payload: dict):
     """Raise ConnectError for the first `failures` calls, then return payload."""
     calls = {"n": 0}
 
-    def respond(request: httpx.Request) -> httpx.Response:
+    def respond(request: httpx2.Request) -> httpx2.Response:
         calls["n"] += 1
         if calls["n"] <= failures:
-            raise httpx.ConnectError("boom")
-        return httpx.Response(200, json=payload)
+            raise httpx2.ConnectError("boom")
+        return httpx2.Response(200, json=payload)
 
     return respond
 

--- a/tests/test_geoip_home.py
+++ b/tests/test_geoip_home.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import httpx
+import httpx2
 
 from geometrikks.config.settings import GeoIPSettings, MapSettings
 from geometrikks.services.geoip.home import resolve_home_location
@@ -24,10 +24,10 @@ async def test_configured_home_skips_public_ip_lookup():
 
 
 async def test_external_ip_is_geolocated_with_local_database():
-    def respond(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"ip": "81.2.69.142"}, request=request)
+    def respond(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, json={"ip": "81.2.69.142"}, request=request)
 
-    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(respond)) as client:
         home = await resolve_home_location(
             MapSettings(auto_detect_home=True, _env_file=None),
             GeoIPSettings(
@@ -46,10 +46,10 @@ async def test_external_ip_is_geolocated_with_local_database():
 
 
 async def test_discovery_failure_degrades_without_raising():
-    def respond(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(503, request=request)
+    def respond(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(503, request=request)
 
-    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(respond)) as client:
         home = await resolve_home_location(
             MapSettings(auto_detect_home=True, _env_file=None),
             GeoIPSettings(validate_db_path=False, _env_file=None),

--- a/uv.lock
+++ b/uv.lock
@@ -504,8 +504,7 @@ dependencies = [
     { name = "geoalchemy2" },
     { name = "geohash2" },
     { name = "geoip2" },
-    { name = "httpx" },
-    { name = "httpx-oauth" },
+    { name = "httpx2" },
     { name = "ipy" },
     { name = "litestar", extra = ["brotli", "jwt", "pydantic", "standard", "structlog"] },
     { name = "litestar-geoalchemy" },
@@ -533,8 +532,7 @@ requires-dist = [
     { name = "geoalchemy2", specifier = ">=0.20.0" },
     { name = "geohash2", specifier = ">=1.1" },
     { name = "geoip2", specifier = ">=5.3.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "httpx-oauth", specifier = ">=0.17.0" },
+    { name = "httpx2", specifier = ">=2.12.0" },
     { name = "ipy", specifier = ">=1.1" },
     { name = "litestar", extras = ["standard", "brotli", "jwt", "structlog", "pydantic"], specifier = ">=2.24.0,<3" },
     { name = "litestar-geoalchemy", specifier = ">=0.3.0" },
@@ -632,6 +630,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -662,15 +673,28 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-oauth"
-version = "0.17.0"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/91/8b9f58cbf6e8914577183731233e66d3e586f1397b23190f46a929206b96/httpx_oauth-0.17.0.tar.gz", hash = "sha256:d279997ea80e7fc6f713acc8ed0fcc07ec319bae939753a2579d1fb7a753167b", size = 124506, upload-time = "2026-05-13T14:47:08.744Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/23/db1df57aeb6b96ad6c2c3b84bf45d22fc3293949cee7c506cbd5aa1805a3/httpx_oauth-0.17.0-py3-none-any.whl", hash = "sha256:8098e48dfeb97d0f35a83aa7bfaf18d2e7dcd9f3962f19f60fc0ec939e5d6bd2", size = 38083, upload-time = "2026-05-13T14:47:07.659Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -1379,6 +1403,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/89/b4a0bcfdf4f71a3dea31379f095929613d7e4528a0996bca6aa964cd0dca/structlog-26.1.0.tar.gz", hash = "sha256:f63a716cbd1b1291cf7661de7794b455acfa4c43c5bcf1630e6ad5ddc1adb3b7", size = 1459881, upload-time = "2026-06-06T07:33:39.348Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/18/489c97b834dfff9cf2fc2507cede4bcd4b11e67f84bc462acd1992496f86/structlog-26.1.0-py3-none-any.whl", hash = "sha256:e081a26d6c373e6d201eca24eede26d8ffab07f88f477822e679183428d3d91e", size = 73764, upload-time = "2026-06-06T07:33:38.046Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "geometrikks"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "advanced-alchemy", extra = ["argon2", "cli", "passlib", "pwdlib"] },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
   build: {
     outDir: "public",
     emptyOutDir: true,
+    // maplibre-gl alone is ~990 kB minified and already ships as its own
+    // lazy chunk behind the map route; the default 500 kB limit only ever
+    // flagged it.
+    chunkSizeWarningLimit: 1100,
   },
   // No server block: Litestar is the single dev origin. litestar-vite runs
   // Vite as a sidecar on an ephemeral localhost port (written to the
@@ -78,7 +82,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "resources"),
+      "@": path.resolve(import.meta.dirname, "resources"),
     },
   },
 });


### PR DESCRIPTION
Release 0.12.1.

- The map runs on MapLibre GL JS 6 (6.6.0, up from 5.24.0).
- The backend's HTTP client is `httpx2` 2.12 instead of `httpx`; the unused `httpx-oauth` dependency is dropped. The container image builds on `oven/bun` 1.4.0.
- The API reference at `/schema` is rendered by Scalar. The ReDoc, Swagger UI, RapiDoc and Stoplight pages and `/schema/openapi.yaml` are gone; `/schema/openapi.json` is unchanged.
