### PR TITLE
fix(traefik): take the rightmost X-Forwarded-For hop from ClientHost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Startup refuses an `ANALYTICS_RAW_RETENTION_DAYS` below 4 with a message naming the aggregate and the floor. The daily aggregates refresh their last 3 days from raw rows, so a shorter raw retention made every refresh find empty raw data under part of that window and delete the materialized rows, with nothing in the logs.
 - Changing any of the `ANALYTICS_*` policy settings (`RAW_RETENTION_DAYS`, `DEBUG_RETENTION_DAYS`, `HOURLY_RETENTION_DAYS`, `COMPRESSION_AFTER_DAYS`, `CAGG_REFRESH_INTERVAL_MINUTES`) on an existing database now updates the TimescaleDB policies on the next start (`policy_updated` in the logs). Until now the policies kept whatever values the database was first created with, and the new value was only logged at debug level and dropped.
+- The `traefik-json` format takes the rightmost address of an `X-Forwarded-For` chain in `ClientHost`, not the leftmost. Traefik logs the chain as it arrived from a trusted peer without appending the peer, so the leftmost entry is whatever the client sent and any client could put an arbitrary address on the map; the rightmost entry is the one the trusted proxy added.
 
 ## [0.12.1] - 2026-08-30
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,11 @@ to pin it. Notes:
   `docker kill --signal=USR1 traefik`. GeoMetrikks follows the rotation.
 - Behind a CDN or load balancer, configure Traefik's
   `entryPoints.<name>.forwardedHeaders.trustedIPs` so the logged client IP
-  is the real client, not the proxy.
+  is the real client, not the proxy. With a trusted peer, Traefik logs the
+  `X-Forwarded-For` chain as it arrived; GeoMetrikks takes the rightmost
+  entry, the one your proxy appended. Do not set `forwardedHeaders.insecure`:
+  it trusts the header from anyone, and a client can then place any address
+  on the map.
 - A file path is required; GeoMetrikks cannot read Traefik's stdout.
 
 ## MaxMind GeoLite2

--- a/geometrikks/services/logparser/formats/traefik.py
+++ b/geometrikks/services/logparser/formats/traefik.py
@@ -3,7 +3,11 @@
 Field reference verified against Traefik v2.11/v3.x source
 (pkg/middlewares/accesslog/): Duration/OriginDuration are integer
 nanoseconds; ClientHost is the raw X-Forwarded-For value (possibly a
-comma-separated chain) when XFF is present, else the peer IP; header
+comma-separated chain) when XFF is present, else the peer IP. Traefik
+strips X-Forwarded-For from untrusted peers, so a chain only appears when
+forwardedHeaders.trustedIPs (or insecure) let it through, and Traefik does
+not append the peer itself: the rightmost entry is the address the trusted
+proxy added, the leftmost is whatever the client sent. Header
 fields (request_User-Agent, request_Referer) exist only when the user
 keeps headers; every line also carries logrus level/msg/time keys.
 """
@@ -68,7 +72,7 @@ class TraefikJsonFormat:
 
         ip = data.get("ClientHost") or ""
         if "," in ip:
-            ip = ip.split(",", 1)[0]
+            ip = ip.rsplit(",", 1)[1]
         ip = ip.strip()
         if not ip:
             ip = _host_from_addr(str(data.get("ClientAddr") or ""))

--- a/tests/test_logparser_formats.py
+++ b/tests/test_logparser_formats.py
@@ -180,9 +180,20 @@ def test_traefik_parse_headers_dropped() -> None:
     assert norm.referrer is None
 
 
-def test_traefik_parse_xff_chain_takes_first_hop() -> None:
+def test_traefik_parse_xff_chain_takes_last_hop() -> None:
+    """ClientHost carries the client-supplied X-Forwarded-For chain verbatim
+    when the peer is trusted, and the leftmost entry is whatever the client
+    sent. The rightmost entry is the address the trusted proxy appended."""
     data = json.loads(TRAEFIK_FULL)
-    data["ClientHost"] = "203.0.113.7, 10.0.0.2"
+    data["ClientHost"] = "8.8.8.8, 203.0.113.7"
+    norm = TraefikJsonFormat().parse(json.dumps(data))
+    assert norm is not None
+    assert norm.ip_address == "203.0.113.7"
+
+
+def test_traefik_parse_xff_chain_strips_whitespace_around_last_hop() -> None:
+    data = json.loads(TRAEFIK_FULL)
+    data["ClientHost"] = "8.8.8.8,203.0.113.7 "
     norm = TraefikJsonFormat().parse(json.dumps(data))
     assert norm is not None
     assert norm.ip_address == "203.0.113.7"


### PR DESCRIPTION
## What changes

- `TraefikJsonFormat.parse()` takes the rightmost entry of a comma-separated `ClientHost` instead of the leftmost.
- The module docstring describes when Traefik puts a chain in `ClientHost` and which end of it the proxy added.
- The README's Traefik section says which entry GeoMetrikks uses and warns against `forwardedHeaders.insecure`.

## Why

Traefik's access log sets `ClientHost` to the `X-Forwarded-For` header whenever one is present (`pkg/middlewares/accesslog/logger.go`). The `forwardedheaders` middleware, which runs before the access log, deletes the header from untrusted peers and keeps it as-is from trusted ones, and never appends the peer's own address. So a chain only reaches the log through `trustedIPs` or `insecure`, and in that chain the leftmost entry is whatever the client sent while the rightmost is the address the trusted proxy appended. With the leftmost split, a request carrying `X-Forwarded-For: 8.8.8.8` through a trusted CDN was mapped to 8.8.8.8.

## Tests

- `test_traefik_parse_xff_chain_takes_last_hop` and `test_traefik_parse_xff_chain_strips_whitespace_around_last_hop` replace `test_traefik_parse_xff_chain_takes_first_hop`.
- Full unit suite and `ty check geometrikks tests` pass.
