### PR TITLE
feat: add Caddy JSON log format support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,13 +19,15 @@ APP_TRUSTED_PROXIES=
 MAXMINDDB_USER_ID=
 MAXMINDDB_LICENSE_KEY=
 
-# Access log(s) to tail (nginx or Traefik JSON) - a single path or JSON list.
-# The compose file mounts $ACCESS_LOG_DIR (default /var/log/nginx) read-only
-# at /var/log/access inside the container. See README for Traefik setup.
+# Access log(s) to tail (nginx, Traefik JSON or Caddy JSON) - a single path
+# or JSON list. The compose file mounts $ACCESS_LOG_DIR (default
+# /var/log/nginx) read-only at /var/log/access inside the container. See
+# README for Traefik and Caddy setup.
 LOGPARSER_LOG_PATHS=/var/log/access/access.log
 
-# Format of the file(s) above: auto (default, detected per file), nginx, or
-# traefik-json. Only needed if you want to pin a format instead of detecting.
+# Format of the file(s) above: auto (default, detected per file),
+# geometrikks-json, nginx, traefik-json, or caddy-json. Only needed if you
+# want to pin a format instead of detecting.
 #LOGPARSER_LOG_FORMATS=auto
 
 # Hostname label attached to ingested events

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Caddy is a supported log source: the `caddy-json` format parses Caddy's native JSON access logs, auto-detected like the other formats and available to `import-logs --format caddy-json`. Behind a CDN or another proxy, set `servers.trusted_proxies` so Caddy logs the visitor's address; the README's Caddy setup section has the details.
+
 ### Fixed
 
 - Add missing status codes (444, 499) in access logs status code filter dropdown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Caddy is a supported log source: the `caddy-json` format parses Caddy's native JSON access logs, auto-detected like the other formats and available to `import-logs --format caddy-json`. Behind a CDN or another proxy, set `servers.trusted_proxies` so Caddy logs the visitor's address; the README's Caddy setup section has the details.
+- Caddy is a supported log source: the `caddy-json` format parses Caddy's native JSON access logs, auto-detected like the other formats and available to `import-logs --format caddy-json`. Add `log_append upstream_duration_ms {rp.upstream.duration_ms}` to record optional upstream timing. Behind a CDN or another proxy, set `servers.trusted_proxies` so Caddy logs the visitor's address; the README's Caddy setup section has the details.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ![Map](/data/screenshots/live.png)
 
-GeoMetrikks tails your reverse-proxy access logs (nginx and Traefik),
+GeoMetrikks tails your reverse-proxy access logs (nginx, Traefik and Caddy),
 geolocates every request with MaxMind GeoLite2, and shows the result on a
 real-time map and a traffic analytics dashboard. It runs on your own
 hardware from one Docker image. Outbound traffic is the GeoLite2 download
@@ -285,6 +285,45 @@ to pin it. Notes:
   on the map. See `docs/proxy-setup.md` for the full real-IP setup,
   including tunnels.
 - A file path is required; GeoMetrikks cannot read Traefik's stdout.
+
+## Caddy setup
+
+GeoMetrikks parses Caddy's native JSON access logs. Caddy logs to stderr
+by default, so give the site (or a wildcard site block) a `log` directive
+that writes to a file:
+
+```caddyfile
+example.com {
+    log {
+        output file /var/log/caddy/access.log
+        format json
+    }
+}
+```
+
+Mount the log directory into the GeoMetrikks container and point the
+parser at it:
+
+```env
+ACCESS_LOG_DIR=/var/log/caddy
+LOGPARSER_LOG_PATHS=/var/log/access/access.log
+```
+
+The format is auto-detected per file; set `LOGPARSER_LOG_FORMATS=caddy-json`
+to pin it. Notes:
+
+- Caddy rotates the log file itself by default; GeoMetrikks follows the
+  rotation.
+- Behind a CDN or another proxy, set `trusted_proxies` under `servers` in
+  Caddy's global options. Caddy then resolves the visitor's address into
+  the logged `client_ip`, which is the field GeoMetrikks reads (falling
+  back to `remote_ip` on logs from Caddy older than 2.7). Without it the
+  log carries the proxy's address and the map shows the proxy. See
+  `docs/proxy-setup.md`.
+- Keep the json encoder's `time_format` at its default or any ISO variant,
+  and `duration_format` at its default. Lines with `wall`, `common_log` or
+  custom time layouts are skipped, and a non-default `duration_format`
+  loses response times.
 
 ## MaxMind GeoLite2
 
@@ -706,8 +745,8 @@ Every command supports `--help`.
 ### import-logs: backfill history
 
 Live tailing only picks up lines written after the app starts. To backfill
-rotated or archived access logs (nginx or Traefik JSON, plain or gzip),
-use `import-logs`:
+rotated or archived access logs (nginx, Traefik JSON or Caddy JSON, plain
+or gzip), use `import-logs`:
 
 ```bash
 docker compose exec -u geometrikks app litestar import-logs /var/log/access/access.log.1.gz
@@ -717,8 +756,8 @@ It reuses the live ingestion pipeline (same parsing, GeoIP lookup and DB
 writes), uses the timestamps in each log line rather than wall-clock time,
 and refreshes the continuous aggregates for the imported range when done.
 The log format is auto-detected per file, as with live tailing; pass
-`--format geometrikks-json`, `--format nginx` or `--format traefik-json`
-to pin it. You can pass several
+`--format geometrikks-json`, `--format nginx`, `--format traefik-json` or
+`--format caddy-json` to pin it. You can pass several
 files in one invocation. Paths are **container** paths, and the import runs
 as the non-root `geometrikks` user (`PUID`:`PGID`, default 1000:1000), so
 host files must be readable by it (`-u geometrikks` keeps `exec` from
@@ -941,12 +980,12 @@ Yes. The GHCR image is a multi-arch manifest for `linux/amd64` and
 Check four things in order: (1) the geo-degraded banner; if it shows,
 MaxMind credentials or the GeoLite2 database are missing; (2) that
 `LOGPARSER_LOG_PATHS` points at a file receiving traffic in a supported
-format (the nginx JSON `log_format` above, the legacy nginx format, or
-Traefik JSON); (3) that some time has passed since you last restarted. The
-map only shows events ingested after startup unless you have run a batch
-import. (4) that your proxy logs the visitor's address, not an upstream
-proxy or tunnel; Settings > Status shows an advisory when it does not. See
-docs/proxy-setup.md.
+format (the nginx JSON `log_format` above, the legacy nginx format,
+Traefik JSON, or Caddy JSON); (3) that some time has passed since you last
+restarted. The map only shows events ingested after startup unless you
+have run a batch import. (4) that your proxy logs the visitor's address,
+not an upstream proxy or tunnel; Settings > Status shows an advisory when
+it does not. See docs/proxy-setup.md.
 
 **What does the "geo-degraded" banner mean?**
 The app started without a usable GeoLite2 database: either

--- a/README.md
+++ b/README.md
@@ -298,8 +298,18 @@ example.com {
         output file /var/log/caddy/access.log
         format json
     }
+
+    reverse_proxy app:8000
+    log_append upstream_duration_ms {rp.upstream.duration_ms}
 }
 ```
+
+The optional `log_append` line populates the `Upstream res time` column in
+Access Logs and the `Upstream response` field in the selected request's
+details panel. Without it, the column shows `-` and the detail field reads
+`Not recorded`. Caddy's measurement includes writing the response body to
+the client, so it is not exactly equivalent to nginx's
+`$upstream_response_time`.
 
 Mount the log directory into the GeoMetrikks container and point the
 parser at it:
@@ -323,7 +333,8 @@ to pin it. Notes:
 - Keep the json encoder's `time_format` at its default or any ISO variant,
   and `duration_format` at its default. Lines with `wall`, `common_log` or
   custom time layouts are skipped, and a non-default `duration_format`
-  loses response times.
+  loses request times. The appended `upstream_duration_ms` field always uses
+  milliseconds.
 
 ## MaxMind GeoLite2
 

--- a/dev/docker-compose.agents.yml
+++ b/dev/docker-compose.agents.yml
@@ -6,8 +6,9 @@
 #   agent-nginx         APP_MODE=agent tailing nginx_logs/nginx.log
 #   agent-traefik       APP_MODE=agent tailing nginx_logs/traefik.log
 #   agent-json          APP_MODE=agent tailing nginx_logs/nginx-json.log
+#   agent-caddy         APP_MODE=agent tailing nginx_logs/caddy.log
 #
-# All four app services build the production Dockerfile locally and share
+# All five app services build the production Dockerfile locally and share
 # one image tag, so compose builds it once.
 #
 # Usage, from the repo root (--env-file: the compose project directory is
@@ -30,17 +31,18 @@
 #     flag above only feeds the ${...} interpolations below (admin login,
 #     MaxMind creds, and the CrowdSec LAPI settings on the head, which stay
 #     empty and therefore disabled when .env has none).
-#   - ./data/geoip (the dev mmdb) is bind-mounted rw into all four
+#   - ./data/geoip (the dev mmdb) is bind-mounted rw into all five
 #     services; the entrypoint chowns it, and rw lets the agents' weekly
 #     geoip-refresh job work. Fine for a test stack, one-volume-per-agent
 #     in real deployments.
-#   - Site homes (Phase 5): all three agents share this machine's public IP,
-#     so their auto-detected homes coincide. The head below pins two of them
-#     so routes and beacons visibly split: nginx-01 in New York and traefik-01
-#     in Los Angeles (MAP_HOME_LOCATIONS), plus its own home in Chicago
+#   - Site homes (Phase 5): all four agents share this machine's public IP,
+#     so their auto-detected homes coincide. The head below pins three of them
+#     so routes and beacons visibly split: nginx-01 in New York, traefik-01
+#     in Los Angeles, and caddy-01 in Miami (MAP_HOME_LOCATIONS), plus its own
+#     home in Chicago
 #     (MAP_HOME_LATITUDE/LONGITUDE, the default beacon). json-01 is left
 #     unpinned, so its beacon is the auto-detected home instead. Only the
-#     agents ingest, so only their three beacons draw routes; Chicago is the
+#     agents ingest, so only their four beacons draw routes; Chicago is the
 #     head. Edit or remove the overrides to test the pure-auto path (the
 #     override rows are deleted at the next head restart, and each pinned
 #     agent's next write restores it as auto). Inspect the table:
@@ -104,10 +106,10 @@ services:
       # beacon. Setting both coordinates skips public-IP auto-detection.
       MAP_HOME_LATITUDE: 41.8781
       MAP_HOME_LONGITUDE: -87.6298
-      # Demo override so the two sites' homes differ (see header notes).
+      # Demo overrides for the three pinned sites (see header notes).
       # Hardcoded rather than ${...}-interpolated: compose interpolation
       # defaults cannot carry JSON braces.
-      MAP_HOME_LOCATIONS: '{"nginx-01": [40.7128, -74.0060], "traefik-01": [34.0522, -118.2437]}'
+      MAP_HOME_LOCATIONS: '{"nginx-01": [40.7128, -74.0060], "traefik-01": [34.0522, -118.2437], "caddy-01": [25.7617, -80.1918]}'
       DB_HOST: timescale_agent_db
       DB_PORT: 5432
       DB_USER: geouser
@@ -229,6 +231,41 @@ services:
       DB_DATABASE: geometrikks
     ports:
       - "8003:8000"
+    volumes:
+      - ../nginx_logs:/var/log/access:ro
+      - ../data/geoip:/app/data/geoip
+    networks:
+      - geometrikks_agent_net
+    depends_on:
+      timescale_agent_db:
+        condition: service_healthy
+
+  agent-caddy:
+    container_name: geometrikks_agent_caddy
+    build:
+      context: ..
+      dockerfile: Dockerfile
+      args:
+        GIT_SHA: ${GIT_SHA:-}
+    image: geometrikks:agent-mode
+    restart: unless-stopped
+    hostname: agent-caddy
+    stop_grace_period: 20s
+    environment:
+      APP_MODE: agent
+      MAP_HOME_REFRESH_HOURS: 1
+      LOGPARSER_HOST_NAME: caddy-01
+      LOGPARSER_LOG_PATHS: /var/log/access/caddy.log
+      LOGPARSER_LOG_FORMATS: caddy-json
+      MAXMINDDB_USER_ID: ${MAXMINDDB_USER_ID:-}
+      MAXMINDDB_LICENSE_KEY: ${MAXMINDDB_LICENSE_KEY:-}
+      DB_HOST: timescale_agent_db
+      DB_PORT: 5432
+      DB_USER: geouser
+      DB_PASSWORD: geopass
+      DB_DATABASE: geometrikks
+    ports:
+      - "8004:8000"
     volumes:
       - ../nginx_logs:/var/log/access:ro
       - ../data/geoip:/app/data/geoip

--- a/dev/inject-logs.sh
+++ b/dev/inject-logs.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-# Appends one synthetic nginx line, one traefik JSON line and one
-# geometrikks-json line per second to nginx_logs/, with fresh timestamps
-# and a rotating pool of real public IPs, so the agents compose stack
-# (dev/docker-compose.agents.yml) has live traffic to ingest.
+# Appends one synthetic nginx line, one traefik JSON line, one
+# geometrikks-json line and one caddy-json line per second to nginx_logs/,
+# with fresh timestamps and a rotating pool of real public IPs, so the
+# agents compose stack (dev/docker-compose.agents.yml) has live traffic to
+# ingest.
 #
 # Runs automatically as the compose stack's log-injector service (for the
 # stack's lifetime; `down` stops it). Standalone usage, from the repo root:
@@ -25,7 +26,7 @@ MAX_SECONDS=${INJECT_MAX_SECONDS:-1800}
 
 # nginx_logs/ is gitignored; create the tailed files so the agents find
 # them on first start instead of waiting for the first line.
-touch "$REPO/nginx_logs/nginx.log" "$REPO/nginx_logs/traefik.log" "$REPO/nginx_logs/nginx-json.log"
+touch "$REPO/nginx_logs/nginx.log" "$REPO/nginx_logs/traefik.log" "$REPO/nginx_logs/nginx-json.log" "$REPO/nginx_logs/caddy.log"
 
 IPS=(8.8.8.8 1.1.1.1 81.2.69.142 91.198.174.192 185.60.216.35 34.71.167.225 104.28.42.7 197.248.21.8 133.242.187.207 200.160.2.3 77.88.55.242 129.226.3.47)
 PRIVATE_IPS=(172.18.0.1 172.19.0.4 10.0.0.2 192.168.1.9 100.64.0.7)
@@ -70,6 +71,24 @@ json_line() {
   jts=$(date +"%Y-%m-%dT%H:%M:%S%:z")
   printf '{"client_ip":"%s","timestamp":"%s","method":"%s","path":"%s","protocol":"HTTP/2.0","status":"%s","bytes":"%s","host":"json.example.com","referrer":"%s","user_agent":"%s","remote_user":"%s","request_time":"%s","upstream_time":"%s","request_raw":"%s %s HTTP/2.0"}\n' \
     "$ip" "$jts" "$method" "$path" "$status" "$bytes" "$ref" "$agent" "$user" "$rt" "$ut" "$method" "$path" >> "$REPO/nginx_logs/nginx-json.log"
+}
+
+# One caddy-json line for the IP in $1 (zap defaults: epoch float ts,
+# float-second duration, header arrays; client_ip == remote_ip, no proxy).
+caddy_line() {
+  local ip=$1 path method status agent ref user bytes cts refh
+  path=${PATHS[$((RANDOM % ${#PATHS[@]}))]}
+  method=${METHODS[$((RANDOM % ${#METHODS[@]}))]}
+  status=${STATUSES[$((RANDOM % ${#STATUSES[@]}))]}
+  agent=${AGENTS[$((RANDOM % ${#AGENTS[@]}))]}
+  ref=${REFERRERS[$((RANDOM % ${#REFERRERS[@]}))]}
+  user=${USERS[$((RANDOM % ${#USERS[@]}))]}
+  bytes=$((RANDOM % 5000 + 100))
+  timings "$path"
+  cts=$(date +%s.%3N)
+  refh=""; [ -n "$ref" ] && refh=",\"Referer\":[\"$ref\"]"
+  printf '{"level":"info","ts":%s,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"%s","remote_port":"%s","client_ip":"%s","proto":"HTTP/2.0","method":"%s","host":"caddy.example.com","uri":"%s","headers":{"User-Agent":["%s"]%s}},"bytes_read":0,"user_id":"%s","duration":%s,"size":%s,"status":%s,"resp_headers":{"Server":["Caddy"]}}\n' \
+    "$cts" "$ip" "$((RANDOM % 50000 + 1024))" "$ip" "$method" "$path" "$agent" "$refh" "$user" "$rt" "$bytes" "$status" >> "$REPO/nginx_logs/caddy.log"
 }
 
 case "${1:-}" in
@@ -130,12 +149,16 @@ while [ ! -f "$STOPFILE" ] && { [ "$MAX_SECONDS" -eq 0 ] || [ "$i" -lt "$MAX_SEC
   ip=${IPS[$((RANDOM % ${#IPS[@]}))]}
   json_line "$ip"
 
+  ip=${IPS[$((RANDOM % ${#IPS[@]}))]}
+  caddy_line "$ip"
+
   # Every tenth line is one the parser cannot fully use, so the Debug logs
   # page has parse failures to show: a TLS probe on the plain port, a line
   # cut off mid-request by a rotation, and a request with no method. The
   # nginx file gets all three; the JSON file gets the two nginx can express
   # through escape=json (control bytes arrive as \uXXXX, the method is
-  # empty). Traefik never writes lines like these.
+  # empty). Traefik never writes lines like these. Caddy gets the method-less
+  # variant only; it never logs raw probe bytes.
   if [ $((i % 10)) -eq 9 ]; then
     jts=$(date +"%Y-%m-%dT%H:%M:%S%:z")
     case $((RANDOM % 3)) in
@@ -147,6 +170,9 @@ while [ ! -f "$STOPFILE" ] && { [ "$MAX_SECONDS" -eq 0 ] || [ "$i" -lt "$MAX_SEC
       0) printf '{"client_ip":"%s","timestamp":"%s","method":"","path":"","protocol":"","status":"400","bytes":"157","host":"json.example.com","referrer":"","user_agent":"","remote_user":"","request_time":"0.000","upstream_time":"","request_raw":"\\u0016\\u0003\\u0001\\u0002\\u0000\\u0001\\u0000\\u0001\\u00fc\\u0003\\u0003"}\n' "$ip" "$jts" ;;
       1) printf '{"client_ip":"%s","timestamp":"%s","method":"","path":"/","protocol":"HTTP/1.1","status":"400","bytes":"0","host":"json.example.com","referrer":"","user_agent":"","remote_user":"","request_time":"0.000","upstream_time":"","request_raw":"/ HTTP/1.1"}\n' "$ip" "$jts" ;;
     esac >> "$REPO/nginx_logs/nginx-json.log"
+    cts=$(date +%s.%3N)
+    printf '{"level":"info","ts":%s,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"%s","client_ip":"%s","proto":"","method":"","host":"caddy.example.com","uri":"","headers":{}},"user_id":"","duration":0.0,"size":0,"status":400,"resp_headers":{}}\n' \
+      "$cts" "$ip" "$ip" >> "$REPO/nginx_logs/caddy.log"
   fi
 
   i=$((i + 1))

--- a/dev/inject-logs.sh
+++ b/dev/inject-logs.sh
@@ -74,9 +74,9 @@ json_line() {
 }
 
 # One caddy-json line for the IP in $1 (zap defaults: epoch float ts,
-# float-second duration, header arrays; client_ip == remote_ip, no proxy).
+# float-second duration, header arrays; optional log_append upstream timing).
 caddy_line() {
-  local ip=$1 path method status agent ref user bytes cts refh
+  local ip=$1 path method status agent ref user bytes cts refh upstreamh
   path=${PATHS[$((RANDOM % ${#PATHS[@]}))]}
   method=${METHODS[$((RANDOM % ${#METHODS[@]}))]}
   status=${STATUSES[$((RANDOM % ${#STATUSES[@]}))]}
@@ -87,8 +87,9 @@ caddy_line() {
   timings "$path"
   cts=$(date +%s.%3N)
   refh=""; [ -n "$ref" ] && refh=",\"Referer\":[\"$ref\"]"
-  printf '{"level":"info","ts":%s,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"%s","remote_port":"%s","client_ip":"%s","proto":"HTTP/2.0","method":"%s","host":"caddy.example.com","uri":"%s","headers":{"User-Agent":["%s"]%s}},"bytes_read":0,"user_id":"%s","duration":%s,"size":%s,"status":%s,"resp_headers":{"Server":["Caddy"]}}\n' \
-    "$cts" "$ip" "$((RANDOM % 50000 + 1024))" "$ip" "$method" "$path" "$agent" "$refh" "$user" "$rt" "$bytes" "$status" >> "$REPO/nginx_logs/caddy.log"
+  upstreamh=""; [ "$utms" -gt 0 ] && upstreamh=",\"upstream_duration_ms\":$utms"
+  printf '{"level":"info","ts":%s,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"%s","remote_port":"%s","client_ip":"%s","proto":"HTTP/2.0","method":"%s","host":"caddy.example.com","uri":"%s","headers":{"User-Agent":["%s"]%s}},"bytes_read":0,"user_id":"%s","duration":%s%s,"size":%s,"status":%s,"resp_headers":{"Server":["Caddy"]}}\n' \
+    "$cts" "$ip" "$((RANDOM % 50000 + 1024))" "$ip" "$method" "$path" "$agent" "$refh" "$user" "$rt" "$upstreamh" "$bytes" "$status" >> "$REPO/nginx_logs/caddy.log"
 }
 
 case "${1:-}" in

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,7 +93,7 @@ from real environment variables. It is read once at import time.
 |---|---|---|
 | `LOGPARSER_ENABLED` | `true` | Enable log parser ingestion service |
 | `LOGPARSER_LOG_PATHS` | *(computed)* | Access log files to tail. Env accepts a single path or a JSON list of paths. Default: /var/log/access/access.log |
-| `LOGPARSER_LOG_FORMATS` | *(computed)* | Log format per tailed file: 'auto' (default, detected from the file's content), 'geometrikks-json', 'nginx', or 'traefik-json'. Env accepts a single value applied to every path, or a JSON list matching LOGPARSER_LOG_PATHS by position. |
+| `LOGPARSER_LOG_FORMATS` | *(computed)* | Log format per tailed file: 'auto' (default, detected from the file's content), 'geometrikks-json', 'nginx', 'traefik-json', or 'caddy-json'. Env accepts a single value applied to every path, or a JSON list matching LOGPARSER_LOG_PATHS by position. |
 | `LOGPARSER_POLL_INTERVAL` | `1.0` | Interval in seconds to poll the log file for new entries |
 | `LOGPARSER_SEND_LOGS` | `true` | Send parsed logs to the database |
 | `LOGPARSER_HOST_NAME` | *(computed)* | Source hostname stamped on ingested records. Env accepts a single value applied to every tailed file, or a JSON list matching LOGPARSER_LOG_PATHS by position. Default: this machine's hostname. |

--- a/geometrikks/config/settings.py
+++ b/geometrikks/config/settings.py
@@ -258,9 +258,9 @@ class LogParserSettings(BaseSettings):
         default_factory=lambda: ["auto"],
         description=(
             "Log format per tailed file: 'auto' (default, detected from the "
-            "file's content), 'geometrikks-json', 'nginx', or 'traefik-json'. "
-            "Env accepts a single value applied to every path, or a JSON list "
-            "matching LOGPARSER_LOG_PATHS by position."
+            "file's content), 'geometrikks-json', 'nginx', 'traefik-json', "
+            "or 'caddy-json'. Env accepts a single value applied to every "
+            "path, or a JSON list matching LOGPARSER_LOG_PATHS by position."
         ),
     )
     poll_interval: float = Field(

--- a/geometrikks/services/logparser/formats/__init__.py
+++ b/geometrikks/services/logparser/formats/__init__.py
@@ -4,16 +4,19 @@ from __future__ import annotations
 from typing import NamedTuple
 
 from .base import LogLineFormat, NormalizedLine
+from .caddy import CaddyJsonFormat
 from .geometrikks_json import GeometrikksJsonFormat
 from .nginx import NginxFormat
 from .traefik import TraefikJsonFormat
 
 # Sniffing order: the recommended format first, then the other cheap '{'
-# prefix check, then the regex. The two JSON adapters decline each other's
-# lines on required keys (client_ip vs ClientHost), so order is cost only.
+# prefix checks, then the regex. The JSON adapters decline each other's
+# lines on required keys (client_ip vs ClientHost vs the nested request
+# object), so order is cost only.
 FORMATS: dict[str, LogLineFormat] = {
     GeometrikksJsonFormat.name: GeometrikksJsonFormat(),
     TraefikJsonFormat.name: TraefikJsonFormat(),
+    CaddyJsonFormat.name: CaddyJsonFormat(),
     NginxFormat.name: NginxFormat(),
 }
 

--- a/geometrikks/services/logparser/formats/base.py
+++ b/geometrikks/services/logparser/formats/base.py
@@ -84,6 +84,16 @@ def parse_seconds(raw: str | None) -> float | None:
     return value if math.isfinite(value) else None
 
 
+def host_from_addr(addr: str) -> str:
+    """IP or hostname from an 'addr:port' / '[v6]:port' value; best effort."""
+    if addr.startswith("["):
+        end = addr.find("]")
+        return addr[1:end] if end > 0 else addr
+    if addr.count(":") == 1:
+        return addr.rsplit(":", 1)[0]
+    return addr
+
+
 def detect_probe(
     request_raw: str | None, method: str | None, status_code: int
 ) -> tuple[bool, str | None]:

--- a/geometrikks/services/logparser/formats/caddy.py
+++ b/geometrikks/services/logparser/formats/caddy.py
@@ -8,7 +8,9 @@ configs that delete ``client_ip``. ``ts`` is unix seconds by default but
 the encoder is configurable: numbers pick their unit by magnitude and
 strings go through ``fromisoformat``. ``duration`` is read as seconds, the
 default; the ms/ns variants are numerically indistinguishable from it and
-stay unsupported. Caddy logs no upstream timing and no raw request bytes.
+stay unsupported. Default logs omit upstream timing; users can add numeric
+``upstream_duration_ms`` with Caddy's ``log_append`` directive. Caddy logs no
+raw request bytes.
 """
 
 import math
@@ -39,6 +41,7 @@ class CaddyLine(msgspec.Struct, kw_only=True):
     status: int | None = None
     size: int | None = None
     duration: float | int | str | None = None
+    upstream_duration_ms: float | int | str | None = None
     user_id: str | None = None
 
 
@@ -51,15 +54,15 @@ def _parse_timestamp(raw: float | int | str | None) -> datetime | None:
             return None
         try:
             value = float(raw)
-            # Unit by magnitude: seconds below 1e11 (year 5138), millis below
-            # 1e14, else nanos. Covers unix_seconds_float (the default),
-            # unix_milli_float and unix_nano without ambiguity for real dates.
-            if raw < 1e11:
+            # Unit by magnitude: seconds below 100_000_000_000 (year 5138),
+            # milliseconds below 100_000_000_000_000, else nanoseconds. Covers
+            # the supported unix formats without ambiguity for real dates.
+            if raw < 100_000_000_000:
                 seconds = value
-            elif raw < 1e14:
-                seconds = value / 1e3
+            elif raw < 100_000_000_000_000:
+                seconds = value / 1_000
             else:
-                seconds = value / 1e9
+                seconds = value / 1_000_000_000
             if not math.isfinite(seconds):
                 return None
             return datetime.fromtimestamp(seconds, tz=timezone.utc)
@@ -136,6 +139,7 @@ class CaddyJsonFormat:
             return None
 
         raw_host = convert_dash_to_none(req.host)
+        upstream_duration_ms = _parse_duration(data.upstream_duration_ms)
         return NormalizedLine(
             ip_address=ip,
             timestamp=ts,
@@ -148,7 +152,13 @@ class CaddyJsonFormat:
             referrer=_header(req.headers, "Referer"),
             user_agent=_header(req.headers, "User-Agent"),
             request_time=_parse_duration(data.duration),
-            upstream_response_time=None,
+            # Caddy includes writing the response body to the client, so this
+            # is not perfectly equivalent to nginx's $upstream_response_time.
+            upstream_response_time=(
+                upstream_duration_ms / 1_000
+                if upstream_duration_ms is not None
+                else None
+            ),
             host=host_from_addr(raw_host) if raw_host else None,
         )
 

--- a/geometrikks/services/logparser/formats/caddy.py
+++ b/geometrikks/services/logparser/formats/caddy.py
@@ -1,0 +1,148 @@
+"""Adapter for Caddy JSON access logs (zap encoder, one object per line).
+
+Field shapes verified against Caddy v2.11.4 and a production instance
+behind Cloudflare (2026-08-30 caddy-json spec). ``request.client_ip`` is
+Caddy's own trusted_proxies resolution (2.7+), so this adapter never reads
+X-Forwarded-For; ``remote_ip`` is the fallback for older logs or filter
+configs that delete ``client_ip``. ``ts`` is unix seconds by default but
+the encoder is configurable: numbers pick their unit by magnitude and
+strings go through ``fromisoformat``. ``duration`` is read as seconds, the
+default; the ms/ns variants are numerically indistinguishable from it and
+stay unsupported. Caddy logs no upstream timing and no raw request bytes.
+"""
+
+from datetime import datetime, timezone
+
+import msgspec
+
+from .base import NormalizedLine, VALID_HTTP_METHODS, convert_dash_to_none, host_from_addr
+
+
+class CaddyRequest(msgspec.Struct, kw_only=True):
+    """The nested ``request`` object; presence marks an access-log line."""
+
+    remote_ip: str | None = None
+    client_ip: str | None = None
+    proto: str | None = None
+    method: str | None = None
+    host: str | None = None
+    uri: str | None = None
+    headers: dict[str, list[str]] | None = None
+
+
+class CaddyLine(msgspec.Struct, kw_only=True):
+    """One access-log entry; user-configurable fields get lenient unions."""
+
+    ts: float | int | str | None = None
+    request: CaddyRequest | None = None
+    status: int | None = None
+    size: int | None = None
+    duration: float | int | str | None = None
+    user_id: str | None = None
+
+
+_decoder = msgspec.json.Decoder(CaddyLine)
+
+
+def _parse_timestamp(raw: float | int | str | None) -> datetime | None:
+    if isinstance(raw, (int, float)):
+        if raw <= 0:
+            return None
+        # Unit by magnitude: seconds below 1e11 (year 5138), millis below
+        # 1e14, else nanos. Covers unix_seconds_float (the default),
+        # unix_milli_float and unix_nano without ambiguity for real dates.
+        if raw < 1e11:
+            seconds = float(raw)
+        elif raw < 1e14:
+            seconds = raw / 1e3
+        else:
+            seconds = raw / 1e9
+        try:
+            return datetime.fromtimestamp(seconds, tz=timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            return None
+    if isinstance(raw, str) and raw:
+        try:
+            ts = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+        return ts if ts.tzinfo is not None else None
+    return None
+
+
+def _header(headers: dict[str, list[str]] | None, name: str) -> str | None:
+    """First value of a header; names arrive Go-canonicalized, exact lookup."""
+    if not headers:
+        return None
+    values = headers.get(name)
+    if not values:
+        return None
+    return convert_dash_to_none(values[0])
+
+
+class CaddyJsonFormat:
+    """Parses one Caddy JSON access-log object per line."""
+
+    name = "caddy-json"
+
+    def parse(self, line: str, *, geo_only: bool = False) -> NormalizedLine | None:
+        """Parse one Caddy JSON access-log line into a NormalizedLine.
+
+        Args:
+            line: Raw log line (one JSON object).
+            geo_only: Only require the client IP and the timestamp
+                (send_logs=False mode).
+
+        Returns:
+            NormalizedLine on success; None for non-JSON lines, runtime log
+            objects without a ``request``, or lines missing the client IP /
+            parseable timestamp.
+        """
+        stripped = line.strip()
+        if not stripped.startswith("{"):
+            return None
+        try:
+            data = _decoder.decode(stripped)
+        except msgspec.DecodeError:
+            # ValidationError (wrong type for a field) is a DecodeError subclass.
+            return None
+        req = data.request
+        if req is None:
+            return None
+
+        ip = convert_dash_to_none(req.client_ip) or convert_dash_to_none(req.remote_ip)
+        ts = _parse_timestamp(data.ts)
+        if ip is None or ts is None:
+            return None
+
+        if geo_only:
+            return NormalizedLine(ip_address=ip, timestamp=ts)
+
+        if data.status is None:
+            return None
+
+        raw_host = convert_dash_to_none(req.host)
+        duration = data.duration
+        return NormalizedLine(
+            ip_address=ip,
+            timestamp=ts,
+            remote_user=convert_dash_to_none(data.user_id),
+            method=convert_dash_to_none(req.method),
+            path=convert_dash_to_none(req.uri),
+            http_version=convert_dash_to_none(req.proto),
+            status_code=data.status,
+            bytes_sent=data.size if isinstance(data.size, int) else 0,
+            referrer=_header(req.headers, "Referer"),
+            user_agent=_header(req.headers, "User-Agent"),
+            request_time=float(duration) if isinstance(duration, (int, float)) else None,
+            upstream_response_time=None,
+            host=host_from_addr(raw_host) if raw_host else None,
+        )
+
+    def detect_malformed(self, norm: NormalizedLine) -> tuple[bool, str | None]:
+        """Caddy never logs raw probe garbage; only method validity applies."""
+        if norm.method is None:
+            return True, "No HTTP method in request"
+        if norm.method.upper() not in VALID_HTTP_METHODS:
+            return True, f"Invalid HTTP method: {norm.method}"
+        return False, None

--- a/geometrikks/services/logparser/formats/caddy.py
+++ b/geometrikks/services/logparser/formats/caddy.py
@@ -11,6 +11,7 @@ default; the ms/ns variants are numerically indistinguishable from it and
 stay unsupported. Caddy logs no upstream timing and no raw request bytes.
 """
 
+import math
 from datetime import datetime, timezone
 
 import msgspec
@@ -48,16 +49,19 @@ def _parse_timestamp(raw: float | int | str | None) -> datetime | None:
     if isinstance(raw, (int, float)):
         if raw <= 0:
             return None
-        # Unit by magnitude: seconds below 1e11 (year 5138), millis below
-        # 1e14, else nanos. Covers unix_seconds_float (the default),
-        # unix_milli_float and unix_nano without ambiguity for real dates.
-        if raw < 1e11:
-            seconds = float(raw)
-        elif raw < 1e14:
-            seconds = raw / 1e3
-        else:
-            seconds = raw / 1e9
         try:
+            value = float(raw)
+            # Unit by magnitude: seconds below 1e11 (year 5138), millis below
+            # 1e14, else nanos. Covers unix_seconds_float (the default),
+            # unix_milli_float and unix_nano without ambiguity for real dates.
+            if raw < 1e11:
+                seconds = value
+            elif raw < 1e14:
+                seconds = value / 1e3
+            else:
+                seconds = value / 1e9
+            if not math.isfinite(seconds):
+                return None
             return datetime.fromtimestamp(seconds, tz=timezone.utc)
         except (OverflowError, OSError, ValueError):
             return None
@@ -68,6 +72,16 @@ def _parse_timestamp(raw: float | int | str | None) -> datetime | None:
             return None
         return ts if ts.tzinfo is not None else None
     return None
+
+
+def _parse_duration(raw: float | int | str | None) -> float | None:
+    if not isinstance(raw, (int, float)):
+        return None
+    try:
+        value = float(raw)
+    except OverflowError:
+        return None
+    return value if math.isfinite(value) else None
 
 
 def _header(headers: dict[str, list[str]] | None, name: str) -> str | None:
@@ -122,7 +136,6 @@ class CaddyJsonFormat:
             return None
 
         raw_host = convert_dash_to_none(req.host)
-        duration = data.duration
         return NormalizedLine(
             ip_address=ip,
             timestamp=ts,
@@ -134,7 +147,7 @@ class CaddyJsonFormat:
             bytes_sent=data.size if isinstance(data.size, int) else 0,
             referrer=_header(req.headers, "Referer"),
             user_agent=_header(req.headers, "User-Agent"),
-            request_time=float(duration) if isinstance(duration, (int, float)) else None,
+            request_time=_parse_duration(data.duration),
             upstream_response_time=None,
             host=host_from_addr(raw_host) if raw_host else None,
         )

--- a/geometrikks/services/logparser/formats/traefik.py
+++ b/geometrikks/services/logparser/formats/traefik.py
@@ -17,17 +17,7 @@ import json
 from datetime import datetime
 from typing import Any
 
-from .base import NormalizedLine, VALID_HTTP_METHODS, convert_dash_to_none
-
-
-def _host_from_addr(addr: str) -> str:
-    """IP from an 'IP:port' / '[v6]:port' ClientAddr; best effort."""
-    if addr.startswith("["):
-        end = addr.find("]")
-        return addr[1:end] if end > 0 else addr
-    if addr.count(":") == 1:
-        return addr.rsplit(":", 1)[0]
-    return addr
+from .base import NormalizedLine, VALID_HTTP_METHODS, convert_dash_to_none, host_from_addr
 
 
 def _parse_timestamp(data: dict[str, Any]) -> datetime | None:
@@ -75,7 +65,7 @@ class TraefikJsonFormat:
             ip = ip.rsplit(",", 1)[1]
         ip = ip.strip()
         if not ip:
-            ip = _host_from_addr(str(data.get("ClientAddr") or ""))
+            ip = host_from_addr(str(data.get("ClientAddr") or ""))
         ts = _parse_timestamp(data)
         if not ip or ts is None:
             return None

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -266,6 +266,63 @@ async def test_import_file_geometrikks_json(tmp_path, geoip_reader, monkeypatch)
     assert result.time_end is not None and result.time_end.day == 5
 
 
+def make_caddy_line(ip: str, day: int = 3) -> str:
+    return (
+        '{"level":"info","ts":"2024-08-' + f"{day:02d}" + 'T13:14:17+02:00",'
+        '"logger":"http.log.access.log0","msg":"handled request",'
+        '"request":{"remote_ip":"' + ip + '","client_ip":"' + ip + '",'
+        '"proto":"HTTP/2.0","method":"GET","host":"caddy.example.com","uri":"/index.php",'
+        '"headers":{"User-Agent":["Mozilla/5.0"]}},'
+        '"user_id":"","duration":0.002,"size":1024,"status":200}'
+    )
+
+
+async def test_import_file_caddy_json(tmp_path, geoip_reader, monkeypatch):
+    from geometrikks.services import importer
+
+    log = tmp_path / "old.caddy.log"
+    log.write_text("".join(make_caddy_line(TEST_IP, day=d) + "\n" for d in (1, 5, 3)))
+
+    service, FakeRepo, session_maker = _import_deps(tmp_path)
+    monkeypatch.setattr(importer, "ImportJobRepository", FakeRepo)
+    parser = LogParser(log_path=log, send_logs=True, log_format="caddy-json")
+
+    result = await importer.import_file(
+        log, service=service, parser=parser, reader=geoip_reader,
+        session_maker=session_maker,
+    )
+    assert result.skipped is False
+    assert result.lines_total == 3
+    assert result.lines_skipped == 0
+    assert result.records_written == 3
+    assert result.time_start is not None and result.time_start.day == 1
+    assert result.time_end is not None and result.time_end.day == 5
+
+
+async def test_import_file_traefik_pinned_to_caddy_json_is_rejected(tmp_path, geoip_reader, monkeypatch):
+    """Pinning the wrong JSON format aborts before anything is written."""
+    from geometrikks.services import importer
+
+    traefik_line = (
+        '{"ClientAddr":"172.19.0.1:34567","ClientHost":"203.0.113.7","DownstreamStatus":200,'
+        '"Duration":45678900,"RequestMethod":"GET","RequestPath":"/","RequestProtocol":"HTTP/2.0",'
+        '"StartUTC":"2026-08-07T10:34:56.123456789Z","level":"info","msg":""}\n'
+    )
+    log = tmp_path / "traefik.log"
+    log.write_text(traefik_line * 20)
+
+    service, FakeRepo, session_maker = _import_deps(tmp_path)
+    monkeypatch.setattr(importer, "ImportJobRepository", FakeRepo)
+    parser = LogParser(log_path=log, send_logs=True, log_format="caddy-json")
+
+    with pytest.raises(importer.UnrecognizedLogFormatError):
+        await importer.import_file(
+            log, service=service, parser=parser, reader=geoip_reader,
+            session_maker=session_maker,
+        )
+    assert service.flush_records.await_count == 0
+
+
 async def test_import_file_traefik_pinned_to_geometrikks_json_is_rejected(tmp_path, geoip_reader, monkeypatch):
     """Pinning the wrong JSON format aborts before anything is written."""
     from geometrikks.services import importer

--- a/tests/test_logparser.py
+++ b/tests/test_logparser.py
@@ -903,3 +903,49 @@ def test_parse_line_geometrikks_json_auto_detects(tmp_path: Path, geoip_reader: 
     assert record is not None and record.ip_address == "2.125.160.216"
     assert parser.format is not None and parser.format.name == "geometrikks-json"
     assert parser.send_logs is True
+
+
+def make_caddy_line(ip: str) -> str:
+    """One Caddy JSON access-log line (zap encoder defaults)."""
+    return (
+        '{"level":"info","ts":1722683657.123,"logger":"http.log.access.log0","msg":"handled request",'
+        '"request":{"remote_ip":"' + ip + '","remote_port":"56002","client_ip":"' + ip + '",'
+        '"proto":"HTTP/2.0","method":"GET","host":"caddy.example.com","uri":"/index.php",'
+        '"headers":{"User-Agent":["Mozilla/5.0"]}},'
+        '"bytes_read":0,"user_id":"","duration":0.002,"size":1024,"status":200,'
+        '"resp_headers":{"Server":["Caddy"]}}\n'
+    )
+
+
+def test_parse_line_caddy_json_end_to_end(tmp_path: Path, geoip_reader: Reader) -> None:
+    """Geo data and the access log are assembled for the Caddy format."""
+    ip = "2.125.160.216"  # present in the GeoLite2 test database
+    parser = LogParser(log_path=tmp_path / "caddy.log", send_logs=True, log_format="caddy-json")
+    lookup = make_cached_city_lookup(geoip_reader)
+
+    record = parser.parse_line(make_caddy_line(ip), lookup)
+
+    assert record is not None
+    assert record.ip_address == ip
+    assert record.log_format == "caddy-json"
+    assert record.is_malformed is False
+    assert record.geo_data is not None
+    assert record.geo_data.country_code == "GB"
+    assert record.access_log is not None
+    assert record.access_log.url == "/index.php"
+    assert record.access_log.host == "caddy.example.com"
+    assert record.access_log.status_code == 200
+    assert record.access_log.request_time == pytest.approx(0.002)
+    assert record.access_log.upstream_response_time is None
+    offset = record.access_log.timestamp.utcoffset()
+    assert offset is not None and offset.total_seconds() == 0
+    assert parser.parsed_lines == 1
+
+
+def test_parse_line_caddy_json_auto_detects(tmp_path: Path, geoip_reader: Reader) -> None:
+    parser = LogParser(log_path=tmp_path / "caddy.log", send_logs=True)
+    lookup = make_cached_city_lookup(geoip_reader)
+    record = parser.parse_line(make_caddy_line("2.125.160.216"), lookup)
+    assert record is not None and record.ip_address == "2.125.160.216"
+    assert parser.format is not None and parser.format.name == "caddy-json"
+    assert parser.send_logs is True

--- a/tests/test_logparser.py
+++ b/tests/test_logparser.py
@@ -912,7 +912,8 @@ def make_caddy_line(ip: str) -> str:
         '"request":{"remote_ip":"' + ip + '","remote_port":"56002","client_ip":"' + ip + '",'
         '"proto":"HTTP/2.0","method":"GET","host":"caddy.example.com","uri":"/index.php",'
         '"headers":{"User-Agent":["Mozilla/5.0"]}},'
-        '"bytes_read":0,"user_id":"","duration":0.002,"size":1024,"status":200,'
+        '"bytes_read":0,"user_id":"","duration":0.002,"upstream_duration_ms":1.25,'
+        '"size":1024,"status":200,'
         '"resp_headers":{"Server":["Caddy"]}}\n'
     )
 
@@ -936,7 +937,7 @@ def test_parse_line_caddy_json_end_to_end(tmp_path: Path, geoip_reader: Reader) 
     assert record.access_log.host == "caddy.example.com"
     assert record.access_log.status_code == 200
     assert record.access_log.request_time == pytest.approx(0.002)
-    assert record.access_log.upstream_response_time is None
+    assert record.access_log.upstream_response_time == pytest.approx(0.00125)
     offset = record.access_log.timestamp.utcoffset()
     assert offset is not None and offset.total_seconds() == 0
     assert parser.parsed_lines == 1

--- a/tests/test_logparser_formats.py
+++ b/tests/test_logparser_formats.py
@@ -5,7 +5,11 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from geometrikks.services.logparser.formats import FORMATS, sniff_format
-from geometrikks.services.logparser.formats.base import detect_probe, parse_seconds
+from geometrikks.services.logparser.formats.base import (
+    detect_probe,
+    host_from_addr,
+    parse_seconds,
+)
 from geometrikks.services.logparser.formats.geometrikks_json import GeometrikksJsonFormat
 from geometrikks.services.logparser.formats.nginx import NginxFormat
 from geometrikks.services.logparser.formats.traefik import TraefikJsonFormat
@@ -565,6 +569,20 @@ def test_json_adapters_decline_each_others_lines() -> None:
 )
 def test_parse_seconds(raw: str | None, expected: float | None) -> None:
     assert parse_seconds(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "addr, expected",
+    [
+        ("203.0.113.7:443", "203.0.113.7"),
+        ("[2001:db8::1]:443", "2001:db8::1"),
+        ("2001:db8::1", "2001:db8::1"),
+        ("caddy.example.com:8443", "caddy.example.com"),
+        ("caddy.example.com", "caddy.example.com"),
+    ],
+)
+def test_host_from_addr(addr: str, expected: str) -> None:
+    assert host_from_addr(addr) == expected
 
 
 def test_gjson_request_time_absent_is_none() -> None:

--- a/tests/test_logparser_formats.py
+++ b/tests/test_logparser_formats.py
@@ -557,6 +557,7 @@ CADDY_FULL = json.dumps(
         "bytes_read": 0,
         "user_id": "",
         "duration": 0.175457236,
+        "upstream_duration_ms": 43.21,
         "size": 5043,
         "status": 200,
         "resp_headers": {"Server": ["Caddy"]},
@@ -591,7 +592,7 @@ def test_caddy_parse_full_line() -> None:
     assert norm.user_agent == "Mozilla/5.0 (compatible; test-crawler/1.0)"
     assert norm.remote_user is None  # user_id ""
     assert norm.request_time == pytest.approx(0.175457236)
-    assert norm.upstream_response_time is None  # Caddy logs no upstream timing
+    assert norm.upstream_response_time == pytest.approx(0.04321)
     assert norm.request_raw is None
 
 
@@ -646,6 +647,26 @@ def test_caddy_oversized_integer_duration_is_none_not_fatal() -> None:
     norm = CaddyJsonFormat().parse(caddy(duration=10**400))
     assert norm is not None
     assert norm.request_time is None
+    assert norm.status_code == 200
+
+
+def test_caddy_missing_upstream_duration_is_none() -> None:
+    norm = CaddyJsonFormat().parse(caddy(upstream_duration_ms=None))
+    assert norm is not None
+    assert norm.upstream_response_time is None
+
+
+def test_caddy_zero_upstream_duration_is_preserved() -> None:
+    norm = CaddyJsonFormat().parse(caddy(upstream_duration_ms=0))
+    assert norm is not None
+    assert norm.upstream_response_time == 0
+
+
+@pytest.mark.parametrize("raw", ["43.21", 10**400])
+def test_caddy_invalid_upstream_duration_is_none_not_fatal(raw: str | int) -> None:
+    norm = CaddyJsonFormat().parse(caddy(upstream_duration_ms=raw))
+    assert norm is not None
+    assert norm.upstream_response_time is None
     assert norm.status_code == 200
 
 

--- a/tests/test_logparser_formats.py
+++ b/tests/test_logparser_formats.py
@@ -709,7 +709,7 @@ def test_caddy_detect_malformed() -> None:
 
 
 def test_registry_order() -> None:
-    assert list(FORMATS) == ["geometrikks-json", "traefik-json", "nginx"]
+    assert list(FORMATS) == ["geometrikks-json", "traefik-json", "caddy-json", "nginx"]
     assert FORMATS["geometrikks-json"].name == "geometrikks-json"
 
 
@@ -721,12 +721,24 @@ def test_sniff_format_gjson() -> None:
 
 
 def test_json_adapters_decline_each_others_lines() -> None:
-    assert GeometrikksJsonFormat().parse(TRAEFIK_FULL) is None
-    assert GeometrikksJsonFormat().parse(TRAEFIK_FULL, geo_only=True) is None
-    assert TraefikJsonFormat().parse(gjson()) is None
-    assert TraefikJsonFormat().parse(gjson(), geo_only=True) is None
+    for foreign in (TRAEFIK_FULL, CADDY_FULL):
+        assert GeometrikksJsonFormat().parse(foreign) is None
+        assert GeometrikksJsonFormat().parse(foreign, geo_only=True) is None
+    for foreign in (gjson(), CADDY_FULL):
+        assert TraefikJsonFormat().parse(foreign) is None
+        assert TraefikJsonFormat().parse(foreign, geo_only=True) is None
+    for foreign in (gjson(), TRAEFIK_FULL):
+        assert CaddyJsonFormat().parse(foreign) is None
+        assert CaddyJsonFormat().parse(foreign, geo_only=True) is None
     sniffed = sniff_format([TRAEFIK_FULL])
     assert sniffed is not None and sniffed.format.name == "traefik-json"
+
+
+def test_sniff_format_caddy() -> None:
+    sniffed = sniff_format([NGINX_GARBAGE, caddy()])
+    assert sniffed is not None
+    assert sniffed.format.name == "caddy-json"
+    assert sniffed.geo_only is False
 
 
 @pytest.mark.parametrize(

--- a/tests/test_logparser_formats.py
+++ b/tests/test_logparser_formats.py
@@ -10,6 +10,7 @@ from geometrikks.services.logparser.formats.base import (
     host_from_addr,
     parse_seconds,
 )
+from geometrikks.services.logparser.formats.caddy import CaddyJsonFormat
 from geometrikks.services.logparser.formats.geometrikks_json import GeometrikksJsonFormat
 from geometrikks.services.logparser.formats.nginx import NginxFormat
 from geometrikks.services.logparser.formats.traefik import TraefikJsonFormat
@@ -528,6 +529,181 @@ def test_gjson_connection_statuses_are_well_formed() -> None:
 def test_gjson_detect_malformed_ok_line() -> None:
     fmt = GeometrikksJsonFormat()
     norm = fmt.parse(gjson())
+    assert norm is not None
+    assert fmt.detect_malformed(norm) == (False, None)
+
+
+CADDY_FULL = json.dumps(
+    {
+        "level": "info",
+        "ts": 1788204125.4837868,
+        "logger": "http.log.access.log1",
+        "msg": "handled request",
+        "request": {
+            "remote_ip": "198.51.100.9",
+            "remote_port": "11085",
+            "client_ip": "203.0.113.7",
+            "proto": "HTTP/2.0",
+            "method": "GET",
+            "host": "caddy.example.com",
+            "uri": "/robots.txt",
+            "headers": {
+                "User-Agent": ["Mozilla/5.0 (compatible; test-crawler/1.0)"],
+                "Referer": ["https://caddy.example.com/"],
+                "X-Forwarded-For": ["203.0.113.7"],
+            },
+            "tls": {"resumed": False, "version": 772},
+        },
+        "bytes_read": 0,
+        "user_id": "",
+        "duration": 0.175457236,
+        "size": 5043,
+        "status": 200,
+        "resp_headers": {"Server": ["Caddy"]},
+    }
+)
+
+
+def caddy(request_overrides: dict | None = None, **overrides) -> str:
+    """One caddy-json line; an override of None removes the key."""
+    data = json.loads(CADDY_FULL)
+    for target, changes in ((data["request"], request_overrides or {}), (data, overrides)):
+        for key, value in changes.items():
+            if value is None:
+                target.pop(key, None)
+            else:
+                target[key] = value
+    return json.dumps(data) + "\n"
+
+
+def test_caddy_parse_full_line() -> None:
+    norm = CaddyJsonFormat().parse(caddy())
+    assert norm is not None
+    assert norm.ip_address == "203.0.113.7"  # client_ip, not the remote_ip peer
+    assert norm.timestamp == datetime.fromtimestamp(1788204125.4837868, tz=timezone.utc)
+    assert norm.method == "GET"
+    assert norm.path == "/robots.txt"
+    assert norm.http_version == "HTTP/2.0"
+    assert norm.status_code == 200
+    assert norm.bytes_sent == 5043
+    assert norm.host == "caddy.example.com"
+    assert norm.referrer == "https://caddy.example.com/"
+    assert norm.user_agent == "Mozilla/5.0 (compatible; test-crawler/1.0)"
+    assert norm.remote_user is None  # user_id ""
+    assert norm.request_time == pytest.approx(0.175457236)
+    assert norm.upstream_response_time is None  # Caddy logs no upstream timing
+    assert norm.request_raw is None
+
+
+def test_caddy_client_ip_fallback_to_remote_ip() -> None:
+    norm = CaddyJsonFormat().parse(caddy({"client_ip": None}))
+    assert norm is not None
+    assert norm.ip_address == "198.51.100.9"
+
+
+def test_caddy_missing_both_ips_rejected() -> None:
+    line = caddy({"client_ip": None, "remote_ip": None})
+    assert CaddyJsonFormat().parse(line) is None
+    assert CaddyJsonFormat().parse(line, geo_only=True) is None
+
+
+@pytest.mark.parametrize(
+    "ts",
+    [
+        1788204125.4837868,  # unix_seconds_float (default)
+        1788204125,  # integer seconds
+        1788204125483.7868,  # unix_milli_float
+        1788204125483786752,  # unix_nano
+        "2026-08-31T19:22:05.483786+00:00",  # rfc3339 fraction
+        "2026-08-31T19:22:05Z",  # rfc3339
+        "2026-08-31T21:22:05+0200",  # zap iso8601 offset style
+    ],
+)
+def test_caddy_ts_variants(ts: float | int | str) -> None:
+    norm = CaddyJsonFormat().parse(caddy(ts=ts))
+    assert norm is not None
+    expected = datetime(2026, 8, 31, 19, 22, 5, tzinfo=timezone.utc)
+    assert abs((norm.timestamp - expected).total_seconds()) < 1
+
+
+@pytest.mark.parametrize("ts", ["2026-08-31T19:22:05", "1m32s", 0, -5, ""])
+def test_caddy_bad_ts_rejected(ts: float | int | str) -> None:
+    assert CaddyJsonFormat().parse(caddy(ts=ts)) is None
+
+
+def test_caddy_duration_string_is_none_not_fatal() -> None:
+    norm = CaddyJsonFormat().parse(caddy(duration="1m32.05s"))
+    assert norm is not None
+    assert norm.request_time is None
+    assert norm.status_code == 200
+
+
+def test_caddy_host_port_stripped() -> None:
+    norm = CaddyJsonFormat().parse(caddy({"host": "caddy.example.com:8443"}))
+    assert norm is not None
+    assert norm.host == "caddy.example.com"
+    norm = CaddyJsonFormat().parse(caddy({"host": "[2001:db8::1]:443"}))
+    assert norm is not None
+    assert norm.host == "2001:db8::1"
+
+
+def test_caddy_absent_headers_and_fields_become_none() -> None:
+    fmt = CaddyJsonFormat()
+    for line in (
+        caddy({"headers": None}),
+        caddy({"headers": {}}),
+        caddy({"headers": {"User-Agent": [], "Referer": []}}),
+    ):
+        norm = fmt.parse(line)
+        assert norm is not None
+        assert norm.user_agent is None
+        assert norm.referrer is None
+    norm = fmt.parse(
+        caddy(
+            {"method": None, "uri": None, "proto": None, "host": None},
+            size=None,
+            duration=None,
+            user_id=None,
+        )
+    )
+    assert norm is not None
+    assert norm.method is None
+    assert norm.path is None
+    assert norm.http_version is None
+    assert norm.host is None
+    assert norm.bytes_sent == 0
+    assert norm.request_time is None
+    assert norm.remote_user is None
+
+
+def test_caddy_geo_only() -> None:
+    norm = CaddyJsonFormat().parse(caddy(status=None), geo_only=True)
+    assert norm is not None
+    assert norm.ip_address == "203.0.113.7"
+    assert norm.timestamp.tzinfo is not None
+    assert norm.method is None
+
+
+def test_caddy_rejections() -> None:
+    fmt = CaddyJsonFormat()
+    runtime_line = '{"level":"info","ts":1788204125.4,"logger":"tls","msg":"certificate obtained"}\n'
+    assert fmt.parse("not json") is None
+    assert fmt.parse("[1, 2, 3]") is None
+    assert fmt.parse(runtime_line) is None  # no request object
+    assert fmt.parse(runtime_line, geo_only=True) is None
+    assert fmt.parse(caddy(status=None)) is None  # full parse needs int status
+    assert fmt.parse(caddy(status="200")) is None  # wrong JSON type fails the decode
+
+
+def test_caddy_detect_malformed() -> None:
+    fmt = CaddyJsonFormat()
+    norm = fmt.parse(caddy({"method": ""}, status=400))
+    assert norm is not None
+    assert fmt.detect_malformed(norm) == (True, "No HTTP method in request")
+    norm = fmt.parse(caddy({"method": "PROPFIND"}))
+    assert norm is not None
+    assert fmt.detect_malformed(norm) == (True, "Invalid HTTP method: PROPFIND")
+    norm = fmt.parse(caddy())
     assert norm is not None
     assert fmt.detect_malformed(norm) == (False, None)
 

--- a/tests/test_logparser_formats.py
+++ b/tests/test_logparser_formats.py
@@ -631,8 +631,19 @@ def test_caddy_bad_ts_rejected(ts: float | int | str) -> None:
     assert CaddyJsonFormat().parse(caddy(ts=ts)) is None
 
 
+def test_caddy_oversized_integer_ts_rejected() -> None:
+    assert CaddyJsonFormat().parse(caddy(ts=10**400)) is None
+
+
 def test_caddy_duration_string_is_none_not_fatal() -> None:
     norm = CaddyJsonFormat().parse(caddy(duration="1m32.05s"))
+    assert norm is not None
+    assert norm.request_time is None
+    assert norm.status_code == 200
+
+
+def test_caddy_oversized_integer_duration_is_none_not_fatal() -> None:
+    norm = CaddyJsonFormat().parse(caddy(duration=10**400))
     assert norm is not None
     assert norm.request_time is None
     assert norm.status_code == 200


### PR DESCRIPTION
## Summary

- Add a `caddy-json` adapter for Caddy access logs.
- Register the format for explicit selection and auto-detection through `LogParser` and the log importer.
- Document Caddy setup and configuration, then add a Caddy emitter and service to the development agents stack.

## Implementation notes

- Move `host_from_addr` into the shared format base and reuse it from the Traefik adapter.
- Decline malformed or unsupported Caddy records, including oversized numeric fields, without raising from format detection.

## Verification

- `uv run pytest -W default -ra`: 1133 passed
- `uv run ty check`: passed
- `docker compose -f dev/docker-compose.agents.yml config`: passed
- Injector and compose smoke checks: passed
