### PR TITLE
feat(analytics): refresh the vendored CDN ASN list

### DIFF
--- a/geometrikks/domain/analytics/cdn_asns.py
+++ b/geometrikks/domain/analytics/cdn_asns.py
@@ -4,10 +4,17 @@ Deliberately separate from hosting_asns.csv: that list answers "is this
 traffic probably automated", this one answers "is my geo data wrong".
 CDN77 (60068) appears in both, which is harmless.
 
-Hyperscalers (AWS 16509/14618, GCP 15169, Azure 8075) stay out: inbound
-traffic from those is scanners, not a fronting CDN.
+Imperva and Sucuri are fronting WAFs rather than CDNs, but the symptom is
+identical: every peer is their scrubbing network.
 
-Org names checked against https://bgp.tools/as/<asn> on 2026-08-31.
+Hyperscalers (AWS 16509/14618, GCP 15169, Azure 8075) stay out: inbound
+traffic from those is scanners, not a fronting CDN. The cost is that
+CloudFront, Azure Front Door and Cloud CDN setups never get the advisory.
+
+Edgio/Limelight (22822) was removed: the network shut down 2025-01-15 and
+the ASN is no longer announced. Do not re-add it.
+
+Org names checked against RIPEstat (https://stat.ripe.net/data/as-overview/data.json?resource=AS<asn>) on 2026-09-01.
 """
 from __future__ import annotations
 
@@ -17,7 +24,10 @@ CDN_ASNS: dict[int, str] = {
     54113: "Fastly",
     20940: "Akamai",
     16625: "Akamai",
+    35994: "Akamai",
     60068: "CDN77",
-    22822: "Edgio",
     199524: "G-Core",
+    200325: "bunny.net",
+    19551: "Imperva",
+    30148: "Sucuri",
 }

--- a/tests/test_cdn_asns.py
+++ b/tests/test_cdn_asns.py
@@ -15,6 +15,11 @@ def test_cloudflare_present() -> None:
     assert CDN_ASNS[13335] == "Cloudflare"
 
 
+def test_dead_networks_excluded() -> None:
+    """Edgio (22822) shut down 2025-01-15 and no longer announces routes."""
+    assert 22822 not in CDN_ASNS
+
+
 def test_hyperscalers_excluded() -> None:
     """AWS/GCP/Azure inbound traffic is scanners, not a fronting CDN;
     including them would fire on every low-traffic site."""


### PR DESCRIPTION
Refreshes the vendored CDN peer ASN list behind the proxy advisory.

### What changes

- Adds bunny.net (AS200325), the third announced Akamai edge ASN (AS35994), and the fronting WAFs Imperva/Incapsula (AS19551) and Sucuri (AS30148). A proxy behind any of these logs the provider's network as the peer, which is exactly the "my geo data is wrong" case the advisory detects.
- Removes Edgio (AS22822). The network shut down on 2025-01-15 after the bankruptcy and the ASN is no longer announced, so the entry could never match traffic again. A test now guards against re-adding it.
- Every org name in the list was re-verified against RIPEstat; the docstring records the date and source.

The hyperscaler exclusion (AWS, GCP, Azure) is unchanged, and the docstring now spells out its cost: CloudFront, Azure Front Door and Cloud CDN setups never get the advisory.
