### PR TITLE
Support WebDAV HTTP methods in log parser

### DIFF
--- a/geometrikks/services/logparser/formats/base.py
+++ b/geometrikks/services/logparser/formats/base.py
@@ -57,7 +57,27 @@ class LogLineFormat(Protocol):
 
 
 VALID_HTTP_METHODS: frozenset[str] = frozenset(
-    {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT", "TRACE"}
+    {
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+        "HEAD",
+        "OPTIONS",
+        "CONNECT",
+        "TRACE",
+        "PROPFIND",
+        "PROPPATCH",
+        "MKCOL",
+        "COPY",
+        "MOVE",
+        "LOCK",
+        "UNLOCK",
+        "REPORT",
+        "MKCALENDAR",
+        "ACL",
+    }
 )
 
 

--- a/resources/components/access-logs/access-logs-filter-bar.tsx
+++ b/resources/components/access-logs/access-logs-filter-bar.tsx
@@ -25,6 +25,8 @@ import {
 
 const HTTP_METHODS = [
   "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "CONNECT", "TRACE",
+  "PROPFIND", "PROPPATCH", "MKCOL", "COPY", "MOVE", "LOCK", "UNLOCK", "REPORT",
+  "MKCALENDAR", "ACL",
 ] as const
 const STATUS_CODES = [
   100, 101, 102, 103, 200, 201, 202, 203, 204, 205, 206, 207, 208, 226,

--- a/tests/test_logparser_formats.py
+++ b/tests/test_logparser_formats.py
@@ -303,7 +303,7 @@ def test_detect_probe_ssh_and_smb() -> None:
 def test_detect_probe_method_and_status_rules() -> None:
     assert detect_probe("", None, 400) == (True, "TLS probe: HTTP request sent to HTTPS port")
     assert detect_probe("", None, 200) == (True, "No HTTP method in request")
-    assert detect_probe("", "PROPFIND", 200) == (True, "Invalid HTTP method: PROPFIND")
+    assert detect_probe("", "UNKNOWN", 200) == (True, "Invalid HTTP method: UNKNOWN")
     assert detect_probe("GET / HTTP/1.1", "GET", 200) == (False, None)
     for status in (408, 444, 499):
         assert detect_probe("GET / HTTP/1.1", "GET", status) == (False, None)
@@ -509,7 +509,7 @@ def test_gjson_detect_malformed_method_rules() -> None:
     cases = {
         gjson(method="", status="400", request_raw="/ HTTP/1.1"): "TLS probe: HTTP request sent to HTTPS port",
         gjson(method="", status="200", request_raw="/ HTTP/1.1"): "No HTTP method in request",
-        gjson(method="PROPFIND", request_raw="PROPFIND / HTTP/1.1"): "Invalid HTTP method: PROPFIND",
+        gjson(method="UNKNOWN", request_raw="UNKNOWN / HTTP/1.1"): "Invalid HTTP method: UNKNOWN",
         gjson(method=None, request_raw=None): "No HTTP method in request",
     }
     for line, expected in cases.items():
@@ -732,9 +732,9 @@ def test_caddy_detect_malformed() -> None:
     norm = fmt.parse(caddy({"method": ""}, status=400))
     assert norm is not None
     assert fmt.detect_malformed(norm) == (True, "No HTTP method in request")
-    norm = fmt.parse(caddy({"method": "PROPFIND"}))
+    norm = fmt.parse(caddy({"method": "UNKNOWN"}))
     assert norm is not None
-    assert fmt.detect_malformed(norm) == (True, "Invalid HTTP method: PROPFIND")
+    assert fmt.detect_malformed(norm) == (True, "Invalid HTTP method: UNKNOWN")
     norm = fmt.parse(caddy())
     assert norm is not None
     assert fmt.detect_malformed(norm) == (False, None)

--- a/tests/test_logparser_formats.py
+++ b/tests/test_logparser_formats.py
@@ -21,6 +21,28 @@ NGINX_LINE = (
 )
 NGINX_GARBAGE = "not a log line at all\n"
 
+SUPPORTED_HTTP_METHODS = (
+    "GET",
+    "POST",
+    "PUT",
+    "DELETE",
+    "PATCH",
+    "HEAD",
+    "OPTIONS",
+    "CONNECT",
+    "TRACE",
+    "PROPFIND",
+    "PROPPATCH",
+    "MKCOL",
+    "COPY",
+    "MOVE",
+    "LOCK",
+    "UNLOCK",
+    "REPORT",
+    "MKCALENDAR",
+    "ACL",
+)
+
 
 def test_nginx_parse_full_line_corrected_semantics() -> None:
     """path comes from the request line; referrer from the Referer position."""
@@ -290,6 +312,33 @@ def test_detect_probe_tls_raw_bytes() -> None:
     is_malformed, reason = detect_probe("\x16\x03\x01\x02\x00\x01", None, 400)
     assert is_malformed is True
     assert reason == "TLS handshake sent to HTTP port (raw)"
+
+@pytest.mark.parametrize("method", SUPPORTED_HTTP_METHODS)
+def test_detect_probe_supported_http_methods_are_well_formed(method: str) -> None:
+    assert detect_probe("", method, 200) == (False, None)
+
+
+@pytest.mark.parametrize("method", SUPPORTED_HTTP_METHODS)
+def test_traefik_supported_http_methods_are_well_formed(method: str) -> None:
+    data = json.loads(TRAEFIK_FULL)
+    data["RequestMethod"] = method
+
+    norm = TraefikJsonFormat().parse(json.dumps(data))
+
+    assert norm is not None
+    assert norm.method == method
+    assert TraefikJsonFormat().detect_malformed(norm) == (False, None)
+
+
+@pytest.mark.parametrize("method", SUPPORTED_HTTP_METHODS)
+def test_caddy_supported_http_methods_are_well_formed(method: str) -> None:
+    fmt = CaddyJsonFormat()
+
+    norm = fmt.parse(caddy({"method": method}))
+
+    assert norm is not None
+    assert norm.method == method
+    assert fmt.detect_malformed(norm) == (False, None)
 
 
 def test_detect_probe_ssh_and_smb() -> None:


### PR DESCRIPTION
Adds support for common WebDAV/DAV HTTP methods such as PROPFIND, PROPPATCH, MKCOL, REPORT, etc.

This prevents valid WebDAV requests, such as Nextcloud PROPFIND requests returning 207 Multi-Status, from being classified as malformed.

Fixes #208 