### PR TITLE
chore(site): wrangler environment for a develop worker

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -46,6 +46,22 @@ branch and pull request gets a preview URL. The custom domain is attached
 to the worker under Settings, Domains & Routes, once the domain's
 nameservers point at Cloudflare.
 
+A second worker, connected to the same repository, serves `develop` at
+develop.geometrikks.dev. It uses the `develop` environment from
+`wrangler.jsonc` and differs from the table above in two settings:
+
+| Setting | Value |
+| --- | --- |
+| Production branch | `develop` |
+| Deploy command | `bunx wrangler deploy --env develop` |
+
+Turn non-production branch builds off on that worker so feature branches
+build once, on the main one. With an environment defined, wrangler warns
+when the main worker's deploy command names none; it still deploys the
+top-level configuration. `public/_headers` sends `X-Robots-Tag: noindex`
+for the develop hostname, and every page's canonical URL points at
+geometrikks.dev, so the staging copy stays out of search results.
+
 `public/_headers` sets HSTS, nosniff and the referrer policy. There is no
 Content-Security-Policy yet: Astro's CSP support does not work with the
 inline styles Starlight's code blocks use.

--- a/site/README.md
+++ b/site/README.md
@@ -46,8 +46,10 @@ branch and pull request gets a preview URL. The custom domain is attached
 to the worker under Settings, Domains & Routes, once the domain's
 nameservers point at Cloudflare.
 
-A second worker, connected to the same repository, serves `develop` at
-develop.geometrikks.dev. It uses the `develop` environment from
+The worker is named `geometrikks`; Workers Builds refuses a config whose
+name differs from the worker it is attached to. A second worker,
+`geometrikks-develop`, connected to the same repository, serves `develop`
+at develop.geometrikks.dev. It uses the `develop` environment from
 `wrangler.jsonc` and differs from the table above in two settings:
 
 | Setting | Value |

--- a/site/public/_headers
+++ b/site/public/_headers
@@ -2,3 +2,6 @@
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
+
+https://develop.geometrikks.dev/*
+  X-Robots-Tag: noindex

--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -1,5 +1,12 @@
 {
   "name": "geometrikks-dev",
   "compatibility_date": "2026-09-03",
-  "assets": { "directory": "./dist" }
+  "assets": { "directory": "./dist" },
+  // Environments do not inherit assets, so the block repeats.
+  "env": {
+    "develop": {
+      "name": "geometrikks-dev-develop",
+      "assets": { "directory": "./dist" }
+    }
+  }
 }

--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -1,11 +1,11 @@
 {
-  "name": "geometrikks-dev",
+  "name": "geometrikks",
   "compatibility_date": "2026-09-03",
   "assets": { "directory": "./dist" },
   // Environments do not inherit assets, so the block repeats.
   "env": {
     "develop": {
-      "name": "geometrikks-dev-develop",
+      "name": "geometrikks-develop",
       "assets": { "directory": "./dist" }
     }
   }


### PR DESCRIPTION
Adds a `develop` environment to `site/wrangler.jsonc` so a second Worker, `geometrikks-dev-develop`, can serve the `develop` branch at develop.geometrikks.dev from the same repository. The assets block repeats inside the environment because Wrangler does not inherit it.

`site/public/_headers` gains a rule for that hostname that sends `X-Robots-Tag: noindex`. Every page's canonical URL already points at geometrikks.dev, so the staging copy stays out of search results.

`site/README.md` documents the second Worker: same root directory and build command, production branch `develop`, deploy command `bunx wrangler deploy --env develop`, non-production builds off.

Both `wrangler deploy --dry-run` and `wrangler deploy --dry-run --env develop` read the built assets and exit clean. With an environment defined, the main Worker's `bunx wrangler deploy` prints a warning that no environment was named and deploys the top-level configuration, which is the intended result.
