### PR TITLE
fix: virtualize log tables for responsive detail sheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The live rail on the map stops short of the bottom-left corner, so it no longer covers the basemap attribution pill.
+- Access, geo, and debug log tables render only visible rows, reducing the delay when opening record details or the IP Inspector on large pages.
 
 ## [0.14.2] - 2026-09-05
 

--- a/resources/components/access-logs/access-logs-table.tsx
+++ b/resources/components/access-logs/access-logs-table.tsx
@@ -6,7 +6,7 @@
  * (search, IP, host, hostname, source format, status, method, country and
  * city live in access-logs-filter-bar.tsx). Pairs with GET /api/v1/access-logs/.
  */
-import { useState } from "react"
+import { memo, useState } from "react"
 import { ArrowDown, ArrowUp, ChevronsUpDown, Columns3 } from "lucide-react"
 import {
   Table,
@@ -133,6 +133,41 @@ function renderCell(column: AccessLogColumn, r: AccessLog): React.ReactNode {
       )
   }
 }
+
+const AccessLogTableBody = memo(function AccessLogTableBody({
+  rows,
+  shownColumns,
+  onSelect,
+}: {
+  rows: AccessLog[]
+  shownColumns: AccessLogColumn[]
+  onSelect: (row: AccessLog) => void
+}) {
+  return (
+    <TableBody>
+      {rows.map((row) => (
+        <TableRow
+          key={row.id}
+          aria-label={`Request ${row.id}, ${row.method ?? ""} ${row.url ?? ""}, HTTP ${row.statusCode}`}
+          {...rowActivation<HTMLTableRowElement>(() => onSelect(row))}
+        >
+          {shownColumns.map((c) => (
+            <TableCell key={c.key} className={cn(c.align === "right" && "text-right")}>
+              {renderCell(c, row)}
+              {c.key === "ipAddress" && (
+                <span {...stopRowActivation}>
+                  <IpBanControls ip={row.ipAddress}>
+                    <InspectIpButton ip={row.ipAddress} className="ml-1" />
+                  </IpBanControls>
+                </span>
+              )}
+            </TableCell>
+          ))}
+        </TableRow>
+      ))}
+    </TableBody>
+  )
+})
 
 interface AccessLogsTableProps {
   page: number
@@ -280,28 +315,7 @@ export function AccessLogsTable({
               })}
             </TableRow>
           </TableHeader>
-          <TableBody>
-            {rows.map((row) => (
-              <TableRow
-                key={row.id}
-                aria-label={`Request ${row.id}, ${row.method ?? ""} ${row.url ?? ""}, HTTP ${row.statusCode}`}
-                {...rowActivation<HTMLTableRowElement>(() => setSelected(row))}
-              >
-                {shownColumns.map((c) => (
-                  <TableCell key={c.key} className={cn(c.align === "right" && "text-right")}>
-                    {renderCell(c, row)}
-                    {c.key === "ipAddress" && (
-                      <span {...stopRowActivation}>
-                        <IpBanControls ip={row.ipAddress}>
-                          <InspectIpButton ip={row.ipAddress} className="ml-1" />
-                        </IpBanControls>
-                      </span>
-                    )}
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))}
-          </TableBody>
+          <AccessLogTableBody rows={rows} shownColumns={shownColumns} onSelect={setSelected} />
         </Table>
       </DataTableFrame>
 

--- a/resources/components/access-logs/access-logs-table.tsx
+++ b/resources/components/access-logs/access-logs-table.tsx
@@ -9,13 +9,13 @@
 import { memo, useState } from "react"
 import { ArrowDown, ArrowUp, ChevronsUpDown, Columns3 } from "lucide-react"
 import {
-  Table,
-  TableBody,
   TableCell,
   TableHead,
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { VirtualTable, VirtualTableBody } from "@/components/data/virtual-table"
+import { useTimeRange } from "@/lib/time-range-context"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { DataTableFrame } from "@/components/data/data-table-frame"
@@ -134,6 +134,8 @@ function renderCell(column: AccessLogColumn, r: AccessLog): React.ReactNode {
   }
 }
 
+const getRowKey = (row: AccessLog) => row.id
+
 const AccessLogTableBody = memo(function AccessLogTableBody({
   rows,
   shownColumns,
@@ -144,15 +146,15 @@ const AccessLogTableBody = memo(function AccessLogTableBody({
   onSelect: (row: AccessLog) => void
 }) {
   return (
-    <TableBody>
-      {rows.map((row) => (
+    <VirtualTableBody rows={rows} columnCount={shownColumns.length} getRowKey={getRowKey}>
+      {(row) => (
         <TableRow
           key={row.id}
           aria-label={`Request ${row.id}, ${row.method ?? ""} ${row.url ?? ""}, HTTP ${row.statusCode}`}
           {...rowActivation<HTMLTableRowElement>(() => onSelect(row))}
         >
           {shownColumns.map((c) => (
-            <TableCell key={c.key} className={cn(c.align === "right" && "text-right")}>
+            <TableCell key={c.key} className={cn(c.align === "right" && "text-right", c.key === "ipAddress" && "whitespace-normal break-all")}>
               {renderCell(c, row)}
               {c.key === "ipAddress" && (
                 <span {...stopRowActivation}>
@@ -164,8 +166,8 @@ const AccessLogTableBody = memo(function AccessLogTableBody({
             </TableCell>
           ))}
         </TableRow>
-      ))}
-    </TableBody>
+      )}
+    </VirtualTableBody>
   )
 })
 
@@ -189,6 +191,7 @@ export function AccessLogsTable({
   onSortChange,
 }: AccessLogsTableProps) {
   const { filters } = useAccessLogFilters()
+  const { range, customRange } = useTimeRange()
   useCrowdsecLiveUpdates()
   const [selected, setSelected] = useState<AccessLog | null>(null)
 
@@ -279,7 +282,7 @@ export function AccessLogsTable({
           />
         }
       >
-        <Table>
+        <VirtualTable columns={shownColumns} rowCount={rows.length} resetKey={JSON.stringify([page, pageSize, sortField, sortOrder, filters, range, customRange])}>
           <TableHeader>
             <TableRow>
               {shownColumns.map((c) => {
@@ -316,7 +319,7 @@ export function AccessLogsTable({
             </TableRow>
           </TableHeader>
           <AccessLogTableBody rows={rows} shownColumns={shownColumns} onSelect={setSelected} />
-        </Table>
+        </VirtualTable>
       </DataTableFrame>
 
       <AccessLogDetailSheet entry={selected} onOpenChange={(open) => !open && setSelected(null)} />

--- a/resources/components/access-logs/access-logs-table.tsx
+++ b/resources/components/access-logs/access-logs-table.tsx
@@ -69,13 +69,13 @@ function renderCell(column: AccessLogColumn, r: AccessLog): React.ReactNode {
       return <span className="font-mono">{r.method ?? "-"}</span>
     case "url":
       return (
-        <span className="block max-w-[320px] truncate font-mono" title={r.url ?? undefined}>
+        <span className="block truncate font-mono" title={r.url ?? undefined}>
           {r.url ?? "-"}
         </span>
       )
     case "host":
       return (
-        <span className="block max-w-[200px] truncate font-mono" title={r.host ?? undefined}>
+        <span className="block truncate font-mono" title={r.host ?? undefined}>
           {r.host ?? "-"}
         </span>
       )
@@ -91,7 +91,7 @@ function renderCell(column: AccessLogColumn, r: AccessLog): React.ReactNode {
       return <span className="font-mono">{r.httpVersion ?? "-"}</span>
     case "referrer":
       return (
-        <span className="block max-w-[240px] truncate font-mono" title={r.referrer ?? undefined}>
+        <span className="block truncate font-mono" title={r.referrer ?? undefined}>
           {r.referrer ?? "-"}
         </span>
       )
@@ -101,7 +101,7 @@ function renderCell(column: AccessLogColumn, r: AccessLog): React.ReactNode {
       return <span className="font-mono">{r.logFormat ?? "-"}</span>
     case "userAgent":
       return (
-        <span className="block max-w-[280px] truncate font-mono" title={r.userAgent ?? undefined}>
+        <span className="block truncate font-mono" title={r.userAgent ?? undefined}>
           {r.userAgent ?? "-"}
         </span>
       )
@@ -127,7 +127,7 @@ function renderCell(column: AccessLogColumn, r: AccessLog): React.ReactNode {
       )
     case "asnOrganization":
       return (
-        <span className="block max-w-[220px] truncate" title={r.autonomousSystemOrganization ?? undefined}>
+        <span className="block truncate" title={r.autonomousSystemOrganization ?? undefined}>
           {r.autonomousSystemOrganization ?? "-"}
         </span>
       )
@@ -154,7 +154,7 @@ const AccessLogTableBody = memo(function AccessLogTableBody({
           {...rowActivation<HTMLTableRowElement>(() => onSelect(row))}
         >
           {shownColumns.map((c) => (
-            <TableCell key={c.key} className={cn(c.align === "right" && "text-right", c.key === "ipAddress" && "whitespace-normal break-all")}>
+            <TableCell key={c.key} className={cn(c.grow && "max-w-0 truncate", c.align === "right" && "text-right")}>
               {renderCell(c, row)}
               {c.key === "ipAddress" && (
                 <span {...stopRowActivation}>

--- a/resources/components/access-logs/columns.ts
+++ b/resources/components/access-logs/columns.ts
@@ -31,28 +31,29 @@ export type AccessLogColumnKey =
 export interface AccessLogColumn extends VisibilityColumn {
   key: AccessLogColumnKey
   label: string
+  width: number
   sortField?: AccessLogSortField
   align?: "right"
 }
 
 export const ACCESS_LOG_COLUMNS = [
-  { key: "timestamp", label: "Time", sortField: "timestamp", defaultVisible: true },
-  { key: "statusCode", label: "Status", sortField: "statusCode", defaultVisible: true },
-  { key: "method", label: "Method", sortField: "method", defaultVisible: true },
-  { key: "url", label: "URL", sortField: "url", defaultVisible: true },
-  { key: "host", label: "Host", sortField: "host", defaultVisible: true, mobileHidden: true },
-  { key: "ipAddress", label: "IP", sortField: "ipAddress", defaultVisible: true },
-  { key: "bytesSent", label: "Bytes", sortField: "bytesSent", defaultVisible: true, align: "right", mobileHidden: true },
-  { key: "requestTime", label: "Req time", sortField: "requestTime", defaultVisible: true, align: "right", mobileHidden: true },
-  { key: "remoteUser", label: "Remote user", defaultVisible: false },
-  { key: "httpVersion", label: "HTTP ver", defaultVisible: false },
-  { key: "referrer", label: "Referrer", defaultVisible: true, mobileHidden: true },
-  { key: "hostname", label: "Recorded by", defaultVisible: false, mobileHidden: true },
-  { key: "logFormat", label: "Source format", defaultVisible: false, mobileHidden: true },
-  { key: "userAgent", label: "User agent", defaultVisible: false },
-  { key: "upstreamResponseTime", label: "Upstream res time", defaultVisible: false, align: "right" },
-  { key: "country", label: "Country", defaultVisible: true, mobileHidden: true },
-  { key: "city", label: "City", defaultVisible: true, mobileHidden: true },
-  { key: "asn", label: "ASN", defaultVisible: false, mobileHidden: true },
-  { key: "asnOrganization", label: "AS organization", defaultVisible: false, mobileHidden: true },
+  { key: "timestamp", width: 205, label: "Time", sortField: "timestamp", defaultVisible: true },
+  { key: "statusCode", width: 90, label: "Status", sortField: "statusCode", defaultVisible: true },
+  { key: "method", width: 100, label: "Method", sortField: "method", defaultVisible: true },
+  { key: "url", width: 320, label: "URL", sortField: "url", defaultVisible: true },
+  { key: "host", width: 220, label: "Host", sortField: "host", defaultVisible: true, mobileHidden: true },
+  { key: "ipAddress", width: 250, label: "IP", sortField: "ipAddress", defaultVisible: true },
+  { key: "bytesSent", width: 105, label: "Bytes", sortField: "bytesSent", defaultVisible: true, align: "right", mobileHidden: true },
+  { key: "requestTime", width: 105, label: "Req time", sortField: "requestTime", defaultVisible: true, align: "right", mobileHidden: true },
+  { key: "remoteUser", width: 160, label: "Remote user", defaultVisible: false },
+  { key: "httpVersion", width: 100, label: "HTTP ver", defaultVisible: false },
+  { key: "referrer", width: 280, label: "Referrer", defaultVisible: true, mobileHidden: true },
+  { key: "hostname", width: 180, label: "Recorded by", defaultVisible: false, mobileHidden: true },
+  { key: "logFormat", width: 180, label: "Source format", defaultVisible: false, mobileHidden: true },
+  { key: "userAgent", width: 300, label: "User agent", defaultVisible: false },
+  { key: "upstreamResponseTime", width: 155, label: "Upstream res time", defaultVisible: false, align: "right" },
+  { key: "country", width: 120, label: "Country", defaultVisible: true, mobileHidden: true },
+  { key: "city", width: 160, label: "City", defaultVisible: true, mobileHidden: true },
+  { key: "asn", width: 120, label: "ASN", defaultVisible: false, mobileHidden: true },
+  { key: "asnOrganization", width: 240, label: "AS organization", defaultVisible: false, mobileHidden: true },
 ] satisfies readonly AccessLogColumn[] as readonly AccessLogColumn[]

--- a/resources/components/access-logs/columns.ts
+++ b/resources/components/access-logs/columns.ts
@@ -31,29 +31,29 @@ export type AccessLogColumnKey =
 export interface AccessLogColumn extends VisibilityColumn {
   key: AccessLogColumnKey
   label: string
-  width: number
+  grow?: boolean
   sortField?: AccessLogSortField
   align?: "right"
 }
 
 export const ACCESS_LOG_COLUMNS = [
-  { key: "timestamp", width: 205, label: "Time", sortField: "timestamp", defaultVisible: true },
-  { key: "statusCode", width: 90, label: "Status", sortField: "statusCode", defaultVisible: true },
-  { key: "method", width: 100, label: "Method", sortField: "method", defaultVisible: true },
-  { key: "url", width: 320, label: "URL", sortField: "url", defaultVisible: true },
-  { key: "host", width: 220, label: "Host", sortField: "host", defaultVisible: true, mobileHidden: true },
-  { key: "ipAddress", width: 250, label: "IP", sortField: "ipAddress", defaultVisible: true },
-  { key: "bytesSent", width: 105, label: "Bytes", sortField: "bytesSent", defaultVisible: true, align: "right", mobileHidden: true },
-  { key: "requestTime", width: 105, label: "Req time", sortField: "requestTime", defaultVisible: true, align: "right", mobileHidden: true },
-  { key: "remoteUser", width: 160, label: "Remote user", defaultVisible: false },
-  { key: "httpVersion", width: 100, label: "HTTP ver", defaultVisible: false },
-  { key: "referrer", width: 280, label: "Referrer", defaultVisible: true, mobileHidden: true },
-  { key: "hostname", width: 180, label: "Recorded by", defaultVisible: false, mobileHidden: true },
-  { key: "logFormat", width: 180, label: "Source format", defaultVisible: false, mobileHidden: true },
-  { key: "userAgent", width: 300, label: "User agent", defaultVisible: false },
-  { key: "upstreamResponseTime", width: 155, label: "Upstream res time", defaultVisible: false, align: "right" },
-  { key: "country", width: 120, label: "Country", defaultVisible: true, mobileHidden: true },
-  { key: "city", width: 160, label: "City", defaultVisible: true, mobileHidden: true },
-  { key: "asn", width: 120, label: "ASN", defaultVisible: false, mobileHidden: true },
-  { key: "asnOrganization", width: 240, label: "AS organization", defaultVisible: false, mobileHidden: true },
+  { key: "timestamp", label: "Time", sortField: "timestamp", defaultVisible: true },
+  { key: "statusCode", label: "Status", sortField: "statusCode", defaultVisible: true },
+  { key: "method", label: "Method", sortField: "method", defaultVisible: true },
+  { key: "url", grow: true, label: "URL", sortField: "url", defaultVisible: true },
+  { key: "host", grow: true, label: "Host", sortField: "host", defaultVisible: true, mobileHidden: true },
+  { key: "ipAddress", label: "IP", sortField: "ipAddress", defaultVisible: true },
+  { key: "bytesSent", label: "Bytes", sortField: "bytesSent", defaultVisible: true, align: "right", mobileHidden: true },
+  { key: "requestTime", label: "Req time", sortField: "requestTime", defaultVisible: true, align: "right", mobileHidden: true },
+  { key: "remoteUser", grow: true, label: "Remote user", defaultVisible: false },
+  { key: "httpVersion", label: "HTTP ver", defaultVisible: false },
+  { key: "referrer", grow: true, label: "Referrer", defaultVisible: true, mobileHidden: true },
+  { key: "hostname", grow: true, label: "Recorded by", defaultVisible: false, mobileHidden: true },
+  { key: "logFormat", grow: true, label: "Source format", defaultVisible: false, mobileHidden: true },
+  { key: "userAgent", grow: true, label: "User agent", defaultVisible: false },
+  { key: "upstreamResponseTime", label: "Upstream res time", defaultVisible: false, align: "right" },
+  { key: "country", label: "Country", defaultVisible: true, mobileHidden: true },
+  { key: "city", grow: true, label: "City", defaultVisible: true, mobileHidden: true },
+  { key: "asn", label: "ASN", defaultVisible: false, mobileHidden: true },
+  { key: "asnOrganization", grow: true, label: "AS organization", defaultVisible: false, mobileHidden: true },
 ] satisfies readonly AccessLogColumn[] as readonly AccessLogColumn[]

--- a/resources/components/data/detail-sheet.tsx
+++ b/resources/components/data/detail-sheet.tsx
@@ -25,8 +25,8 @@ export function DetailSheet({
   className?: string
 }) {
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" size="full-mobile" className={cn("gap-0", className)}>
+    <Sheet open={open} onOpenChange={onOpenChange} modal={false}>
+      <SheetContent side="right" size="full-mobile" containedModal className={cn("gap-0", className)}>
         <SheetHeader className="shrink-0 border-b border-border/50 pr-16">
           <SheetTitle>{title}</SheetTitle>
           <SheetDescription className={cn(!description && "sr-only")}>

--- a/resources/components/data/detail-sheet.tsx
+++ b/resources/components/data/detail-sheet.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react"
 import {
   Sheet,
   SheetContent,
@@ -6,6 +7,10 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet"
 import { cn } from "@/lib/utils"
+
+// An IP inspector can replace a record sheet. Keep the original row as a
+// fallback when the inspector's immediate opener unmounts with that sheet.
+const sheetOpeners = new WeakMap<EventTarget, HTMLElement[]>()
 
 /** Right-side record viewer: full-screen on phones, a bounded panel from
  * `sm` up. The body scrolls; the header stays. */
@@ -24,9 +29,30 @@ export function DetailSheet({
   children: React.ReactNode
   className?: string
 }) {
+  const openerRef = useRef<HTMLElement[]>([])
   return (
-    <Sheet open={open} onOpenChange={onOpenChange} modal={false}>
-      <SheetContent side="right" size="full-mobile" containedModal className={cn("gap-0", className)}>
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        size="full-mobile"
+        aria-modal="true"
+        className={cn("gap-0", className)}
+        onOpenAutoFocus={(event) => {
+          const opener = document.activeElement
+          const previousSheet = opener?.closest('[data-slot="sheet-content"]')
+            ?? document.querySelector('[data-slot="sheet-content"][data-state="closed"]')
+          const previousOpeners = previousSheet ? sheetOpeners.get(previousSheet) ?? [] : []
+          openerRef.current = opener instanceof HTMLElement && opener !== document.body
+            ? [opener, ...previousOpeners]
+            : previousOpeners
+          if (event.target) sheetOpeners.set(event.target, openerRef.current)
+        }}
+        onCloseAutoFocus={(event) => {
+          event.preventDefault()
+          if (document.querySelector('[data-slot="sheet-content"][data-state="open"]')) return
+          openerRef.current.find((element) => element.isConnected)?.focus({ preventScroll: true })
+        }}
+      >
         <SheetHeader className="shrink-0 border-b border-border/50 pr-16">
           <SheetTitle>{title}</SheetTitle>
           <SheetDescription className={cn(!description && "sr-only")}>

--- a/resources/components/data/virtual-table.tsx
+++ b/resources/components/data/virtual-table.tsx
@@ -1,0 +1,108 @@
+import {
+  cloneElement, createContext, Fragment, useCallback, useContext, useLayoutEffect,
+  useMemo, useState, type ComponentProps, type ReactElement,
+} from "react"
+import { defaultRangeExtractor, useVirtualizer } from "@tanstack/react-virtual"
+import { Table, TableBody } from "@/components/ui/table"
+
+const HEADER_HEIGHT = 40
+const ScrollContext = createContext<{
+  scrollElement: HTMLDivElement | null
+  resetKey: string
+} | null>(null)
+
+/** One viewport for both axes, with column widths independent of mounted rows. */
+export function VirtualTable({
+  columns, rowCount, resetKey, children, ...props
+}: ComponentProps<"table"> & {
+  columns: readonly { key: string; width?: number }[]
+  rowCount: number
+  resetKey: string
+}) {
+  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null)
+  const context = useMemo(() => ({ scrollElement, resetKey }), [scrollElement, resetKey])
+  return (
+    <ScrollContext.Provider value={context}>
+      <Table
+        {...props}
+        containerRef={setScrollElement}
+        containerClassName="max-h-[65dvh] overflow-auto overscroll-contain"
+        className="table-fixed [&_thead]:sticky [&_thead]:top-0 [&_thead]:z-10 [&_thead]:bg-card [&_td]:overflow-hidden [&_td]:text-ellipsis"
+        style={{ minWidth: columns.reduce((sum, column) => sum + (column.width ?? 160), 0) }}
+        aria-rowcount={rowCount + 1}
+      >
+        <colgroup>
+          {columns.map((column) => <col key={column.key} style={{ width: column.width ?? 160 }} />)}
+        </colgroup>
+        {children}
+      </Table>
+    </ScrollContext.Provider>
+  )
+}
+
+/** Measure rows because IP controls and touch targets can change their height. */
+export function VirtualTableBody<T>({ rows, columnCount, getRowKey, children }: {
+  rows: readonly T[]
+  columnCount: number
+  getRowKey: (row: T) => string | number
+  children: (row: T) => ReactElement<ComponentProps<"tr">>
+}) {
+  const context = useContext(ScrollContext)
+  if (!context) throw new Error("VirtualTableBody requires VirtualTable")
+  const { scrollElement, resetKey } = context
+  const [focusedIndex, setFocusedIndex] = useState<number | null>(null)
+  const getItemKey = useCallback((index: number) => getRowKey(rows[index]), [getRowKey, rows])
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollElement,
+    getItemKey,
+    estimateSize: () => 48,
+    overscan: 15,
+    paddingStart: HEADER_HEIGHT,
+    scrollPaddingStart: HEADER_HEIGHT,
+    // Keep the focused row and its neighbours mounted so Tab can cross the
+    // rendered window, and a sheet can return focus to its original row.
+    rangeExtractor: useCallback((range) => {
+      const indexes = defaultRangeExtractor(range)
+      if (focusedIndex === null) return indexes
+      for (let index = focusedIndex - 1; index <= focusedIndex + 1; index++) {
+        if (index >= 0 && index < range.count) indexes.push(index)
+      }
+      return [...new Set(indexes)].sort((a, b) => a - b)
+    }, [focusedIndex]),
+  })
+
+  useLayoutEffect(() => {
+    setFocusedIndex(null)
+    virtualizer.scrollToOffset(0)
+  }, [resetKey, virtualizer])
+
+  const items = virtualizer.getVirtualItems()
+  const spacer = (height: number, key: string) => height > 0 ? (
+    <tr key={key} aria-hidden="true" role="presentation">
+      <td colSpan={columnCount} style={{ height, padding: 0, border: 0 }} />
+    </tr>
+  ) : null
+
+  return (
+    <TableBody
+      onFocusCapture={(event) => {
+        const row = (event.target as HTMLElement).closest<HTMLTableRowElement>("tr[data-index]")
+        if (row) setFocusedIndex(Number(row.dataset.index))
+      }}
+    >
+      {items.map((item, index) => (
+        <Fragment key={item.key}>
+          {spacer(item.start - (items[index - 1]?.end ?? HEADER_HEIGHT), `before-${item.key}`)}
+          {cloneElement(children(rows[item.index]), {
+            ref: virtualizer.measureElement,
+            "data-index": item.index,
+            "aria-rowindex": item.index + 2,
+            role: "row",
+          } as ComponentProps<"tr">)}
+        </Fragment>
+      ))}
+      {spacer(virtualizer.getTotalSize() - (items.at(-1)?.end ?? HEADER_HEIGHT), "after")}
+    </TableBody>
+  )
+}

--- a/resources/components/data/virtual-table.tsx
+++ b/resources/components/data/virtual-table.tsx
@@ -11,11 +11,11 @@ const ScrollContext = createContext<{
   resetKey: string
 } | null>(null)
 
-/** One viewport for both axes, with column widths independent of mounted rows. */
+/** Short fields take their natural width; text columns share the remaining space. */
 export function VirtualTable({
   columns, rowCount, resetKey, children, ...props
 }: ComponentProps<"table"> & {
-  columns: readonly { key: string; width?: number }[]
+  columns: readonly { key: string; grow?: boolean }[]
   rowCount: number
   resetKey: string
 }) {
@@ -26,13 +26,14 @@ export function VirtualTable({
       <Table
         {...props}
         containerRef={setScrollElement}
-        containerClassName="max-h-[65dvh] overflow-auto overscroll-contain"
-        className="table-fixed [&_thead]:sticky [&_thead]:top-0 [&_thead]:z-10 [&_thead]:bg-card [&_td]:overflow-hidden [&_td]:text-ellipsis"
-        style={{ minWidth: columns.reduce((sum, column) => sum + (column.width ?? 160), 0) }}
+        containerClassName="max-h-[65dvh] overflow-auto overscroll-x-contain"
+        className="table-auto [&_thead]:sticky [&_thead]:top-0 [&_thead]:z-10 [&_thead]:bg-card"
         aria-rowcount={rowCount + 1}
       >
         <colgroup>
-          {columns.map((column) => <col key={column.key} style={{ width: column.width ?? 160 }} />)}
+          {/* In auto layout, 1% keeps short fields at their content width.
+              Unconstrained text columns get the remaining space. */}
+          {columns.map((column) => <col key={column.key} style={{ width: column.grow ? undefined : "1%" }} />)}
         </colgroup>
         {children}
       </Table>

--- a/resources/components/debug-logs/debug-logs-table.tsx
+++ b/resources/components/debug-logs/debug-logs-table.tsx
@@ -4,7 +4,7 @@
  * city, malformed tri-state. Clicking a row opens the raw-line detail
  * dialog. Pairs with GET /api/v1/access-log-debug/.
  */
-import { useEffect, useState } from "react"
+import { memo, useEffect, useState } from "react"
 import { useSearch } from "@tanstack/react-router"
 import {
   ArrowDown,
@@ -213,13 +213,52 @@ const COLUMNS: ColumnDef[] = [
   },
 ]
 
+const DebugLogTableBody = memo(function DebugLogTableBody({
+  rows,
+  shownColumns,
+  onSelect,
+}: {
+  rows: AccessLogDebugEntry[]
+  shownColumns: ColumnDef[]
+  onSelect: (row: AccessLogDebugEntry) => void
+}) {
+  return (
+    <TableBody>
+      {rows.map((row) => (
+        <TableRow
+          key={row.id}
+          aria-label={`Debug line ${row.id}, ${row.isMalformed ? "malformed" : "parsed"}`}
+          {...rowActivation<HTMLTableRowElement>(() => onSelect(row))}
+        >
+          {shownColumns.map((c) => (
+            <TableCell key={c.key}>
+              {c.render(row)}
+              {c.key === "ipAddress" && row.ipAddress && (
+                <span {...stopRowActivation}>
+                  <IpBanControls ip={row.ipAddress}>
+                    <InspectIpButton ip={row.ipAddress} />
+                  </IpBanControls>
+                </span>
+              )}
+            </TableCell>
+          ))}
+        </TableRow>
+      ))}
+    </TableBody>
+  )
+})
+
 export function DebugLogsTable() {
   const isMobile = useIsMobile()
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(20)
 
   // Filters (raw input; text inputs are debounced before hitting the query).
-  const initial = useSearch({ from: "/debug-logs" })
+  const initial = useSearch({
+    from: "/debug-logs",
+    select: ({ ip, malformed }) => ({ ip, malformed }),
+    structuralSharing: true,
+  })
   const [searchInput, setSearchInput] = useState("")
   const [ipInput, setIpInput] = useState(initial.ip ?? "")
   const [cities, setCities] = useState<string[]>([])
@@ -487,28 +526,7 @@ export function DebugLogsTable() {
               })}
             </TableRow>
           </TableHeader>
-          <TableBody>
-            {rows.map((row) => (
-              <TableRow
-                key={row.id}
-                aria-label={`Debug line ${row.id}, ${row.isMalformed ? "malformed" : "parsed"}`}
-                {...rowActivation<HTMLTableRowElement>(() => setSelected(row))}
-              >
-                {shownColumns.map((c) => (
-                  <TableCell key={c.key}>
-                    {c.render(row)}
-                    {c.key === "ipAddress" && row.ipAddress && (
-                      <span {...stopRowActivation}>
-                        <IpBanControls ip={row.ipAddress}>
-                          <InspectIpButton ip={row.ipAddress} />
-                        </IpBanControls>
-                      </span>
-                    )}
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))}
-          </TableBody>
+          <DebugLogTableBody rows={rows} shownColumns={shownColumns} onSelect={setSelected} />
         </Table>
       </DataTableFrame>
 

--- a/resources/components/debug-logs/debug-logs-table.tsx
+++ b/resources/components/debug-logs/debug-logs-table.tsx
@@ -65,7 +65,7 @@ type MalformedFilter = "all" | "malformed" | "wellformed"
 
 interface ColumnDef {
   key: string
-  width?: number
+  grow?: boolean
   label: string
   sortField?: AccessLogDebugSortField
   defaultVisible: boolean
@@ -77,7 +77,6 @@ interface ColumnDef {
 const COLUMNS: ColumnDef[] = [
   {
     key: "createdAt",
-    width: 205,
     label: "Captured",
     sortField: "createdAt",
     defaultVisible: true,
@@ -103,24 +102,24 @@ const COLUMNS: ColumnDef[] = [
   },
   {
     key: "parseError",
-    width: 240,
+    grow: true,
     label: "Parse error",
     sortField: "parseError",
     defaultVisible: true,
     mobileHidden: true,
     render: (r) => (
-      <span className="block max-w-[220px] truncate" title={r.parseError ?? undefined}>
+      <span className="block truncate" title={r.parseError ?? undefined}>
         {r.parseError ?? "-"}
       </span>
     ),
   },
   {
     key: "rawLine",
-    width: 380,
+    grow: true,
     label: "Raw line",
     defaultVisible: true,
     render: (r) => (
-      <span className="block max-w-[360px] truncate font-mono" title={r.rawLine}>
+      <span className="block truncate font-mono" title={r.rawLine}>
         {r.rawLine}
       </span>
     ),
@@ -149,7 +148,6 @@ const COLUMNS: ColumnDef[] = [
   },
   {
     key: "ipAddress",
-    width: 250,
     label: "IP",
     sortField: "ipAddress",
     defaultVisible: true,
@@ -158,22 +156,23 @@ const COLUMNS: ColumnDef[] = [
   },
   {
     key: "url",
-    width: 340,
+    grow: true,
     label: "URL",
     defaultVisible: false,
     render: (r) => (
-      <span className="block max-w-[320px] truncate font-mono" title={r.url ?? undefined}>
+      <span className="block truncate font-mono" title={r.url ?? undefined}>
         {r.url ?? "-"}
       </span>
     ),
   },
   {
     key: "host",
+    grow: true,
     label: "Host",
     sortField: "host",
     defaultVisible: false,
     render: (r) => (
-      <span className="block max-w-[200px] truncate font-mono" title={r.host ?? undefined}>
+      <span className="block truncate font-mono" title={r.host ?? undefined}>
         {r.host ?? "-"}
       </span>
     ),
@@ -202,6 +201,7 @@ const COLUMNS: ColumnDef[] = [
   },
   {
     key: "city",
+    grow: true,
     label: "City",
     sortField: "city",
     defaultVisible: false,
@@ -209,11 +209,11 @@ const COLUMNS: ColumnDef[] = [
   },
   {
     key: "userAgent",
-    width: 300,
+    grow: true,
     label: "User agent",
     defaultVisible: false,
     render: (r) => (
-      <span className="block max-w-[280px] truncate font-mono" title={r.userAgent ?? undefined}>
+      <span className="block truncate font-mono" title={r.userAgent ?? undefined}>
         {r.userAgent ?? "-"}
       </span>
     ),
@@ -240,7 +240,7 @@ const DebugLogTableBody = memo(function DebugLogTableBody({
           {...rowActivation<HTMLTableRowElement>(() => onSelect(row))}
         >
           {shownColumns.map((c) => (
-            <TableCell key={c.key} className={cn(c.key === "ipAddress" && "whitespace-normal break-all")}>
+            <TableCell key={c.key} className={cn(c.grow && "max-w-0 truncate")}>
               {c.render(row)}
               {c.key === "ipAddress" && row.ipAddress && (
                 <span {...stopRowActivation}>

--- a/resources/components/debug-logs/debug-logs-table.tsx
+++ b/resources/components/debug-logs/debug-logs-table.tsx
@@ -14,13 +14,13 @@ import {
   Search,
 } from "lucide-react"
 import {
-  Table,
-  TableBody,
   TableCell,
   TableHead,
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { VirtualTable, VirtualTableBody } from "@/components/data/virtual-table"
+import { useTimeRange } from "@/lib/time-range-context"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -65,6 +65,7 @@ type MalformedFilter = "all" | "malformed" | "wellformed"
 
 interface ColumnDef {
   key: string
+  width?: number
   label: string
   sortField?: AccessLogDebugSortField
   defaultVisible: boolean
@@ -76,6 +77,7 @@ interface ColumnDef {
 const COLUMNS: ColumnDef[] = [
   {
     key: "createdAt",
+    width: 205,
     label: "Captured",
     sortField: "createdAt",
     defaultVisible: true,
@@ -101,6 +103,7 @@ const COLUMNS: ColumnDef[] = [
   },
   {
     key: "parseError",
+    width: 240,
     label: "Parse error",
     sortField: "parseError",
     defaultVisible: true,
@@ -113,6 +116,7 @@ const COLUMNS: ColumnDef[] = [
   },
   {
     key: "rawLine",
+    width: 380,
     label: "Raw line",
     defaultVisible: true,
     render: (r) => (
@@ -145,6 +149,7 @@ const COLUMNS: ColumnDef[] = [
   },
   {
     key: "ipAddress",
+    width: 250,
     label: "IP",
     sortField: "ipAddress",
     defaultVisible: true,
@@ -153,6 +158,7 @@ const COLUMNS: ColumnDef[] = [
   },
   {
     key: "url",
+    width: 340,
     label: "URL",
     defaultVisible: false,
     render: (r) => (
@@ -203,6 +209,7 @@ const COLUMNS: ColumnDef[] = [
   },
   {
     key: "userAgent",
+    width: 300,
     label: "User agent",
     defaultVisible: false,
     render: (r) => (
@@ -212,6 +219,8 @@ const COLUMNS: ColumnDef[] = [
     ),
   },
 ]
+
+const getRowKey = (row: AccessLogDebugEntry) => row.id
 
 const DebugLogTableBody = memo(function DebugLogTableBody({
   rows,
@@ -223,15 +232,15 @@ const DebugLogTableBody = memo(function DebugLogTableBody({
   onSelect: (row: AccessLogDebugEntry) => void
 }) {
   return (
-    <TableBody>
-      {rows.map((row) => (
+    <VirtualTableBody rows={rows} columnCount={shownColumns.length} getRowKey={getRowKey}>
+      {(row) => (
         <TableRow
           key={row.id}
           aria-label={`Debug line ${row.id}, ${row.isMalformed ? "malformed" : "parsed"}`}
           {...rowActivation<HTMLTableRowElement>(() => onSelect(row))}
         >
           {shownColumns.map((c) => (
-            <TableCell key={c.key}>
+            <TableCell key={c.key} className={cn(c.key === "ipAddress" && "whitespace-normal break-all")}>
               {c.render(row)}
               {c.key === "ipAddress" && row.ipAddress && (
                 <span {...stopRowActivation}>
@@ -243,12 +252,13 @@ const DebugLogTableBody = memo(function DebugLogTableBody({
             </TableCell>
           ))}
         </TableRow>
-      ))}
-    </TableBody>
+      )}
+    </VirtualTableBody>
   )
 })
 
 export function DebugLogsTable() {
+  const { range, customRange } = useTimeRange()
   const isMobile = useIsMobile()
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(20)
@@ -491,7 +501,7 @@ export function DebugLogsTable() {
           />
         }
       >
-        <Table>
+        <VirtualTable columns={shownColumns} rowCount={rows.length} resetKey={JSON.stringify([page, pageSize, sortField, sortOrder, search, ip, cities, countries, malformedFilter, range, customRange])}>
           <TableHeader>
             <TableRow>
               {shownColumns.map((c) => {
@@ -527,7 +537,7 @@ export function DebugLogsTable() {
             </TableRow>
           </TableHeader>
           <DebugLogTableBody rows={rows} shownColumns={shownColumns} onSelect={setSelected} />
-        </Table>
+        </VirtualTable>
       </DataTableFrame>
 
       <DebugLogDetailSheet entry={selected} onOpenChange={(open) => !open && setSelected(null)} />

--- a/resources/components/geo-logs/columns.ts
+++ b/resources/components/geo-logs/columns.ts
@@ -23,21 +23,22 @@ export type GeoLogColumnKey =
 export interface GeoLogColumn extends VisibilityColumn {
   key: GeoLogColumnKey
   label: string
+  width: number
   /** Present when the column is server-sortable; absent for hostnames. */
   sortField?: GeoLogSortField
   align?: "right"
 }
 
 export const GEO_LOG_COLUMNS = [
-  { key: "city", label: "City", sortField: "city", defaultVisible: true },
-  { key: "postalCode", label: "Postal Code", sortField: "postalCode", defaultVisible: true, mobileHidden: true },
-  { key: "state", label: "State", sortField: "state", defaultVisible: true, mobileHidden: true },
-  { key: "countryCode", label: "Country Code", sortField: "countryCode", defaultVisible: true, mobileHidden: true },
-  { key: "countryName", label: "Country", sortField: "countryName", defaultVisible: true },
-  { key: "ipAddress", label: "IP", sortField: "ipAddress", defaultVisible: true },
-  { key: "latitude", label: "Lat", sortField: "latitude", defaultVisible: true, align: "right", mobileHidden: true },
-  { key: "longitude", label: "Long", sortField: "longitude", defaultVisible: true, align: "right", mobileHidden: true },
-  { key: "eventCount", label: "Count", sortField: "eventCount", defaultVisible: true, align: "right" },
-  { key: "lastSeen", label: "Last seen", sortField: "lastSeen", defaultVisible: true, mobileHidden: true },
-  { key: "hostnames", label: "Hostnames", defaultVisible: false },
+  { key: "city", width: 160, label: "City", sortField: "city", defaultVisible: true },
+  { key: "postalCode", width: 130, label: "Postal Code", sortField: "postalCode", defaultVisible: true, mobileHidden: true },
+  { key: "state", width: 160, label: "State", sortField: "state", defaultVisible: true, mobileHidden: true },
+  { key: "countryCode", width: 140, label: "Country Code", sortField: "countryCode", defaultVisible: true, mobileHidden: true },
+  { key: "countryName", width: 180, label: "Country", sortField: "countryName", defaultVisible: true },
+  { key: "ipAddress", width: 250, label: "IP", sortField: "ipAddress", defaultVisible: true },
+  { key: "latitude", width: 110, label: "Lat", sortField: "latitude", defaultVisible: true, align: "right", mobileHidden: true },
+  { key: "longitude", width: 110, label: "Long", sortField: "longitude", defaultVisible: true, align: "right", mobileHidden: true },
+  { key: "eventCount", width: 115, label: "Count", sortField: "eventCount", defaultVisible: true, align: "right" },
+  { key: "lastSeen", width: 205, label: "Last seen", sortField: "lastSeen", defaultVisible: true, mobileHidden: true },
+  { key: "hostnames", width: 260, label: "Hostnames", defaultVisible: false },
 ] satisfies readonly GeoLogColumn[] as readonly GeoLogColumn[]

--- a/resources/components/geo-logs/columns.ts
+++ b/resources/components/geo-logs/columns.ts
@@ -23,22 +23,22 @@ export type GeoLogColumnKey =
 export interface GeoLogColumn extends VisibilityColumn {
   key: GeoLogColumnKey
   label: string
-  width: number
+  grow?: boolean
   /** Present when the column is server-sortable; absent for hostnames. */
   sortField?: GeoLogSortField
   align?: "right"
 }
 
 export const GEO_LOG_COLUMNS = [
-  { key: "city", width: 160, label: "City", sortField: "city", defaultVisible: true },
-  { key: "postalCode", width: 130, label: "Postal Code", sortField: "postalCode", defaultVisible: true, mobileHidden: true },
-  { key: "state", width: 160, label: "State", sortField: "state", defaultVisible: true, mobileHidden: true },
-  { key: "countryCode", width: 140, label: "Country Code", sortField: "countryCode", defaultVisible: true, mobileHidden: true },
-  { key: "countryName", width: 180, label: "Country", sortField: "countryName", defaultVisible: true },
-  { key: "ipAddress", width: 250, label: "IP", sortField: "ipAddress", defaultVisible: true },
-  { key: "latitude", width: 110, label: "Lat", sortField: "latitude", defaultVisible: true, align: "right", mobileHidden: true },
-  { key: "longitude", width: 110, label: "Long", sortField: "longitude", defaultVisible: true, align: "right", mobileHidden: true },
-  { key: "eventCount", width: 115, label: "Count", sortField: "eventCount", defaultVisible: true, align: "right" },
-  { key: "lastSeen", width: 205, label: "Last seen", sortField: "lastSeen", defaultVisible: true, mobileHidden: true },
-  { key: "hostnames", width: 260, label: "Hostnames", defaultVisible: false },
+  { key: "city", grow: true, label: "City", sortField: "city", defaultVisible: true },
+  { key: "postalCode", label: "Postal Code", sortField: "postalCode", defaultVisible: true, mobileHidden: true },
+  { key: "state", grow: true, label: "State", sortField: "state", defaultVisible: true, mobileHidden: true },
+  { key: "countryCode", label: "Country Code", sortField: "countryCode", defaultVisible: true, mobileHidden: true },
+  { key: "countryName", grow: true, label: "Country", sortField: "countryName", defaultVisible: true },
+  { key: "ipAddress", label: "IP", sortField: "ipAddress", defaultVisible: true },
+  { key: "latitude", label: "Lat", sortField: "latitude", defaultVisible: true, align: "right", mobileHidden: true },
+  { key: "longitude", label: "Long", sortField: "longitude", defaultVisible: true, align: "right", mobileHidden: true },
+  { key: "eventCount", label: "Count", sortField: "eventCount", defaultVisible: true, align: "right" },
+  { key: "lastSeen", label: "Last seen", sortField: "lastSeen", defaultVisible: true, mobileHidden: true },
+  { key: "hostnames", grow: true, label: "Hostnames", defaultVisible: false },
 ] satisfies readonly GeoLogColumn[] as readonly GeoLogColumn[]

--- a/resources/components/geo-logs/geo-logs-table.tsx
+++ b/resources/components/geo-logs/geo-logs-table.tsx
@@ -5,7 +5,7 @@
  * arrives here as props; the filter set comes from GeoLogFiltersContext like
  * everything else on the page. Selecting a row opens GeoLogDetailSheet.
  */
-import { useState } from "react"
+import { memo, useState } from "react"
 import { ArrowDown, ArrowUp, ChevronsUpDown, Columns3 } from "lucide-react"
 import {
   Table,
@@ -76,6 +76,41 @@ function renderCell(column: GeoLogColumn, r: GeoLogEntry): React.ReactNode {
       )
   }
 }
+
+const GeoLogTableBody = memo(function GeoLogTableBody({
+  rows,
+  shownColumns,
+  onSelect,
+}: {
+  rows: GeoLogEntry[]
+  shownColumns: GeoLogColumn[]
+  onSelect: (row: GeoLogEntry) => void
+}) {
+  return (
+    <TableBody>
+      {rows.map((row) => (
+        <TableRow
+          key={`${row.locationId}-${row.ipAddress}`}
+          aria-label={`${row.city ?? row.countryName}, ${row.ipAddress}, ${formatNumber(row.eventCount)} events`}
+          {...rowActivation<HTMLTableRowElement>(() => onSelect(row))}
+        >
+          {shownColumns.map((c) => (
+            <TableCell key={c.key} className={cn(c.align === "right" && "text-right")}>
+              {renderCell(c, row)}
+              {c.key === "ipAddress" && (
+                <span {...stopRowActivation}>
+                  <IpBanControls ip={row.ipAddress}>
+                    <InspectIpButton ip={row.ipAddress} className="ml-1" />
+                  </IpBanControls>
+                </span>
+              )}
+            </TableCell>
+          ))}
+        </TableRow>
+      ))}
+    </TableBody>
+  )
+})
 
 export function GeoLogsTable({
   page,
@@ -206,28 +241,7 @@ export function GeoLogsTable({
               })}
             </TableRow>
           </TableHeader>
-          <TableBody>
-            {rows.map((row) => (
-              <TableRow
-                key={`${row.locationId}-${row.ipAddress}`}
-                aria-label={`${row.city ?? row.countryName}, ${row.ipAddress}, ${formatNumber(row.eventCount)} events`}
-                {...rowActivation<HTMLTableRowElement>(() => setSelected(row))}
-              >
-                {shownColumns.map((c) => (
-                  <TableCell key={c.key} className={cn(c.align === "right" && "text-right")}>
-                    {renderCell(c, row)}
-                    {c.key === "ipAddress" && (
-                      <span {...stopRowActivation}>
-                        <IpBanControls ip={row.ipAddress}>
-                          <InspectIpButton ip={row.ipAddress} className="ml-1" />
-                        </IpBanControls>
-                      </span>
-                    )}
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))}
-          </TableBody>
+          <GeoLogTableBody rows={rows} shownColumns={shownColumns} onSelect={setSelected} />
         </Table>
       </DataTableFrame>
 

--- a/resources/components/geo-logs/geo-logs-table.tsx
+++ b/resources/components/geo-logs/geo-logs-table.tsx
@@ -8,13 +8,14 @@
 import { memo, useState } from "react"
 import { ArrowDown, ArrowUp, ChevronsUpDown, Columns3 } from "lucide-react"
 import {
-  Table,
-  TableBody,
   TableCell,
   TableHead,
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { VirtualTable, VirtualTableBody } from "@/components/data/virtual-table"
+import { useTimeRange } from "@/lib/time-range-context"
+import { useGeoLogFilters } from "@/lib/geo-log-filters-context"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -77,6 +78,8 @@ function renderCell(column: GeoLogColumn, r: GeoLogEntry): React.ReactNode {
   }
 }
 
+const getRowKey = (row: GeoLogEntry) => `${row.locationId}-${row.ipAddress}`
+
 const GeoLogTableBody = memo(function GeoLogTableBody({
   rows,
   shownColumns,
@@ -87,15 +90,15 @@ const GeoLogTableBody = memo(function GeoLogTableBody({
   onSelect: (row: GeoLogEntry) => void
 }) {
   return (
-    <TableBody>
-      {rows.map((row) => (
+    <VirtualTableBody rows={rows} columnCount={shownColumns.length} getRowKey={getRowKey}>
+      {(row) => (
         <TableRow
           key={`${row.locationId}-${row.ipAddress}`}
           aria-label={`${row.city ?? row.countryName}, ${row.ipAddress}, ${formatNumber(row.eventCount)} events`}
           {...rowActivation<HTMLTableRowElement>(() => onSelect(row))}
         >
           {shownColumns.map((c) => (
-            <TableCell key={c.key} className={cn(c.align === "right" && "text-right")}>
+            <TableCell key={c.key} className={cn(c.align === "right" && "text-right", c.key === "ipAddress" && "whitespace-normal break-all")}>
               {renderCell(c, row)}
               {c.key === "ipAddress" && (
                 <span {...stopRowActivation}>
@@ -107,8 +110,8 @@ const GeoLogTableBody = memo(function GeoLogTableBody({
             </TableCell>
           ))}
         </TableRow>
-      ))}
-    </TableBody>
+      )}
+    </VirtualTableBody>
   )
 })
 
@@ -130,6 +133,8 @@ export function GeoLogsTable({
   onSortChange: (sortField: GeoLogSortField, sortOrder: GeoLogSortOrder) => void
 }) {
   const [selected, setSelected] = useState<GeoLogEntry | null>(null)
+  const { range, customRange } = useTimeRange()
+  const { filters } = useGeoLogFilters()
   const { visible, shownColumns, toggleColumn, resetColumns, hasOverrides } =
     useColumnVisibility("geometrikks-columns-geo-logs", GEO_LOG_COLUMNS)
 
@@ -205,7 +210,7 @@ export function GeoLogsTable({
           />
         }
       >
-        <Table>
+        <VirtualTable columns={shownColumns} rowCount={rows.length} resetKey={JSON.stringify([page, pageSize, sortField, sortOrder, filters, range, customRange])}>
           <TableHeader>
             <TableRow>
               {shownColumns.map((c) => {
@@ -242,7 +247,7 @@ export function GeoLogsTable({
             </TableRow>
           </TableHeader>
           <GeoLogTableBody rows={rows} shownColumns={shownColumns} onSelect={setSelected} />
-        </Table>
+        </VirtualTable>
       </DataTableFrame>
 
       <GeoLogDetailSheet entry={selected} onOpenChange={(open) => !open && setSelected(null)} />

--- a/resources/components/geo-logs/geo-logs-table.tsx
+++ b/resources/components/geo-logs/geo-logs-table.tsx
@@ -71,7 +71,7 @@ function renderCell(column: GeoLogColumn, r: GeoLogEntry): React.ReactNode {
       )
     case "hostnames":
       return (
-        <span className="block max-w-[240px] truncate font-mono" title={r.hostnames.join(", ") || undefined}>
+        <span className="block truncate font-mono" title={r.hostnames.join(", ") || undefined}>
           {r.hostnames.length ? r.hostnames.join(", ") : "-"}
         </span>
       )
@@ -98,7 +98,7 @@ const GeoLogTableBody = memo(function GeoLogTableBody({
           {...rowActivation<HTMLTableRowElement>(() => onSelect(row))}
         >
           {shownColumns.map((c) => (
-            <TableCell key={c.key} className={cn(c.align === "right" && "text-right", c.key === "ipAddress" && "whitespace-normal break-all")}>
+            <TableCell key={c.key} className={cn(c.grow && "max-w-0 truncate", c.align === "right" && "text-right")}>
               {renderCell(c, row)}
               {c.key === "ipAddress" && (
                 <span {...stopRowActivation}>

--- a/resources/components/ip-inspector/inspect-ip-button.tsx
+++ b/resources/components/ip-inspector/inspect-ip-button.tsx
@@ -1,7 +1,7 @@
 import { ScanSearch } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { stopRowActivation } from "@/components/data/row-activation"
-import { useIpInspector } from "@/lib/ip-inspector"
+import { useIpInspectorActions } from "@/lib/ip-inspector"
 import { cn } from "@/lib/utils"
 
 /** Opens the IP inspector. Safe inside activatable table rows: it stops
@@ -20,7 +20,7 @@ export function InspectIpButton({
   className?: string
   onOpen?: () => void
 }) {
-  const { open } = useIpInspector()
+  const { open } = useIpInspectorActions()
   return (
     <Button
       variant="ghost"

--- a/resources/components/ip-inspector/ip-locations-block.tsx
+++ b/resources/components/ip-inspector/ip-locations-block.tsx
@@ -3,13 +3,13 @@ import { LocateFixed } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { formatNumber } from "@/lib/api"
-import { useIpInspector } from "@/lib/ip-inspector"
+import { useIpInspectorOrigin } from "@/lib/ip-inspector"
 import { useIpLocations } from "@/lib/queries"
 
 /** Every location this IP resolved to, minus the one the sheet was opened
  *  from. "Fly to" lands on the map with that location's popup open. */
 export function IpLocationsBlock({ ip }: { ip: string }) {
-  const { originLocationId } = useIpInspector()
+  const originLocationId = useIpInspectorOrigin()
   const navigate = useNavigate()
   const { data, isLoading, isError } = useIpLocations(ip)
   const rows = (data?.items ?? []).filter((r) => r.locationId !== originLocationId)

--- a/resources/components/map/InspectIpButton.tsx
+++ b/resources/components/map/InspectIpButton.tsx
@@ -4,10 +4,10 @@
  * reason IpBanControls exists twice.
  */
 import { ScanSearch } from "lucide-react"
-import { useIpInspector } from "@/lib/ip-inspector"
+import { useIpInspectorActions } from "@/lib/ip-inspector"
 
 export function InspectIpButton({ ip, fromLocationId }: { ip: string; fromLocationId?: number }) {
-  const { open } = useIpInspector()
+  const { open } = useIpInspectorActions()
   return (
     <button
       type="button"

--- a/resources/components/ui/sheet.tsx
+++ b/resources/components/ui/sheet.tsx
@@ -40,12 +40,27 @@ function SheetOverlay({
   )
 }
 
+/** Radix only renders its overlay in modal mode. Detail sheets use a
+ * contained modal mode below to avoid hiding a large table subtree. */
+function ContainedSheetOverlay({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-overlay"
+      data-state="open"
+      className={cn("data-open:animate-in fade-in-0 bg-black/50 duration-100 fixed inset-0 z-50 motion-reduce:animate-none", className)}
+      {...props}
+    />
+  )
+}
+
 function SheetContent({
   className,
   children,
   side = "right",
   size = "default",
   showCloseButton = true,
+  containedModal = false,
+  ref,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: "top" | "right" | "bottom" | "left"
@@ -53,14 +68,48 @@ function SheetContent({
    * with a rounded outer edge from `sm` up. */
   size?: "default" | "full-mobile"
   showCloseButton?: boolean
+  /** Pair with `<Sheet modal={false}>`. Preserves modal semantics without
+   * applying `aria-hidden` to the application subtree. */
+  containedModal?: boolean
 }) {
+  const contentRef = React.useRef<HTMLDivElement | null>(null)
+  const composedRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      contentRef.current = node
+      if (typeof ref === "function") ref(node)
+      else if (ref) ref.current = node
+    },
+    [ref],
+  )
+
+  React.useEffect(() => {
+    if (!containedModal) return
+    const app = document.getElementById("app")
+    const content = contentRef.current
+    if (!app || !content) return
+
+    const keepFocusInSheet = (event: FocusEvent) => {
+      const target = event.target
+      if (!(target instanceof Node) || !app.contains(target)) return
+      const fallback = content.querySelector<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      )
+      ;(fallback ?? content).focus({ preventScroll: true })
+    }
+
+    document.addEventListener("focusin", keepFocusInSheet, true)
+    return () => document.removeEventListener("focusin", keepFocusInSheet, true)
+  }, [containedModal])
+
   return (
     <SheetPortal>
-      <SheetOverlay />
+      {containedModal ? <ContainedSheetOverlay /> : <SheetOverlay />}
       <SheetPrimitive.Content
+        ref={composedRef}
         data-slot="sheet-content"
         data-side={side}
         data-size={size}
+        aria-modal={containedModal || undefined}
         className={cn(
           "bg-background data-open:animate-in data-closed:animate-out data-[side=right]:data-closed:slide-out-to-right-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=top]:data-closed:slide-out-to-top-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:fade-out-0 data-open:fade-in-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=bottom]:data-open:slide-in-from-bottom-10 fixed z-50 flex flex-col gap-4 bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out motion-reduce:animate-none motion-reduce:transition-none",
           size === "default" &&

--- a/resources/components/ui/sheet.tsx
+++ b/resources/components/ui/sheet.tsx
@@ -40,27 +40,12 @@ function SheetOverlay({
   )
 }
 
-/** Radix only renders its overlay in modal mode. Detail sheets use a
- * contained modal mode below to avoid hiding a large table subtree. */
-function ContainedSheetOverlay({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="sheet-overlay"
-      data-state="open"
-      className={cn("data-open:animate-in fade-in-0 bg-black/50 duration-100 fixed inset-0 z-50 motion-reduce:animate-none", className)}
-      {...props}
-    />
-  )
-}
-
 function SheetContent({
   className,
   children,
   side = "right",
   size = "default",
   showCloseButton = true,
-  containedModal = false,
-  ref,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: "top" | "right" | "bottom" | "left"
@@ -68,48 +53,14 @@ function SheetContent({
    * with a rounded outer edge from `sm` up. */
   size?: "default" | "full-mobile"
   showCloseButton?: boolean
-  /** Pair with `<Sheet modal={false}>`. Preserves modal semantics without
-   * applying `aria-hidden` to the application subtree. */
-  containedModal?: boolean
 }) {
-  const contentRef = React.useRef<HTMLDivElement | null>(null)
-  const composedRef = React.useCallback(
-    (node: HTMLDivElement | null) => {
-      contentRef.current = node
-      if (typeof ref === "function") ref(node)
-      else if (ref) ref.current = node
-    },
-    [ref],
-  )
-
-  React.useEffect(() => {
-    if (!containedModal) return
-    const app = document.getElementById("app")
-    const content = contentRef.current
-    if (!app || !content) return
-
-    const keepFocusInSheet = (event: FocusEvent) => {
-      const target = event.target
-      if (!(target instanceof Node) || !app.contains(target)) return
-      const fallback = content.querySelector<HTMLElement>(
-        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      )
-      ;(fallback ?? content).focus({ preventScroll: true })
-    }
-
-    document.addEventListener("focusin", keepFocusInSheet, true)
-    return () => document.removeEventListener("focusin", keepFocusInSheet, true)
-  }, [containedModal])
-
   return (
     <SheetPortal>
-      {containedModal ? <ContainedSheetOverlay /> : <SheetOverlay />}
+      <SheetOverlay />
       <SheetPrimitive.Content
-        ref={composedRef}
         data-slot="sheet-content"
         data-side={side}
         data-size={size}
-        aria-modal={containedModal || undefined}
         className={cn(
           "bg-background data-open:animate-in data-closed:animate-out data-[side=right]:data-closed:slide-out-to-right-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=top]:data-closed:slide-out-to-top-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:fade-out-0 data-open:fade-in-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=bottom]:data-open:slide-in-from-bottom-10 fixed z-50 flex flex-col gap-4 bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out motion-reduce:animate-none motion-reduce:transition-none",
           size === "default" &&

--- a/resources/components/ui/table.tsx
+++ b/resources/components/ui/table.tsx
@@ -7,10 +7,12 @@ import { cn } from "@/lib/utils"
 function Table({
   className,
   containerClassName,
+  containerRef,
   ...props
-}: React.ComponentProps<"table"> & { containerClassName?: string }) {
+}: React.ComponentProps<"table"> & { containerClassName?: string; containerRef?: React.Ref<HTMLDivElement> }) {
   return (
     <div
+      ref={containerRef}
       data-slot="table-container"
       className={cn("relative w-full overflow-x-auto", containerClassName)}
     >

--- a/resources/lib/ip-inspector.tsx
+++ b/resources/lib/ip-inspector.tsx
@@ -6,26 +6,17 @@
 import { createContext, useCallback, useContext, useMemo, useState } from "react"
 import { useNavigate, useSearch } from "@tanstack/react-router"
 
-interface OriginState {
-  originLocationId: number | null
-  setOrigin: (id: number | null) => void
+interface ActionsState {
+  open: (ip: string, fromLocationId?: number) => void
+  close: () => void
 }
 
-const OriginContext = createContext<OriginState | null>(null)
+const ActionsContext = createContext<ActionsState | null>(null)
+const OriginContext = createContext<number | null | undefined>(undefined)
 
 export function IpInspectorProvider({ children }: { children: React.ReactNode }) {
-  const [originLocationId, setOrigin] = useState<number | null>(null)
-  const value = useMemo(() => ({ originLocationId, setOrigin }), [originLocationId])
-  return <OriginContext.Provider value={value}>{children}</OriginContext.Provider>
-}
-
-export function useIpInspector() {
   const navigate = useNavigate()
-  const search = useSearch({ strict: false })
-  const origin = useContext(OriginContext)
-  if (!origin) throw new Error("useIpInspector must be used within an IpInspectorProvider")
-  const { originLocationId, setOrigin } = origin
-  const ip = typeof search.inspect === "string" && search.inspect ? search.inspect : undefined
+  const [originLocationId, setOrigin] = useState<number | null>(null)
 
   const open = useCallback(
     (nextIp: string, fromLocationId?: number) => {
@@ -45,5 +36,33 @@ export function useIpInspector() {
     })
   }, [navigate, setOrigin])
 
-  return { ip, originLocationId, open, close }
+  const actions = useMemo(() => ({ open, close }), [open, close])
+  return (
+    <ActionsContext.Provider value={actions}>
+      <OriginContext.Provider value={originLocationId}>{children}</OriginContext.Provider>
+    </ActionsContext.Provider>
+  )
+}
+
+export function useIpInspectorActions() {
+  const actions = useContext(ActionsContext)
+  if (!actions) throw new Error("useIpInspectorActions must be used within an IpInspectorProvider")
+  return actions
+}
+
+export function useIpInspectorOrigin() {
+  const originLocationId = useContext(OriginContext)
+  if (originLocationId === undefined) {
+    throw new Error("useIpInspectorOrigin must be used within an IpInspectorProvider")
+  }
+  return originLocationId
+}
+
+export function useIpInspector() {
+  const inspect = useSearch({ strict: false, select: (search) => search.inspect })
+  const actions = useIpInspectorActions()
+  const originLocationId = useIpInspectorOrigin()
+  const ip = typeof inspect === "string" && inspect ? inspect : undefined
+
+  return { ip, originLocationId, ...actions }
 }

--- a/resources/routes/__root.tsx
+++ b/resources/routes/__root.tsx
@@ -59,8 +59,7 @@ const routeLabels: Record<string, string> = {
 }
 
 function AppBreadcrumb() {
-  const routerState = useRouterState()
-  const pathname = routerState.location.pathname
+  const pathname = useRouterState({ select: (state) => state.location.pathname })
   const currentLabel = routeLabels[pathname] || "Page"
   const isSettingsChild = pathname.startsWith("/settings/")
 
@@ -120,8 +119,7 @@ function GeoDegradedBanner() {
 }
 
 function RootLayout() {
-  const routerState = useRouterState()
-  const isLogin = routerState.location.pathname === "/login"
+  const isLogin = useRouterState({ select: (state) => state.location.pathname === "/login" })
 
   // The login page renders without the app chrome (sidebar, toolbar).
   if (isLogin) {

--- a/resources/routes/access-logs.tsx
+++ b/resources/routes/access-logs.tsx
@@ -117,7 +117,10 @@ const RESET_ON_CHANGE: Partial<AccessLogsSearch> = { page: undefined }
 type Mode = "history" | "live"
 
 function AccessLogsPage() {
-  const search = Route.useSearch()
+  const search = Route.useSearch({
+    select: ({ inspect: _inspect, ...routeSearch }) => routeSearch,
+    structuralSharing: true,
+  })
   const navigate = Route.useNavigate()
   const [mode, setMode] = useState<Mode>("history")
 

--- a/resources/routes/geo-logs.tsx
+++ b/resources/routes/geo-logs.tsx
@@ -96,7 +96,10 @@ function encode(filters: GeoLogFilterState): Partial<GeoLogsSearch> {
 const RESET_ON_CHANGE: Partial<GeoLogsSearch> = { page: undefined }
 
 function GeoLogsPage() {
-  const search = Route.useSearch()
+  const search = Route.useSearch({
+    select: ({ inspect: _inspect, ...routeSearch }) => routeSearch,
+    structuralSharing: true,
+  })
   const navigate = Route.useNavigate()
   // Keep banned badges (Top IPs card + geo-logs table) in sync with external
   // cscli/console decisions; one subscription for the whole page.

--- a/tests/browser/virtual-tables.pw.ts
+++ b/tests/browser/virtual-tables.pw.ts
@@ -23,6 +23,91 @@ const debugRows: AccessLogDebugEntry[] = accessRows.map((row) => ({
   rawLine: `GET ${row.url}`, accessLogId: row.id, parseError: null,
 }))
 
+const longText = "a detailed value that should use the available column space without an arbitrary text limit"
+const truncationCases = [
+  {
+    path: "debug-logs", endpoint: "/api/v1/access-log-debug", row: debugRows[0],
+    fields: [
+      { key: "parseError", label: "Parse error", value: "Line did not match expected log format." },
+      { key: "rawLine", label: "Raw line", value: longText },
+      { key: "url", label: "URL", value: `/debug/${longText}` },
+      { key: "host", label: "Host", value: `debug-${longText}` },
+      { key: "userAgent", label: "User agent", value: `DebugAgent ${longText}` },
+    ],
+  },
+  {
+    path: "access-logs", endpoint: "/api/v1/access-logs", row: accessRows[0],
+    fields: [
+      { key: "url", label: "URL", value: `/access/${longText}` },
+      { key: "host", label: "Host", value: `access-${longText}` },
+      { key: "referrer", label: "Referrer", value: `https://example.test/${longText}` },
+      { key: "userAgent", label: "User agent", value: `AccessAgent ${longText}` },
+      { key: "autonomousSystemOrganization", label: "AS organization", value: longText },
+    ],
+  },
+  {
+    path: "geo-logs", endpoint: "/api/v1/geo-events/logs",
+    row: { ...geoRows[0], hostnames: [longText] },
+    fields: [{ key: "hostnames", label: "Hostnames", value: longText }],
+  },
+]
+
+for (const fixture of truncationCases) {
+  test(`${fixture.path}: truncation uses the full cell width`, async ({ page }) => {
+    const item = {
+      ...fixture.row,
+      ...Object.fromEntries(fixture.fields
+        .filter((field) => field.key !== "hostnames")
+        .map((field) => [field.key, field.value])),
+    }
+    await page.route((url) => url.pathname.replace(/\/$/, "") === fixture.endpoint,
+      (route) => route.fulfill({ json: { items: [item], total: 1, limit: 20, offset: 0 } }))
+    await page.goto(`/${fixture.path}`)
+    const table = page.locator("table[aria-rowcount]")
+    await expect(table).toHaveAttribute("aria-rowcount", "2")
+    await page.evaluate(() => document.fonts.ready)
+
+    for (const field of fixture.fields) {
+      await page.getByRole("button", { name: "Columns", exact: true }).click()
+      const target = page.getByRole("menuitemcheckbox", { name: field.label, exact: true })
+      if (await target.getAttribute("aria-checked") !== "true") await target.click()
+      const choices = page.getByRole("menuitemcheckbox")
+      for (const choice of await choices.all()) {
+        const wanted = (await choice.innerText()).trim() === field.label
+        if (!wanted && await choice.getAttribute("aria-checked") === "true") await choice.click()
+      }
+      await page.keyboard.press("Escape")
+      await expect(table.locator("th")).toHaveCount(1)
+      const text = table.locator('tr[data-index="0"] span[title]').first()
+      await expect(text).toHaveAttribute("title", field.value)
+      for (const width of [1920, 1280]) {
+        await page.setViewportSize({ width, height: 900 })
+        await expect.poll(() => text.evaluate((element) => {
+          const cell = element.closest("td")!
+          const style = getComputedStyle(cell)
+          return Math.abs(element.getBoundingClientRect().width - (
+            cell.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight)
+          ))
+        })).toBeLessThanOrEqual(1)
+        // These values fit a wide cell and must not be cut at the old pixel caps.
+        expect(await text.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(false)
+      }
+    }
+
+    // With every column enabled, text still truncates at the cell boundary.
+    await page.getByRole("button", { name: "Columns", exact: true }).click()
+    for (const choice of await page.getByRole("menuitemcheckbox").all()) {
+      if (await choice.getAttribute("aria-checked") !== "true") await choice.click()
+    }
+    await page.keyboard.press("Escape")
+    const lastValue = fixture.fields.at(-1)!.value
+    const text = table.locator(`tr[data-index="0"] span[title=${JSON.stringify(lastValue)}]`)
+    await expect.poll(() => text.evaluate((element) =>
+      element.scrollWidth > element.clientWidth)).toBe(true)
+    await expect(text).toHaveCSS("text-overflow", "ellipsis")
+  })
+}
+
 test.beforeEach(async ({ page }) => {
   const password = process.env.SMOKE_ADMIN_PASSWORD
   if (!password) throw new Error("SMOKE_ADMIN_PASSWORD is required")
@@ -44,7 +129,7 @@ for (const fixture of [
   { path: "debug-logs", endpoint: "/api/v1/access-log-debug", rows: debugRows, size: 1_000 },
   { path: "access-logs", endpoint: "/api/v1/access-logs", rows: accessRows, size: 1_000, mobile: true },
 ]) {
-  test(`${fixture.path}${"mobile" in fixture ? " mobile, reduced motion" : ""}: bounded rows, deep scrolling, keyboard and modal focus`, async ({ page }) => {
+  test(`${fixture.path}${"mobile" in fixture ? " mobile, reduced motion" : ""}: bounded rows, deep scrolling, keyboard and modal focus`, async ({ page }, testInfo) => {
     if ("mobile" in fixture) {
       await page.setViewportSize({ width: 390, height: 844 })
       await page.emulateMedia({ reducedMotion: "reduce" })
@@ -67,9 +152,65 @@ for (const fixture of [
     const rows = table.locator("tr[data-index]")
     await expect(table).toHaveAttribute("aria-rowcount", String(fixture.size + 1))
     await expect(rows.first()).toHaveAttribute("data-index", "0")
+    await page.evaluate(() => document.fonts.ready)
     expect(await rows.count()).toBeLessThan(80)
+    const layout = await table.evaluate((element) => ({
+      table: element.getBoundingClientRect().width,
+      available: element.parentElement!.clientWidth,
+      overflow: element.parentElement!.scrollWidth - element.parentElement!.clientWidth,
+    }))
+    if ("mobile" in fixture) {
+      // Compact fields may need horizontal scrolling on a phone, but the
+      // five mobile columns must not keep the old 965px minimum width.
+      expect(layout.table).toBeLessThan(700)
+    } else {
+      expect(layout.overflow).toBeLessThanOrEqual(1)
+      await page.setViewportSize({ width: 1440, height: 900 })
+      await expect.poll(() => table.evaluate((element) =>
+        element.getBoundingClientRect().width)).toBeGreaterThan(layout.table)
+      expect(await table.evaluate((element) =>
+        element.parentElement!.scrollWidth - element.parentElement!.clientWidth)).toBeLessThanOrEqual(1)
+      await page.setViewportSize({ width: 1280, height: 720 })
+      await expect.poll(() => table.evaluate((element) =>
+        element.getBoundingClientRect().width)).toBeCloseTo(layout.table, 0)
+    }
+    await table.scrollIntoViewIfNeeded()
+    await page.screenshot({ path: testInfo.outputPath("responsive-columns.png") })
     const widths = await table.locator("th").evaluateAll((cells) =>
       cells.map((cell) => cell.getBoundingClientRect().width))
+
+    if (!("mobile" in fixture)) {
+      const container = table.locator("..")
+      const main = table.locator("xpath=ancestor::main[1]")
+      await main.evaluate((element) => { element.scrollTop = element.scrollHeight })
+      await container.evaluate((element) => { element.scrollTop = 0 })
+      expect(await main.evaluate((element) => element.scrollTop)).toBeGreaterThan(0)
+      await container.hover({ position: { x: 100, y: 100 } })
+      await expect.poll(async () => {
+        await page.mouse.wheel(0, -1_000)
+        return main.evaluate((element) => element.scrollTop)
+      }).toBe(0)
+      expect(await container.evaluate((element) => element.scrollTop)).toBe(0)
+
+      await container.evaluate((element) => { element.scrollTop = element.scrollHeight })
+      // Keep the table in view while leaving room for the page to scroll down.
+      await main.evaluate((element) => {
+        element.scrollTop = element.scrollHeight
+        element.scrollTop = Math.max(0, element.scrollTop - 100)
+      })
+      expect(await main.evaluate((element) =>
+        element.scrollHeight - element.clientHeight - element.scrollTop)).toBeGreaterThan(0)
+      const bounds = (await container.boundingBox())!
+      await page.mouse.move(bounds.x + 100, Math.min(bounds.y + 100, page.viewportSize()!.height - 50))
+      await expect.poll(async () => {
+        await page.mouse.wheel(0, 1_000)
+        return main.evaluate((element) =>
+          element.scrollHeight - element.clientHeight - element.scrollTop)
+      }).toBeLessThanOrEqual(1)
+      await expect(container).toHaveCSS("overscroll-behavior-x", "contain")
+      await container.evaluate((element) => { element.scrollTop = 0 })
+      await expect(rows.first()).toHaveAttribute("data-index", "0")
+    }
 
     // Tab must cross the mounted window rather than skip to pagination.
     const edge = Number(await rows.last().getAttribute("data-index"))

--- a/tests/browser/virtual-tables.pw.ts
+++ b/tests/browser/virtual-tables.pw.ts
@@ -1,0 +1,148 @@
+import { expect, test } from "@playwright/test"
+import type { AccessLog } from "../../resources/lib/api"
+import type { AccessLogDebugEntry, GeoLogEntry } from "../../resources/generated/api/types.gen"
+
+const timestamp = "2026-08-16T12:00:00Z"
+const accessRows: AccessLog[] = Array.from({ length: 1_000 }, (_, index) => ({
+  id: index + 1, timestamp, ipAddress: "192.0.2.1", remoteUser: null,
+  method: "GET", url: `/request/${index}/${"long-path/".repeat(index % 20)}`,
+  httpVersion: "HTTP/2", statusCode: 200, bytesSent: 100, referrer: null,
+  userAgent: null, requestTime: 10, upstreamResponseTime: null,
+  host: "example.test", hostname: null, logFormat: null, countryCode: "NO",
+  countryName: "Norway", city: "Oslo", autonomousSystemNumber: null,
+  autonomousSystemOrganization: null,
+}))
+const geoRows: GeoLogEntry[] = accessRows.slice(0, 500).map((row) => ({
+  locationId: row.id, ipAddress: row.ipAddress, city: row.city,
+  countryCode: "NO", countryName: "Norway", eventCount: row.id,
+  hostnames: ["example.test"], lastSeen: timestamp, latitude: 59.9,
+  longitude: 10.7, postalCode: null, state: null, stateCode: null,
+}))
+const debugRows: AccessLogDebugEntry[] = accessRows.map((row) => ({
+  ...row, createdAt: timestamp, isMalformed: false,
+  rawLine: `GET ${row.url}`, accessLogId: row.id, parseError: null,
+}))
+
+test.beforeEach(async ({ page }) => {
+  const password = process.env.SMOKE_ADMIN_PASSWORD
+  if (!password) throw new Error("SMOKE_ADMIN_PASSWORD is required")
+  const login = await page.request.post("/api/v1/auth/login", {
+    data: { username: process.env.SMOKE_ADMIN_USER ?? "admin", password },
+  })
+  expect(login.ok()).toBe(true)
+  await page.addInitScript(() => {
+    localStorage.setItem("geometrikks-time-range", JSON.stringify({
+      range: "custom", pollInterval: 0, granularity: "auto",
+      customRange: { from: "2026-08-01T00:00:00Z", to: "2026-08-17T00:00:00Z" },
+    }))
+  })
+})
+
+for (const fixture of [
+  { path: "access-logs", endpoint: "/api/v1/access-logs", rows: accessRows, size: 1_000 },
+  { path: "geo-logs", endpoint: "/api/v1/geo-events/logs", rows: geoRows, size: 500 },
+  { path: "debug-logs", endpoint: "/api/v1/access-log-debug", rows: debugRows, size: 1_000 },
+  { path: "access-logs", endpoint: "/api/v1/access-logs", rows: accessRows, size: 1_000, mobile: true },
+]) {
+  test(`${fixture.path}${"mobile" in fixture ? " mobile, reduced motion" : ""}: bounded rows, deep scrolling, keyboard and modal focus`, async ({ page }) => {
+    if ("mobile" in fixture) {
+      await page.setViewportSize({ width: 390, height: 844 })
+      await page.emulateMedia({ reducedMotion: "reduce" })
+    }
+    const errors: string[] = []
+    page.on("pageerror", (error) => errors.push(error.message))
+    await page.route((url) => url.pathname.replace(/\/$/, "") === fixture.endpoint, async (route) => {
+      const url = new URL(route.request().url())
+      const limit = Number(url.searchParams.get("pageSize") ?? 20)
+      await route.fulfill({ json: {
+        items: fixture.rows.slice(0, limit), total: fixture.rows.length, limit, offset: 0,
+      } })
+    })
+    await page.goto(`/${fixture.path}?pageSize=${fixture.size}`)
+    if (fixture.path === "debug-logs") {
+      await page.getByRole("combobox", { name: "Rows per page" }).click()
+      await page.getByRole("option", { name: String(fixture.size), exact: true }).click()
+    }
+    const table = page.locator("table[aria-rowcount]")
+    const rows = table.locator("tr[data-index]")
+    await expect(table).toHaveAttribute("aria-rowcount", String(fixture.size + 1))
+    await expect(rows.first()).toHaveAttribute("data-index", "0")
+    expect(await rows.count()).toBeLessThan(80)
+    const widths = await table.locator("th").evaluateAll((cells) =>
+      cells.map((cell) => cell.getBoundingClientRect().width))
+
+    // Tab must cross the mounted window rather than skip to pagination.
+    const edge = Number(await rows.last().getAttribute("data-index"))
+    await rows.last().focus()
+    for (let index = 0; index < 4; index++) await page.keyboard.press("Tab")
+    expect(await page.evaluate(() => Number(
+      document.activeElement?.closest("tr")?.getAttribute("data-index"),
+    ))).toBeGreaterThan(edge)
+
+    await table.evaluate((element) => {
+      element.parentElement!.scrollTop = element.parentElement!.scrollHeight
+    })
+    const lastRow = table.locator(`tr[data-index="${fixture.size - 1}"]`)
+    await expect(lastRow).toBeVisible()
+    expect(await rows.count()).toBeLessThan(80)
+    expect(await table.locator("th").evaluateAll((cells) =>
+      cells.map((cell) => cell.getBoundingClientRect().width))).toEqual(widths)
+
+    await lastRow.focus()
+    await page.keyboard.press("Enter")
+    const dialog = page.getByRole("dialog")
+    await expect(dialog).toBeVisible()
+    await expect(dialog).toHaveAttribute("aria-modal", "true")
+    await page.getByRole("button", { name: "Columns", exact: true, includeHidden: true }).evaluate((button: HTMLElement) => button.focus())
+    await expect.poll(() => dialog.evaluate((element) => element.contains(document.activeElement))).toBe(true)
+    await page.keyboard.press("Escape")
+    await expect(dialog).toHaveCount(0)
+    await expect(lastRow).toBeFocused()
+
+    const inspect = lastRow.getByRole("button", { name: "Inspect 192.0.2.1", exact: true })
+    await inspect.click()
+    await expect(dialog).toBeVisible()
+    await page.keyboard.press("Escape")
+    await expect(dialog).toHaveCount(0)
+    await expect(inspect).toBeFocused()
+
+    // Replacing a record sheet with the inspector still returns to its row.
+    await lastRow.focus()
+    await page.keyboard.press("Enter")
+    await dialog.getByRole("button", { name: "Inspect 192.0.2.1", exact: true }).click()
+    await expect(dialog).toHaveCount(1)
+    await expect(dialog.getByRole("heading", { level: 2 })).toContainText("192.0.2.1")
+    await page.keyboard.press("Escape")
+    await expect(dialog).toHaveCount(0)
+    await expect(lastRow).toBeFocused()
+
+    if (!("mobile" in fixture)) {
+      await lastRow.press("Enter")
+      await expect(dialog).toBeVisible()
+      await page.locator('[data-slot="sheet-overlay"]').click({ position: { x: 5, y: 5 } })
+      await expect(dialog).toHaveCount(0)
+      await expect(lastRow).toBeFocused()
+    }
+
+    await table.locator("th button").first().click()
+    await expect.poll(() => table.evaluate((element) => element.parentElement!.scrollTop)).toBe(0)
+    await expect(rows.first()).toHaveAttribute("data-index", "0")
+
+    await page.getByRole("combobox", { name: "Rows per page" }).click()
+    await page.getByRole("option", { name: "20", exact: true }).click()
+    await expect(table).toHaveAttribute("aria-rowcount", "21")
+    await expect(rows.first()).toHaveAttribute("data-index", "0")
+    await expect.poll(() => table.evaluate((element) => element.parentElement!.scrollTop)).toBe(0)
+
+    const columnCount = await table.locator("th").count()
+    await page.getByRole("button", { name: "Columns", exact: true }).click()
+    await page.getByRole("menuitemcheckbox").first().click()
+    await page.keyboard.press("Escape")
+    await expect(table.locator("th")).toHaveCount(columnCount - 1)
+    await page.getByRole("button", { name: "Columns", exact: true }).click()
+    await page.getByRole("menuitemcheckbox").first().click()
+    await page.keyboard.press("Escape")
+    await expect(table.locator("th")).toHaveCount(columnCount)
+    expect(errors).toEqual([])
+  })
+}


### PR DESCRIPTION
## What changed

Access, geo, and debug log tables now use TanStack Virtual. They mount the visible rows plus an overscan buffer, with a bounded scroll area, sticky headers, and stable column widths. Pagination and server-side filtering stay unchanged.

The earlier subscription and table-body memoization fixes remain. Virtualization also lets us remove the custom modal workaround and restore Radix focus trapping, background accessibility hiding, and scroll locking. Closing the IP Inspector returns focus to its opener, including when it replaces a record sheet.

## Local result

With a production build and 1,000 access-log rows, the foreground browser mounted 31 rows. Across five runs per dialog:

- Record details reached the first visible frame in 44 to 77 ms, median 57 ms.
- IP Inspector reached the first visible frame in 74 to 99 ms, median 77 ms.

These are local interaction timings, not API completion times or a cross-device benchmark. They replace the earlier mount-only measurements in this PR.

## Validation

- 308 unit tests pass.
- Typecheck and production build pass.
- Four browser regression cases pass against the production build: access with 1,000 rows, geo with 500, debug with 1,000, and mobile access with reduced motion.
- Browser coverage checks bounded row counts, the final row, stable widths, keyboard navigation across the rendered window, focus containment and restoration, record-to-inspector replacement, dismissal, sorting, page-size changes, and column visibility.
