### PR TITLE
Recover from database outages at startup and report paused services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
           fi
 
           docker logs geometrikks-smoke > smoke-artifacts/shutdown.log 2>&1
-          for marker in "Stopped log ingestion service" "Stopped APScheduler" "Granian shutdown completed"; do
+          for marker in "ingestion_stopped" "scheduler_stopped" "Granian shutdown completed"; do
             if ! grep --quiet "${marker}" smoke-artifacts/shutdown.log; then
               echo "Missing graceful-shutdown marker: ${marker}"
               tail -50 smoke-artifacts/shutdown.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Startup waits for the database for up to `DB_STARTUP_WAIT_SECONDS`, which defaults to 30 seconds. If it remains unreachable, the app serves in degraded mode with a critical Status advisory and keeps checking. When the database returns, recovery runs the deferred migrations and starts the paused services.
+- Status page advisories for a disconnected live-feed listener, a GeoLite2 database past MaxMind's 30-day window, an undetected map home, failed TimescaleDB policy updates, dropped ingestion batches, and a failing CDN peer scan. The sidebar dot turns amber while any advisory is open.
+
 ### Changed
 
+- Health reports degraded whenever database-bound services are paused, even with ingestion disabled by configuration, and the database card says "Reachable, services paused" for that state.
+- The Scheduler page identifies database unavailability as the reason jobs have not started.
+- Live feed indicators say "paused" when the server refuses the stream, and the CrowdSec card notes when live updates are paused.
 - `.env.example` and the quickstart now list `MAP_CARTO_API_KEY` next to the MaxMind credentials.
 
 ### Fixed
 
+- Failures from the GeoIP refresh, location refresh and aggregate refresh jobs appear on the Scheduler page.
+- A configured log file that has not appeared is listed as missing, and tailing starts when the file appears.
+- The site-home refresh job updates the map home without a restart.
+- A failed CDN peer scan retains the previous findings and keeps the advisory open.
 - The live rail on the map stops short of the bottom-left corner, so it no longer covers the basemap attribution pill.
 
 ## [0.14.2] - 2026-09-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Startup waits for the database for up to `DB_STARTUP_WAIT_SECONDS`, which defaults to 30 seconds. If it remains unreachable, the app serves in degraded mode with a critical Status advisory and keeps checking. When the database returns, recovery runs the deferred migrations and starts the paused services.
-- Status page advisories for a disconnected live-feed listener, a GeoLite2 database past MaxMind's 30-day window, an undetected map home, failed TimescaleDB policy updates, dropped ingestion batches, and a failing CDN peer scan. The sidebar dot turns amber while any advisory is open.
-- Status page advisories now call out a missing City database and ingestion that stops unexpectedly, so a stopped data path is visible without opening the logs.
+- Status page advisories for a disconnected live-feed listener, a missing or stale GeoLite2 database, an undetected map home, failed TimescaleDB policy updates, dropped ingestion batches, stopped ingestion, and a failing CDN peer scan. The sidebar dot turns amber while any advisory is open.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Startup waits for the database for up to `DB_STARTUP_WAIT_SECONDS`, which defaults to 30 seconds. If it remains unreachable, the app serves in degraded mode with a critical Status advisory and keeps checking. When the database returns, recovery runs the deferred migrations and starts the paused services.
 - Status page advisories for a disconnected live-feed listener, a GeoLite2 database past MaxMind's 30-day window, an undetected map home, failed TimescaleDB policy updates, dropped ingestion batches, and a failing CDN peer scan. The sidebar dot turns amber while any advisory is open.
+- Status page advisories now call out a missing City database and ingestion that stops unexpectedly, so a stopped data path is visible without opening the logs.
 
 ### Changed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,7 @@ from real environment variables. It is read once at import time.
 | `DB_DATABASE` | `geometrikks` | Database name |
 | `DB_DROP_ON_STARTUP` | `false` | Drop all tables on startup (development only) |
 | `DB_MIGRATE_ON_STARTUP` | `true` | Run alembic migrations automatically at app startup. Disable when migrations run as a separate deployment step (`litestar database upgrade`); the app then expects the schema to already be at head and fails startup if it is not usable |
+| `DB_STARTUP_WAIT_SECONDS` | `30` | How long startup waits for the database before serving in degraded mode. 0 probes once. The app keeps re-probing in the background after this window and recovers on its own when the database answers. |
 
 ## GeoIP
 

--- a/geometrikks/config/settings.py
+++ b/geometrikks/config/settings.py
@@ -71,6 +71,15 @@ class DatabaseSettings(BaseSettings):
             "and fails startup if it is not usable"
         ),
     )
+    startup_wait_seconds: int = Field(
+        default=30,
+        ge=0,
+        description=(
+            "How long startup waits for the database before serving in degraded "
+            "mode. 0 probes once. The app keeps re-probing in the background after "
+            "this window and recovers on its own when the database answers."
+        ),
+    )
     
     @property
     def url(self) -> str:

--- a/geometrikks/domain/security/controllers.py
+++ b/geometrikks/domain/security/controllers.py
@@ -54,6 +54,8 @@ class CrowdSecStatusResponse(msgspec.Struct, rename="camel"):
     enabled: bool
     write_enabled: bool
     lapi_reachable: bool
+    # False while DB-degraded mode pauses the decision-stream poller.
+    live_updates: bool = False
 
 
 class DecisionView(msgspec.Struct, rename="camel"):
@@ -201,6 +203,7 @@ class CrowdSecController(Controller):
             enabled=True,
             write_enabled=settings.crowdsec.write_enabled,
             lapi_reachable=cached if cached is not None else await crowdsec.ping(),
+            live_updates=crowdsec_poller is not None,
         )
 
     @get("/decisions")

--- a/geometrikks/domain/security/controllers.py
+++ b/geometrikks/domain/security/controllers.py
@@ -54,7 +54,7 @@ class CrowdSecStatusResponse(msgspec.Struct, rename="camel"):
     enabled: bool
     write_enabled: bool
     lapi_reachable: bool
-    # False while DB-degraded mode pauses the decision-stream poller.
+    # False while DB-degraded or scheduler-disabled mode omits the poller.
     live_updates: bool = False
 
 
@@ -194,8 +194,8 @@ class CrowdSecController(Controller):
         # The stream poller probes the LAPI every poll interval; its cached
         # verdict avoids a live ping per status request (which can block for
         # the full request timeout against a black-holed host). Live ping
-        # remains the fallback when the poller is absent (DB-degraded mode)
-        # or has not completed a poll yet.
+        # remains the fallback when the poller is absent (DB-degraded or
+        # scheduler-disabled mode) or has not completed a poll yet.
         cached: bool | None = (
             crowdsec_poller.lapi_reachable if crowdsec_poller is not None else None
         )

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -178,6 +178,25 @@ def _collect_advisories(app: Litestar, settings: Settings) -> list[Advisory]:
             f for f in proxy_scan.get_scan_findings() if f.hostname not in covered
         ]
         advisories.extend(proxy_advisories(findings))
+    policy_failures = timescale.get_policy_failures()
+    if policy_failures:
+        listed = ", ".join(
+            f"{failure.policy} on {failure.target}" for failure in policy_failures
+        )
+        noun = "policy" if len(policy_failures) == 1 else "policies"
+        advisories.append(Advisory(
+            id="timescale-policy-update-failed",
+            severity="warning",
+            summary=(
+                f"{len(policy_failures)} TimescaleDB {noun} could not be updated to "
+                f"match the current settings: {listed}; the previous intervals stay "
+                "in force."
+            ),
+            detail=(
+                "The app retries the updates at the next startup; check the app log "
+                "for policy_update_failed before restarting."
+            ),
+        ))
     return advisories
 
 

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -117,6 +117,8 @@ def _stale_geoip_advisories(settings: Settings) -> list[Advisory]:
     ]
     advisories: list[Advisory] = []
     credentials_available = has_credentials(settings.geoip)
+    refresh_days = settings.geoip.refresh_days
+    refresh_interval = f"{refresh_days} {'day' if refresh_days == 1 else 'days'}"
     for edition, path, enabled, advisory_id in editions:
         if not enabled:
             continue
@@ -128,20 +130,51 @@ def _stale_geoip_advisories(settings: Settings) -> list[Advisory]:
         ):
             continue
         if credentials_available:
+            if settings.scheduler.enabled:
+                summary = (
+                    f"The GeoLite2 {edition} database is {info.age_days} days old and "
+                    "is outside MaxMind's 30-day refresh window."
+                )
+                detail = (
+                    "The app keeps using the stale database. The geoip-refresh job "
+                    f"attempts a replacement every {refresh_interval}; inspect its next "
+                    "run and last result in Scheduler, then check the app logs for any "
+                    "reported error."
+                )
+            else:
+                summary = (
+                    f"The GeoLite2 {edition} database is {info.age_days} days old and "
+                    "automatic refresh is disabled."
+                )
+                detail = (
+                    "The app keeps using the stale database and automatic refresh is "
+                    f"disabled. Download a current GeoLite2 {edition} database to {path} "
+                    "and restart the app, or set SCHEDULER_ENABLED=true and restart to "
+                    f"schedule automatic refresh every {refresh_interval}."
+                )
             advisories.append(Advisory(
                 id=advisory_id,
                 severity="warning",
-                summary=(
-                    f"The GeoLite2 {edition} database is {info.age_days} days old; "
-                    "the weekly refresh is not succeeding."
-                ),
-                detail=(
-                    "The app keeps using the stale database and retries through the "
-                    "weekly geoip-refresh job; check that job in Scheduler and the app "
-                    "logs for the last error."
-                ),
+                summary=summary,
+                detail=detail,
             ))
         else:
+            if settings.scheduler.enabled:
+                detail = (
+                    "The app keeps using the stale database even though MaxMind requires "
+                    "a fresh copy within 30 days. The geoip-refresh job checks for a "
+                    f"replacement every {refresh_interval}, but it cannot download one "
+                    "without credentials. Configure the credentials below and restart "
+                    "the app so it loads them; inspect the job in Scheduler and the app "
+                    "logs if a later refresh fails."
+                )
+            else:
+                detail = (
+                    "The app keeps using the stale database even though MaxMind requires "
+                    "a fresh copy within 30 days. Automatic refresh is disabled; "
+                    "configure the credentials below and restart the app so it loads "
+                    f"them, then replace {path} manually or set SCHEDULER_ENABLED=true."
+                )
             advisories.append(Advisory(
                 id=advisory_id,
                 severity="warning",
@@ -150,11 +183,7 @@ def _stale_geoip_advisories(settings: Settings) -> list[Advisory]:
                     "cannot refresh because no MaxMind credentials are configured, "
                     "which is outside MaxMind's 30-day refresh window."
                 ),
-                detail=(
-                    "The app keeps using the stale database even though MaxMind requires "
-                    "a fresh copy within 30 days; configure the credentials below so the "
-                    "weekly geoip-refresh job can replace it."
-                ),
+                detail=detail,
                 remedy="MAXMINDDB_USER_ID and MAXMINDDB_LICENSE_KEY",
             ))
     return advisories

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -255,6 +255,24 @@ def _collect_advisories(app: Litestar, settings: Settings) -> list[Advisory]:
                 ),
             ))
     advisories.extend(_stale_geoip_advisories(settings))
+    backend = runtime.get_channels_backend(app)
+    if (
+        backend is not None
+        and backend.state in {"degraded", "reconnecting"}
+        and runtime.is_db_available(app, default=True)
+    ):
+        advisories.append(Advisory(
+            id="live-feed-listener-down",
+            severity="warning",
+            summary=(
+                "The live feed's database listener is disconnected; the map and "
+                "live tail receive no events until it reconnects."
+            ),
+            detail=(
+                "The app reconnects on its own with backoff. If this lasts more than "
+                "a minute, check the database container and its connection limit."
+            ),
+        ))
     policy_failures = timescale.get_policy_failures()
     if policy_failures:
         listed = ", ".join(

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -260,6 +260,11 @@ def _collect_advisories(app: Litestar, settings: Settings) -> list[Advisory]:
     advisories: list[Advisory] = runtime.get_advisories(app).snapshot()
     service = runtime.get_ingestion_service(app)
     if service is not None and service.failed_batches > 0:
+        ingestion_state = (
+            "Ingestion continues processing new records."
+            if service.is_running
+            else "Ingestion is not running. Fix the problem, then restart the app."
+        )
         advisories.append(Advisory(
             id="ingestion-write-failures",
             severity="warning",
@@ -268,9 +273,9 @@ def _collect_advisories(app: Litestar, settings: Settings) -> list[Advisory]:
                 "could not be written to the database since startup."
             ),
             detail=(
-                "The app drops the affected records and continues ingestion. "
-                "Check the app log for ingestion_batch_failed; persistent failures "
-                "usually mean a schema mismatch or a full disk."
+                "The app dropped the affected records and will not retry them. "
+                f"{ingestion_state} Check the app log for ingestion_batch_failed. "
+                "Persistent failures usually mean a schema mismatch or a full disk."
             ),
         ))
     pollution = timescale.get_hostname_pollution()

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -44,6 +44,9 @@ class IngestionHealth(msgspec.Struct, rename="camel"):
 
 class DatabaseHealth(msgspec.Struct, rename="camel"):
     reachable: bool
+    # Additive: False while the app runs DB-degraded (scheduler, ingestion
+    # and live feeds paused) even though `reachable` may already be True.
+    services_active: bool = True
 
 
 class GeoIPHealth(msgspec.Struct, rename="camel"):
@@ -100,7 +103,7 @@ async def _database_reachable(app: Litestar, timeout: float = 2.0) -> bool:
 def _collect_advisories(app: Litestar, settings: Settings) -> list[Advisory]:
     from geometrikks.server import timescale
 
-    advisories: list[Advisory] = []
+    advisories: list[Advisory] = runtime.get_advisories(app).snapshot()
     pollution = timescale.get_hostname_pollution()
     # No early return: the pollution gate must not swallow the ASN advisory.
     hostname_pollution_active = bool(
@@ -198,6 +201,7 @@ async def health(
     # being ingested from those files and status must not read as healthy.
     missing_files = ingestion_service.missing_files if ingestion_service else []
     db_reachable = await _database_reachable(request.app)
+    services_active = runtime.is_db_available(request.app, default=True)
 
     poller = runtime.get_crowdsec_poller(request.app)
 
@@ -215,7 +219,12 @@ async def health(
         # geoip does not flip status on its own: without a GeoLite2 database
         # file, ingestion refuses to start and ingestion.running reflects that.
         status="healthy"
-        if (db_reachable and not missing_files and ingestion_status != "degraded")
+        if (
+            db_reachable
+            and services_active
+            and not missing_files
+            and ingestion_status != "degraded"
+        )
         else "degraded",
         started_at=_iso(runtime.get_started_at(request.app)),
         ingestion=IngestionHealth(
@@ -231,7 +240,10 @@ async def health(
                 ingestion_service.publish_dropped if ingestion_service else 0
             ),
         ),
-        database=DatabaseHealth(reachable=db_reachable),
+        database=DatabaseHealth(
+            reachable=db_reachable,
+            services_active=services_active,
+        ),
         # build_date comes from the mmdb metadata (geoip_info), the actual
         # GeoLite2 build, not the file's mtime.
         geoip=GeoIPHealth(

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -27,8 +27,13 @@ from geometrikks.domain.system.proxy_detection import proxy_advisories, proxy_fi
 from geometrikks.lib.utils import geoip_info
 from geometrikks.lib.advisories import Advisory
 from geometrikks.server import runtime
+from geometrikks.services.geoip.downloader import has_credentials
 from geometrikks.services.ingestion import LogIngestionService
 from geometrikks.domain.system.dependencies import provide_ingestion_service as pis
+
+
+# This license window is independent of the configured refresh schedule.
+MAXMIND_REFRESH_WINDOW_DAYS = 30
 
 
 class IngestionHealth(msgspec.Struct, rename="camel"):
@@ -98,6 +103,61 @@ async def _database_reachable(app: Litestar, timeout: float = 2.0) -> bool:
         return True
     except Exception:
         return False
+
+
+def _stale_geoip_advisories(settings: Settings) -> list[Advisory]:
+    editions = [
+        ("City", settings.geoip.db_path, True, "geoip-database-stale"),
+        (
+            "ASN",
+            settings.geoip.asn_db_path,
+            settings.geoip.asn_enabled,
+            "asn-database-stale",
+        ),
+    ]
+    advisories: list[Advisory] = []
+    credentials_available = has_credentials(settings.geoip)
+    for edition, path, enabled, advisory_id in editions:
+        if not enabled:
+            continue
+        info = geoip_info(path)
+        if (
+            not info.available
+            or info.age_days is None
+            or info.age_days <= MAXMIND_REFRESH_WINDOW_DAYS
+        ):
+            continue
+        if credentials_available:
+            advisories.append(Advisory(
+                id=advisory_id,
+                severity="warning",
+                summary=(
+                    f"The GeoLite2 {edition} database is {info.age_days} days old; "
+                    "the weekly refresh is not succeeding."
+                ),
+                detail=(
+                    "The app keeps using the stale database and retries through the "
+                    "weekly geoip-refresh job; check that job in Scheduler and the app "
+                    "logs for the last error."
+                ),
+            ))
+        else:
+            advisories.append(Advisory(
+                id=advisory_id,
+                severity="warning",
+                summary=(
+                    f"The GeoLite2 {edition} database is {info.age_days} days old and "
+                    "cannot refresh because no MaxMind credentials are configured, "
+                    "which is outside MaxMind's 30-day refresh window."
+                ),
+                detail=(
+                    "The app keeps using the stale database even though MaxMind requires "
+                    "a fresh copy within 30 days; configure the credentials below so the "
+                    "weekly geoip-refresh job can replace it."
+                ),
+                remedy="MAXMINDDB_USER_ID and MAXMINDDB_LICENSE_KEY",
+            ))
+    return advisories
 
 
 def _collect_advisories(app: Litestar, settings: Settings) -> list[Advisory]:
@@ -194,6 +254,7 @@ def _collect_advisories(app: Litestar, settings: Settings) -> list[Advisory]:
                     "logs for the cause."
                 ),
             ))
+    advisories.extend(_stale_geoip_advisories(settings))
     policy_failures = timescale.get_policy_failures()
     if policy_failures:
         listed = ", ".join(

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -187,7 +187,12 @@ def _collect_advisories(app: Litestar, settings: Settings) -> list[Advisory]:
                     "The CDN peer scan is failing; the proxy advisories above "
                     "may be stale."
                 ),
-                detail=scan_error,
+                detail=(
+                    "The previous proxy findings remain visible while scheduled "
+                    f"scans retry. The latest scan failed with: {scan_error}. "
+                    "Inspect the proxy-peer-scan job in Scheduler and the app "
+                    "logs for the cause."
+                ),
             ))
     policy_failures = timescale.get_policy_failures()
     if policy_failures:

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -45,6 +45,8 @@ class IngestionHealth(msgspec.Struct, rename="camel"):
     # Additive: kept alongside `running` for wire compatibility.
     status: Literal["running", "degraded", "disabled"] = "running"
     publish_dropped: int = 0
+    failed_batches: int = 0
+    failed_records: int = 0
 
 
 class DatabaseHealth(msgspec.Struct, rename="camel"):
@@ -256,6 +258,21 @@ def _collect_advisories(app: Litestar, settings: Settings) -> list[Advisory]:
     from geometrikks.server import timescale
 
     advisories: list[Advisory] = runtime.get_advisories(app).snapshot()
+    service = runtime.get_ingestion_service(app)
+    if service is not None and service.failed_batches > 0:
+        advisories.append(Advisory(
+            id="ingestion-write-failures",
+            severity="warning",
+            summary=(
+                f"{service.failed_batches} batches ({service.failed_records} records) "
+                "could not be written to the database since startup."
+            ),
+            detail=(
+                "The app drops the affected records and continues ingestion. "
+                "Check the app log for ingestion_batch_failed; persistent failures "
+                "usually mean a schema mismatch or a full disk."
+            ),
+        ))
     pollution = timescale.get_hostname_pollution()
     # No early return: the pollution gate must not swallow the ASN advisory.
     hostname_pollution_active = bool(
@@ -322,7 +339,6 @@ def _collect_advisories(app: Litestar, settings: Settings) -> list[Advisory]:
     if settings.app.proxy_advisory:
         from geometrikks.domain.system import proxy_scan
 
-        service = runtime.get_ingestion_service(app)
         parsers = service.parsers if service is not None else []
         local = proxy_findings(parsers)
         covered = {f.hostname for f in local} | {p.hostname for p in parsers}
@@ -444,6 +460,12 @@ async def health(
             status=ingestion_status,
             publish_dropped=(
                 ingestion_service.publish_dropped if ingestion_service else 0
+            ),
+            failed_batches=(
+                ingestion_service.failed_batches if ingestion_service else 0
+            ),
+            failed_records=(
+                ingestion_service.failed_records if ingestion_service else 0
             ),
         ),
         database=DatabaseHealth(

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -178,6 +178,17 @@ def _collect_advisories(app: Litestar, settings: Settings) -> list[Advisory]:
             f for f in proxy_scan.get_scan_findings() if f.hostname not in covered
         ]
         advisories.extend(proxy_advisories(findings))
+        scan_error = proxy_scan.get_scan_error()
+        if scan_error is not None:
+            advisories.append(Advisory(
+                id="proxy-scan-failed",
+                severity="warning",
+                summary=(
+                    "The CDN peer scan is failing; the proxy advisories above "
+                    "may be stale."
+                ),
+                detail=scan_error,
+            ))
     policy_failures = timescale.get_policy_failures()
     if policy_failures:
         listed = ", ".join(

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -25,6 +25,7 @@ from sqlalchemy import text
 from geometrikks.config.settings import Settings
 from geometrikks.domain.system.proxy_detection import proxy_advisories, proxy_findings
 from geometrikks.lib.utils import geoip_info
+from geometrikks.lib.advisories import Advisory
 from geometrikks.server import runtime
 from geometrikks.services.ingestion import LogIngestionService
 from geometrikks.domain.system.dependencies import provide_ingestion_service as pis
@@ -56,18 +57,6 @@ class GeoIPHealth(msgspec.Struct, rename="camel"):
 class CrowdSecHealth(msgspec.Struct, rename="camel"):
     enabled: bool
     lapi_reachable: bool | None
-
-
-class Advisory(msgspec.Struct, rename="camel"):
-    """One operator-actionable warning; the status page renders a card per
-    advisory, so producers must write user-facing text, not log lines."""
-
-    id: str
-    severity: Literal["warning", "critical"]
-    summary: str
-    detail: str | None = None
-    remedy: str | None = None
-    docs_url: str | None = None
 
 
 class HealthResponse(msgspec.Struct, rename="camel"):

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -119,6 +119,7 @@ def _stale_geoip_advisories(settings: Settings) -> list[Advisory]:
     credentials_available = has_credentials(settings.geoip)
     refresh_days = settings.geoip.refresh_days
     refresh_interval = f"{refresh_days} {'day' if refresh_days == 1 else 'days'}"
+    long_cadence = refresh_days > MAXMIND_REFRESH_WINDOW_DAYS
     for edition, path, enabled, advisory_id in editions:
         if not enabled:
             continue
@@ -129,6 +130,63 @@ def _stale_geoip_advisories(settings: Settings) -> list[Advisory]:
             or info.age_days <= MAXMIND_REFRESH_WINDOW_DAYS
         ):
             continue
+        if long_cadence:
+            if credentials_available:
+                summary = (
+                    f"The GeoLite2 {edition} database is {info.age_days} days old and "
+                    "is outside MaxMind's 30-day refresh window."
+                )
+            else:
+                summary = (
+                    f"The GeoLite2 {edition} database is {info.age_days} days old and "
+                    "cannot refresh automatically because no MaxMind credentials are "
+                    "configured, which is outside MaxMind's 30-day refresh window."
+                )
+
+            if settings.scheduler.enabled:
+                detail = (
+                    "The app keeps using the stale database. The geoip-refresh job "
+                    f"runs every {refresh_interval}, which exceeds MaxMind's 30-day "
+                    "window."
+                )
+            else:
+                detail = (
+                    "The app keeps using the stale database and automatic refresh is "
+                    f"disabled. To update manually, replace {path}, then restart the app "
+                    "so the active reader loads it."
+                )
+                if not credentials_available:
+                    detail += (
+                        " MaxMind credentials are not required for manual replacement."
+                    )
+
+            automatic_steps: list[str] = []
+            remedy_lines: list[str] = []
+            if not credentials_available:
+                automatic_steps.append("configure the credentials below")
+                remedy_lines.extend([
+                    "MAXMINDDB_USER_ID=<account-id>",
+                    "MAXMINDDB_LICENSE_KEY=<license-key>",
+                ])
+            if not settings.scheduler.enabled:
+                automatic_steps.append("set SCHEDULER_ENABLED=true")
+                remedy_lines.append("SCHEDULER_ENABLED=true")
+            automatic_steps.append("set GEOIP_REFRESH_DAYS to 30 or less")
+            remedy_lines.append("GEOIP_REFRESH_DAYS=30")
+            detail += (
+                f" For automatic refresh, {', '.join(automatic_steps)}, then restart "
+                "the app. After the restart, when database services are active, open "
+                "Settings > Scheduler, find geoip-refresh, and select Run now. Check "
+                "Last run and the app logs if it fails."
+            )
+            advisories.append(Advisory(
+                id=advisory_id,
+                severity="warning",
+                summary=summary,
+                detail=detail,
+                remedy="\n".join(remedy_lines),
+            ))
+            continue
         if credentials_available:
             remedy = None
             if settings.scheduler.enabled:
@@ -136,21 +194,11 @@ def _stale_geoip_advisories(settings: Settings) -> list[Advisory]:
                     f"The GeoLite2 {edition} database is {info.age_days} days old and "
                     "is outside MaxMind's 30-day refresh window."
                 )
-                if refresh_days > MAXMIND_REFRESH_WINDOW_DAYS:
-                    detail = (
-                        "The app keeps using the stale database. The geoip-refresh job "
-                        f"runs every {refresh_interval}, which exceeds MaxMind's 30-day "
-                        "window. In Settings > Scheduler, find geoip-refresh and select "
-                        "Run now, then set GEOIP_REFRESH_DAYS to 30 or less and restart "
-                        "the app. Check Last run and the app logs if the manual run fails."
-                    )
-                    remedy = "GEOIP_REFRESH_DAYS=30"
-                else:
-                    detail = (
-                        "The app keeps using the stale database. In Settings > Scheduler, "
-                        "find geoip-refresh and select Run now. If it fails, check Last run "
-                        "and the app logs for the error."
-                    )
+                detail = (
+                    "The app keeps using the stale database. In Settings > Scheduler, "
+                    "find geoip-refresh and select Run now. If it fails, check Last run "
+                    "and the app logs for the error."
+                )
             else:
                 summary = (
                     f"The GeoLite2 {edition} database is {info.age_days} days old and "
@@ -195,8 +243,8 @@ def _stale_geoip_advisories(settings: Settings) -> list[Advisory]:
                 severity="warning",
                 summary=(
                     f"The GeoLite2 {edition} database is {info.age_days} days old and "
-                    "cannot refresh because no MaxMind credentials are configured, "
-                    "which is outside MaxMind's 30-day refresh window."
+                    "cannot refresh automatically because no MaxMind credentials are "
+                    "configured, which is outside MaxMind's 30-day refresh window."
                 ),
                 detail=detail,
                 remedy="MAXMINDDB_USER_ID and MAXMINDDB_LICENSE_KEY",

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -130,17 +130,27 @@ def _stale_geoip_advisories(settings: Settings) -> list[Advisory]:
         ):
             continue
         if credentials_available:
+            remedy = None
             if settings.scheduler.enabled:
                 summary = (
                     f"The GeoLite2 {edition} database is {info.age_days} days old and "
                     "is outside MaxMind's 30-day refresh window."
                 )
-                detail = (
-                    "The app keeps using the stale database. The geoip-refresh job "
-                    f"attempts a replacement every {refresh_interval}; inspect its next "
-                    "run and last result in Scheduler, then check the app logs for any "
-                    "reported error."
-                )
+                if refresh_days > MAXMIND_REFRESH_WINDOW_DAYS:
+                    detail = (
+                        "The app keeps using the stale database. The geoip-refresh job "
+                        f"runs every {refresh_interval}, which exceeds MaxMind's 30-day "
+                        "window. In Settings > Scheduler, find geoip-refresh and select "
+                        "Run now, then set GEOIP_REFRESH_DAYS to 30 or less and restart "
+                        "the app. Check Last run and the app logs if the manual run fails."
+                    )
+                    remedy = "GEOIP_REFRESH_DAYS=30"
+                else:
+                    detail = (
+                        "The app keeps using the stale database. In Settings > Scheduler, "
+                        "find geoip-refresh and select Run now. If it fails, check Last run "
+                        "and the app logs for the error."
+                    )
             else:
                 summary = (
                     f"The GeoLite2 {edition} database is {info.age_days} days old and "
@@ -157,6 +167,7 @@ def _stale_geoip_advisories(settings: Settings) -> list[Advisory]:
                 severity="warning",
                 summary=summary,
                 detail=detail,
+                remedy=remedy,
             ))
         else:
             if settings.scheduler.enabled:
@@ -171,9 +182,13 @@ def _stale_geoip_advisories(settings: Settings) -> list[Advisory]:
             else:
                 detail = (
                     "The app keeps using the stale database even though MaxMind requires "
-                    "a fresh copy within 30 days. Automatic refresh is disabled; "
-                    "configure the credentials below and restart the app so it loads "
-                    f"them, then replace {path} manually or set SCHEDULER_ENABLED=true."
+                    "a fresh copy within 30 days. Automatic refresh is disabled. To "
+                    f"update manually, replace {path}, then restart the app so the active "
+                    "reader loads it; MaxMind credentials are not required for manual "
+                    "replacement. For automatic refresh, configure the credentials "
+                    "below, set SCHEDULER_ENABLED=true, restart the app, then find "
+                    "geoip-refresh in Settings > Scheduler and select Run now or wait "
+                    "for its next run."
                 )
             advisories.append(Advisory(
                 id=advisory_id,

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -416,7 +416,9 @@ def _collect_advisories(app: Litestar, settings: Settings) -> list[Advisory]:
                 "for policy_update_failed before restarting."
             ),
         ))
-    return advisories
+    # Registry and computed advisories share one severity order. Python's
+    # stable sort preserves producer order within each severity.
+    return sorted(advisories, key=lambda advisory: advisory.severity != "critical")
 
 
 @get(

--- a/geometrikks/domain/system/controllers/health.py
+++ b/geometrikks/domain/system/controllers/health.py
@@ -25,7 +25,7 @@ from sqlalchemy import text
 from geometrikks.config.settings import Settings
 from geometrikks.domain.system.proxy_detection import proxy_advisories, proxy_findings
 from geometrikks.lib.utils import geoip_info
-from geometrikks.lib.advisories import Advisory
+from geometrikks.lib.advisories import Advisory, CITY_DATABASE_MISSING, INGESTION_STOPPED
 from geometrikks.server import runtime
 from geometrikks.services.geoip.downloader import has_credentials
 from geometrikks.services.ingestion import LogIngestionService
@@ -259,6 +259,17 @@ def _collect_advisories(app: Litestar, settings: Settings) -> list[Advisory]:
 
     advisories: list[Advisory] = runtime.get_advisories(app).snapshot()
     service = runtime.get_ingestion_service(app)
+    logparser_settings = getattr(settings, "logparser", None)
+    if (
+        getattr(logparser_settings, "enabled", True)
+        and (
+            not runtime.is_geoip_available(app, default=True)
+            or getattr(service, "start_failure", None) == "geoip"
+        )
+    ):
+        advisories.append(CITY_DATABASE_MISSING)
+    if service is not None and getattr(service, "unexpected_stop", False):
+        advisories.append(INGESTION_STOPPED)
     if service is not None and service.failed_batches > 0:
         ingestion_state = (
             "Ingestion continues processing new records."

--- a/geometrikks/domain/system/controllers/system.py
+++ b/geometrikks/domain/system/controllers/system.py
@@ -11,7 +11,7 @@ import platform
 import msgspec
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, version as dist_version
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from litestar import Controller, Litestar, Request, get, post
 from litestar.di import NamedDependency
@@ -59,10 +59,15 @@ class SchedulerJobView(msgspec.Struct, rename="camel"):
     last_error: str | None
 
 
+SchedulerStatus = Literal["running", "disabled", "unavailable"]
+
+
 class SchedulerJobsResponse(msgspec.Struct, rename="camel"):
     scheduler_enabled: bool
     scheduler_running: bool
     jobs: list[SchedulerJobView]
+    # "unavailable" means DB-degraded mode never started the scheduler.
+    status: SchedulerStatus = "running"
 
 
 REPO_URL = "https://github.com/GilbN/geometrikks"
@@ -425,13 +430,17 @@ class SystemController(Controller):
         scheduler = runtime.get_scheduler(request.app)
         if scheduler is None:
             return SchedulerJobsResponse(
-                scheduler_enabled=False, scheduler_running=False, jobs=[]
+                scheduler_enabled=False,
+                scheduler_running=False,
+                jobs=[],
+                status="unavailable",
             )
         tracker = runtime.get_scheduler_tracker(request.app)
         return SchedulerJobsResponse(
             scheduler_enabled=settings.scheduler.enabled,
             scheduler_running=scheduler.running,
             jobs=[_job_view(job, tracker) for job in scheduler.get_jobs()],
+            status="running" if settings.scheduler.enabled else "disabled",
         )
 
     @post("/scheduler/jobs/{job_id:str}/run", status_code=HTTP_202_ACCEPTED)

--- a/geometrikks/domain/system/proxy_detection.py
+++ b/geometrikks/domain/system/proxy_detection.py
@@ -1,15 +1,13 @@
 """Turn parser peer windows into Settings > Status advisories.
 
 Pure functions; /health calls them per request, so no I/O and no state.
-Advisory is imported lazily: controllers.health imports this module.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Iterable, Literal
+from typing import Any, Iterable, Literal
 
-if TYPE_CHECKING:
-    from geometrikks.domain.system.controllers.health import Advisory
+from geometrikks.lib.advisories import Advisory
 
 PROXY_SETUP_DOCS_URL = "https://github.com/GilbN/geometrikks/blob/main/docs/proxy-setup.md"
 
@@ -81,9 +79,7 @@ def _remedy(findings: list[ProxyFinding], nginx_remedy: str) -> str:
     return " ".join(parts)
 
 
-def _cdn_card(findings: list[ProxyFinding], docs_url: str) -> "Advisory":
-    from geometrikks.domain.system.controllers.health import Advisory
-
+def _cdn_card(findings: list[ProxyFinding], docs_url: str) -> Advisory:
     if len(findings) == 1:
         f = findings[0]
         summary = (
@@ -114,9 +110,7 @@ def _cdn_card(findings: list[ProxyFinding], docs_url: str) -> "Advisory":
     )
 
 
-def _private_card(findings: list[ProxyFinding], docs_url: str) -> "Advisory":
-    from geometrikks.domain.system.controllers.health import Advisory
-
+def _private_card(findings: list[ProxyFinding], docs_url: str) -> Advisory:
     if len(findings) == 1:
         f = findings[0]
         summary = (
@@ -149,7 +143,7 @@ def _private_card(findings: list[ProxyFinding], docs_url: str) -> "Advisory":
 
 def proxy_advisories(
     findings: list[ProxyFinding], *, docs_url: str = PROXY_SETUP_DOCS_URL
-) -> "list[Advisory]":
+) -> list[Advisory]:
     cards: list[Advisory] = []
     cdn = [f for f in findings if f.kind == "cdn"]
     private = [f for f in findings if f.kind == "private"]

--- a/geometrikks/domain/system/proxy_scan.py
+++ b/geometrikks/domain/system/proxy_scan.py
@@ -4,11 +4,10 @@ Same question as the parser's PeerWindow, answered from the database so
 agent-tailed sources appear on the head's Status page. Private peers are
 out of reach here: those lines are dropped before storage.
 
-State is module-level like timescale._hostname_pollution: the scheduler
-job writes it, /health reads it synchronously. A failed run clears both
-cache and hysteresis state so a down database drops the cards within one
-job interval instead of serving stale ones; the re-detect log line after
-an outage is the accepted cost.
+State is module-level like timescale._hostname_pollution: the scheduler job
+writes it, /health reads it synchronously. A failed run keeps the last good
+findings and records the error so /health can say the scan is broken rather
+than silently dropping the cards.
 """
 from __future__ import annotations
 
@@ -53,16 +52,24 @@ class ScanProvider:
 
 _findings: list[ProxyFinding] = []
 _active: dict[str, bool] = {}
+_last_error: str | None = None
 
 
 def get_scan_findings() -> list[ProxyFinding]:
-    """Findings from the last successful run; [] before it or after a failure."""
+    """Findings from the last successful run; [] before it."""
     return list(_findings)
 
 
+def get_scan_error() -> str | None:
+    """Error text from the last run when it failed; None after a success."""
+    return _last_error
+
+
 def reset_scan_state() -> None:
+    global _last_error
     _findings.clear()
     _active.clear()
+    _last_error = None
 
 
 def apply_scan_results(groups: list[ScanGroup], providers: list[ScanProvider]) -> None:
@@ -179,11 +186,13 @@ async def _query_scan_rows(
 async def run_proxy_scan(
     session_factory: "Callable[[], AsyncSession]", exclude_hostnames: set[str]
 ) -> None:
+    global _last_error
     try:
         async with session_factory() as session:
             groups, providers = await _query_scan_rows(session, exclude_hostnames)
     except Exception as exc:
         logger.warning("proxy_scan_failed", error=str(exc))
-        reset_scan_state()
+        _last_error = str(exc)
         return
+    _last_error = None
     apply_scan_results(groups, providers)

--- a/geometrikks/domain/system/proxy_scan.py
+++ b/geometrikks/domain/system/proxy_scan.py
@@ -194,5 +194,9 @@ async def run_proxy_scan(
         logger.warning("proxy_scan_failed", error=str(exc))
         _last_error = str(exc)
         return
+    had_error = _last_error is not None
+    previous_error = _last_error
     _last_error = None
+    if had_error:
+        logger.info("proxy_scan_recovered", previous_error=previous_error)
     apply_scan_results(groups, providers)

--- a/geometrikks/lib/advisories.py
+++ b/geometrikks/lib/advisories.py
@@ -1,0 +1,84 @@
+"""Operator advisories and the registry that stores open advisories."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import msgspec
+
+from geometrikks.server.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class Advisory(msgspec.Struct, rename="camel"):
+    id: str
+    severity: Literal["warning", "critical"]
+    summary: str
+    detail: str | None = None
+    remedy: str | None = None
+    docs_url: str | None = None
+
+
+class AdvisoryRegistry:
+    """Per-process set of open advisories, keyed by id."""
+
+    def __init__(self) -> None:
+        self._items: dict[str, Advisory] = {}
+
+    def set(self, advisory: Advisory) -> None:
+        """Upsert by id; a repeat set keeps the original position."""
+        if advisory.id not in self._items:
+            logger.info("advisory_set", id=advisory.id, severity=advisory.severity)
+        self._items[advisory.id] = advisory
+
+    def clear(self, advisory_id: str) -> bool:
+        if self._items.pop(advisory_id, None) is None:
+            return False
+        logger.info("advisory_cleared", id=advisory_id)
+        return True
+
+    def snapshot(self) -> list[Advisory]:
+        """Critical first, then insertion order."""
+        items = list(self._items.values())
+        return [a for a in items if a.severity == "critical"] + [
+            a for a in items if a.severity != "critical"
+        ]
+
+
+DATABASE_UNAVAILABLE = Advisory(
+    id="database-unavailable",
+    severity="critical",
+    summary=(
+        "The database was unreachable when the app started. Background jobs, "
+        "ingestion and the live feeds are paused."
+    ),
+    detail=(
+        "The app keeps checking every few seconds and resumes on its own when "
+        "the database answers. Dashboards work as soon as it does, but nothing "
+        "new is ingested or refreshed until recovery completes. Check the "
+        "database container if this persists."
+    ),
+)
+
+DATABASE_RECOVERY_FAILED = Advisory(
+    id="database-recovery-failed",
+    severity="critical",
+    summary="The database is reachable again but the startup migration failed.",
+    detail="Restart the container. If it fails again, check the app log for the migration error.",
+)
+
+MAP_HOME_UNDETECTED = Advisory(
+    id="map-home-undetected",
+    severity="warning",
+    summary=(
+        "The map's home location could not be detected, so routes have no "
+        "origin and the home marker is hidden."
+    ),
+    detail=(
+        "Detection needs outbound access to the public-IP service and a City "
+        "database that knows the result. The site-home-refresh job retries on "
+        "its interval."
+    ),
+    remedy="MAP_HOME_LATITUDE and MAP_HOME_LONGITUDE",
+)

--- a/geometrikks/lib/advisories.py
+++ b/geometrikks/lib/advisories.py
@@ -79,9 +79,9 @@ MAP_HOME_UNDETECTED = Advisory(
         "origin and the home marker is hidden."
     ),
     detail=(
-        "Detection needs outbound access to the public-IP service and a City "
-        "database that knows the result. The site-home-refresh job retries on "
-        "its interval."
+        "The app keeps map traffic visible without route origins or a home "
+        "marker. Check outbound access to the public-IP service and that the "
+        "City database can locate its result, or configure the home coordinates."
     ),
     remedy="MAP_HOME_LATITUDE and MAP_HOME_LONGITUDE",
 )

--- a/geometrikks/lib/advisories.py
+++ b/geometrikks/lib/advisories.py
@@ -81,7 +81,9 @@ MAP_HOME_UNDETECTED = Advisory(
     detail=(
         "The app keeps map traffic visible without route origins or a home "
         "marker. Check outbound access to the public-IP service and that the "
-        "City database can locate its result, or configure the home coordinates."
+        "City database can locate its result, or configure the home coordinates. "
+        "When scheduling and background jobs are active, the site-home refresh "
+        "job retries detection."
     ),
     remedy="MAP_HOME_LATITUDE and MAP_HOME_LONGITUDE",
 )

--- a/geometrikks/lib/advisories.py
+++ b/geometrikks/lib/advisories.py
@@ -50,7 +50,7 @@ DATABASE_UNAVAILABLE = Advisory(
     id="database-unavailable",
     severity="critical",
     summary=(
-        "The database was unreachable when the app started. Background jobs, "
+        "The database was unreachable when the app started; background jobs, "
         "ingestion and the live feeds are paused."
     ),
     detail=(
@@ -65,7 +65,10 @@ DATABASE_RECOVERY_FAILED = Advisory(
     id="database-recovery-failed",
     severity="critical",
     summary="The database is reachable again but the startup migration failed.",
-    detail="Restart the container. If it fails again, check the app log for the migration error.",
+    detail=(
+        "Automatic recovery has stopped. Restart the container. If it fails "
+        "again, check the app log for the migration error."
+    ),
 )
 
 MAP_HOME_UNDETECTED = Advisory(

--- a/geometrikks/lib/advisories.py
+++ b/geometrikks/lib/advisories.py
@@ -87,3 +87,30 @@ MAP_HOME_UNDETECTED = Advisory(
     ),
     remedy="MAP_HOME_LATITUDE and MAP_HOME_LONGITUDE",
 )
+
+CITY_DATABASE_MISSING = Advisory(
+    id="geoip-database-missing",
+    severity="warning",
+    summary=(
+        "The GeoLite2 City database is missing or unreadable, so log ingestion "
+        "cannot start."
+    ),
+    detail=(
+        "The app keeps serving the UI, but ingestion stays stopped until a usable "
+        "City database is available. If MaxMind credentials and scheduled jobs are "
+        "enabled, the geoip-refresh job retries the download; otherwise replace the "
+        "database file or configure credentials and restart the app."
+    ),
+    remedy="MAXMINDDB_USER_ID and MAXMINDDB_LICENSE_KEY",
+)
+
+INGESTION_STOPPED = Advisory(
+    id="ingestion-stopped",
+    severity="critical",
+    summary="Log ingestion stopped unexpectedly; new records are not being processed.",
+    detail=(
+        "The app detected that its log-tail and database-write task exited while "
+        "ingestion was enabled. Check the app log for the ingestion error and "
+        "restart the app after fixing the cause."
+    ),
+)

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -93,6 +93,7 @@ async def core_state_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
     Runs first so /about reports uptime even when later managers degrade.
     """
     app.state.started_at = datetime.now(timezone.utc)
+    runtime.get_advisories(app)
 
     from geometrikks.server.logging import log_broadcaster
     log_broadcaster.bind_loop(asyncio.get_running_loop())

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -26,15 +26,17 @@ when it is False. Missing GeoLite2 puts the app in geo-degraded mode
 from __future__ import annotations
 
 import asyncio
+import time
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from sqlalchemy import text
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from litestar.plugins import InitPlugin
 
 from geometrikks.config.settings import get_settings
+from geometrikks.lib.utils import retries_disabled
 from geometrikks.server.logging import get_logger
 from geometrikks.server.migrations import migrate_database
 from geometrikks.server import runtime
@@ -62,6 +64,27 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+_PROBE_RETRY_DELAY = 2.0
+
+
+class _Clock(Protocol):
+    def monotonic(self) -> float: ...
+
+    async def sleep(self, seconds: float) -> None: ...
+
+
+class _SystemClock:
+    @staticmethod
+    def monotonic() -> float:
+        return time.monotonic()
+
+    @staticmethod
+    async def sleep(seconds: float) -> None:
+        await asyncio.sleep(seconds)
+
+
+_SYSTEM_CLOCK = _SystemClock()
+
 
 def _resolve_settings(app: "Litestar") -> "Settings":
     """The settings the app was composed with.
@@ -73,7 +96,7 @@ def _resolve_settings(app: "Litestar") -> "Settings":
 
 
 async def _db_available(app: "Litestar", timeout: float = 10.0) -> bool:
-    """Return True if the app's database accepts connections; False otherwise."""
+    """Run one bounded database connection probe."""
     try:
         async def _probe():
             async with get_app_db_config(app).get_engine().connect() as conn:
@@ -82,8 +105,45 @@ async def _db_available(app: "Litestar", timeout: float = 10.0) -> bool:
         await asyncio.wait_for(_probe(), timeout=timeout)
         return True
     except Exception as e:
-        logger.warning("Database unavailable at startup: %s", e)
+        logger.debug("database_probe_failed", error=str(e))
         return False
+
+
+async def _wait_for_database(
+    app: "Litestar", wait_seconds: float, *, _clock: _Clock = _SYSTEM_CLOCK
+) -> bool:
+    """Probe until the database answers or the startup window expires."""
+    if wait_seconds == 0 or retries_disabled():
+        available = await _db_available(app)
+        if not available:
+            logger.warning(
+                "database_startup_wait_expired",
+                wait_seconds=wait_seconds,
+                retrying_in_background=True,
+            )
+        return available
+
+    deadline = _clock.monotonic() + wait_seconds
+    while True:
+        remaining = deadline - _clock.monotonic()
+        if remaining <= 0:
+            logger.warning(
+                "database_startup_wait_expired",
+                wait_seconds=wait_seconds,
+                retrying_in_background=True,
+            )
+            return False
+        if await _db_available(app, timeout=min(10.0, remaining)):
+            return True
+        remaining = deadline - _clock.monotonic()
+        if remaining <= 0:
+            logger.warning(
+                "database_startup_wait_expired",
+                wait_seconds=wait_seconds,
+                retrying_in_background=True,
+            )
+            return False
+        await _clock.sleep(min(_PROBE_RETRY_DELAY, remaining))
 
 
 @asynccontextmanager
@@ -227,8 +287,7 @@ async def database_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
         yield
         return
 
-    if not await _db_available(app):
-        logger.warning("Starting without database: skipping migrations and ingestion.")
+    if not await _wait_for_database(app, settings.database.startup_wait_seconds):
         app.state.db_available = False
         if runtime.get_crowdsec_poller(app) is not None:
             # The poll job runs on the scheduler, which never starts without a

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -61,6 +61,7 @@ from geometrikks.server.scheduler_tracking import JobRunTracker
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
+    from geometrikks.server.plugins import DegradedTolerantAsyncPgBackend
     from geometrikks.config.settings import Settings
     from litestar import Litestar
     from litestar.config.app import AppConfig
@@ -493,6 +494,11 @@ class LifecyclePlugin(InitPlugin):
     nest inside the plugin-owned ones (channels, database engine).
     """
 
+    def __init__(self, channels_backend: DegradedTolerantAsyncPgBackend | None = None) -> None:
+        self._channels_backend = channels_backend
+
     def on_app_init(self, app_config: "AppConfig") -> "AppConfig":
         app_config.lifespan.extend(LIFESPAN)
+        if self._channels_backend is not None:
+            app_config.state.channels_backend = self._channels_backend
         return app_config

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -17,10 +17,11 @@ constructor they would sit ahead of it, exit first, and ingestion's final
 flush would publish into a channels plugin that had already torn down its
 queue.
 
-Degraded modes are decided once: :func:`database_lifespan` records
-``app.state.db_available`` and the scheduler and ingestion managers no-op
-when it is False. Missing GeoLite2 puts the app in geo-degraded mode
-(API/UI up, ingestion inert) without failing startup.
+DB-degraded mode is entered once by :func:`database_lifespan`; the scheduler
+and ingestion managers start nothing while ``app.state.db_available`` is
+False. :func:`db_recovery_lifespan` (Task 6) re-probes and runs the
+deferred startup in-process. Missing GeoLite2 puts the app in geo-degraded
+mode (API/UI up, ingestion inert) without failing startup.
 """
 
 from __future__ import annotations
@@ -33,9 +34,11 @@ from typing import TYPE_CHECKING, Protocol
 
 from sqlalchemy import text
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.events import EVENT_SCHEDULER_SHUTDOWN
 from litestar.plugins import InitPlugin
 
 from geometrikks.config.settings import get_settings
+from geometrikks.lib.advisories import DATABASE_UNAVAILABLE, Advisory
 from geometrikks.lib.utils import retries_disabled
 from geometrikks.server.logging import get_logger
 from geometrikks.server.migrations import migrate_database
@@ -239,91 +242,39 @@ async def crowdsec_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
             await crowdsec_service.aclose()
 
 
-@asynccontextmanager
-async def database_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
-    """Database gate: availability probe, migrations, TimescaleDB objects.
+def _enter_db_degraded(app: "Litestar", *, detail: str | None = None) -> None:
+    """Record DB-degraded mode and pause database-bound services."""
+    app.state.db_available = False
+    app.state.db_degraded_since = datetime.now(timezone.utc)
+    poller = runtime.get_crowdsec_poller(app)
+    if poller is not None:
+        app.state.crowdsec_stream_poller_deferred = poller
+        app.state.crowdsec_stream_poller = None
+        logger.warning("crowdsec_stream_poller_deferred")
+    advisory = DATABASE_UNAVAILABLE
+    if detail is not None:
+        advisory = Advisory(
+            id=advisory.id,
+            severity=advisory.severity,
+            summary=advisory.summary,
+            detail=detail,
+        )
+    runtime.get_advisories(app).set(advisory)
+    logger.warning("database_degraded_mode_entered", detail=detail)
 
-    - If the DB is unavailable, record ``db_available = False`` and serve in
-      degraded mode (no migrations; scheduler and ingestion never start).
-    - If the DB is reachable but migration fails, that failure propagates
-      and fails startup deliberately: a reachable DB with a broken schema is
-      an error to surface, not an outage to degrade around.
 
-    Engine disposal belongs to the SQLAlchemy plugin, so there is no teardown.
-
-    Agent mode never migrates and never touches TimescaleDB objects -- the
-    primary instance owns the schema. It waits for that schema to reach (or
-    pass) the head this build was compiled against instead.
-    """
+async def bring_up_database(app: "Litestar") -> None:
+    """Prepare a reachable database for startup or in-process recovery."""
     settings = _resolve_settings(app)
-
-    if settings.is_agent:
-        engine = get_app_db_config(app).get_engine()
-        result = await wait_for_schema(engine)
-        app.state.schema_wait_result = result
-        if result == "timeout":
-            app.state.db_available = False
-            logger.error(
-                "Timed out waiting for the database schema to be ready; "
-                "starting in degraded mode."
-            )
-        else:
-            app.state.db_available = True
-            session_maker = get_app_db_config(app).create_session_maker()
-            # Home was resolved by geoip_lifespan (runs before this manager);
-            # a failure here is presentation data, not a startup blocker.
-            try:
-                await upsert_auto_homes(
-                    session_maker,
-                    settings.logparser.resolved_hostnames(),
-                    runtime.get_map_home_location(app),
-                )
-            except Exception:
-                logger.warning(
-                    "site_homes startup write failed; map falls back to the "
-                    "default home",
-                    exc_info=True,
-                )
-        yield
-        return
-
-    if not await _wait_for_database(app, settings.database.startup_wait_seconds):
-        app.state.db_available = False
-        if runtime.get_crowdsec_poller(app) is not None:
-            # The poll job runs on the scheduler, which never starts without a
-            # database; a live poller would leave /ws/crowdsec clients hanging
-            # instead of closing 1013 so they fall back to periodic refetch.
-            app.state.crowdsec_stream_poller = None
-            logger.warning(
-                "CrowdSec live updates disabled: the scheduler does not run "
-                "in DB-degraded mode."
-            )
-        yield
-        return
-
-    app.state.db_available = True
     engine = get_app_db_config(app).get_engine()
-
-    # Schema is owned by alembic (migrations/versions). A failed upgrade
-    # raises and fails startup deliberately. Multi-process deployments run
-    # migrations as a separate step instead (litestar database upgrade) and
-    # disable this; TimescaleDB setup below still requires the schema to be
-    # at head and fails startup if the external step was skipped.
     if settings.database.migrate_on_startup:
         await migrate_database(engine, settings)
     else:
-        logger.info(
-            "Startup migrations disabled (DB_MIGRATE_ON_STARTUP=false); "
-            "expecting an external 'litestar database upgrade' step."
-        )
+        logger.info("database_startup_migrations_disabled")
 
-    # TimescaleDB objects (hypertables, CAGGs, policies) deliberately stay
-    # out of alembic: the DDL is idempotent, timescale-version-sensitive,
-    # and alembic autogenerate can neither model nor diff them.
     await setup_timescaledb(engine, settings.analytics)
 
     session_maker = get_app_db_config(app).create_session_maker()
-    # Presentation data: a failure here must never block startup.
     try:
         await reconcile_override_homes(session_maker, settings.map.home_locations)
         if settings.logparser.enabled:
@@ -333,91 +284,120 @@ async def database_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
                 runtime.get_map_home_location(app),
             )
     except Exception:
-        logger.warning(
-            "site_homes startup write failed; map falls back to the default home",
-            exc_info=True,
-        )
-    yield
+        logger.warning("site_homes_startup_write_failed", exc_info=True)
 
 
 @asynccontextmanager
-async def scheduler_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
-    """APScheduler with job-run tracking; no-op in DB-degraded mode."""
-    if not getattr(app.state, "db_available", False):
+async def database_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
+    """Probe the database, then prepare it or enter degraded mode."""
+    settings = _resolve_settings(app)
+
+    if settings.is_agent:
+        engine = get_app_db_config(app).get_engine()
+        result = await wait_for_schema(engine)
+        app.state.schema_wait_result = result
+        if result == "timeout":
+            logger.error("database_schema_wait_timed_out")
+            _enter_db_degraded(
+                app,
+                detail=(
+                    "This agent timed out waiting for the head to finish "
+                    "migrating the database. Restart the agent once the head "
+                    "reports healthy."
+                ),
+            )
+        else:
+            app.state.db_available = True
+            session_maker = get_app_db_config(app).create_session_maker()
+            try:
+                await upsert_auto_homes(
+                    session_maker,
+                    settings.logparser.resolved_hostnames(),
+                    runtime.get_map_home_location(app),
+                )
+            except Exception:
+                logger.warning("site_homes_startup_write_failed", exc_info=True)
         yield
         return
 
+    if not await _wait_for_database(app, settings.database.startup_wait_seconds):
+        _enter_db_degraded(app)
+        yield
+        return
+
+    app.state.db_available = True
+    await bring_up_database(app)
+    yield
+
+
+async def start_scheduler(app: "Litestar") -> None:
+    """Create, attach and start APScheduler."""
     settings = _resolve_settings(app)
     session_maker = get_app_db_config(app).create_session_maker()
-
-    # Tracker must attach before start so no event is missed. mode is only
-    # passed for agent mode, not "full": some hand-built test doubles for
-    # create_scheduler predate the mode parameter and only accept the
-    # original (session_factory, settings, crowdsec_poller) call shape.
     crowdsec_poller = runtime.get_crowdsec_poller(app)
     kwargs = {"mode": "agent"} if settings.is_agent else {}
     scheduler: AsyncIOScheduler = await create_scheduler(
         session_maker, settings, crowdsec_poller=crowdsec_poller, app=app, **kwargs
     )
-    # The finally covers start() itself: if it activates the scheduler and
-    # then raises, the running scheduler is still shut down.
-    try:
-        scheduler_tracker = JobRunTracker()
-        scheduler_tracker.attach(scheduler)
-        scheduler.start()
-        logger.info("Started APScheduler")
+    scheduler_tracker = JobRunTracker()
+    scheduler_tracker.attach(scheduler)
+    app.state.scheduler = scheduler
+    app.state.scheduler_tracker = scheduler_tracker
+    scheduler.start()
+    logger.info("scheduler_started")
 
-        app.state.scheduler = scheduler
-        app.state.scheduler_tracker = scheduler_tracker
-        yield
+
+async def stop_scheduler(app: "Litestar") -> None:
+    """Stop and detach the current scheduler, if any."""
+    scheduler = runtime.get_scheduler(app)
+    try:
+        if scheduler is not None and scheduler.running:
+            if isinstance(scheduler, AsyncIOScheduler):
+                stopped = asyncio.Event()
+
+                def on_shutdown(_event: object) -> None:
+                    stopped.set()
+
+                scheduler.add_listener(on_shutdown, EVENT_SCHEDULER_SHUTDOWN)
+                try:
+                    scheduler.shutdown(wait=True)
+                    await stopped.wait()
+                finally:
+                    scheduler.remove_listener(on_shutdown)
+            else:
+                scheduler.shutdown(wait=True)
+            logger.info("scheduler_stopped")
     finally:
-        running = runtime.get_scheduler(app) or scheduler
-        if running and running.running:
-            running.shutdown(wait=True)
-            logger.info("Stopped APScheduler")
+        if hasattr(app.state, "scheduler") and app.state.scheduler is scheduler:
+            delattr(app.state, "scheduler")
+        if hasattr(app.state, "scheduler_tracker"):
+            delattr(app.state, "scheduler_tracker")
 
 
 @asynccontextmanager
-async def ingestion_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
-    """Log tailing -> parse -> GeoIP -> DB pipeline; no-op in DB-degraded mode.
+async def scheduler_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
+    """Start the scheduler when the database is available."""
+    try:
+        if runtime.is_db_available(app, default=False):
+            await start_scheduler(app)
+        yield
+    finally:
+        await stop_scheduler(app)
 
-    Enters last and therefore exits first: ingestion stops before the
-    scheduler and the CrowdSec client so nothing keeps writing during teardown.
 
-    LOGPARSER_ENABLED=false no-ops the same way, without ever constructing a
-    parser or the service, and independently of database availability: a
-    disabled ingestion is an operator choice, not an outage. /health reads
-    settings.logparser.enabled directly to tell "disabled by configuration"
-    apart from degraded.
-    """
+async def start_ingestion(app: "Litestar") -> None:
+    """Build and start the log ingestion service."""
     settings = _resolve_settings(app)
-    if not settings.logparser.enabled:
-        logger.info("Ingestion disabled (LOGPARSER_ENABLED=false): skipping log tailing.")
-        yield
-        return
-
-    if not getattr(app.state, "db_available", False):
-        yield
-        return
-
     from litestar.channels import ChannelsPlugin
 
-    # Ingestion opens a short-lived session per batch flush.
     session_maker = get_app_db_config(app).create_session_maker()
-
-    # Hand-built test apps in the lifespan suites are bare stand-ins with no
-    # `.plugins` registry at all; real apps always carry ChannelsPlugin
-    # (registered in server/plugins.py), so a genuine lookup miss there is a
-    # wiring bug: log it loudly and degrade the live feed rather than crash
-    # ingestion over it.
     channels: ChannelsPlugin | None = None
     plugins = getattr(app, "plugins", None)
     if plugins is not None:
         try:
             channels = plugins.get(ChannelsPlugin)
         except KeyError:
-            channels = None
-            logger.warning("live_events channel unavailable: ChannelsPlugin not registered")
+            logger.warning("live_events_channel_unavailable")
 
     hostnames = settings.logparser.resolved_hostnames()
     parsers = [
@@ -450,21 +430,41 @@ async def ingestion_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
         channels=channels,
     )
     app.state.ingestion_service = ingestion_service
+    await ingestion_service.start(skip_validation=settings.logparser.skip_validation)
+    logger.info("ingestion_started")
 
-    # The finally covers start() itself: if it activates tailers and then
-    # raises, the partially started service is still stopped.
+
+async def stop_ingestion(app: "Litestar") -> None:
+    """Stop and detach the current ingestion service, if any."""
+    service = runtime.get_ingestion_service(app)
     try:
-        await ingestion_service.start(
-            skip_validation=settings.logparser.skip_validation,
-        )
-        yield
-    finally:
-        service = runtime.get_ingestion_service(app) or ingestion_service
-        if service:
-            # A geoip-refresh job mid-flight must not restart the tail tasks
-            # after this stop (the scheduler shuts down after ingestion).
+        if service is not None:
             service.disable_reloads()
             await service.stop(timeout=5.0)
+            logger.info("ingestion_stopped")
+    finally:
+        if (
+            hasattr(app.state, "ingestion_service")
+            and app.state.ingestion_service is service
+        ):
+            delattr(app.state, "ingestion_service")
+
+
+@asynccontextmanager
+async def ingestion_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
+    """Start ingestion when configured and the database is available."""
+    settings = _resolve_settings(app)
+    if not settings.logparser.enabled:
+        logger.info("ingestion_disabled")
+        yield
+        return
+
+    try:
+        if runtime.is_db_available(app, default=False):
+            await start_ingestion(app)
+        yield
+    finally:
+        await stop_ingestion(app)
 
 
 # Entered in order by Litestar's lifespan AsyncExitStack; exited in reverse.

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -207,8 +207,8 @@ async def crowdsec_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
 
     The LAPI client needs no database, so this runs before the DB gate;
     missing config degrades the feature instead of failing startup. The
-    database manager may later null the poller in DB-degraded mode (the poll
-    job runs on the scheduler, which never starts without a database).
+    stream poller is active only when its scheduler job can run. The database
+    manager may later defer that poller when startup cannot reach the database.
 
     Teardown closes the LAPI client; it exits after the scheduler and
     ingestion managers, so nothing that could still use the client outlives it.
@@ -230,7 +230,13 @@ async def crowdsec_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
         if settings.crowdsec.enabled:
             service = CrowdSecService(settings.crowdsec)
             app.state.crowdsec_service = service
-            app.state.crowdsec_stream_poller = CrowdSecStreamPoller(service)
+            if settings.scheduler.enabled:
+                app.state.crowdsec_stream_poller = CrowdSecStreamPoller(service)
+            else:
+                app.state.crowdsec_stream_poller = None
+                logger.info(
+                    "crowdsec_stream_poller_disabled", reason="scheduler_disabled"
+                )
             logger.info(
                 "CrowdSec integration enabled (write=%s)", settings.crowdsec.write_enabled
             )

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -350,6 +350,7 @@ async def start_scheduler(app: "Litestar") -> None:
 async def stop_scheduler(app: "Litestar") -> None:
     """Stop and detach the current scheduler, if any."""
     scheduler = runtime.get_scheduler(app)
+    stopped_cleanly = scheduler is None or not scheduler.running
     try:
         if scheduler is not None and scheduler.running:
             if isinstance(scheduler, AsyncIOScheduler):
@@ -366,11 +367,15 @@ async def stop_scheduler(app: "Litestar") -> None:
                     scheduler.remove_listener(on_shutdown)
             else:
                 scheduler.shutdown(wait=True)
+            stopped_cleanly = True
             logger.info("scheduler_stopped")
     finally:
-        if hasattr(app.state, "scheduler") and app.state.scheduler is scheduler:
+        owns_scheduler = (
+            hasattr(app.state, "scheduler") and app.state.scheduler is scheduler
+        )
+        if stopped_cleanly and owns_scheduler:
             delattr(app.state, "scheduler")
-        if hasattr(app.state, "scheduler_tracker"):
+        if stopped_cleanly and owns_scheduler and hasattr(app.state, "scheduler_tracker"):
             delattr(app.state, "scheduler_tracker")
 
 
@@ -437,14 +442,17 @@ async def start_ingestion(app: "Litestar") -> None:
 async def stop_ingestion(app: "Litestar") -> None:
     """Stop and detach the current ingestion service, if any."""
     service = runtime.get_ingestion_service(app)
+    stopped_cleanly = service is None
     try:
         if service is not None:
             service.disable_reloads()
             await service.stop(timeout=5.0)
+            stopped_cleanly = True
             logger.info("ingestion_stopped")
     finally:
         if (
-            hasattr(app.state, "ingestion_service")
+            stopped_cleanly
+            and hasattr(app.state, "ingestion_service")
             and app.state.ingestion_service is service
         ):
             delattr(app.state, "ingestion_service")

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -5,8 +5,8 @@ manager. :class:`LifecyclePlugin` registers :data:`LIFESPAN` with Litestar,
 which enters the managers in order on an ``AsyncExitStack`` and exits them
 in reverse:
 
-- teardown order is the exact reverse of startup (ingestion stops first,
-  the scheduler second, the CrowdSec client closes after both), and
+- teardown reverses startup: recovery stops before ingestion, then the
+  scheduler stops and the CrowdSec client closes, and
 - a failure during startup unwinds only the managers that already started,
   so partial startup no longer leaks running services.
 
@@ -19,7 +19,7 @@ queue.
 
 DB-degraded mode is entered once by :func:`database_lifespan`; the scheduler
 and ingestion managers start nothing while ``app.state.db_available`` is
-False. :func:`db_recovery_lifespan` (Task 6) re-probes and runs the
+False. :func:`db_recovery_lifespan` re-probes and runs the
 deferred startup in-process. Missing GeoLite2 puts the app in geo-degraded
 mode (API/UI up, ingestion inert) without failing startup.
 """
@@ -27,6 +27,7 @@ mode (API/UI up, ingestion inert) without failing startup.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import time
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -38,7 +39,7 @@ from apscheduler.events import EVENT_SCHEDULER_SHUTDOWN
 from litestar.plugins import InitPlugin
 
 from geometrikks.config.settings import get_settings
-from geometrikks.lib.advisories import DATABASE_UNAVAILABLE, Advisory
+from geometrikks.lib.advisories import DATABASE_RECOVERY_FAILED, DATABASE_UNAVAILABLE, Advisory
 from geometrikks.lib.utils import retries_disabled
 from geometrikks.server.logging import get_logger
 from geometrikks.server.migrations import migrate_database
@@ -59,7 +60,7 @@ from geometrikks.server.scheduler import create_scheduler
 from geometrikks.server.scheduler_tracking import JobRunTracker
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
+    from collections.abc import AsyncGenerator, Callable
 
     from geometrikks.server.plugins import DegradedTolerantAsyncPgBackend
     from geometrikks.config.settings import Settings
@@ -264,15 +265,21 @@ def _enter_db_degraded(app: "Litestar", *, detail: str | None = None) -> None:
     logger.warning("database_degraded_mode_entered", detail=detail)
 
 
-async def bring_up_database(app: "Litestar") -> None:
+async def bring_up_database(
+    app: "Litestar", *, _on_stage: Callable[[str], None] | None = None
+) -> None:
     """Prepare a reachable database for startup or in-process recovery."""
     settings = _resolve_settings(app)
     engine = get_app_db_config(app).get_engine()
     if settings.database.migrate_on_startup:
+        if _on_stage is not None:
+            _on_stage("migration")
         await migrate_database(engine, settings)
     else:
         logger.info("database_startup_migrations_disabled")
 
+    if _on_stage is not None:
+        _on_stage("database setup")
     await setup_timescaledb(engine, settings.analytics)
 
     session_maker = get_app_db_config(app).create_session_maker()
@@ -476,6 +483,125 @@ async def ingestion_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
         await stop_ingestion(app)
 
 
+_RECOVERY_INITIAL_DELAY = 10.0
+_RECOVERY_MAX_DELAY = 60.0
+
+
+async def _unwind_database_recovery(app: "Litestar") -> None:
+    poller = runtime.get_crowdsec_poller(app)
+    if poller is not None:
+        app.state.crowdsec_stream_poller_deferred = poller
+        app.state.crowdsec_stream_poller = None
+        logger.warning("crowdsec_stream_poller_deferred")
+
+    cancelled: asyncio.CancelledError | None = None
+    for service, stop in (("ingestion", stop_ingestion), ("scheduler", stop_scheduler)):
+        try:
+            await stop(app)
+        except asyncio.CancelledError as exc:
+            cancelled = exc
+            logger.warning("db_recovery_cleanup_cancelled", service=service)
+        except Exception:
+            # Retained state lets the owning lifespan retry cleanup at shutdown.
+            logger.error("db_recovery_cleanup_failed", service=service, exc_info=True)
+    if cancelled is not None:
+        raise cancelled
+
+
+async def _recover_database(app: "Litestar") -> None:
+    """Re-probe with backoff and complete the startup skipped by the DB gate."""
+    settings = _resolve_settings(app)
+    registry = runtime.get_advisories(app)
+    since: datetime | None = getattr(app.state, "db_degraded_since", None)
+    stage = "database connection"
+
+    def set_stage(value: str) -> None:
+        nonlocal stage
+        stage = value
+
+    def degraded_seconds() -> float | None:
+        return (datetime.now(timezone.utc) - since).total_seconds() if since else None
+
+    try:
+        delay = _RECOVERY_INITIAL_DELAY
+        while True:
+            await _SYSTEM_CLOCK.sleep(delay)
+            if await _db_available(app):
+                break
+            delay = min(delay * 2, _RECOVERY_MAX_DELAY)
+
+        logger.info("db_recovery_started", degraded_seconds=degraded_seconds())
+        stage = "database setup"
+        await bring_up_database(app, _on_stage=set_stage)
+
+        deferred = getattr(app.state, "crowdsec_stream_poller_deferred", None)
+        if deferred is not None:
+            app.state.crowdsec_stream_poller = deferred
+            app.state.crowdsec_stream_poller_deferred = None
+            logger.info("crowdsec_stream_poller_restored")
+
+        stage = "channels"
+        backend = runtime.get_channels_backend(app)
+        if backend is not None:
+            try:
+                await backend.recover()
+            except Exception as exc:
+                # The backend owns listener retries independently of DB startup.
+                logger.warning("channels_backend_recover_failed", error=str(exc))
+
+        stage = "scheduler"
+        await start_scheduler(app)
+        if settings.logparser.enabled:
+            stage = "ingestion"
+            await start_ingestion(app)
+    except asyncio.CancelledError:
+        logger.info("db_recovery_cancelled", stage=stage)
+        await _unwind_database_recovery(app)
+        raise
+    except Exception as exc:
+        logger.error("db_recovery_failed", stage=stage, error=str(exc), exc_info=True)
+        advisory = DATABASE_RECOVERY_FAILED
+        if stage != "migration":
+            failed_step = f"{stage} startup" if stage in {"scheduler", "ingestion"} else stage
+            advisory = Advisory(
+                id=advisory.id,
+                severity=advisory.severity,
+                summary=f"Database recovery stopped because {failed_step} failed.",
+                detail=(
+                    "Automatic recovery has stopped. Check the app log for the "
+                    "startup error and fix the reported problem. Restart the "
+                    "container to retry."
+                ),
+            )
+        registry.clear(DATABASE_UNAVAILABLE.id)
+        registry.set(advisory)
+        await _unwind_database_recovery(app)
+        return
+
+    app.state.db_available = True
+    app.state.db_degraded_since = None
+    registry.clear(DATABASE_UNAVAILABLE.id)
+    logger.info("db_recovered", degraded_seconds=degraded_seconds())
+
+
+@asynccontextmanager
+async def db_recovery_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
+    """Recover full-mode degraded startup, cancelling before service teardown."""
+    settings = _resolve_settings(app)
+    task: asyncio.Task[None] | None = None
+    if not settings.is_agent and not runtime.is_db_available(app, default=True):
+        task = asyncio.create_task(_recover_database(app), name="db-recovery")
+        app.state.db_recovery_task = task
+    try:
+        yield
+    finally:
+        if task is not None:
+            if not task.done():
+                task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+
 # Entered in order by Litestar's lifespan AsyncExitStack; exited in reverse.
 LIFESPAN = [
     core_state_lifespan,
@@ -484,6 +610,7 @@ LIFESPAN = [
     database_lifespan,
     scheduler_lifespan,
     ingestion_lifespan,
+    db_recovery_lifespan,
 ]
 
 

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -39,7 +39,12 @@ from apscheduler.events import EVENT_SCHEDULER_SHUTDOWN
 from litestar.plugins import InitPlugin
 
 from geometrikks.config.settings import get_settings
-from geometrikks.lib.advisories import DATABASE_RECOVERY_FAILED, DATABASE_UNAVAILABLE, Advisory
+from geometrikks.lib.advisories import (
+    DATABASE_RECOVERY_FAILED,
+    DATABASE_UNAVAILABLE,
+    MAP_HOME_UNDETECTED,
+    Advisory,
+)
 from geometrikks.lib.utils import retries_disabled
 from geometrikks.server.logging import get_logger
 from geometrikks.server.migrations import migrate_database
@@ -191,6 +196,17 @@ async def geoip_lifespan(app: "Litestar") -> "AsyncGenerator[None]":
         settings.geoip,
         geoip_available=geoip_available,
     )
+    home_configured = (
+        settings.map.home_latitude is not None
+        and settings.map.home_longitude is not None
+    )
+    if (
+        app.state.map_home_location is None
+        and geoip_available
+        and settings.map.auto_detect_home
+        and not home_configured
+    ):
+        runtime.get_advisories(app).set(MAP_HOME_UNDETECTED)
     if not geoip_available:
         logger.warning(
             "Geo-degraded mode: no usable GeoLite2 database. With MaxMind "

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -266,7 +266,10 @@ def _enter_db_degraded(app: "Litestar", *, detail: str | None = None) -> None:
 
 
 async def bring_up_database(
-    app: "Litestar", *, _on_stage: Callable[[str], None] | None = None
+    app: "Litestar",
+    *,
+    _on_stage: Callable[[str], None] | None = None,
+    _shield_migration: bool = False,
 ) -> None:
     """Prepare a reachable database for startup or in-process recovery."""
     settings = _resolve_settings(app)
@@ -274,7 +277,27 @@ async def bring_up_database(
     if settings.database.migrate_on_startup:
         if _on_stage is not None:
             _on_stage("migration")
-        await migrate_database(engine, settings)
+        if _shield_migration:
+            migration = asyncio.create_task(
+                migrate_database(engine, settings), name="db-recovery-migration"
+            )
+            try:
+                await asyncio.shield(migration)
+            except asyncio.CancelledError:
+                # Cancelling to_thread cannot stop Alembic's worker thread.
+                logger.info("db_recovery_waiting_for_migration")
+                while not migration.done():
+                    try:
+                        await asyncio.shield(migration)
+                    except asyncio.CancelledError:
+                        continue
+                    except Exception:
+                        break
+                if not migration.cancelled() and (error := migration.exception()) is not None:
+                    logger.error("db_recovery_migration_failed_after_cancel", error=str(error))
+                raise
+        else:
+            await migrate_database(engine, settings)
     else:
         logger.info("database_startup_migrations_disabled")
 
@@ -532,7 +555,7 @@ async def _recover_database(app: "Litestar") -> None:
 
         logger.info("db_recovery_started", degraded_seconds=degraded_seconds())
         stage = "database setup"
-        await bring_up_database(app, _on_stage=set_stage)
+        await bring_up_database(app, _on_stage=set_stage, _shield_migration=True)
 
         deferred = getattr(app.state, "crowdsec_stream_poller_deferred", None)
         if deferred is not None:

--- a/geometrikks/server/lifecycle.py
+++ b/geometrikks/server/lifecycle.py
@@ -392,9 +392,11 @@ async def start_scheduler(app: "Litestar") -> None:
     scheduler: AsyncIOScheduler = await create_scheduler(
         session_maker, settings, crowdsec_poller=crowdsec_poller, app=app, **kwargs
     )
+    app.state.scheduler = scheduler
+    if not settings.scheduler.enabled:
+        return
     scheduler_tracker = JobRunTracker()
     scheduler_tracker.attach(scheduler)
-    app.state.scheduler = scheduler
     app.state.scheduler_tracker = scheduler_tracker
     scheduler.start()
     logger.info("scheduler_started")

--- a/geometrikks/server/plugins.py
+++ b/geometrikks/server/plugins.py
@@ -13,7 +13,7 @@ import platform
 import shutil
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from litestar.channels import ChannelsPlugin
 from litestar.channels.backends.asyncpg import AsyncPgChannelsBackend
@@ -146,13 +146,7 @@ def create_structlog_plugin(settings: Settings) -> StructlogPlugin:
 
 
 class DegradedTolerantAsyncPgBackend(AsyncPgChannelsBackend):
-    """AsyncPg channels backend that degrades instead of failing startup.
-
-    ChannelsPlugin connects during app startup; an unreachable database must
-    put the app in the existing DB-degraded mode, not crash boot. When
-    degraded, publish and subscribe are no-ops and the event stream stays
-    silent; /ws/live independently gates on db_available and closes 1013.
-    """
+    """Keep the live-events queue running while the LISTEN connection recovers."""
 
     _RECONNECT_INITIAL_DELAY = 1
     _RECONNECT_MAX_DELAY = 30
@@ -162,112 +156,141 @@ class DegradedTolerantAsyncPgBackend(AsyncPgChannelsBackend):
         self.degraded = False
         self._pub_conn: Any | None = None
         self._reconnect_task: asyncio.Task[None] | None = None
+        self._install_task: asyncio.Task[Any] | None = None
         self._closing = False
-        # Serializes subscribe/unsubscribe. A page refresh makes the plugin
-        # unsubscribe the departing /ws/live client and subscribe the new one
-        # concurrently; without the lock, subscribe can interleave into
-        # unsubscribe's awaited UNLISTEN, read the not-yet-updated
-        # bookkeeping as "already subscribed", and skip its LISTEN -- leaving
-        # the process deaf to NOTIFYs until another full cycle.
+        # Installing and subscribing must share a lock so no channel misses
+        # the candidate's LISTEN replay just before it becomes visible.
         self._sub_lock = asyncio.Lock()
+        self._recovered = asyncio.Event()
+
+    @property
+    def state(self) -> Literal["ok", "degraded", "reconnecting"]:
+        if self.degraded:
+            return "degraded"
+        if not self._recovered.is_set() and self._reconnect_task is not None:
+            return "reconnecting"
+        return "ok"
 
     async def on_startup(self) -> None:
+        # The plugin's stream keeps this queue through every connection retry.
+        self._queue = asyncio.Queue()
         try:
-            await super().on_startup()
+            await self._install_listener()
         except Exception as exc:
             self.degraded = True
-            logger.warning("Channels backend degraded (DB unreachable): %s", exc)
+            logger.warning("channels_backend_degraded", error=str(exc))
+            self._ensure_retry()
+
+    async def recover(self) -> None:
+        """Retry degraded startup, raising on failure while background retries continue."""
+        if self._closing:
+            raise RuntimeError("Channels backend is shutting down")
+        if not self.degraded:
             return
-        self._listener_conn.add_termination_listener(self._on_listener_terminated)
-
-    def _on_listener_terminated(self, connection: Any) -> None:
-        """Surface a dropped LISTEN connection and self-heal it.
-
-        Must never raise: asyncpg schedules this via call_soon/create_task,
-        and an escaping exception there is unhandled by our code. A graceful
-        on_shutdown() unregisters this callback before closing, so reaching
-        here means the drop was unexpected -- log it and, unless we're
-        already shutting down or already recovering, spawn the reconnect
-        loop.
-        """
         try:
-            logger.error(
-                "channels listener connection lost; attempting automatic reconnect"
-            )
-        except Exception:  # pragma: no cover - logging itself must not cascade
-            pass
+            await self._install_listener()
+        finally:
+            if self.degraded:
+                self._ensure_retry()
+
+    async def _close_listener(self, conn: Any) -> None:
+        # asyncpg fires termination listeners even on an intentional close.
+        with contextlib.suppress(Exception):
+            conn.remove_termination_listener(self._on_listener_terminated)
+        with contextlib.suppress(Exception):
+            await conn.close()
+
+    async def _install_listener(self) -> None:
+        async with self._sub_lock:
+            if self._closing:
+                raise RuntimeError("Channels backend is shutting down")
+            if self._recovered.is_set():
+                return
+            self._install_task = asyncio.current_task()
+            conn: Any | None = None
+            try:
+                conn = await self._connect()
+                conn.add_termination_listener(self._on_listener_terminated)
+                for channel in list(self._subscribed_channels):
+                    await conn.add_listener(channel, self._listener)
+                if self._closing:
+                    raise RuntimeError("Channels backend is shutting down")
+                if conn.is_closed():
+                    raise OSError("Channels listener closed during registration")
+            except BaseException:
+                if conn is not None:
+                    # Shutdown can cancel an install whose caller already
+                    # cancelled it. Finish closing before releasing the lock.
+                    cleanup = asyncio.create_task(self._close_listener(conn))
+                    cancelled = False
+                    while not cleanup.done():
+                        try:
+                            await asyncio.shield(cleanup)
+                        except asyncio.CancelledError:
+                            cancelled = True
+                    cleanup.result()
+                    if cancelled:
+                        raise asyncio.CancelledError
+                raise
+            finally:
+                self._install_task = None
+            self._listener_conn = conn
+            self.degraded = False
+            self._recovered.set()
+            logger.info("channels_backend_recovered")
+
+    def _ensure_retry(self) -> None:
         if self._closing:
             return
-        if self._reconnect_task is not None and not self._reconnect_task.done():
+        if self._reconnect_task is None or self._reconnect_task.done():
+            self._reconnect_task = asyncio.get_running_loop().create_task(self._reconnect_listener())
+
+    def _on_listener_terminated(self, connection: Any) -> None:
+        """asyncpg callbacks must not raise, including during cleanup."""
+        if self._closing or connection is not getattr(self, "_listener_conn", None):
             return
-        self._reconnect_task = asyncio.get_running_loop().create_task(self._reconnect_listener())
+        self._recovered.clear()
+        try:
+            logger.error("channels listener connection lost; attempting automatic reconnect")
+            self._ensure_retry()
+        except Exception:  # pragma: no cover - callback must not cascade
+            pass
 
     async def _reconnect_listener(self) -> None:
-        """Rebuild the LISTEN connection with capped exponential backoff.
-
-        Each attempt redoes exactly what on_startup() + subscribe() did:
-        open a fresh connection, register the termination callback, and
-        LISTEN every channel still in `_subscribed_channels`. subscribe()
-        itself won't re-issue LISTEN for channels already in that set, so
-        the re-registration goes straight through add_listener() instead.
-        """
         delay = self._RECONNECT_INITIAL_DELAY
+        if self.degraded:
+            await asyncio.sleep(delay)
         while not self._closing:
-            new_conn: Any | None = None
             try:
-                new_conn = await self._connect()
-                new_conn.add_termination_listener(self._on_listener_terminated)
-                # Snapshot: subscribe() mutates this set in place, and a
-                # /ws/live client connecting mid-reconnect would otherwise
-                # blow up the iteration ("set changed size") and waste an
-                # attempt. A channel added after the snapshot stays tracked
-                # and heals on a later reconnect, same as any subscribe that
-                # hits the dead-connection window. In production the set is
-                # a single fixed channel, so that window is a startup edge.
-                for channel in list(self._subscribed_channels):
-                    await new_conn.add_listener(channel, self._listener)
+                await self._install_listener()
             except Exception as exc:
-                logger.warning("channels listener reconnect attempt failed: %s", exc)
-                if new_conn is not None:
-                    # Unregister first: closing an abandoned connection that
-                    # still carries the just-added termination callback
-                    # would fire it and log a false "listener connection
-                    # lost" ERROR for a cleanup close, even though a retry
-                    # follows immediately after.
-                    with contextlib.suppress(Exception):
-                        new_conn.remove_termination_listener(self._on_listener_terminated)
-                    with contextlib.suppress(Exception):
-                        await new_conn.close()
+                logger.warning("channels_listener_reconnect_failed", error=str(exc))
                 await asyncio.sleep(delay)
                 delay = min(delay * 2, self._RECONNECT_MAX_DELAY)
                 continue
-            self._listener_conn = new_conn
-            logger.info("channels listener reconnected")
             return
 
     async def on_shutdown(self) -> None:
         self._closing = True
-        if self._reconnect_task is not None:
-            self._reconnect_task.cancel()
+        tasks = {task for task in (self._reconnect_task, self._install_task) if task is not None}
+        for task in tasks:
+            task.cancel()
+        for task in tasks:
             with contextlib.suppress(asyncio.CancelledError):
-                await self._reconnect_task
-            self._reconnect_task = None
-        if self.degraded:
-            return
-        if self._pub_conn is not None:
-            with contextlib.suppress(Exception):
-                await self._pub_conn.close()
-            self._pub_conn = None
-        # asyncpg fires termination listeners on a graceful close() too (via
-        # Connection._cleanup()), not just on an unexpected drop. Unregister
-        # first so a normal shutdown doesn't log a false "listener lost"
-        # alarm; remove_termination_listener() uses set.discard() internally
-        # so it is a no-op if the listener was never added.
-        try:
-            self._listener_conn.remove_termination_listener(self._on_listener_terminated)
-        except Exception:  # pragma: no cover - shutdown must not be blocked by this
-            pass
-        await super().on_shutdown()
+                await task
+        self._reconnect_task = None
+        async with self._sub_lock:
+            if self._pub_conn is not None:
+                with contextlib.suppress(Exception):
+                    await self._pub_conn.close()
+                self._pub_conn = None
+            conn = getattr(self, "_listener_conn", None)
+            if conn is not None:
+                await self._close_listener(conn)
+                del self._listener_conn
+            self._queue = None
+            self._recovered.clear()
+        logger.info("channels_backend_stopped")
 
     async def publish(self, data: bytes, channels: Iterable[str]) -> None:
         """Publish over one lazily opened, reused connection.
@@ -281,7 +304,7 @@ class DegradedTolerantAsyncPgBackend(AsyncPgChannelsBackend):
         surfaces the drop is the one cost of detecting it -- there is no
         earlier signal to catch it on.
         """
-        if self.degraded:
+        if self.degraded or self._closing:
             return
         try:
             if self._pub_conn is None or self._pub_conn.is_closed():
@@ -310,9 +333,12 @@ class DegradedTolerantAsyncPgBackend(AsyncPgChannelsBackend):
         (which walks `_subscribed_channels`) heals it once the connection
         is replaced.
         """
-        if self.degraded:
-            return
         async with self._sub_lock:
+            if self._closing:
+                return
+            if self.degraded:
+                self._subscribed_channels.update(channels)
+                return
             for channel in set(channels) - self._subscribed_channels:
                 try:
                     await self._listener_conn.add_listener(channel, self._listener)  # type: ignore[arg-type]
@@ -345,15 +371,19 @@ class DegradedTolerantAsyncPgBackend(AsyncPgChannelsBackend):
 
     async def stream_events(self) -> AsyncGenerator[tuple[str, bytes], None]:
         if self.degraded:
-            await asyncio.Event().wait()  # silent forever; plugin task parks here
+            await self._recovered.wait()
         async for item in super().stream_events():
             yield item
 
 
-def create_channels_plugin(settings: Settings) -> ChannelsPlugin:
+def create_channels_plugin(
+    settings: Settings, backend: DegradedTolerantAsyncPgBackend | None = None
+) -> ChannelsPlugin:
     """Cross-process live-events fan-out over Postgres LISTEN/NOTIFY."""
     return ChannelsPlugin(
-        backend=DegradedTolerantAsyncPgBackend(dsn=settings.database.asyncpg_dsn),
+        backend=(
+            backend if backend is not None else DegradedTolerantAsyncPgBackend(dsn=settings.database.asyncpg_dsn)
+        ),
         channels=[LIVE_EVENTS_CHANNEL],
         arbitrary_channels_allowed=False,
         subscriber_max_backlog=1000,
@@ -406,14 +436,15 @@ def create_plugins(
     ]
     if include_vite:
         plugin_list.append(VitePlugin(config=create_vite_config(settings)))
+    channels_backend = DegradedTolerantAsyncPgBackend(dsn=settings.database.asyncpg_dsn)
     plugin_list.extend(
         [
             ImportLogsCLIPlugin(),
             create_structlog_plugin(settings),
-            create_channels_plugin(settings),
+            create_channels_plugin(settings, channels_backend),
             # Last on purpose: its lifespan managers must nest inside the
             # channels plugin's (see lifecycle.LifecyclePlugin).
-            LifecyclePlugin(),
+            LifecyclePlugin(channels_backend=channels_backend),
         ]
     )
     return plugin_list

--- a/geometrikks/server/runtime.py
+++ b/geometrikks/server/runtime.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
     from litestar import Litestar
 
+    from geometrikks.server.plugins import DegradedTolerantAsyncPgBackend
     from geometrikks.services.crowdsec import CrowdSecService
     from geometrikks.services.crowdsec.stream import CrowdSecStreamPoller
     from geometrikks.services.geoip.home import HomeLocation
@@ -94,3 +95,8 @@ def is_asn_available(app: Litestar, *, default: bool = False) -> bool:
 def is_db_available(app: Litestar, *, default: bool = True) -> bool:
     """Whether database-bound services were wired during startup."""
     return bool(getattr(app.state, "db_available", default))
+
+
+def get_channels_backend(app: Litestar) -> DegradedTolerantAsyncPgBackend | None:
+    """The live-events backend; None on hand-built test apps."""
+    return getattr(app.state, "channels_backend", None)

--- a/geometrikks/server/runtime.py
+++ b/geometrikks/server/runtime.py
@@ -48,7 +48,7 @@ def get_crowdsec_service(app: Litestar) -> CrowdSecService | None:
 
 
 def get_crowdsec_poller(app: Litestar) -> CrowdSecStreamPoller | None:
-    """None when CrowdSec is disabled or the app is DB-degraded."""
+    """None when CrowdSec is disabled or the app is DB-degraded or scheduler-disabled."""
     return getattr(app.state, "crowdsec_stream_poller", None)
 
 

--- a/geometrikks/server/runtime.py
+++ b/geometrikks/server/runtime.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from geometrikks.server.scheduler_tracking import JobRunTracker
+from geometrikks.lib.advisories import AdvisoryRegistry
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -29,6 +30,15 @@ if TYPE_CHECKING:
 def get_ingestion_service(app: Litestar) -> LogIngestionService | None:
     """None when ingestion never started (DB- or geo-degraded mode)."""
     return getattr(app.state, "ingestion_service", None)
+
+
+def get_advisories(app: Litestar) -> AdvisoryRegistry:
+    """The app's open advisories, created on first access."""
+    registry: AdvisoryRegistry | None = getattr(app.state, "advisories", None)
+    if registry is None:
+        registry = AdvisoryRegistry()
+        app.state.advisories = registry
+    return registry
 
 
 def get_crowdsec_service(app: Litestar) -> CrowdSecService | None:

--- a/geometrikks/server/runtime.py
+++ b/geometrikks/server/runtime.py
@@ -89,3 +89,8 @@ def is_asn_available(app: Litestar, *, default: bool = False) -> bool:
     ingest without ASN columns. ``default`` mirrors is_geoip_available.
     """
     return bool(getattr(app.state, "asn_available", default))
+
+
+def is_db_available(app: Litestar, *, default: bool = True) -> bool:
+    """Whether database-bound services were wired during startup."""
+    return bool(getattr(app.state, "db_available", default))

--- a/geometrikks/server/scheduler.py
+++ b/geometrikks/server/scheduler.py
@@ -124,17 +124,26 @@ async def refresh_all_caggs_job(
     Args:
         session_factory: SQLAlchemy async session factory.
     """
+    failed: list[str] = []
     for cagg_name in ALL_CAGGS:
         try:
             await _execute_call_outside_transaction(
                 session_factory,
                 f"CALL refresh_continuous_aggregate('{cagg_name}', NULL, NULL)",
             )
-            logger.info("Refreshed %s", cagg_name)
-        except Exception as e:
-            logger.warning("Failed to refresh %s: %s", cagg_name, e)
+            logger.info("cagg_refreshed", cagg_name=cagg_name)
+        except Exception as exc:
+            logger.warning(
+                "cagg_refresh_failed", cagg_name=cagg_name, error=str(exc)
+            )
+            failed.append(cagg_name)
 
-    logger.info("All CAGGs refresh complete")
+    if failed:
+        raise RuntimeError(
+            f"{len(failed)} of {len(ALL_CAGGS)} aggregates failed to refresh: "
+            + ", ".join(failed)
+        )
+    logger.info("all_caggs_refresh_complete", count=len(ALL_CAGGS))
 
 
 async def refresh_site_home_job(
@@ -191,24 +200,24 @@ async def refresh_geoip_job(settings: "Settings", app: "Litestar | None") -> Non
     # Module lookup, not a captured reference: tests monkeypatch this.
     # force: a run of this job (scheduled or the Settings Run button) means
     # "fetch a fresh copy now"; the staleness gate stays for startup only.
-    await downloader.refresh_geoip_databases(settings.geoip, force=True)
+    result = await downloader.refresh_geoip_databases(settings.geoip, force=True)
 
-    if app is None:
-        return
+    if app is not None:
+        from geometrikks.lib.utils import geoip_info
+        from geometrikks.server import runtime
 
-    from geometrikks.lib.utils import geoip_info
-    from geometrikks.server import runtime
+        # /health and the settings overlay read these; a successful download after
+        # a degraded start must flip them without a restart.
+        app.state.geoip_available = geoip_info(settings.geoip.db_path).available
+        if settings.geoip.asn_enabled:
+            app.state.asn_available = geoip_info(settings.geoip.asn_db_path).available
 
-    # /health and the settings overlay read these; a successful download after
-    # a degraded start must flip them without a restart.
-    app.state.geoip_available = geoip_info(settings.geoip.db_path).available
-    if settings.geoip.asn_enabled:
-        app.state.asn_available = geoip_info(settings.geoip.asn_db_path).available
+        service = runtime.get_ingestion_service(app)
+        if service is not None and service.readers_stale():
+            await service.reload_readers()
 
-    service = runtime.get_ingestion_service(app)
-    if service is None or not service.readers_stale():
-        return
-    await service.reload_readers()
+    if result.errors:
+        raise RuntimeError("GeoLite2 refresh failed: " + "; ".join(result.errors))
 
 
 async def create_scheduler(

--- a/geometrikks/server/scheduler.py
+++ b/geometrikks/server/scheduler.py
@@ -147,15 +147,19 @@ async def refresh_all_caggs_job(
 
 
 async def refresh_site_home_job(
-    session_factory: "Callable[[], AsyncSession]", settings: "Settings"
+    session_factory: "Callable[[], AsyncSession]",
+    settings: "Settings",
+    app: "Litestar | None" = None,
 ) -> None:
     """Re-detect this process's home and refresh its site_homes rows.
 
     Homelab IPs change; agents run for weeks. A UI head tails nothing and
     records no events under its own hostname, so it has nothing to write.
+    A successful detection updates this process's map state and clears its
+    undetected-home advisory. Database writes remain ingestion-only.
     """
-    if not settings.logparser.enabled:
-        return
+    from geometrikks.lib.advisories import MAP_HOME_UNDETECTED
+    from geometrikks.server import runtime
     from geometrikks.services.geoip.home import resolve_home_location
     from geometrikks.services.geoip.site_homes import upsert_auto_homes
 
@@ -164,7 +168,13 @@ async def refresh_site_home_job(
         settings.geoip,
         geoip_available=settings.geoip.db_path.exists(),
     )
-    await upsert_auto_homes(session_factory, settings.logparser.resolved_hostnames(), home)
+    if app is not None and home is not None:
+        app.state.map_home_location = home
+        runtime.get_advisories(app).clear(MAP_HOME_UNDETECTED.id)
+    if settings.logparser.enabled:
+        await upsert_auto_homes(
+            session_factory, settings.logparser.resolved_hostnames(), home
+        )
 
 
 async def proxy_scan_job(
@@ -309,17 +319,16 @@ async def create_scheduler(
     )
     logger.info("Scheduled GeoLite2 refresh every %d day(s)", settings.geoip.refresh_days)
 
-    # Registered only when this process ingests (both modes qualify for
-    # agents; a UI head does not): the jobs list is user-visible on the
-    # Settings page, so a permanently no-op job must not appear there. The
-    # job keeps its own parser-enabled guard as cheap defense.
-    if settings.logparser.enabled:
+    # A composed UI head needs this job to refresh its process-local map home.
+    # Hand-built schedulers without an app still skip the job when they ingest
+    # nothing because neither app state nor site_homes can change.
+    if settings.logparser.enabled or app is not None:
         scheduler.add_job(
             refresh_site_home_job,
             IntervalTrigger(hours=settings.map.home_refresh_hours),
             id="site-home-refresh",
             name="Re-detect this instance's site home location",
-            args=[session_factory, settings],
+            args=[session_factory, settings, app],
             replace_existing=True,
         )
         logger.info(

--- a/geometrikks/server/scheduler.py
+++ b/geometrikks/server/scheduler.py
@@ -319,10 +319,12 @@ async def create_scheduler(
     )
     logger.info("Scheduled GeoLite2 refresh every %d day(s)", settings.geoip.refresh_days)
 
-    # A composed UI head needs this job to refresh its process-local map home.
-    # Hand-built schedulers without an app still skip the job when they ingest
-    # nothing because neither app state nor site_homes can change.
-    if settings.logparser.enabled or app is not None:
+    # A composed UI head needs this job only when automatic detection can
+    # refresh its process-local map home. Ingesting instances also persist the
+    # result to site_homes.
+    if settings.logparser.enabled or (
+        app is not None and settings.map.auto_detect_home
+    ):
         scheduler.add_job(
             refresh_site_home_job,
             IntervalTrigger(hours=settings.map.home_refresh_hours),

--- a/geometrikks/server/timescale.py
+++ b/geometrikks/server/timescale.py
@@ -693,23 +693,24 @@ async def _add_refresh_policies(
 
     for cagg, start_offset, end_offset in CAGG_REFRESH_CONFIG:
         try:
-            await conn.execute(text(f"""
-                SELECT add_continuous_aggregate_policy(
-                    '{cagg}',
-                    start_offset => INTERVAL '{start_offset}',
-                    end_offset => INTERVAL '{end_offset}',
-                    schedule_interval => INTERVAL '{refresh_interval}',
-                    if_not_exists => TRUE
+            async with conn.begin_nested():
+                await conn.execute(text(f"""
+                    SELECT add_continuous_aggregate_policy(
+                        '{cagg}',
+                        start_offset => INTERVAL '{start_offset}',
+                        end_offset => INTERVAL '{end_offset}',
+                        schedule_interval => INTERVAL '{refresh_interval}',
+                        if_not_exists => TRUE
+                    )
+                """))
+                await _sync_policy_schedule(
+                    conn,
+                    policy="refresh",
+                    proc="policy_refresh_continuous_aggregate",
+                    target=cagg,
+                    interval=timedelta(minutes=refresh_interval_minutes),
                 )
-            """))
             logger.info("Refresh policy added/verified: %s (every %s)", cagg, refresh_interval)
-        except Exception as e:
-            logger.debug("Refresh policy for %s: %s", cagg, e)
-        try:
-            await _sync_policy_schedule(
-                conn, policy="refresh", proc="policy_refresh_continuous_aggregate", target=cagg,
-                interval=timedelta(minutes=refresh_interval_minutes),
-            )
         except Exception as e:
             logger.warning("policy_update_failed", policy="refresh", target=cagg, error=str(e))
             _record_policy_failure("refresh", cagg, str(e))
@@ -732,21 +733,23 @@ async def _add_retention_policies(
 
     for target, days in retention_configs:
         try:
-            await conn.execute(text(f"""
-                SELECT add_retention_policy(
-                    '{target}',
-                    drop_after => INTERVAL '{days} days',
-                    if_not_exists => TRUE
+            async with conn.begin_nested():
+                await conn.execute(text(f"""
+                    SELECT add_retention_policy(
+                        '{target}',
+                        drop_after => INTERVAL '{days} days',
+                        if_not_exists => TRUE
+                    )
+                """))
+                await _sync_policy_config(
+                    conn,
+                    policy="retention",
+                    proc="policy_retention",
+                    target=target,
+                    key="drop_after",
+                    interval=timedelta(days=days),
                 )
-            """))
             logger.info("Retention policy added/verified: %s (%d days)", target, days)
-        except Exception as e:
-            logger.debug("Retention policy for %s: %s", target, e)
-        try:
-            await _sync_policy_config(
-                conn, policy="retention", proc="policy_retention", target=target,
-                key="drop_after", interval=timedelta(days=days),
-            )
         except Exception as e:
             logger.warning("policy_update_failed", policy="retention", target=target, error=str(e))
             _record_policy_failure("retention", target, str(e))
@@ -817,32 +820,34 @@ async def _add_compression_policies(
         ("access_log_debug", "created_at"),
     ]:
         try:
-            # Enable compression on the hypertable
-            await conn.execute(text(f"""
-                ALTER TABLE {table} SET (
-                    timescaledb.compress,
-                    timescaledb.compress_orderby = '{time_col} DESC'
+            async with conn.begin_nested():
+                # Enable compression on the hypertable
+                await conn.execute(text(f"""
+                    ALTER TABLE {table} SET (
+                        timescaledb.compress,
+                        timescaledb.compress_orderby = '{time_col} DESC'
+                    )
+                """))
+                # Add compression policy
+                await conn.execute(text(f"""
+                    SELECT add_compression_policy(
+                        '{table}',
+                        compress_after => INTERVAL '{compression_after_days} days',
+                        if_not_exists => TRUE
+                    )
+                """))
+                await _sync_policy_config(
+                    conn,
+                    policy="compression",
+                    proc="policy_compression",
+                    target=table,
+                    key="compress_after",
+                    interval=timedelta(days=compression_after_days),
                 )
-            """))
-            # Add compression policy
-            await conn.execute(text(f"""
-                SELECT add_compression_policy(
-                    '{table}',
-                    compress_after => INTERVAL '{compression_after_days} days',
-                    if_not_exists => TRUE
-                )
-            """))
             logger.info(
                 "Compression policy added/verified: %s (after %d days)",
                 table,
                 compression_after_days,
-            )
-        except Exception as e:
-            logger.debug("Compression policy for %s: %s", table, e)
-        try:
-            await _sync_policy_config(
-                conn, policy="compression", proc="policy_compression", target=table,
-                key="compress_after", interval=timedelta(days=compression_after_days),
             )
         except Exception as e:
             logger.warning("policy_update_failed", policy="compression", target=table, error=str(e))

--- a/geometrikks/server/timescale.py
+++ b/geometrikks/server/timescale.py
@@ -118,6 +118,29 @@ def _set_hostname_pollution(value: HostnamePollution | None) -> None:
     _hostname_pollution = value
 
 
+@dataclass(frozen=True)
+class PolicyFailure:
+    policy: str
+    target: str
+    error: str
+
+
+_policy_failures: list[PolicyFailure] = []
+
+
+def get_policy_failures() -> list[PolicyFailure]:
+    """Return policy intervals that could not be synced during the last setup run."""
+    return list(_policy_failures)
+
+
+def _record_policy_failure(policy: str, target: str, error: str) -> None:
+    _policy_failures.append(PolicyFailure(policy, target, error))
+
+
+def _reset_policy_failures() -> None:
+    _policy_failures.clear()
+
+
 # =============================================================================
 # Hypertable Configuration
 # =============================================================================
@@ -689,6 +712,7 @@ async def _add_refresh_policies(
             )
         except Exception as e:
             logger.warning("policy_update_failed", policy="refresh", target=cagg, error=str(e))
+            _record_policy_failure("refresh", cagg, str(e))
 
 
 async def _add_retention_policies(
@@ -725,6 +749,7 @@ async def _add_retention_policies(
             )
         except Exception as e:
             logger.warning("policy_update_failed", policy="retention", target=target, error=str(e))
+            _record_policy_failure("retention", target, str(e))
 
 
 _POLICY_JOB_FOR_TARGET = """
@@ -821,6 +846,7 @@ async def _add_compression_policies(
             )
         except Exception as e:
             logger.warning("policy_update_failed", policy="compression", target=table, error=str(e))
+            _record_policy_failure("compression", table, str(e))
 
 
 async def _enable_realtime_aggregation(conn: "AsyncConnection") -> None:
@@ -1234,6 +1260,7 @@ async def setup_timescaledb(
             (see ``check_refresh_offsets``).
     """
     check_refresh_offsets(raw_retention_days=analytics.raw_retention_days)
+    _reset_policy_failures()
 
     async with engine.begin() as conn:
         # Enable extensions

--- a/geometrikks/server/timescale.py
+++ b/geometrikks/server/timescale.py
@@ -138,7 +138,11 @@ def _record_policy_failure(policy: str, target: str, error: str) -> None:
 
 
 def _reset_policy_failures() -> None:
+    count = len(_policy_failures)
+    if count == 0:
+        return
     _policy_failures.clear()
+    logger.info("policy_failures_cleared", count=count)
 
 
 # =============================================================================

--- a/geometrikks/services/aggregation/service.py
+++ b/geometrikks/services/aggregation/service.py
@@ -81,9 +81,9 @@ class AggregationService:
                 self.total_location_refreshes += updated
                 logger.info("Refreshed last_hit for %d locations", updated)
             return updated
-        except Exception as e:
-            logger.exception("Failed to refresh location last_hits: %s", e)
-            return 0
+        except Exception as exc:
+            logger.exception("location_last_hits_refresh_failed", error=str(exc))
+            raise
 
     async def force_refresh_continuous_aggregates(self) -> None:
         """Force refresh of TimescaleDB continuous aggregates.

--- a/geometrikks/services/geoip/downloader.py
+++ b/geometrikks/services/geoip/downloader.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import tarfile
 import tempfile
 import time
+from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -33,6 +34,23 @@ ASN_EDITION = "GeoLite2-ASN"
 
 class GeoIPDownloadError(Exception):
     """Download or extraction failed."""
+
+
+@dataclass
+class RefreshResult:
+    """Download failures from a City and ASN refresh attempt."""
+
+    city_error: str | None = None
+    asn_error: str | None = None
+
+    @property
+    def errors(self) -> list[str]:
+        """Return present errors in refresh order."""
+        return [
+            error
+            for error in (self.city_error, self.asn_error)
+            if error is not None
+        ]
 
 
 def has_credentials(settings: "GeoIPSettings") -> bool:
@@ -127,7 +145,12 @@ async def download_database(
     return db_path
 
 
-async def ensure_geoip_database(settings: "GeoIPSettings", *, force: bool = False) -> bool:
+async def ensure_geoip_database(
+    settings: "GeoIPSettings",
+    *,
+    force: bool = False,
+    errors: list[str] | None = None,
+) -> bool:
     """Make the mmdb present-and-fresh if possible. Returns usability.
 
     - fresh db, no creds        -> True (nothing to do)
@@ -170,16 +193,25 @@ async def ensure_geoip_database(settings: "GeoIPSettings", *, force: bool = Fals
         )
         return True
     except GeoIPDownloadError as exc:
-        logger.error("GeoIP download failed: %s", exc)
+        logger.error("geoip_city_download_failed", error=str(exc))
+        if errors is not None:
+            errors.append(f"City: {exc}")
         return geoip_info(settings.db_path).available
-    except Exception:
+    except Exception as exc:
         # Startup/scheduler entry point: a full volume, bad mount permissions,
         # or a truncated stream must degrade, never crash the app.
-        logger.exception("Unexpected error while refreshing the GeoLite2 database")
+        logger.exception("geoip_city_refresh_failed", error=str(exc))
+        if errors is not None:
+            errors.append(f"City: {exc}")
         return geoip_info(settings.db_path).available
 
 
-async def ensure_asn_database(settings: "GeoIPSettings", *, force: bool = False) -> bool:
+async def ensure_asn_database(
+    settings: "GeoIPSettings",
+    *,
+    force: bool = False,
+    errors: list[str] | None = None,
+) -> bool:
     """Download or refresh the GeoLite2-ASN mmdb when possible; never raises.
 
     Unlike ensure_geoip_database, False is not degraded mode, only
@@ -220,14 +252,20 @@ async def ensure_asn_database(settings: "GeoIPSettings", *, force: bool = False)
         )
         return True
     except GeoIPDownloadError as exc:
-        logger.error("GeoLite2-ASN download failed: %s", exc)
+        logger.error("geoip_asn_download_failed", error=str(exc))
+        if errors is not None:
+            errors.append(f"ASN: {exc}")
         return geoip_info(settings.asn_db_path).available
-    except Exception:
-        logger.exception("Unexpected error while refreshing the GeoLite2-ASN database")
+    except Exception as exc:
+        logger.exception("geoip_asn_refresh_failed", error=str(exc))
+        if errors is not None:
+            errors.append(f"ASN: {exc}")
         return geoip_info(settings.asn_db_path).available
 
 
-async def refresh_geoip_databases(settings: "GeoIPSettings", *, force: bool = False) -> None:
+async def refresh_geoip_databases(
+    settings: "GeoIPSettings", *, force: bool = False
+) -> RefreshResult:
     """Scheduler entry point: refresh City always, ASN when enabled.
 
     Looked up through the module (not captured references) so tests can
@@ -235,6 +273,12 @@ async def refresh_geoip_databases(settings: "GeoIPSettings", *, force: bool = Fa
     """
     from geometrikks.services.geoip import downloader as _self
 
-    await _self.ensure_geoip_database(settings, force=force)
+    city_errors: list[str] = []
+    asn_errors: list[str] = []
+    await _self.ensure_geoip_database(settings, force=force, errors=city_errors)
     if settings.asn_enabled:
-        await _self.ensure_asn_database(settings, force=force)
+        await _self.ensure_asn_database(settings, force=force, errors=asn_errors)
+    return RefreshResult(
+        city_error=city_errors[0] if city_errors else None,
+        asn_error=asn_errors[0] if asn_errors else None,
+    )

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -322,31 +322,58 @@ class LogIngestionService:
                 task.cancel()
             await asyncio.gather(*pending, return_exceptions=True)
 
-        try:
-            await asyncio.wait_for(self._ingestion_task, timeout=timeout)
-        except asyncio.TimeoutError:
+        consumer_task = self._ingestion_task
+        _done, pending = await asyncio.wait({consumer_task}, timeout=timeout)
+        if pending:
             logger.warning("Ingestion did not stop gracefully, cancelling")
-            self._ingestion_task.cancel()
-            try:
-                await self._ingestion_task
-            except asyncio.CancelledError:
-                pass
+            consumer_task.cancel()
+
+        consumer_failure: BaseException | None = None
+        try:
+            await consumer_task
         except asyncio.CancelledError:
             pass
+        except BaseException as e:
+            consumer_failure = e
+            logger.error(
+                "ingestion_consumer_failed_during_stop",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
         finally:
             self.is_running = False
 
         # Every task that used the readers is done; release their mmaps.
-        if self._reader is not None:
-            self._reader.close()
-            self._reader = None
-        if self._asn_reader is not None:
-            self._asn_reader.close()
-            self._asn_reader = None
+        cleanup_failure: BaseException | None = None
+        for attribute, reader_name in (
+            ("_reader", "city"),
+            ("_asn_reader", "asn"),
+        ):
+            reader = getattr(self, attribute)
+            if reader is None:
+                continue
+            try:
+                reader.close()
+            except BaseException as e:
+                if cleanup_failure is None:
+                    cleanup_failure = e
+                logger.exception(
+                    "ingestion_reader_close_failed",
+                    reader=reader_name,
+                    error=str(e),
+                )
+            finally:
+                setattr(self, attribute, None)
+
+        self._ingestion_task = None
 
         logger.info(
             "Stopped log ingestion service. Total processed: %d", self.total_processed
         )
+        if consumer_failure is not None:
+            raise consumer_failure
+        if cleanup_failure is not None:
+            raise cleanup_failure
 
     def readers_stale(self) -> bool:
         """True when a database file on disk differs from what the readers opened.

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import aiofiles.os
 from geoip2.database import Reader
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -33,7 +34,7 @@ from geometrikks.domain.realtime.events import LIVE_EVENTS_CHANNEL, encode_guard
 from geometrikks.services.logparser.schemas import ParsedLogRecord, ParsedGeoData, ParsedAccessLog
 from geometrikks.services.logparser.constants import ALLOWED_GEOIP_LOCALES, GEOIP_LOCALES_DEFAULT
 from geometrikks.services.logparser.logparser import LogParser
-from geometrikks.lib.utils import wait_for_path
+from geometrikks.lib.utils import sleep_unless_stopped, wait_for_path
 from geometrikks.server.logging import get_logger
 
 if TYPE_CHECKING:
@@ -41,6 +42,8 @@ if TYPE_CHECKING:
 
 
 logger = get_logger(__name__)
+
+MISSING_FILE_GRACE_SECONDS = 60.0
 
 
 @dataclass
@@ -280,12 +283,19 @@ class LogIngestionService:
         """Tail a single log file, pushing parsed records onto the shared queue."""
         logger.debug("Waiting for log file: %s", parser.log_path)
         if not await wait_for_path(
-            parser.log_path, timeout_seconds=60.0, stop_event=self._stop_event
+            parser.log_path,
+            timeout_seconds=MISSING_FILE_GRACE_SECONDS,
+            stop_event=self._stop_event,
         ):
             if self._stop_event and self._stop_event.is_set():
                 return  # shutting down, not a missing-file problem
-            logger.error("Skipping ingestion for missing log file: %s", parser.log_path)
-            return
+            parser.mark_missing()
+            while not await aiofiles.os.path.exists(parser.log_path):
+                if await sleep_unless_stopped(
+                    parser.poll_interval, self._stop_event
+                ):
+                    return
+            parser.mark_present()
         assert self._queue is not None
         async for record in parser.iter_parsed_records(
             reader, asn_reader, skip_validation=skip_validation
@@ -380,7 +390,7 @@ class LogIngestionService:
             while True:
                 # Exit once every producer is done and the queue is drained.
                 # This covers graceful stop() and the case where all tail
-                # tasks died on their own (e.g. every log file missing);
+                # tasks died on their own after unexpected failures;
                 # without the latter, is_running would stay True forever and
                 # /health would keep reporting a healthy ingestion.
                 if self._queue.empty() and all(

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -524,6 +524,13 @@ class LogIngestionService:
             self._location_cache.pop(geohash, None)
         self._uncommitted_geohashes.clear()
 
+    def _evict_batch_locations(self, batch: list[ParsedLogRecord]) -> None:
+        """Drop all cached locations associated with a failed transaction."""
+        self._evict_uncommitted_locations()
+        for record in batch:
+            if record.geo_data:
+                self._location_cache.pop(record.geo_data.geohash, None)
+
     def _sanitize_for_postgres(self, value: str | None) -> str | None:
         """Remove null bytes from strings for PostgreSQL compatibility.
 
@@ -610,7 +617,14 @@ class LogIngestionService:
                         try:
                             await session.rollback()
                         except Exception as rollback_err:
-                            logger.error("Rollback failed: %s", rollback_err)
+                            logger.error(
+                                "ingestion_batch_rollback_failed",
+                                records=len(batch),
+                                error=str(rollback_err),
+                            )
+                            lost_records = len(batch)
+                            self._evict_batch_locations(batch)
+                            return
                         self._evict_uncommitted_locations()
                         # The failing record may have hit a poisoned cache entry
                         # (an id cached before this service run whose row does not
@@ -630,14 +644,12 @@ class LogIngestionService:
                     )
                     batch_failed = True
                     lost_records += commit_lost_records
-                    await session.rollback()
-                    self._evict_uncommitted_locations()
-                    # Same poisoned-entry hazard as above, but here we don't know
-                    # which record broke the commit, so evict every geohash the
-                    # batch touched so the next flush re-resolves it from the DB.
-                    for record in batch:
-                        if record.geo_data:
-                            self._location_cache.pop(record.geo_data.geohash, None)
+                    try:
+                        await session.rollback()
+                    finally:
+                        # The failed commit does not identify which cached
+                        # location poisoned the transaction.
+                        self._evict_batch_locations(batch)
                 else:
                     self._uncommitted_geohashes.clear()
                     self._publish(committed_candidates)

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -772,5 +772,5 @@ class LogIngestionService:
 
     @property
     def missing_files(self) -> list[str]:
-        """Tailed log files that have disappeared mid-flight (see /health)."""
+        """Configured log files currently absent, since startup or after removal."""
         return [str(parser.log_path) for parser in self.parsers if parser.file_missing]

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -157,6 +157,8 @@ class LogIngestionService:
         self._queue_maxsize: int = queue_maxsize
         self._channels: "ChannelsPlugin | None" = channels
         self.publish_dropped: int = 0
+        self.failed_batches: int = 0
+        self.failed_records: int = 0
 
         # In-memory cache: geohash -> committed (or pending-commit) GeoLocation id.
         # Ids cached since the last successful commit are tracked so a rollback
@@ -584,47 +586,65 @@ class LogIngestionService:
         # post-commit. A per-record failure rolls back earlier records of this
         # batch (matching existing semantics), so reset the list on failure too.
         committed_candidates: list[ParsedLogRecord] = []
+        batch_failed = False
+        lost_records = 0
 
-        async with self._session_maker() as session:
-            repos = self._repos_factory(session)
-            for record in batch:
-                try:
-                    await self._process_record(record, repos, flushed)
-                    committed_candidates.append(record)
-                except Exception as e:
-                    logger.error(
-                        "Failed to process record (rolling back batch): %s - raw_line preview: %.100s",
-                        e,
-                        record.raw_line[:100] if record.raw_line else "N/A",
-                    )
-                    committed_candidates = []
-                    try:
-                        await session.rollback()
-                    except Exception as rollback_err:
-                        logger.error("Rollback failed: %s", rollback_err)
-                    self._evict_uncommitted_locations()
-                    # The failing record may have hit a poisoned cache entry
-                    # (an id cached before this service run whose row does not
-                    # exist, e.g. after a crashed commit). Uncommitted-tracking
-                    # can't see those, so drop the record's own geohash too.
-                    if record.geo_data:
-                        self._location_cache.pop(record.geo_data.geohash, None)
-
-            try:
-                await session.commit()
-            except Exception as e:
-                logger.error("Batch commit failed (rolling back): %s", e)
-                await session.rollback()
-                self._evict_uncommitted_locations()
-                # Same poisoned-entry hazard as above, but here we don't know
-                # which record broke the commit — evict every geohash the
-                # batch touched so the next flush re-resolves them from the DB.
+        try:
+            async with self._session_maker() as session:
+                repos = self._repos_factory(session)
                 for record in batch:
-                    if record.geo_data:
-                        self._location_cache.pop(record.geo_data.geohash, None)
-            else:
-                self._uncommitted_geohashes.clear()
-                self._publish(committed_candidates)
+                    try:
+                        await self._process_record(record, repos, flushed)
+                        committed_candidates.append(record)
+                    except Exception as e:
+                        rolled_back_records = len(committed_candidates) + 1
+                        logger.error(
+                            "ingestion_batch_failed",
+                            records=rolled_back_records,
+                            error=str(e),
+                            raw_line=(record.raw_line or "")[:100],
+                        )
+                        batch_failed = True
+                        lost_records += rolled_back_records
+                        committed_candidates = []
+                        try:
+                            await session.rollback()
+                        except Exception as rollback_err:
+                            logger.error("Rollback failed: %s", rollback_err)
+                        self._evict_uncommitted_locations()
+                        # The failing record may have hit a poisoned cache entry
+                        # (an id cached before this service run whose row does not
+                        # exist, e.g. after a crashed commit). Uncommitted-tracking
+                        # can't see those, so drop the record's own geohash too.
+                        if record.geo_data:
+                            self._location_cache.pop(record.geo_data.geohash, None)
+
+                try:
+                    await session.commit()
+                except Exception as e:
+                    commit_lost_records = len(committed_candidates)
+                    logger.error(
+                        "ingestion_batch_failed",
+                        records=commit_lost_records,
+                        error=str(e),
+                    )
+                    batch_failed = True
+                    lost_records += commit_lost_records
+                    await session.rollback()
+                    self._evict_uncommitted_locations()
+                    # Same poisoned-entry hazard as above, but here we don't know
+                    # which record broke the commit, so evict every geohash the
+                    # batch touched so the next flush re-resolves it from the DB.
+                    for record in batch:
+                        if record.geo_data:
+                            self._location_cache.pop(record.geo_data.geohash, None)
+                else:
+                    self._uncommitted_geohashes.clear()
+                    self._publish(committed_candidates)
+        finally:
+            if batch_failed:
+                self.failed_batches += 1
+                self.failed_records += lost_records
 
         logger.debug(
             "Committed batch of %d records. (Geo: %d | Log: %d | Debug: %d)",

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -186,6 +186,13 @@ class LogIngestionService:
         self._queue: asyncio.Queue[ParsedLogRecord] | None = None
         self._tail_tasks: list[asyncio.Task[None]] = []
         self.is_running: bool = False
+        # A service can be constructed successfully while its asynchronous
+        # consumer later stops because every tailer exited or a persistence
+        # error escaped. Keep that signal separate from ``is_running`` so
+        # health can distinguish an unexpected runtime stop from a deliberate
+        # disabled/DB-degraded startup or normal teardown.
+        self.unexpected_stop: bool = False
+        self.start_failure: str | None = None
 
         # Statistics
         self.total_processed: int = 0
@@ -213,8 +220,11 @@ class LogIngestionService:
             return
 
         self._skip_validation = skip_validation
+        self.unexpected_stop = False
+        self.start_failure = None
 
         if not (reader := create_reader(self.geoip_path, self.locales)):
+            self.start_failure = "geoip"
             logger.error(
                 "Cannot start ingestion: failed to create GeoIP2 reader with database at %s",
                 self.geoip_path,
@@ -462,6 +472,11 @@ class LogIngestionService:
                     await self._flush_batch()
                 except Exception as e:
                     logger.exception("Final flush failed: %s", e)
+            # ``stop()`` sets the event before waiting for this task. If the
+            # consumer reaches this point without that signal, the service
+            # died on its own and health should expose an operator advisory.
+            if not self._stop_event.is_set():
+                self.unexpected_stop = True
             self.is_running = False
 
     async def _process_record(self, record: ParsedLogRecord, repos: IngestionRepos, flushed: dict[str, int]) -> None:

--- a/geometrikks/services/ingestion/service.py
+++ b/geometrikks/services/ingestion/service.py
@@ -408,10 +408,17 @@ class LogIngestionService:
         a replaced database file."""
         if not self._reloads_enabled:
             return
-        await self.stop()
-        if not self._reloads_enabled:  # shutdown began while draining
-            return
-        await self.start(skip_validation=self._skip_validation)
+        try:
+            await self.stop()
+            if not self._reloads_enabled:  # shutdown began while draining
+                return
+            await self.start(skip_validation=self._skip_validation)
+        except (Exception, asyncio.CancelledError):
+            # Reload stops the consumer intentionally, but a failed reload can
+            # leave ingestion stopped for the rest of this process's lifetime.
+            if self._reloads_enabled and not self.is_running:
+                self.unexpected_stop = True
+            raise
         if self._reader is not None:  # start() logs its own failure path
             logger.info(
                 "geoip_readers_reloaded",

--- a/geometrikks/services/logparser/logparser.py
+++ b/geometrikks/services/logparser/logparser.py
@@ -174,8 +174,8 @@ class LogParser:
         self.skipped_lines: int = 0
         self.ignored_lines: int = 0
 
-        # True while the tailed file is missing mid-flight (deleted/moved);
-        # surfaced through LogIngestionService.missing_files into /health.
+        # True while the configured file is absent. This is surfaced through
+        # LogIngestionService.missing_files into /health.
         self.file_missing: bool = False
 
         # Stop event for graceful shutdown (set by ingestion service)
@@ -191,8 +191,22 @@ class LogParser:
         """Set the stop event for graceful shutdown."""
         self._stop_event = event
 
+    def mark_missing(self) -> None:
+        """Flag the file as absent and expose it through health status."""
+        if not self.file_missing:
+            logger.error(
+                "Log file does not exist: %s - waiting for it to appear", self.log_path
+            )
+            self.file_missing = True
+
+    def mark_present(self) -> None:
+        """Clear the missing flag, logging the recovery once."""
+        if self.file_missing:
+            logger.info("Log file reappeared, resuming tail: %s", self.log_path)
+            self.file_missing = False
+
     def _mark_file_missing(self, err: OSError) -> None:
-        """Record (and log exactly once) that the tailed file disappeared."""
+        """Record a mid-flight absence with the operating system error."""
         if not self.file_missing:
             logger.error(
                 "Log file no longer exists or cannot be read: %s - "
@@ -203,10 +217,7 @@ class LogParser:
             self.file_missing = True
 
     def _mark_file_present(self) -> None:
-        """Clear the missing flag, logging the recovery once."""
-        if self.file_missing:
-            logger.info("Log file reappeared, resuming tail: %s", self.log_path)
-            self.file_missing = False
+        self.mark_present()
 
     def parsed_lines_count(self) -> int:
         """Return the number of parsed lines."""

--- a/resources/components/access-logs/live-tail.tsx
+++ b/resources/components/access-logs/live-tail.tsx
@@ -10,7 +10,7 @@ import { Pause, Play } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { useMediaQuery } from "@/hooks/use-media-query"
-import { useLiveEvents } from "@/lib/live-feed-context"
+import { useLiveEvents, useLiveFeedStatus } from "@/lib/live-feed-context"
 import { formatBytes } from "@/lib/api"
 import { statusBadgeClass } from "@/lib/status-badge"
 import { formatDurationOrNa } from "@/lib/timing"
@@ -36,6 +36,7 @@ export function LiveTail({ enabled }: { enabled: boolean }) {
   const pausedBufferRef = useRef<AccessLogData[]>([])
   const [pausedCount, setPausedCount] = useState(0)
   const parentRef = useRef<HTMLDivElement>(null)
+  const feedStatus = useLiveFeedStatus()
 
   useLiveEvents((events, droppedCount) => {
     const logs = events.flatMap((e) => (e.log ? [e.log] : []))
@@ -70,11 +71,13 @@ export function LiveTail({ enabled }: { enabled: boolean }) {
     <div className="rounded-md border">
       <div className="flex items-center justify-between gap-2 px-3 py-1.5 text-xs text-muted-foreground border-b">
         <span>
-          {paused
-            ? manuallyPaused
-              ? "Paused"
-              : "Paused (pointer over list)"
-            : "Streaming"}
+          {feedStatus === "unavailable"
+            ? "Live feed paused"
+            : paused
+              ? manuallyPaused
+                ? "Paused"
+                : "Paused (pointer over list)"
+              : "Streaming"}
           {" - "}
           {rows.length} rows
           {pausedCount > 0 && `, +${pausedCount} while paused`}

--- a/resources/components/app-sidebar.tsx
+++ b/resources/components/app-sidebar.tsx
@@ -240,7 +240,7 @@ function LiveIndicator({ collapsed }: { collapsed: boolean }) {
   const { color, label, tooltip: baseTooltip } = INDICATOR_STYLES[variant]
   const tooltip =
     variant === "degraded" || variant === "attention"
-      ? sidebarStatusTooltip(baseTooltip, health?.advisories?.length ?? 0)
+      ? sidebarStatusTooltip(baseTooltip, health?.advisories?.length ?? 0, variant)
       : baseTooltip
 
   if (collapsed) {

--- a/resources/components/app-sidebar.tsx
+++ b/resources/components/app-sidebar.tsx
@@ -43,6 +43,7 @@ import { BrandMark } from "@/components/brand/brand-mark"
 import { Wordmark } from "@/components/brand/wordmark"
 import {
   sidebarIngestionVariant,
+  sidebarStatusTooltip,
   type SidebarIngestionVariant,
 } from "@/components/settings/status-logic"
 import { useLiveFeedStatus } from "@/lib/live-feed-context"
@@ -228,6 +229,7 @@ function LiveIndicator({ collapsed }: { collapsed: boolean }) {
   const INDICATOR_STYLES: Record<SidebarIngestionVariant, { color: string; label: string; tooltip: string }> = {
     offline: { color: "bg-gray-400", label: "Offline", tooltip: "Cannot connect to backend" },
     degraded: { color: "bg-amber-400", label: "Degraded", tooltip: "Service degraded - see Settings > Status" },
+    attention: { color: "bg-amber-400", label: "Attention", tooltip: "Advisories need attention - see Settings > Status" },
     // Neutral, not amber: LOGPARSER_ENABLED=false is a deliberate setting
     // (UI-head deployments); other instances or agents write the data.
     disabled: { color: "bg-sidebar-foreground/30", label: "Ingestion off", tooltip: "Log tailing is turned off (LOGPARSER_ENABLED=false)" },
@@ -235,7 +237,11 @@ function LiveIndicator({ collapsed }: { collapsed: boolean }) {
     inactive: { color: "bg-gray-400", label: "Inactive", tooltip: "Service status unknown" },
   }
 
-  const { color, label, tooltip } = INDICATOR_STYLES[variant]
+  const { color, label, tooltip: baseTooltip } = INDICATOR_STYLES[variant]
+  const tooltip =
+    variant === "degraded" || variant === "attention"
+      ? sidebarStatusTooltip(baseTooltip, health?.advisories?.length ?? 0)
+      : baseTooltip
 
   if (collapsed) {
     return (
@@ -314,15 +320,25 @@ function LiveFeedIndicator({ collapsed }: { collapsed: boolean }) {
       ? "bg-emerald-400"
       : status === "connecting"
         ? "bg-amber-400 animate-pulse"
-        : "bg-sidebar-foreground/30"
+        : status === "unavailable"
+          ? "bg-amber-400"
+          : "bg-sidebar-foreground/30"
   const label =
-    status === "connected" ? "Live feed" : status === "connecting" ? "Connecting" : "Live feed off"
+    status === "connected"
+      ? "Live feed"
+      : status === "connecting"
+        ? "Connecting"
+        : status === "unavailable"
+          ? "Live feed paused"
+          : "Live feed off"
   const tooltip =
     status === "connected"
       ? "Live event feed connected"
       : status === "connecting"
         ? "Connecting to live event feed"
-        : "Live feed idle (no active subscribers)"
+        : status === "unavailable"
+          ? "The server is not streaming events right now. See Settings > Status."
+          : "Live feed idle (no active subscribers)"
 
   if (collapsed) {
     return (

--- a/resources/components/map/LiveSummary.tsx
+++ b/resources/components/map/LiveSummary.tsx
@@ -122,7 +122,7 @@ function Rate({ dense }: { dense: boolean }) {
           )}
         />
         <span className="text-[9px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-          {disconnected ? "Reconnecting" : "Last 5 minutes"}
+          {disconnected ? (feedState === "paused" ? "Live feed paused" : "Reconnecting") : "Last 5 minutes"}
         </span>
       </div>
 

--- a/resources/components/map/LiveVitalsPill.tsx
+++ b/resources/components/map/LiveVitalsPill.tsx
@@ -24,7 +24,9 @@ export function LiveVitalsPill({ onOpenFeed }: { onOpenFeed: () => void }) {
       onClick={onOpenFeed}
       aria-label={
         disconnected
-          ? "Live feed reconnecting. Open the live request feed"
+          ? feedState === "paused"
+            ? "Live feed paused by the server. Open the live request feed"
+            : "Live feed reconnecting. Open the live request feed"
           : `${vitals.rpm} requests per minute, ${vitals.threatCount} threats. Open the live request feed`
       }
       className={cn(
@@ -44,7 +46,9 @@ export function LiveVitalsPill({ onOpenFeed }: { onOpenFeed: () => void }) {
       />
 
       {disconnected ? (
-        <span className="text-muted-foreground">Reconnecting</span>
+        <span className="text-muted-foreground">
+          {feedState === "paused" ? "Live feed paused" : "Reconnecting"}
+        </span>
       ) : (
         <>
           <span className="flex items-baseline gap-1">

--- a/resources/components/settings/scheduler-overview.tsx
+++ b/resources/components/settings/scheduler-overview.tsx
@@ -150,7 +150,8 @@ export function SchedulerOverview() {
     return <Skeleton className="h-64 w-full" />
   }
 
-  if (!data.schedulerEnabled) {
+  if (data.status !== "running") {
+    const unavailable = data.status === "unavailable"
     return (
       <Card>
         <CardHeader>
@@ -161,13 +162,14 @@ export function SchedulerOverview() {
             <div>
               <CardTitle className="text-base">
                 <span className="inline-flex items-center gap-2">
-                  <StatusLed tone="red" />
-                  Scheduler disabled
+                  <StatusLed tone={unavailable ? "amber" : "red"} />
+                  {unavailable ? "Background jobs not started" : "Scheduler disabled"}
                 </span>
               </CardTitle>
               <CardDescription>
-                Background tasks are turned off (SCHEDULER_ENABLED=false) or the scheduler did
-                not start. Enable it and restart to see jobs here.
+                {unavailable
+                  ? "The database was unreachable when the app started. Jobs start on their own once it answers; see Settings > Status."
+                  : "Background tasks are turned off (SCHEDULER_ENABLED=false)."}
               </CardDescription>
             </div>
           </div>

--- a/resources/components/settings/status-logic.test.ts
+++ b/resources/components/settings/status-logic.test.ts
@@ -94,7 +94,7 @@ describe("ingestionState", () => {
     expect(state.label).toBe("Not running")
     expect(state.detail).toBeTruthy()
   })
-  it("is amber when running but a tailed file is missing", () => {
+  it("is amber when a configured log file is missing", () => {
     const state = ingestionState(
       makeHealth({
         ingestion: {
@@ -109,7 +109,9 @@ describe("ingestionState", () => {
     )
     expect(state.tone).toBe("amber")
     expect(state.label).toBe("Running, log file missing")
-    expect(state.detail).toBeTruthy()
+    expect(state.detail).toBe(
+      "A configured log file is missing. Ingestion is waiting for it to appear.",
+    )
   })
   it("is muted when health failed or is loading", () => {
     expect(ingestionState(undefined, true).tone).toBe("muted")

--- a/resources/components/settings/status-logic.test.ts
+++ b/resources/components/settings/status-logic.test.ts
@@ -27,6 +27,7 @@ import {
   relativeTime,
   schedulerJobState,
   sidebarIngestionVariant,
+  sidebarStatusTooltip,
   siteHomeRows,
 } from "./status-logic"
 
@@ -159,6 +160,34 @@ describe("sidebarIngestionVariant", () => {
   })
   it("is inactive while health is still loading", () => {
     expect(sidebarIngestionVariant(undefined, false)).toBe("inactive")
+  })
+
+  it("is attention when healthy but an advisory is open", () => {
+    const health = makeHealth({
+      ingestion: disabledIngestion,
+      advisories: [{ id: "x", severity: "warning", summary: "x" }],
+    })
+    expect(sidebarIngestionVariant(health, false)).toBe("attention")
+  })
+
+  it("degraded still wins over attention", () => {
+    const health = makeHealth({
+      status: "degraded",
+      advisories: [{ id: "x", severity: "critical", summary: "x" }],
+    })
+    expect(sidebarIngestionVariant(health, false)).toBe("degraded")
+  })
+})
+
+describe("sidebarStatusTooltip", () => {
+  it("keeps the base text and appends the advisory count", () => {
+    expect(sidebarStatusTooltip("base", 0)).toBe("base")
+    expect(sidebarStatusTooltip("Service degraded - see Settings > Status", 1)).toBe(
+      "Service degraded - see Settings > Status. 1 advisory needs attention.",
+    )
+    expect(sidebarStatusTooltip("base.", 3)).toBe(
+      "base. 3 advisories need attention. See Settings > Status.",
+    )
   })
 })
 
@@ -349,6 +378,12 @@ describe("liveFeedState", () => {
     expect(down.tone).toBe("amber")
     expect(down.label).toBe("Not connected")
     expect(down.detail).toBeTruthy()
+  })
+
+  it("shows a server pause as an amber unavailable state", () => {
+    const paused = liveFeedState("unavailable")
+    expect(paused.tone).toBe("amber")
+    expect(paused.label).toBe("Paused by server")
   })
 })
 

--- a/resources/components/settings/status-logic.test.ts
+++ b/resources/components/settings/status-logic.test.ts
@@ -183,13 +183,23 @@ describe("sidebarIngestionVariant", () => {
 
 describe("sidebarStatusTooltip", () => {
   it("keeps the base text and appends the advisory count", () => {
-    expect(sidebarStatusTooltip("base", 0)).toBe("base")
-    expect(sidebarStatusTooltip("Service degraded - see Settings > Status", 1)).toBe(
-      "Service degraded - see Settings > Status. 1 advisory needs attention.",
-    )
-    expect(sidebarStatusTooltip("base.", 3)).toBe(
+    expect(sidebarStatusTooltip("base", 0, "degraded")).toBe("base")
+    expect(
+      sidebarStatusTooltip("Service degraded - see Settings > Status", 1, "degraded"),
+    ).toBe("Service degraded - see Settings > Status. 1 advisory needs attention.")
+    expect(sidebarStatusTooltip("base.", 3, "degraded")).toBe(
       "base. 3 advisories need attention. See Settings > Status.",
     )
+  })
+
+  it("counts the actual attention tooltip without repeating its message", () => {
+    expect(
+      sidebarStatusTooltip(
+        "Advisories need attention - see Settings > Status",
+        2,
+        "attention",
+      ),
+    ).toBe("2 advisories need attention. See Settings > Status.")
   })
 })
 

--- a/resources/components/settings/status-logic.test.ts
+++ b/resources/components/settings/status-logic.test.ts
@@ -168,7 +168,15 @@ describe("databaseState / geoipState", () => {
       tone: "red",
       label: "Unreachable",
     })
-    expect(databaseState(makeHealth())).toMatchObject({ tone: "emerald", label: "Reachable" })
+    expect(databaseState(makeHealth())).toMatchObject({ tone: "emerald", label: "Connected" })
+  })
+  it("database reachable but services paused is amber", () => {
+    const state = databaseState(
+      makeHealth({ database: { reachable: true, servicesActive: false } }),
+    )
+    expect(state.tone).toBe("amber")
+    expect(state.label).toBe("Reachable, services paused")
+    expect(state.detail).toContain("recovery")
   })
   it("geoip missing is amber", () => {
     expect(geoipState(makeHealth({ geoip: { available: false, dbBuildDate: null, asnAvailable: false, asnDbBuildDate: null } }))).toMatchObject({

--- a/resources/components/settings/status-logic.ts
+++ b/resources/components/settings/status-logic.ts
@@ -102,12 +102,20 @@ export function sidebarIngestionVariant(
   return "inactive"
 }
 
-export function sidebarStatusTooltip(base: string, advisoryCount: number): string {
+export function sidebarStatusTooltip(
+  base: string,
+  advisoryCount: number,
+  variant: "degraded" | "attention",
+): string {
   if (advisoryCount === 0) return base
-  const separator = /[.!?]$/.test(base) ? " " : ". "
   const noun = advisoryCount === 1 ? "advisory needs" : "advisories need"
+  const countedAdvisories = `${advisoryCount} ${noun} attention.`
+  if (variant === "attention") {
+    return `${countedAdvisories} See Settings > Status.`
+  }
+  const separator = /[.!?]$/.test(base) ? " " : ". "
   const statusLink = base.includes("Settings > Status") ? "" : " See Settings > Status."
-  return `${base}${separator}${advisoryCount} ${noun} attention.${statusLink}`
+  return `${base}${separator}${countedAdvisories}${statusLink}`
 }
 
 export function databaseState(health: HealthResponse | undefined): CardState {

--- a/resources/components/settings/status-logic.ts
+++ b/resources/components/settings/status-logic.ts
@@ -72,7 +72,7 @@ export function ingestionState(health: HealthResponse | undefined, isError: bool
     return {
       tone: "amber",
       label: "Running, log file missing",
-      detail: "A tailed log file has disappeared. Ingestion is waiting for it to reappear.",
+      detail: "A configured log file is missing. Ingestion is waiting for it to appear.",
     }
   }
   return { tone: "emerald", label: "Running" }

--- a/resources/components/settings/status-logic.ts
+++ b/resources/components/settings/status-logic.ts
@@ -78,11 +78,17 @@ export function ingestionState(health: HealthResponse | undefined, isError: bool
   return { tone: "emerald", label: "Running" }
 }
 
-export type SidebarIngestionVariant = "offline" | "degraded" | "disabled" | "running" | "inactive"
+export type SidebarIngestionVariant =
+  | "offline"
+  | "degraded"
+  | "attention"
+  | "disabled"
+  | "running"
+  | "inactive"
 
 /** Semantics of the sidebar's ingestion-health dot; the component maps the
- *  variant to colors/labels. Degraded wins over running: the backend can
- *  report running=true while a tailed log file is missing. */
+ * variant to colors/labels. Degraded wins over advisories, which win over the
+ * configured-off state. */
 export function sidebarIngestionVariant(
   health: HealthResponse | undefined,
   isError: boolean,
@@ -90,9 +96,18 @@ export function sidebarIngestionVariant(
   if (isError) return "offline"
   if (!health) return "inactive"
   if (health.status === "degraded") return "degraded"
+  if ((health.advisories ?? []).length > 0) return "attention"
   if (health.ingestion.status === "disabled") return "disabled"
   if (health.ingestion.running) return "running"
   return "inactive"
+}
+
+export function sidebarStatusTooltip(base: string, advisoryCount: number): string {
+  if (advisoryCount === 0) return base
+  const separator = /[.!?]$/.test(base) ? " " : ". "
+  const noun = advisoryCount === 1 ? "advisory needs" : "advisories need"
+  const statusLink = base.includes("Settings > Status") ? "" : " See Settings > Status."
+  return `${base}${separator}${advisoryCount} ${noun} attention.${statusLink}`
 }
 
 export function databaseState(health: HealthResponse | undefined): CardState {
@@ -294,6 +309,14 @@ export function filterErrorRecords(
 export function liveFeedState(status: LiveFeedStatus): CardState {
   if (status === "connected") return { tone: "emerald", label: "Connected" }
   if (status === "connecting") return { tone: "amber", label: "Connecting" }
+  if (status === "unavailable") {
+    return {
+      tone: "amber",
+      label: "Paused by server",
+      detail:
+        "The server accepted the connection and closed it because the database or ingestion is not available. It reconnects on its own.",
+    }
+  }
   return {
     tone: "amber",
     label: "Not connected",

--- a/resources/components/settings/status-logic.ts
+++ b/resources/components/settings/status-logic.ts
@@ -97,9 +97,17 @@ export function sidebarIngestionVariant(
 
 export function databaseState(health: HealthResponse | undefined): CardState {
   if (!health) return { tone: "muted", label: "Unknown" }
-  return health.database.reachable
-    ? { tone: "emerald", label: "Reachable" }
-    : { tone: "red", label: "Unreachable", detail: "Running in degraded mode without a database." }
+  if (!health.database.reachable) {
+    return { tone: "red", label: "Unreachable", detail: "Running in degraded mode without a database." }
+  }
+  if (health.database.servicesActive === false) {
+    return {
+      tone: "amber",
+      label: "Reachable, services paused",
+      detail: "Background jobs and ingestion are waiting for recovery. See the advisory above.",
+    }
+  }
+  return { tone: "emerald", label: "Connected" }
 }
 
 export function geoipState(health: HealthResponse | undefined): CardState {

--- a/resources/components/settings/status-overview.tsx
+++ b/resources/components/settings/status-overview.tsx
@@ -426,6 +426,9 @@ export function StatusOverview() {
           </CardHeader>
           <CardContent className="space-y-2">
             <StateLine state={crowdsecState(crowdsec, crowdsecError)} />
+            {crowdsec?.enabled && !crowdsec.liveUpdates && (
+              <p className="text-xs text-muted-foreground">Live updates paused</p>
+            )}
             <div className="flex items-center gap-2">
               {crowdsec?.enabled && (
                 <Badge variant="outline">

--- a/resources/components/settings/status-overview.tsx
+++ b/resources/components/settings/status-overview.tsx
@@ -288,6 +288,12 @@ export function StatusOverview() {
                 <Counter label="Skipped lines" value={stats?.totalSkippedLines} />
                 <Counter label="Ignored lines" value={stats?.totalIgnoredLines} />
                 <Counter label="Pending records" value={stats?.totalPendingRecords} />
+                {(health?.ingestion.failedBatches ?? 0) > 0 && (
+                  <Counter label="Failed batches" value={health?.ingestion.failedBatches} />
+                )}
+                {(health?.ingestion.failedRecords ?? 0) > 0 && (
+                  <Counter label="Dropped records" value={health?.ingestion.failedRecords} />
+                )}
               </div>
             )}
             {health && (

--- a/resources/generated/api/schemas.gen.ts
+++ b/resources/generated/api/schemas.gen.ts
@@ -1866,6 +1866,14 @@ export const HypertableStatsViewSchema = {
 
 export const IngestionHealthSchema = {
   properties: {
+    failedBatches: {
+      default: 0,
+      type: "integer",
+    },
+    failedRecords: {
+      default: 0,
+      type: "integer",
+    },
     lastRecordAt: {
       oneOf: [
         {

--- a/resources/generated/api/schemas.gen.ts
+++ b/resources/generated/api/schemas.gen.ts
@@ -742,6 +742,10 @@ export const CrowdSecStatusResponseSchema = {
     lapiReachable: {
       type: "boolean",
     },
+    liveUpdates: {
+      default: false,
+      type: "boolean",
+    },
     writeEnabled: {
       type: "boolean",
     },
@@ -3241,6 +3245,11 @@ export const SchedulerJobsResponseSchema = {
     },
     schedulerRunning: {
       type: "boolean",
+    },
+    status: {
+      default: "running",
+      enum: ["running", "disabled", "unavailable"],
+      type: "string",
     },
   },
   required: ["jobs", "schedulerEnabled", "schedulerRunning"],

--- a/resources/generated/api/schemas.gen.ts
+++ b/resources/generated/api/schemas.gen.ts
@@ -804,6 +804,10 @@ export const DatabaseHealthSchema = {
     reachable: {
       type: "boolean",
     },
+    servicesActive: {
+      default: true,
+      type: "boolean",
+    },
   },
   required: ["reachable"],
   title: "DatabaseHealth",

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -560,6 +560,8 @@ export type HypertableStatsView = {
  * IngestionHealth
  */
 export type IngestionHealth = {
+  failedBatches?: number;
+  failedRecords?: number;
   lastRecordAt: string | null;
   missingFiles: Array<string>;
   parsedLines: number;

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -259,6 +259,7 @@ export type CumulativeTimeSeriesResponse = {
  */
 export type DatabaseHealth = {
   reachable: boolean;
+  servicesActive?: boolean;
 };
 
 /**

--- a/resources/generated/api/types.gen.ts
+++ b/resources/generated/api/types.gen.ts
@@ -231,6 +231,7 @@ export type CrowdSecStatsResponse = {
 export type CrowdSecStatusResponse = {
   enabled: boolean;
   lapiReachable: boolean;
+  liveUpdates?: boolean;
   writeEnabled: boolean;
 };
 
@@ -937,6 +938,7 @@ export type SchedulerJobsResponse = {
   jobs: Array<SchedulerJobView>;
   schedulerEnabled: boolean;
   schedulerRunning: boolean;
+  status?: "running" | "disabled" | "unavailable";
 };
 
 /**

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -863,6 +863,10 @@
         "properties": {
           "reachable": {
             "type": "boolean"
+          },
+          "servicesActive": {
+            "default": true,
+            "type": "boolean"
           }
         },
         "required": [

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -1978,6 +1978,14 @@
       },
       "IngestionHealth": {
         "properties": {
+          "failedBatches": {
+            "default": 0,
+            "type": "integer"
+          },
+          "failedRecords": {
+            "default": 0,
+            "type": "integer"
+          },
           "lastRecordAt": {
             "oneOf": [
               {

--- a/resources/generated/openapi.json
+++ b/resources/generated/openapi.json
@@ -797,6 +797,10 @@
           "lapiReachable": {
             "type": "boolean"
           },
+          "liveUpdates": {
+            "default": false,
+            "type": "boolean"
+          },
           "writeEnabled": {
             "type": "boolean"
           }
@@ -3432,6 +3436,15 @@
           },
           "schedulerRunning": {
             "type": "boolean"
+          },
+          "status": {
+            "default": "running",
+            "enum": [
+              "running",
+              "disabled",
+              "unavailable"
+            ],
+            "type": "string"
           }
         },
         "required": [

--- a/resources/lib/api.ts
+++ b/resources/lib/api.ts
@@ -131,7 +131,9 @@ export interface HealthResponse {
   /** App start time; null in test harnesses without lifecycle startup. */
   startedAt: string | null
   ingestion: HealthIngestionStatus
-  database: { reachable: boolean }
+  /** servicesActive is false while the backend runs DB-degraded: the database
+   *  may answer while the scheduler, ingestion and live feeds are paused. */
+  database: { reachable: boolean; servicesActive?: boolean }
   /** Build dates come from the mmdb metadata, one per GeoLite2 edition. */
   geoip: {
     available: boolean

--- a/resources/lib/api.ts
+++ b/resources/lib/api.ts
@@ -114,6 +114,8 @@ export interface HealthIngestionStatus {
   /** Tri-state: "disabled" is a deliberate LOGPARSER_ENABLED=false setting,
    *  not a fault. Optional: absent on pre-tri-state backends. */
   status?: "running" | "degraded" | "disabled"
+  failedBatches?: number
+  failedRecords?: number
 }
 
 export interface Advisory {

--- a/resources/lib/live-traffic/context.tsx
+++ b/resources/lib/live-traffic/context.tsx
@@ -21,7 +21,7 @@ import type { LiveRequest, Vitals } from "./types"
  * feeding this" rather than "the socket is open" - the distinction the
  * disconnected states downstream (the rail and the pill) depend on.
  */
-export type LiveFeedState = "connected" | "reconnecting"
+export type LiveFeedState = "connected" | "reconnecting" | "paused"
 
 const EMPTY_VITALS: Vitals = {
   rpm: 0,
@@ -58,7 +58,11 @@ export function LiveTrafficProvider({
   // Demo mode is a feed in its own right: it never opens the socket, so the
   // socket's status alone would read as permanently disconnected.
   const feedState: LiveFeedState =
-    demoMode !== "off" || socketStatus === "connected" ? "connected" : "reconnecting"
+    demoMode !== "off" || socketStatus === "connected"
+      ? "connected"
+      : socketStatus === "unavailable"
+        ? "paused"
+        : "reconnecting"
 
   // Read through a ref so a changed selection does not resubscribe the socket;
   // the reset effect below is what actually applies a new filter to the window.

--- a/resources/lib/queries-crowdsec-live.test.ts
+++ b/resources/lib/queries-crowdsec-live.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { CLOSE_TRY_AGAIN_LATER } from "./websocket"
+
+const mocks = vi.hoisted(() => ({
+  cleanup: undefined as (() => void) | undefined,
+  queryClient: {
+    getQueryData: vi.fn(),
+    setQueryData: vi.fn(),
+    invalidateQueries: vi.fn(),
+  },
+}))
+
+vi.mock("react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react")>()),
+  useEffect: (effect: () => void | (() => void)) => {
+    mocks.cleanup = effect() ?? undefined
+  },
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: vi.fn(),
+  useQuery: () => ({ data: { enabled: true } }),
+  useQueryClient: () => mocks.queryClient,
+}))
+
+import { useCrowdsecLiveUpdates } from "./queries"
+
+class FakeSocket {
+  static instances: FakeSocket[] = []
+  onmessage: ((msg: { data: unknown }) => void) | null = null
+  onclose: ((event: { code: number }) => void) | null = null
+
+  constructor(public url: string) {
+    FakeSocket.instances.push(this)
+  }
+
+  close(): void {
+    this.onclose?.({ code: 1000 })
+  }
+}
+
+describe("useCrowdsecLiveUpdates close handling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    FakeSocket.instances = []
+    mocks.cleanup = undefined
+    vi.stubGlobal("WebSocket", FakeSocket)
+    vi.stubGlobal("window", {
+      location: { protocol: "http:", host: "localhost" },
+    })
+  })
+
+  afterEach(() => {
+    mocks.cleanup?.()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it("retries a 1013 close at the 30s cap", () => {
+    useCrowdsecLiveUpdates()
+
+    FakeSocket.instances[0].onclose?.({ code: CLOSE_TRY_AGAIN_LATER })
+    vi.advanceTimersByTime(29_000)
+    expect(FakeSocket.instances).toHaveLength(1)
+    vi.advanceTimersByTime(1_000)
+    expect(FakeSocket.instances).toHaveLength(2)
+  })
+})

--- a/resources/lib/queries.ts
+++ b/resources/lib/queries.ts
@@ -85,6 +85,7 @@ import { useTimeRange } from "./time-range-context"
 import { currentBuildKey, hasUnseenChanges, saveSeenBuild, useSeenBuild } from "./changelog-seen"
 import { useAnalyticsFilters } from "./analytics-filters-context"
 import { useGeoLogFilters } from "./geo-log-filters-context"
+import { CLOSE_TRY_AGAIN_LATER } from "./websocket"
 
 // ============================================================================
 // Query Keys
@@ -477,8 +478,9 @@ export function useCrowdsecLiveUpdates() {
           (ips) => applyBannedIpsDelta(ips, frame),
         )
       }
-      ws.onclose = () => {
+      ws.onclose = (event) => {
         if (closed) return
+        if (event.code === CLOSE_TRY_AGAIN_LATER) retryMs = 30_000
         timer = setTimeout(connect, retryMs)
         retryMs = Math.min(retryMs * 2, 30_000)
       }
@@ -729,7 +731,7 @@ export function useCumulativeTimeSeries(options: UseCumulativeTimeSeriesOptions 
 
 // ============================================================================
 // Analytics page hooks (generated-SDK fetchers; types infer from the fetcher
-// so the generated shapes — percentiles, unique_cities — flow to the charts)
+// so the generated shapes, including percentiles and unique_cities, flow to the charts)
 // ============================================================================
 
 export interface UseAnalyticsQueryOptions {

--- a/resources/lib/websocket.test.ts
+++ b/resources/lib/websocket.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { CLOSE_TRY_AGAIN_LATER, LiveFeedClient, type LiveFeedStatus } from "./websocket"
+
+class FakeSocket {
+  static instances: FakeSocket[] = []
+  onopen: (() => void) | null = null
+  onmessage: ((msg: { data: unknown }) => void) | null = null
+  onclose: ((event: { code: number }) => void) | null = null
+  onerror: (() => void) | null = null
+
+  constructor(public url: string) {
+    FakeSocket.instances.push(this)
+  }
+
+  close(): void {
+    this.onclose?.({ code: 1000 })
+  }
+}
+
+describe("LiveFeedClient close handling", () => {
+  let clients: LiveFeedClient[]
+  let statuses: LiveFeedStatus[]
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    FakeSocket.instances = []
+    vi.stubGlobal("WebSocket", FakeSocket)
+    vi.stubGlobal("window", {
+      location: { protocol: "http:", host: "localhost" },
+    })
+    clients = []
+    statuses = []
+  })
+
+  afterEach(() => {
+    clients.forEach((client) => client.disconnect())
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  function makeClient(): LiveFeedClient {
+    const client = new LiveFeedClient()
+    clients.push(client)
+    client.onStatus((status) => statuses.push(status))
+    client.onEvents(() => {})
+    return client
+  }
+
+  it("reads a 1013 close as unavailable and retries at the 30s cap", () => {
+    makeClient()
+
+    const first = FakeSocket.instances[0]
+    first.onopen?.()
+    first.onclose?.({ code: CLOSE_TRY_AGAIN_LATER })
+    expect(statuses.at(-1)).toBe("unavailable")
+
+    vi.advanceTimersByTime(29_000)
+    expect(FakeSocket.instances).toHaveLength(1)
+    vi.advanceTimersByTime(1_000)
+    expect(FakeSocket.instances).toHaveLength(2)
+    FakeSocket.instances[1].onopen?.()
+    expect(statuses.at(-1)).toBe("unavailable")
+  })
+
+  it("returns to connected on the first valid frame after a pause", () => {
+    makeClient()
+
+    const first = FakeSocket.instances[0]
+    first.onclose?.({ code: CLOSE_TRY_AGAIN_LATER })
+    vi.advanceTimersByTime(30_000)
+    const second = FakeSocket.instances[1]
+    second.onopen?.()
+    second.onmessage?.({
+      data: JSON.stringify({ type: "batch", events: [], dropped: 0 }),
+    })
+
+    expect(statuses.at(-1)).toBe("connected")
+  })
+
+  it("keeps exponential backoff for ordinary closes", () => {
+    makeClient()
+
+    FakeSocket.instances[0].onclose?.({ code: 1006 })
+    expect(statuses.at(-1)).toBe("disconnected")
+    vi.advanceTimersByTime(999)
+    expect(FakeSocket.instances).toHaveLength(1)
+    vi.advanceTimersByTime(1)
+    expect(FakeSocket.instances).toHaveLength(2)
+  })
+
+  it("ignores a superseded socket close", () => {
+    const client = makeClient()
+    const first = FakeSocket.instances[0]
+
+    client.disconnect()
+    client.connect()
+    first.onclose?.({ code: CLOSE_TRY_AGAIN_LATER })
+
+    expect(statuses.at(-1)).toBe("connecting")
+    vi.advanceTimersByTime(30_000)
+    expect(FakeSocket.instances).toHaveLength(2)
+  })
+})

--- a/resources/lib/websocket.ts
+++ b/resources/lib/websocket.ts
@@ -53,7 +53,12 @@ interface BatchFrame {
   dropped: number
 }
 
-export type LiveFeedStatus = "connecting" | "connected" | "disconnected"
+export type LiveFeedStatus = "connecting" | "connected" | "disconnected" | "unavailable"
+
+/** RFC 6455 "try again later": the server accepted the socket and closed it
+ * because the service behind it is paused. */
+export const CLOSE_TRY_AGAIN_LATER = 1013
+const MAX_BACKOFF_MS = 30_000
 
 type EventsListener = (events: LiveEvent[], dropped: number) => void
 type StatusListener = (status: LiveFeedStatus) => void
@@ -66,6 +71,7 @@ export class LiveFeedClient {
   private backoffMs = 1000
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private shouldRun = false
+  private paused = false
 
   private url(): string {
     const proto = window.location.protocol === "https:" ? "wss:" : "ws:"
@@ -98,11 +104,12 @@ export class LiveFeedClient {
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer)
     this.ws?.close()
     this.ws = null
+    this.paused = false
     this.setStatus("disconnected")
   }
 
   private open(): void {
-    this.setStatus("connecting")
+    if (!this.paused) this.setStatus("connecting")
     // Every callback checks `this.ws === ws` so a superseded socket (closed
     // by disconnect() while its close handshake was still in flight) can
     // neither deliver frames nor schedule a reconnect. Without the guard, a
@@ -111,7 +118,7 @@ export class LiveFeedClient {
     const ws = new WebSocket(this.url())
     this.ws = ws
     ws.onopen = () => {
-      if (this.ws === ws) this.setStatus("connected")
+      if (this.ws === ws && !this.paused) this.setStatus("connected")
     }
     ws.onmessage = (msg) => {
       if (this.ws !== ws) return
@@ -127,18 +134,24 @@ export class LiveFeedClient {
       }
       if (frame.type === "batch") {
         // Reset backoff only on a valid frame, not onopen: the server accepts
-        // and immediately closes 1013 while ingestion is down, so an onopen
+        // and immediately closes 1013 while streaming is paused, so an onopen
         // reset would pin the reconnect loop at the 1s floor.
         this.backoffMs = 1000
+        if (this.paused) {
+          this.paused = false
+          this.setStatus("connected")
+        }
         this.eventsListeners.forEach((cb) => cb(frame.events, frame.dropped))
       }
     }
-    ws.onclose = () => {
+    ws.onclose = (event) => {
       if (this.ws !== ws) return
-      this.setStatus("disconnected")
+      this.paused = event.code === CLOSE_TRY_AGAIN_LATER
+      this.setStatus(this.paused ? "unavailable" : "disconnected")
       if (this.shouldRun) {
+        if (this.paused) this.backoffMs = MAX_BACKOFF_MS
         this.reconnectTimer = setTimeout(() => this.open(), this.backoffMs)
-        this.backoffMs = Math.min(this.backoffMs * 2, 30000)
+        this.backoffMs = Math.min(this.backoffMs * 2, MAX_BACKOFF_MS)
       }
     }
     ws.onerror = () => ws.close()

--- a/tests/browser/container-smoke.pw.ts
+++ b/tests/browser/container-smoke.pw.ts
@@ -90,14 +90,31 @@ test("production image serves the authenticated dashboard without browser errors
   // Wait for the dashboard to render before reloading: reloading straight
   // after the URL change races the router's post-login navigation and the
   // reload gets aborted (net::ERR_ABORTED).
-  await expect(page.getByText("Live ingestion", { exact: true })).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Summary" })).toBeVisible()
+
+  const healthResponse = await page.request.get("/health")
+  expect(healthResponse.ok()).toBe(true)
+  const health = (await healthResponse.json()) as {
+    status: string
+    advisories?: unknown[]
+    database: { reachable: boolean; servicesActive?: boolean }
+    ingestion: { running: boolean; status?: string }
+  }
+  expect(health.status).toBe("healthy")
+  expect(health.database).toMatchObject({ reachable: true, servicesActive: true })
+  expect(health.ingestion).toMatchObject({ running: true, status: "running" })
+  const expectedSidebarStatus = (health.advisories?.length ?? 0) > 0
+    ? "Attention"
+    : "Live ingestion"
+  const serviceStatus = page.getByRole("link", { name: "Service status" })
+  await expect(serviceStatus).toContainText(expectedSidebarStatus)
   // Reload to prove the session cookie survives a fresh page load. The
   // element assertions below do the waiting; "networkidle" would race the
   // dashboard's live polling.
   await page.reload()
 
-  await expect(page.getByText("Live ingestion", { exact: true })).toBeVisible()
   await expect(page.getByRole("heading", { name: "Summary" })).toBeVisible()
+  await expect(serviceStatus).toContainText(expectedSidebarStatus)
   await expect(page.getByRole("heading", { name: "Traffic Overview" })).toBeVisible()
   await expect(page.getByText("Access Log Records", { exact: true })).toBeVisible()
   await expect(page.getByText(/Failed to load analytics data/)).toHaveCount(0)

--- a/tests/integration/test_policy_sync_pg.py
+++ b/tests/integration/test_policy_sync_pg.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 import pytest
 from sqlalchemy import text
 
+from geometrikks.server import timescale
 from geometrikks.server.timescale import (
     _add_compression_policies,
     _add_refresh_policies,
@@ -75,6 +76,44 @@ async def test_changed_retention_days_update_the_existing_policies(pg_engine):
 
     assert await _drop_after(pg_engine, "access_logs") == timedelta(days=180)
     assert await _drop_after(pg_engine, "summary_hourly_stats") == timedelta(days=60)
+
+
+async def test_failed_policy_update_rolls_back_only_its_target(
+    pg_engine, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async with pg_engine.begin() as conn:
+        await _add_retention_policies(conn, **RETENTION_DEFAULTS)
+
+    original_sync = timescale._sync_policy_config
+
+    async def fail_access_logs_after_update(conn, **kwargs):
+        result = await original_sync(conn, **kwargs)
+        if kwargs["target"] == "access_logs":
+            await conn.execute(text("SELECT 1 / 0"))
+        return result
+
+    timescale._reset_policy_failures()
+    monkeypatch.setattr(timescale, "_sync_policy_config", fail_access_logs_after_update)
+    try:
+        async with pg_engine.begin() as conn:
+            await _add_retention_policies(
+                conn,
+                raw_retention_days=90,
+                debug_retention_days=10,
+                hourly_retention_days=45,
+            )
+
+        assert await _drop_after(pg_engine, "geo_events") == timedelta(days=90)
+        assert await _drop_after(pg_engine, "access_logs") == timedelta(days=180)
+        assert await _drop_after(pg_engine, "access_log_debug") == timedelta(days=10)
+        [failure] = timescale.get_policy_failures()
+        assert (failure.policy, failure.target) == ("retention", "access_logs")
+        assert "division by zero" in failure.error
+    finally:
+        monkeypatch.setattr(timescale, "_sync_policy_config", original_sync)
+        async with pg_engine.begin() as conn:
+            await _add_retention_policies(conn, **RETENTION_DEFAULTS)
+        timescale._reset_policy_failures()
 
 
 async def test_changed_refresh_interval_updates_the_existing_policies(pg_engine):

--- a/tests/test_advisories.py
+++ b/tests/test_advisories.py
@@ -1,0 +1,50 @@
+"""Advisory registry: upsert by id, clear, critical-first ordering."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from geometrikks.lib.advisories import Advisory, AdvisoryRegistry
+from geometrikks.server import runtime
+
+
+def _adv(id_: str, severity: str = "warning") -> Advisory:
+    return Advisory(id=id_, severity=cast("Any", severity), summary=f"{id_} summary")
+
+
+def test_set_then_snapshot_returns_the_advisory() -> None:
+    reg = AdvisoryRegistry()
+    reg.set(_adv("a"))
+    assert [a.id for a in reg.snapshot()] == ["a"]
+
+
+def test_set_same_id_replaces_without_duplicating() -> None:
+    reg = AdvisoryRegistry()
+    reg.set(_adv("a"))
+    reg.set(Advisory(id="a", severity="warning", summary="updated"))
+    snap = reg.snapshot()
+    assert len(snap) == 1 and snap[0].summary == "updated"
+
+
+def test_clear_returns_whether_it_was_set() -> None:
+    reg = AdvisoryRegistry()
+    reg.set(_adv("a"))
+    assert reg.clear("a") is True
+    assert reg.clear("a") is False
+    assert reg.snapshot() == []
+
+
+def test_snapshot_orders_critical_first_then_insertion() -> None:
+    reg = AdvisoryRegistry()
+    reg.set(_adv("w1"))
+    reg.set(_adv("c1", "critical"))
+    reg.set(_adv("w2"))
+    assert [a.id for a in reg.snapshot()] == ["c1", "w1", "w2"]
+
+
+def test_runtime_accessor_creates_one_registry_per_app() -> None:
+    app = SimpleNamespace(state=SimpleNamespace())
+    first = runtime.get_advisories(cast("Any", app))
+    first.set(_adv("a"))
+    assert runtime.get_advisories(cast("Any", app)) is first
+    assert [a.id for a in runtime.get_advisories(cast("Any", app)).snapshot()] == ["a"]

--- a/tests/test_channels_backend.py
+++ b/tests/test_channels_backend.py
@@ -92,6 +92,9 @@ class FakeConnection:
         for cb in list(self._listeners):
             cb(self)
 
+    def is_closed(self) -> bool:
+        return self.close_called
+
     async def close(self) -> None:
         self.close_called = True
         self._call_termination_listeners()
@@ -539,3 +542,273 @@ async def test_stale_unsubscribe_after_winning_subscribe_keeps_listening() -> No
 
     assert "live_events" in conn._listened_channels
     assert "live_events" in backend._subscribed_channels
+
+
+@pytest.fixture(autouse=True)
+async def shutdown_backends(monkeypatch):
+    backends = []
+    original_init = DegradedTolerantAsyncPgBackend.__init__
+
+    def tracked_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        backends.append(self)
+
+    monkeypatch.setattr(DegradedTolerantAsyncPgBackend, "__init__", tracked_init)
+    yield
+    for backend in backends:
+        await backend.on_shutdown()
+
+
+async def test_state_reflects_degraded_and_reconnecting() -> None:
+    conn = FakeConnection()
+
+    async def connect():
+        return conn
+
+    backend = DegradedTolerantAsyncPgBackend(make_connection=connect)
+    await backend.on_startup()
+    assert backend.state == "ok"
+    conn._call_termination_listeners()
+    assert backend.state == "reconnecting"
+
+
+async def test_degraded_state_and_recover_relistens_tracked_channels() -> None:
+    conn = FakeConnection()
+    calls = 0
+
+    async def connect():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("connection refused")
+        return conn
+
+    backend = DegradedTolerantAsyncPgBackend(make_connection=connect)
+    await backend.on_startup()
+    assert backend.state == "degraded"
+    await backend.subscribe(["live_events"])
+    queue = backend._queue
+    stream = backend.stream_events()
+    waiter = asyncio.create_task(anext(stream))
+    try:
+        await asyncio.sleep(0)
+        await backend.recover()
+        assert backend.state == "ok"
+        assert conn._listened_channels == {"live_events"}
+        assert backend._on_listener_terminated in conn._listeners
+        assert backend._queue is queue
+        backend._listener(conn, 1, "live_events", "{}")
+        assert await asyncio.wait_for(waiter, 1) == ("live_events", b"{}")
+    finally:
+        waiter.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await waiter
+        await stream.aclose()
+
+
+async def test_recover_failure_keeps_backend_degraded() -> None:
+    async def connect():
+        raise OSError("connection refused")
+
+    backend = DegradedTolerantAsyncPgBackend(make_connection=connect)
+    await backend.on_startup()
+    with pytest.raises(OSError, match="connection refused"):
+        await backend.recover()
+    assert backend.state == "degraded"
+    assert backend._reconnect_task is not None
+    assert not backend._reconnect_task.done()
+
+
+async def test_recover_is_a_no_op_when_not_degraded() -> None:
+    conn = FakeConnection()
+    calls = 0
+
+    async def connect():
+        nonlocal calls
+        calls += 1
+        return conn
+
+    backend = DegradedTolerantAsyncPgBackend(make_connection=connect)
+    await backend.on_startup()
+    await backend.recover()
+    assert backend._listener_conn is conn
+    assert calls == 1
+
+
+@pytest.mark.parametrize("explicit_failure", [False, True])
+async def test_backend_retries_without_database_recovery(explicit_failure, monkeypatch) -> None:
+    conn = FakeConnection()
+    attempts = 0
+    retry_waiting = asyncio.Event()
+    retry_allowed = asyncio.Event()
+
+    async def gated_sleep(delay):
+        retry_waiting.set()
+        await retry_allowed.wait()
+
+    async def connect():
+        nonlocal attempts
+        attempts += 1
+        if attempts <= (2 if explicit_failure else 1):
+            raise OSError("connection refused")
+        return conn
+
+    monkeypatch.setattr(asyncio, "sleep", gated_sleep)
+    backend = DegradedTolerantAsyncPgBackend(make_connection=connect)
+    await backend.on_startup()
+    await backend.subscribe(["live_events"])
+    assert backend._reconnect_task is not None
+    await asyncio.wait_for(retry_waiting.wait(), 1)
+    if explicit_failure:
+        with pytest.raises(OSError):
+            await backend.recover()
+    retry_allowed.set()
+    await asyncio.wait_for(backend._reconnect_task, 1)
+    assert backend.state == "ok"
+    assert conn._listened_channels == {"live_events"}
+
+
+class GatedListenerConnection(FakeConnection):
+    def __init__(self):
+        super().__init__()
+        self.registering = asyncio.Event()
+        self.release = asyncio.Event()
+        self.registrations = []
+
+    async def add_listener(self, channel, callback):
+        self.registrations.append(channel)
+        self.registering.set()
+        await self.release.wait()
+        await super().add_listener(channel, callback)
+
+
+async def degraded_with_candidate(candidate):
+    attempts = 0
+
+    async def connect():
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OSError("connection refused")
+        return candidate
+
+    backend = DegradedTolerantAsyncPgBackend(make_connection=connect)
+    await backend.on_startup()
+    await backend.subscribe(["existing"])
+    return backend
+
+
+async def test_concurrent_recover_and_subscribe_install_once() -> None:
+    conn = GatedListenerConnection()
+    backend = await degraded_with_candidate(conn)
+    recover = asyncio.create_task(backend.recover())
+    await asyncio.wait_for(conn.registering.wait(), 1)
+    second_recover = asyncio.create_task(backend.recover())
+    subscribe = asyncio.create_task(backend.subscribe(["late"]))
+    await asyncio.sleep(0)
+    assert not subscribe.done()
+    conn.release.set()
+    await asyncio.wait_for(asyncio.gather(recover, second_recover, subscribe), 1)
+    assert backend.state == "ok"
+    assert conn._listened_channels == {"existing", "late"}
+    assert conn.registrations == ["existing", "late"]
+    assert not conn.close_called
+
+
+@pytest.mark.parametrize("shutdown", [False, True])
+async def test_recover_cancellation_closes_unpublished_candidate(shutdown) -> None:
+    conn = GatedListenerConnection()
+    backend = await degraded_with_candidate(conn)
+    recover = asyncio.create_task(backend.recover())
+    await asyncio.wait_for(conn.registering.wait(), 1)
+    if shutdown:
+        await asyncio.wait_for(backend.on_shutdown(), 1)
+    else:
+        recover.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await recover
+    assert conn.close_called
+    assert not conn._listeners
+    assert getattr(backend, "_listener_conn", None) is not conn
+    assert backend.state == "degraded"
+    if shutdown:
+        assert backend._reconnect_task is None
+        with pytest.raises(RuntimeError, match="shutting down"):
+            await backend.recover()
+
+
+async def test_shutdown_cancels_retry_during_listener_registration(monkeypatch) -> None:
+    conn = GatedListenerConnection()
+    backend = await degraded_with_candidate(conn)
+    monkeypatch.setattr(backend, "_RECONNECT_INITIAL_DELAY", 0)
+    assert backend._reconnect_task is not None
+    retry = backend._reconnect_task
+    await asyncio.wait_for(conn.registering.wait(), 1)
+    await asyncio.wait_for(backend.on_shutdown(), 1)
+    assert retry.cancelled()
+    assert conn.close_called
+    assert not conn._listeners
+    assert getattr(backend, "_listener_conn", None) is not conn
+
+
+async def test_channels_backend_app_state_wiring() -> None:
+    from litestar import Litestar
+    from geometrikks.config.settings import Settings
+    from geometrikks.server.lifecycle import LifecyclePlugin
+    from geometrikks.server.plugins import create_channels_plugin
+    from geometrikks.server.runtime import get_channels_backend
+
+    backend = DegradedTolerantAsyncPgBackend(make_connection=lambda: None)
+    channels = create_channels_plugin(Settings(), backend)
+    app = Litestar(plugins=[channels, LifecyclePlugin(channels_backend=backend)])
+    assert get_channels_backend(app) is backend
+    assert channels._backend is backend
+    assert get_channels_backend(Litestar()) is None
+
+
+async def test_shutdown_awaits_cleanup_already_started_by_cancellation() -> None:
+    class SlowCloseConnection(GatedListenerConnection):
+        def __init__(self):
+            super().__init__()
+            self.closing = asyncio.Event()
+            self.close_allowed = asyncio.Event()
+
+        async def close(self):
+            self.closing.set()
+            await self.close_allowed.wait()
+            await super().close()
+
+    conn = SlowCloseConnection()
+    backend = await degraded_with_candidate(conn)
+    recover = asyncio.create_task(backend.recover())
+    await asyncio.wait_for(conn.registering.wait(), 1)
+    recover.cancel()
+    await asyncio.wait_for(conn.closing.wait(), 1)
+    shutdown = asyncio.create_task(backend.on_shutdown())
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    conn.close_allowed.set()
+    await asyncio.wait_for(shutdown, 1)
+    with pytest.raises(asyncio.CancelledError):
+        await recover
+    assert conn.close_called
+    assert backend._reconnect_task is None
+
+
+async def test_recover_rejects_candidate_that_dies_during_registration() -> None:
+    class DyingConnection(FakeConnection):
+        async def add_listener(self, channel, callback):
+            await super().add_listener(channel, callback)
+            self._call_termination_listeners()
+
+        def is_closed(self):
+            return True
+
+    conn = DyingConnection()
+    backend = await degraded_with_candidate(conn)
+    with pytest.raises(OSError, match="closed during registration"):
+        await backend.recover()
+    assert backend.state == "degraded"
+    assert conn.close_called
+    assert not conn._listeners
+    assert getattr(backend, "_listener_conn", None) is not conn

--- a/tests/test_city_database_advisory.py
+++ b/tests/test_city_database_advisory.py
@@ -1,0 +1,95 @@
+"""The City database failure is visible when log ingestion is enabled."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from geometrikks.config.settings import Settings
+from geometrikks.domain.system.controllers import health
+from geometrikks.lib.utils import GeoIPInfoView
+from geometrikks.server import timescale
+
+
+def _city_advisories(monkeypatch, *, available: bool, ingestion_enabled: bool):
+    monkeypatch.setattr(timescale, "_hostname_pollution", None)
+    monkeypatch.setattr(
+        health,
+        "geoip_info",
+        lambda path: GeoIPInfoView(
+            available=available,
+            db_path=str(path),
+            build_date=None,
+            age_days=None,
+        ),
+    )
+    settings = Settings()
+    settings.app.proxy_advisory = False
+    settings.logparser.enabled = ingestion_enabled
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            geoip_available=available,
+            asn_available=False,
+        )
+    )
+    return health._collect_advisories(cast("Any", app), settings)
+
+
+def test_missing_city_database_emits_advisory_when_ingestion_is_enabled(monkeypatch):
+    advisories = _city_advisories(
+        monkeypatch,
+        available=False,
+        ingestion_enabled=True,
+    )
+
+    [advisory] = [item for item in advisories if item.id == "geoip-database-missing"]
+    assert advisory.severity == "warning"
+    assert "City" in advisory.summary
+    assert "MAXMINDDB_USER_ID" in (advisory.remedy or "")
+    assert "MAXMINDDB_LICENSE_KEY" in (advisory.remedy or "")
+
+
+def test_city_database_advisory_is_absent_when_database_is_available(monkeypatch):
+    advisories = _city_advisories(
+        monkeypatch,
+        available=True,
+        ingestion_enabled=True,
+    )
+
+    assert all(item.id != "geoip-database-missing" for item in advisories)
+
+
+def test_city_database_advisory_is_absent_when_ingestion_is_disabled(monkeypatch):
+    advisories = _city_advisories(
+        monkeypatch,
+        available=False,
+        ingestion_enabled=False,
+    )
+
+    assert all(item.id != "geoip-database-missing" for item in advisories)
+
+
+def test_city_database_advisory_is_distinct_from_stale_database(monkeypatch):
+    """A usable but old file keeps the stale advisory path instead."""
+    monkeypatch.setattr(timescale, "_hostname_pollution", None)
+    monkeypatch.setattr(
+        health,
+        "geoip_info",
+        lambda path: GeoIPInfoView(
+            available=True,
+            db_path=str(path),
+            build_date=None,
+            age_days=31,
+        ),
+    )
+    monkeypatch.setattr(health, "has_credentials", lambda settings: False)
+    settings = Settings()
+    settings.app.proxy_advisory = False
+    settings.logparser.enabled = True
+    app = SimpleNamespace(
+        state=SimpleNamespace(geoip_available=True, asn_available=False)
+    )
+
+    advisories = health._collect_advisories(cast("Any", app), settings)
+    ids = [item.id for item in advisories]
+    assert "geoip-database-stale" in ids
+    assert "geoip-database-missing" not in ids

--- a/tests/test_crowdsec_controller.py
+++ b/tests/test_crowdsec_controller.py
@@ -97,6 +97,7 @@ async def test_status_disabled():
         "enabled": False,
         "writeEnabled": False,
         "lapiReachable": False,
+        "liveUpdates": False,
     }
 
 
@@ -111,6 +112,7 @@ async def test_status_enabled_read_only(monkeypatch, tmp_path):
         "enabled": True,
         "writeEnabled": False,
         "lapiReachable": True,
+        "liveUpdates": False,
     }
 
 

--- a/tests/test_crowdsec_lifecycle.py
+++ b/tests/test_crowdsec_lifecycle.py
@@ -131,3 +131,26 @@ async def test_startup_creates_stream_poller_when_enabled(monkeypatch):
             create_scheduler_mock.await_args.kwargs["crowdsec_poller"]
             is app.state.crowdsec_stream_poller
         )
+
+
+async def test_scheduler_disabled_keeps_service_without_stream_poller(monkeypatch):
+    from geometrikks.server import lifecycle as lc
+
+    monkeypatch.setenv("CROWDSEC_LAPI_URL", "http://crowdsec:8080")
+    monkeypatch.setenv("CROWDSEC_BOUNCER_API_KEY", "key")
+    monkeypatch.setenv("SCHEDULER_ENABLED", "false")
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=True, ensure=AsyncMock(return_value=True)
+    )
+    poller_factory = MagicMock()
+    monkeypatch.setattr(lc, "CrowdSecStreamPoller", poller_factory)
+
+    app = make_app()
+    async with enter_lifespan(app):
+        assert isinstance(app.state.crowdsec_service, CrowdSecService)
+        assert app.state.crowdsec_stream_poller is None
+        create_scheduler_mock = cast("AsyncMock", lc.create_scheduler)
+        assert create_scheduler_mock.await_args is not None
+        assert create_scheduler_mock.await_args.kwargs["crowdsec_poller"] is None
+
+    poller_factory.assert_not_called()

--- a/tests/test_crowdsec_status.py
+++ b/tests/test_crowdsec_status.py
@@ -1,0 +1,55 @@
+"""/crowdsec/status must say whether live updates (the poller) are running."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from litestar import Litestar
+from litestar.di import Provide
+from litestar.testing import AsyncTestClient
+
+from geometrikks.domain.security.controllers import CrowdSecController
+from geometrikks.server.routes import create_api_v1_router
+from geometrikks.services.crowdsec import CrowdSecService
+from tests.support import ambient_settings_dependency
+
+pytestmark = pytest.mark.anyio
+
+
+class StubCrowdSecService(CrowdSecService):
+    def __init__(self) -> None:
+        pass
+
+    async def ping(self) -> bool:
+        return True
+
+
+def make_app(*, with_poller: bool) -> Litestar:
+    async def startup(app: Litestar) -> None:
+        app.state.crowdsec_service = StubCrowdSecService()
+        poller = MagicMock(lapi_reachable=True) if with_poller else None
+        app.state.crowdsec_stream_poller = poller
+
+    return Litestar(
+        route_handlers=[create_api_v1_router([CrowdSecController])],
+        on_startup=[startup],
+        dependencies={
+            **ambient_settings_dependency(),
+            "db_session": Provide(lambda: None, sync_to_thread=False),
+        },
+    )
+
+
+async def test_status_reports_live_updates_when_poller_exists():
+    async with AsyncTestClient(app=make_app(with_poller=True)) as client:
+        body = (await client.get("/api/v1/crowdsec/status")).json()
+    assert body["enabled"] is True
+    assert body["liveUpdates"] is True
+
+
+async def test_status_reports_live_updates_paused_without_poller():
+    """DB-degraded mode defers the poller; the LAPI can still be reachable."""
+    async with AsyncTestClient(app=make_app(with_poller=False)) as client:
+        body = (await client.get("/api/v1/crowdsec/status")).json()
+    assert body["lapiReachable"] is True
+    assert body["liveUpdates"] is False

--- a/tests/test_crowdsec_status.py
+++ b/tests/test_crowdsec_status.py
@@ -17,7 +17,10 @@ pytestmark = pytest.mark.anyio
 
 
 class StubCrowdSecService(CrowdSecService):
-    def __init__(self) -> None:
+    def __init__(self, _settings: object | None = None) -> None:
+        pass
+
+    async def aclose(self) -> None:
         pass
 
     async def ping(self) -> bool:
@@ -51,5 +54,31 @@ async def test_status_reports_live_updates_paused_without_poller():
     """DB-degraded mode defers the poller; the LAPI can still be reachable."""
     async with AsyncTestClient(app=make_app(with_poller=False)) as client:
         body = (await client.get("/api/v1/crowdsec/status")).json()
+    assert body["lapiReachable"] is True
+    assert body["liveUpdates"] is False
+
+
+async def test_status_reports_live_updates_paused_when_scheduler_disabled(
+    monkeypatch, tmp_path
+):
+    from geometrikks.server import lifecycle as lc
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CROWDSEC_LAPI_URL", "http://crowdsec:8080")
+    monkeypatch.setenv("CROWDSEC_BOUNCER_API_KEY", "key")
+    monkeypatch.setenv("SCHEDULER_ENABLED", "false")
+    monkeypatch.setattr(lc, "CrowdSecService", StubCrowdSecService)
+
+    app = Litestar(
+        route_handlers=[create_api_v1_router([CrowdSecController])],
+        lifespan=[lc.crowdsec_lifespan],
+        dependencies={
+            **ambient_settings_dependency(),
+            "db_session": Provide(lambda: None, sync_to_thread=False),
+        },
+    )
+    async with AsyncTestClient(app=app) as client:
+        body = (await client.get("/api/v1/crowdsec/status")).json()
+    assert body["enabled"] is True
     assert body["lapiReachable"] is True
     assert body["liveUpdates"] is False

--- a/tests/test_geoip_downloader.py
+++ b/tests/test_geoip_downloader.py
@@ -6,6 +6,7 @@ import tarfile
 import time
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -176,7 +177,7 @@ class TestEnsure:
         assert list(settings.db_path.parent.glob("*.tmp")) == []
 
     async def test_os_error_during_extraction_degrades_without_litter(self, tmp_path, monkeypatch):
-        """ensure_geoip_database never raises — an OSError from the filesystem
+        """ensure_geoip_database never raises. An OSError from the filesystem
         (full volume, bad mount permissions) degrades and leaves no .tmp files."""
         from pathlib import Path as PathCls
 
@@ -316,11 +317,11 @@ class TestRefreshBothEditions:
 
         calls: list[str] = []
 
-        async def fake_city(settings, *, force=False):
+        async def fake_city(settings, *, force=False, errors=None):
             calls.append("city")
             return True
 
-        async def fake_asn(settings, *, force=False):
+        async def fake_asn(settings, *, force=False, errors=None):
             calls.append("asn")
             return True
 
@@ -334,11 +335,11 @@ class TestRefreshBothEditions:
 
         calls: list[str] = []
 
-        async def fake_city(settings, *, force=False):
+        async def fake_city(settings, *, force=False, errors=None):
             calls.append("city")
             return True
 
-        async def fake_asn(settings, *, force=False):
+        async def fake_asn(settings, *, force=False, errors=None):
             calls.append("asn")
             return True
 
@@ -354,11 +355,11 @@ class TestRefreshBothEditions:
 
         forces: dict[str, bool] = {}
 
-        async def fake_city(settings, *, force=False):
+        async def fake_city(settings, *, force=False, errors=None):
             forces["city"] = force
             return True
 
-        async def fake_asn(settings, *, force=False):
+        async def fake_asn(settings, *, force=False, errors=None):
             forces["asn"] = force
             return True
 
@@ -366,6 +367,47 @@ class TestRefreshBothEditions:
         monkeypatch.setattr(downloader, "ensure_asn_database", fake_asn)
         await downloader.refresh_geoip_databases(make_settings(tmp_path), force=True)
         assert forces == {"city": True, "asn": True}
+
+    async def test_refresh_collects_download_errors(self, tmp_path, monkeypatch):
+        from geometrikks.services.geoip import downloader
+        from geometrikks.services.geoip.downloader import GeoIPDownloadError
+
+        async def failing_download(settings, *, edition, db_path):
+            raise GeoIPDownloadError(f"{edition} 503")
+
+        monkeypatch.setattr(downloader, "download_database", failing_download)
+        settings = make_settings(
+            tmp_path,
+            account_id="1",
+            license_key="k",
+            asn_enabled=True,
+        )
+
+        result = await downloader.refresh_geoip_databases(settings, force=True)
+
+        assert result.city_error == "City: GeoLite2-City 503"
+        assert result.asn_error == "ASN: GeoLite2-ASN 503"
+        assert result.errors == [
+            "City: GeoLite2-City 503",
+            "ASN: GeoLite2-ASN 503",
+        ]
+
+    async def test_refresh_reports_no_errors_on_success(self, tmp_path, monkeypatch):
+        from geometrikks.services.geoip import downloader
+
+        city = AsyncMock(return_value=True)
+        asn = AsyncMock(return_value=True)
+        monkeypatch.setattr(downloader, "ensure_geoip_database", city)
+        monkeypatch.setattr(downloader, "ensure_asn_database", asn)
+        settings = make_settings(tmp_path)
+
+        result = await downloader.refresh_geoip_databases(settings)
+
+        assert result.city_error is None
+        assert result.asn_error is None
+        assert result.errors == []
+        city.assert_awaited_once_with(settings, force=False, errors=[])
+        asn.assert_awaited_once_with(settings, force=False, errors=[])
 
 
 class TestForcedRefresh:

--- a/tests/test_geoip_reader_reload.py
+++ b/tests/test_geoip_reader_reload.py
@@ -175,8 +175,9 @@ def _fake_ingestion(*, stale: bool) -> MagicMock:
 @pytest.fixture
 def refresh(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
     from geometrikks.services.geoip import downloader
+    from geometrikks.services.geoip.downloader import RefreshResult
 
-    mock = AsyncMock()
+    mock = AsyncMock(return_value=RefreshResult())
     monkeypatch.setattr(downloader, "refresh_geoip_databases", mock)
     return mock
 
@@ -254,6 +255,23 @@ async def test_job_reports_unavailable_databases(
     await refresh_geoip_job(Settings(), cast("Any", app))
 
     assert app.state.geoip_available is False
+
+
+async def test_job_raises_after_reloading_when_a_download_failed(
+    refresh: AsyncMock,
+) -> None:
+    """A failed edition must reach the run tracker after readers reload."""
+    from geometrikks.config.settings import Settings
+    from geometrikks.server.scheduler import refresh_geoip_job
+    from geometrikks.services.geoip.downloader import RefreshResult
+
+    refresh.return_value = RefreshResult(city_error="City: 503")
+    service = _fake_ingestion(stale=True)
+
+    with pytest.raises(RuntimeError, match="City: 503"):
+        await refresh_geoip_job(Settings(), cast("Any", _fake_app(service)))
+
+    service.reload_readers.assert_awaited_once()
 
 
 async def test_create_scheduler_wires_the_wrapper_with_app() -> None:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -688,6 +688,52 @@ def test_stale_geoip_database_without_credentials_when_scheduler_is_disabled(
     assert advisory.remedy == "MAXMINDDB_USER_ID and MAXMINDDB_LICENSE_KEY"
 
 
+@pytest.mark.parametrize(
+    ("scheduler_enabled", "credentials"),
+    [
+        (True, True),
+        (True, False),
+        (False, True),
+        (False, False),
+    ],
+)
+def test_long_geoip_refresh_cadence_has_complete_automatic_recovery(
+    monkeypatch,
+    scheduler_enabled,
+    credentials,
+):
+    [advisory] = _geoip_advisories(
+        monkeypatch,
+        city_age_days=31,
+        credentials=credentials,
+        scheduler_enabled=scheduler_enabled,
+        refresh_days=45,
+    )
+
+    assert advisory.detail is not None
+    automatic_start = advisory.detail.index("For automatic refresh")
+    automatic = advisory.detail[automatic_start:]
+    refresh_setting = automatic.index("GEOIP_REFRESH_DAYS to 30 or less")
+    restart = automatic.index("restart")
+    database_active = automatic.index("database services are active", restart)
+    run_now = automatic.index("Run now", database_active)
+    assert refresh_setting < restart < database_active < run_now
+    assert "Settings > Scheduler" in automatic
+    if not credentials:
+        assert automatic.index("configure the credentials") < restart
+    if not scheduler_enabled:
+        assert automatic.index("SCHEDULER_ENABLED=true") < restart
+        manual = advisory.detail[:automatic_start]
+        assert manual.index("replace") < manual.index("restart")
+    remedy = advisory.remedy or ""
+    assert "GEOIP_REFRESH_DAYS=30" in remedy
+    if not credentials:
+        assert "MAXMINDDB_USER_ID" in remedy
+        assert "MAXMINDDB_LICENSE_KEY" in remedy
+    if not scheduler_enabled:
+        assert "SCHEDULER_ENABLED=true" in remedy
+
+
 def test_geoip_database_without_age_metadata_emits_no_stale_advisory(monkeypatch):
     assert _geoip_advisories(
         monkeypatch,

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -652,3 +652,58 @@ def test_stale_asn_database_is_ignored_when_disabled(monkeypatch):
         asn_enabled=False,
         asn_age_days=31,
     ) == []
+
+
+def _listener_advisories(
+    monkeypatch: pytest.MonkeyPatch,
+    state: str | None,
+    *,
+    db_available: bool = True,
+):
+    from geometrikks.config.settings import Settings
+    from geometrikks.domain.system.controllers.health import _collect_advisories
+    from geometrikks.server import timescale
+
+    monkeypatch.setattr(timescale, "_hostname_pollution", None)
+    settings = Settings()
+    settings.app.proxy_advisory = False
+    app_state = SimpleNamespace(
+        geoip_available=True,
+        asn_available=True,
+        db_available=db_available,
+    )
+    if state is not None:
+        app_state.channels_backend = SimpleNamespace(state=state)
+    app = SimpleNamespace(state=app_state)
+    return [
+        advisory
+        for advisory in _collect_advisories(cast("Any", app), settings)
+        if advisory.id == "live-feed-listener-down"
+    ]
+
+
+def test_listener_reconnecting_emits_advisory(monkeypatch):
+    [advisory] = _listener_advisories(monkeypatch, "reconnecting")
+
+    assert advisory.severity == "warning"
+    assert advisory.summary.count(".") == 1
+    assert "reconnects on its own" in (advisory.detail or "")
+
+
+def test_listener_degraded_with_database_active_emits_advisory(monkeypatch):
+    [advisory] = _listener_advisories(monkeypatch, "degraded")
+
+    assert "receive no events" in advisory.summary
+
+
+def test_listener_ok_or_absent_emits_no_advisory(monkeypatch):
+    assert _listener_advisories(monkeypatch, "ok") == []
+    assert _listener_advisories(monkeypatch, None) == []
+
+
+def test_listener_advisory_is_suppressed_while_database_is_unavailable(monkeypatch):
+    assert _listener_advisories(
+        monkeypatch,
+        "degraded",
+        db_available=False,
+    ) == []

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -499,3 +499,18 @@ def test_health_reports_asn_state(monkeypatch):
         body = client.get("/health").json()
         assert isinstance(body["geoip"]["asnAvailable"], bool)
         assert "asnDbBuildDate" in body["geoip"]
+
+
+def test_health_reports_a_failing_proxy_scan(monkeypatch):
+    async def db_up(app, timeout: float = 2.0) -> bool:
+        return True
+    monkeypatch.setattr(health_module, "_database_reachable", db_up)
+    monkeypatch.setenv("APP_PROXY_ADVISORY", "true")
+    from geometrikks.domain.system import proxy_scan
+    from geometrikks.server import timescale
+    monkeypatch.setattr(timescale, "_hostname_pollution", None)
+    monkeypatch.setattr(proxy_scan, "_last_error", "db down")
+
+    with TestClient(app=make_app()) as client:
+        [a] = [x for x in client.get("/health").json()["advisories"] if x["id"] == "proxy-scan-failed"]
+    assert a["detail"] == "db down"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -17,10 +17,21 @@ from tests.support import ambient_settings_dependency
 
 
 @pytest.fixture(autouse=True)
-def isolate_policy_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+def isolate_computed_advisories(monkeypatch: pytest.MonkeyPatch) -> None:
+    from geometrikks.lib.utils import GeoIPInfoView
     from geometrikks.server import timescale
 
     monkeypatch.setattr(timescale, "_policy_failures", [], raising=False)
+    monkeypatch.setattr(
+        health_module,
+        "geoip_info",
+        lambda path: GeoIPInfoView(
+            available=False,
+            db_path=str(path),
+            build_date=None,
+            age_days=None,
+        ),
+    )
 
 
 def make_app() -> Litestar:
@@ -520,3 +531,124 @@ def test_health_reports_a_failing_proxy_scan(monkeypatch):
     assert "proxy-peer-scan" in detail
     assert "Scheduler" in detail
     assert "app logs" in detail
+
+
+def _stale_view(age_days: int | None):
+    from geometrikks.lib.utils import GeoIPInfoView
+
+    return GeoIPInfoView(
+        available=age_days is not None,
+        db_path="x",
+        build_date=None,
+        age_days=age_days,
+    )
+
+
+def _geoip_advisories(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    city_age_days: int | None,
+    credentials: bool,
+    asn_enabled: bool = False,
+    asn_age_days: int | None = None,
+):
+    from geometrikks.config.settings import Settings
+    from geometrikks.domain.system.controllers.health import _collect_advisories
+    from geometrikks.server import timescale
+
+    monkeypatch.setattr(timescale, "_hostname_pollution", None)
+    monkeypatch.setattr(
+        health_module,
+        "geoip_info",
+        lambda path: _stale_view(
+            asn_age_days if path == settings.geoip.asn_db_path else city_age_days
+        ),
+    )
+    monkeypatch.setattr(
+        health_module,
+        "has_credentials",
+        lambda geoip_settings: credentials,
+    )
+    settings = Settings()
+    settings.geoip.asn_enabled = asn_enabled
+    settings.app.proxy_advisory = False
+    app = SimpleNamespace(
+        state=SimpleNamespace(geoip_available=True, asn_available=asn_enabled)
+    )
+    return [
+        advisory
+        for advisory in _collect_advisories(cast("Any", app), settings)
+        if advisory.id.endswith("-database-stale")
+    ]
+
+
+def test_geoip_database_is_fresh_at_exact_refresh_window(monkeypatch):
+    assert _geoip_advisories(
+        monkeypatch,
+        city_age_days=30,
+        credentials=False,
+    ) == []
+
+
+def test_geoip_database_is_stale_after_refresh_window_without_credentials(
+    monkeypatch,
+):
+    [advisory] = _geoip_advisories(
+        monkeypatch,
+        city_age_days=31,
+        credentials=False,
+    )
+
+    assert advisory.id == "geoip-database-stale"
+    assert advisory.severity == "warning"
+    assert "31 days old" in advisory.summary
+    assert "no MaxMind credentials" in advisory.summary
+    assert advisory.summary.count(".") == 1
+    assert advisory.detail is not None and "30 days" in advisory.detail
+    assert advisory.remedy == "MAXMINDDB_USER_ID and MAXMINDDB_LICENSE_KEY"
+
+
+def test_stale_geoip_database_with_credentials_points_at_refresh_job(monkeypatch):
+    [advisory] = _geoip_advisories(
+        monkeypatch,
+        city_age_days=45,
+        credentials=True,
+    )
+
+    assert "weekly refresh is not succeeding" in advisory.summary
+    assert advisory.summary.count(".") == 1
+    assert advisory.detail is not None and "geoip-refresh" in advisory.detail
+    assert advisory.remedy is None
+
+
+def test_geoip_database_without_age_metadata_emits_no_stale_advisory(monkeypatch):
+    assert _geoip_advisories(
+        monkeypatch,
+        city_age_days=None,
+        credentials=False,
+    ) == []
+
+
+def test_stale_asn_database_gets_its_own_advisory_when_enabled(monkeypatch):
+    advisories = _geoip_advisories(
+        monkeypatch,
+        city_age_days=31,
+        credentials=True,
+        asn_enabled=True,
+        asn_age_days=31,
+    )
+
+    assert sorted(advisory.id for advisory in advisories) == [
+        "asn-database-stale",
+        "geoip-database-stale",
+    ]
+
+
+def test_stale_asn_database_is_ignored_when_disabled(monkeypatch):
+    assert _geoip_advisories(
+        monkeypatch,
+        city_age_days=20,
+        credentials=True,
+        asn_enabled=False,
+        asn_age_days=31,
+    ) == []

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -232,6 +232,48 @@ def test_health_logparser_disabled_is_not_degraded(monkeypatch):
     assert body["status"] == "healthy"
 
 
+def test_health_degraded_when_services_paused_even_with_ingestion_disabled(monkeypatch):
+    """The incident case: a UI head (LOGPARSER_ENABLED=false) whose startup
+    probe failed. The database answers now, but nothing DB-bound is running."""
+    async def db_up(app, timeout: float = 2.0) -> bool:
+        return True
+    monkeypatch.setattr(health_module, "_database_reachable", db_up)
+    monkeypatch.setenv("LOGPARSER_ENABLED", "false")
+
+    app = make_app()
+    app.state.db_available = False
+    with TestClient(app=app) as client:
+        body = client.get("/health").json()
+    assert body["status"] == "degraded"
+    assert body["database"] == {"reachable": True, "servicesActive": False}
+
+
+def test_health_services_active_defaults_true_before_startup(monkeypatch):
+    async def db_up(app, timeout: float = 2.0) -> bool:
+        return True
+    monkeypatch.setattr(health_module, "_database_reachable", db_up)
+
+    with TestClient(app=make_app()) as client:
+        body = client.get("/health").json()
+    assert body["database"]["servicesActive"] is True
+
+
+def test_health_includes_registry_advisories_critical_first(monkeypatch):
+    async def db_up(app, timeout: float = 2.0) -> bool:
+        return True
+    monkeypatch.setattr(health_module, "_database_reachable", db_up)
+    from geometrikks.lib.advisories import Advisory
+    from geometrikks.server import runtime, timescale
+    monkeypatch.setattr(timescale, "_hostname_pollution", None)
+
+    app = make_app()
+    runtime.get_advisories(app).set(Advisory(id="w", severity="warning", summary="w"))
+    runtime.get_advisories(app).set(Advisory(id="c", severity="critical", summary="c"))
+    with TestClient(app=app) as client:
+        body = client.get("/health").json()
+    assert [a["id"] for a in body["advisories"]] == ["c", "w"]
+
+
 def test_health_agent_mode_reports_schema_wait(monkeypatch):
     """Agent mode surfaces mode == "agent" and the recorded schema_wait_result."""
     async def db_up(app, timeout: float = 2.0) -> bool:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -561,6 +561,27 @@ def test_health_reports_a_failing_proxy_scan(monkeypatch):
     assert "app logs" in detail
 
 
+def test_proxy_advisory_setting_suppresses_scan_failure(monkeypatch):
+    async def db_up(app, timeout: float = 2.0) -> bool:
+        return True
+
+    monkeypatch.setattr(health_module, "_database_reachable", db_up)
+    monkeypatch.setenv("APP_PROXY_ADVISORY", "false")
+    from geometrikks.domain.system import proxy_scan
+    from geometrikks.server import timescale
+
+    monkeypatch.setattr(timescale, "_hostname_pollution", None)
+    monkeypatch.setattr(proxy_scan, "get_scan_error", lambda: "db down")
+    monkeypatch.setattr(proxy_scan, "get_scan_findings", lambda: [])
+
+    with TestClient(app=make_app()) as client:
+        advisory_ids = {
+            item["id"] for item in client.get("/health").json()["advisories"]
+        }
+
+    assert "proxy-scan-failed" not in advisory_ids
+
+
 def _stale_view(age_days: int | None, *, available: bool | None = None):
     from geometrikks.lib.utils import GeoIPInfoView
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
+import pytest
 from litestar import Litestar
 from litestar.testing import TestClient
 
@@ -13,6 +14,13 @@ from geometrikks.domain.system.controllers.health import health, health_ready
 from geometrikks.services.ingestion import LogIngestionService
 from geometrikks.services.logparser.logparser import LogParser
 from tests.support import ambient_settings_dependency
+
+
+@pytest.fixture(autouse=True)
+def isolate_policy_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    from geometrikks.server import timescale
+
+    monkeypatch.setattr(timescale, "_policy_failures", [], raising=False)
 
 
 def make_app() -> Litestar:
@@ -300,6 +308,45 @@ def test_health_has_no_advisories_when_clean(monkeypatch):
     with TestClient(app=make_app()) as client:
         body = client.get("/health").json()
     assert body["advisories"] == []
+
+
+def test_health_reports_policy_update_failures(monkeypatch):
+    async def db_up(app, timeout: float = 2.0) -> bool:
+        return True
+    monkeypatch.setattr(health_module, "_database_reachable", db_up)
+
+    from geometrikks.server import timescale
+    monkeypatch.setattr(timescale, "_hostname_pollution", None)
+    monkeypatch.setattr(
+        timescale,
+        "_policy_failures",
+        [
+            timescale.PolicyFailure("retention", "geo_events", "boom"),
+            timescale.PolicyFailure("compression", "access_logs", "boom"),
+        ],
+    )
+
+    with TestClient(app=make_app()) as client:
+        advisories = client.get("/health").json()["advisories"]
+
+    [advisory] = [
+        item for item in advisories if item["id"] == "timescale-policy-update-failed"
+    ]
+    assert advisory == {
+        "id": "timescale-policy-update-failed",
+        "severity": "warning",
+        "summary": (
+            "2 TimescaleDB policies could not be updated to match the current settings: "
+            "retention on geo_events, compression on access_logs; the previous intervals "
+            "stay in force."
+        ),
+        "detail": (
+            "The app retries the updates at the next startup; check the app log for "
+            "policy_update_failed before restarting."
+        ),
+        "remedy": None,
+        "docsUrl": None,
+    }
 
 
 def test_health_reports_hostname_pollution_advisory(monkeypatch):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -498,8 +498,42 @@ def test_health_exposes_write_failures_and_advises(monkeypatch):
         if item["id"] == "ingestion-write-failures"
     ]
     assert "2 batches (37 records)" in advisory["summary"]
-    assert "continues ingestion" in advisory["detail"]
+    assert "dropped the affected records and will not retry them" in advisory["detail"]
+    assert "continues processing new records" in advisory["detail"]
     assert "ingestion_batch_failed" in advisory["detail"]
+
+
+def test_health_write_failure_advisory_reports_stopped_ingestion(monkeypatch):
+    async def db_up(app, timeout: float = 2.0) -> bool:
+        return True
+
+    monkeypatch.setattr(health_module, "_database_reachable", db_up)
+    from geometrikks.server import timescale
+
+    monkeypatch.setattr(timescale, "_hostname_pollution", None)
+
+    app = make_app()
+    service = _running_service(file_missing=False)
+    service.is_running = False
+    service.failed_batches = 2
+    service.failed_records = 37
+    app.state.ingestion_service = service
+    with TestClient(app=app) as client:
+        body = client.get("/health").json()
+
+    assert body["ingestion"]["failedBatches"] == 2
+    assert body["ingestion"]["failedRecords"] == 37
+    [advisory] = [
+        item for item in body["advisories"]
+        if item["id"] == "ingestion-write-failures"
+    ]
+    assert "2 batches (37 records)" in advisory["summary"]
+    assert "dropped the affected records and will not retry them" in advisory["detail"]
+    assert "Ingestion is not running" in advisory["detail"]
+    assert "ingestion_batch_failed" in advisory["detail"]
+    assert "schema mismatch" in advisory["detail"]
+    assert "full disk" in advisory["detail"]
+    assert "restart the app" in advisory["detail"]
 
 
 def _asn_advisories(app_state_asn: bool, asn_enabled: bool) -> list:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -533,11 +533,11 @@ def test_health_reports_a_failing_proxy_scan(monkeypatch):
     assert "app logs" in detail
 
 
-def _stale_view(age_days: int | None):
+def _stale_view(age_days: int | None, *, available: bool | None = None):
     from geometrikks.lib.utils import GeoIPInfoView
 
     return GeoIPInfoView(
-        available=age_days is not None,
+        available=age_days is not None if available is None else available,
         db_path="x",
         build_date=None,
         age_days=age_days,
@@ -551,6 +551,9 @@ def _geoip_advisories(
     credentials: bool,
     asn_enabled: bool = False,
     asn_age_days: int | None = None,
+    scheduler_enabled: bool = True,
+    refresh_days: int = 7,
+    city_available: bool | None = None,
 ):
     from geometrikks.config.settings import Settings
     from geometrikks.domain.system.controllers.health import _collect_advisories
@@ -561,7 +564,10 @@ def _geoip_advisories(
         health_module,
         "geoip_info",
         lambda path: _stale_view(
-            asn_age_days if path == settings.geoip.asn_db_path else city_age_days
+            asn_age_days if path == settings.geoip.asn_db_path else city_age_days,
+            available=(
+                None if path == settings.geoip.asn_db_path else city_available
+            ),
         ),
     )
     monkeypatch.setattr(
@@ -571,6 +577,8 @@ def _geoip_advisories(
     )
     settings = Settings()
     settings.geoip.asn_enabled = asn_enabled
+    settings.geoip.refresh_days = refresh_days
+    settings.scheduler.enabled = scheduler_enabled
     settings.app.proxy_advisory = False
     app = SimpleNamespace(
         state=SimpleNamespace(geoip_available=True, asn_available=asn_enabled)
@@ -605,20 +613,67 @@ def test_geoip_database_is_stale_after_refresh_window_without_credentials(
     assert "no MaxMind credentials" in advisory.summary
     assert advisory.summary.count(".") == 1
     assert advisory.detail is not None and "30 days" in advisory.detail
+    assert "every 7 days" in advisory.detail
+    assert "geoip-refresh" in advisory.detail
+    assert "restart" in advisory.detail
     assert advisory.remedy == "MAXMINDDB_USER_ID and MAXMINDDB_LICENSE_KEY"
 
 
-def test_stale_geoip_database_with_credentials_points_at_refresh_job(monkeypatch):
+def test_stale_geoip_database_with_credentials_reports_configured_cadence(
+    monkeypatch,
+):
+    [advisory] = _geoip_advisories(
+        monkeypatch,
+        city_age_days=31,
+        credentials=True,
+        refresh_days=45,
+    )
+
+    assert "outside MaxMind's 30-day refresh window" in advisory.summary
+    assert "not succeeding" not in advisory.summary
+    assert advisory.summary.count(".") == 1
+    assert advisory.detail is not None and "every 45 days" in advisory.detail
+    assert "geoip-refresh" in advisory.detail
+    assert "Scheduler" in advisory.detail
+    assert "next run" in advisory.detail and "last result" in advisory.detail
+    assert advisory.remedy is None
+
+
+def test_stale_geoip_database_with_credentials_when_scheduler_is_disabled(
+    monkeypatch,
+):
     [advisory] = _geoip_advisories(
         monkeypatch,
         city_age_days=45,
         credentials=True,
+        scheduler_enabled=False,
+        refresh_days=3,
     )
 
-    assert "weekly refresh is not succeeding" in advisory.summary
+    assert "automatic refresh is disabled" in advisory.summary
     assert advisory.summary.count(".") == 1
-    assert advisory.detail is not None and "geoip-refresh" in advisory.detail
-    assert advisory.remedy is None
+    assert advisory.detail is not None and "restart" in advisory.detail
+    assert "SCHEDULER_ENABLED=true" in advisory.detail
+    assert "geoip-refresh job" not in advisory.detail
+
+
+def test_stale_geoip_database_without_credentials_when_scheduler_is_disabled(
+    monkeypatch,
+):
+    [advisory] = _geoip_advisories(
+        monkeypatch,
+        city_age_days=45,
+        credentials=False,
+        scheduler_enabled=False,
+    )
+
+    assert (
+        advisory.detail is not None
+        and "automatic refresh is disabled" in advisory.detail.lower()
+    )
+    assert "configure the credentials below and restart the app" in advisory.detail
+    assert "geoip-refresh job" not in advisory.detail
+    assert advisory.remedy == "MAXMINDDB_USER_ID and MAXMINDDB_LICENSE_KEY"
 
 
 def test_geoip_database_without_age_metadata_emits_no_stale_advisory(monkeypatch):
@@ -626,6 +681,7 @@ def test_geoip_database_without_age_metadata_emits_no_stale_advisory(monkeypatch
         monkeypatch,
         city_age_days=None,
         credentials=False,
+        city_available=True,
     ) == []
 
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -513,4 +513,10 @@ def test_health_reports_a_failing_proxy_scan(monkeypatch):
 
     with TestClient(app=make_app()) as client:
         [a] = [x for x in client.get("/health").json()["advisories"] if x["id"] == "proxy-scan-failed"]
-    assert a["detail"] == "db down"
+    detail = a["detail"]
+    assert "db down" in detail
+    assert "previous proxy findings remain visible" in detail
+    assert "scheduled scans retry" in detail
+    assert "proxy-peer-scan" in detail
+    assert "Scheduler" in detail
+    assert "app logs" in detail

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -474,6 +474,34 @@ def test_health_publish_dropped_present(monkeypatch):
     assert body["ingestion"]["publishDropped"] == 0
 
 
+def test_health_exposes_write_failures_and_advises(monkeypatch):
+    async def db_up(app, timeout: float = 2.0) -> bool:
+        return True
+
+    monkeypatch.setattr(health_module, "_database_reachable", db_up)
+    from geometrikks.server import timescale
+
+    monkeypatch.setattr(timescale, "_hostname_pollution", None)
+
+    app = make_app()
+    service = _running_service(file_missing=False)
+    service.failed_batches = 2
+    service.failed_records = 37
+    app.state.ingestion_service = service
+    with TestClient(app=app) as client:
+        body = client.get("/health").json()
+
+    assert body["ingestion"]["failedBatches"] == 2
+    assert body["ingestion"]["failedRecords"] == 37
+    [advisory] = [
+        item for item in body["advisories"]
+        if item["id"] == "ingestion-write-failures"
+    ]
+    assert "2 batches (37 records)" in advisory["summary"]
+    assert "continues ingestion" in advisory["detail"]
+    assert "ingestion_batch_failed" in advisory["detail"]
+
+
 def _asn_advisories(app_state_asn: bool, asn_enabled: bool) -> list:
     from geometrikks.config.settings import Settings
     from geometrikks.domain.system.controllers.health import _collect_advisories

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -634,9 +634,10 @@ def test_stale_geoip_database_with_credentials_reports_configured_cadence(
     assert advisory.summary.count(".") == 1
     assert advisory.detail is not None and "every 45 days" in advisory.detail
     assert "geoip-refresh" in advisory.detail
-    assert "Scheduler" in advisory.detail
-    assert "next run" in advisory.detail and "last result" in advisory.detail
-    assert advisory.remedy is None
+    assert "Settings > Scheduler" in advisory.detail
+    assert "Run now" in advisory.detail
+    assert "GEOIP_REFRESH_DAYS" in advisory.detail
+    assert advisory.remedy == "GEOIP_REFRESH_DAYS=30"
 
 
 def test_stale_geoip_database_with_credentials_when_scheduler_is_disabled(
@@ -671,7 +672,18 @@ def test_stale_geoip_database_without_credentials_when_scheduler_is_disabled(
         advisory.detail is not None
         and "automatic refresh is disabled" in advisory.detail.lower()
     )
-    assert "configure the credentials below and restart the app" in advisory.detail
+    manual_replace = advisory.detail.index("replace")
+    manual_restart = advisory.detail.index("restart", manual_replace)
+    assert manual_replace < manual_restart
+    assert "credentials are not required" in advisory.detail.lower()
+    automatic = advisory.detail.index("For automatic refresh")
+    configure = advisory.detail.index("configure the credentials", automatic)
+    enable = advisory.detail.index("SCHEDULER_ENABLED=true", configure)
+    restart = advisory.detail.index("restart", enable)
+    trigger = advisory.detail.index("Run now", restart)
+    assert configure < enable < restart < trigger
+    assert "Settings > Scheduler" in advisory.detail
+    assert "next run" in advisory.detail
     assert "geoip-refresh job" not in advisory.detail
     assert advisory.remedy == "MAXMINDDB_USER_ID and MAXMINDDB_LICENSE_KEY"
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -762,6 +762,33 @@ async def test_counters_finalize_when_commit_rollback_raises() -> None:
 
     assert service.failed_batches == 1
     assert service.failed_records == 1
+    assert service._location_cache == {}
+    assert service._uncommitted_geohashes == set()
+
+
+async def test_record_rollback_failure_drops_remainder_and_stops_session() -> None:
+    channels = _channels_stub()
+    service, repos, sessions = make_service([], channels=channels)
+    repos.fail_flush_calls = {2}
+    repos.fail_next_rollbacks = 1
+    records = [
+        _geo_record(TEST_DB_IPS[0], -0.09),
+        _geo_record(TEST_DB_IPS[1], -0.19),
+        _geo_record(TEST_DB_IPS[0], -0.29),
+    ]
+
+    await service.flush_records(records)
+
+    assert service.failed_batches == 1
+    assert service.failed_records == len(records)
+    assert repos.flush_calls == 2
+    assert sessions[0].commits == 0
+    assert repos.geo_event.added == []
+    assert len(repos.geo_event.added) + service.failed_records == len(records)
+    assert sessions[0].closed is True
+    channels.publish.assert_not_called()
+    assert service._location_cache == {}
+    assert service._uncommitted_geohashes == set()
 
 
 def test_service_has_no_inprocess_subscriber_api() -> None:

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -83,6 +83,9 @@ class FakeSession:
 
     async def rollback(self) -> None:
         self.rollbacks += 1
+        if self.repos.fail_next_rollbacks:
+            self.repos.fail_next_rollbacks -= 1
+            raise RuntimeError("simulated rollback error")
         self.pending.clear()
 
     async def flush(self) -> None:
@@ -132,6 +135,7 @@ class FakeRepos:
         self.access_log_debug = FakeRepo(None)
         # failure injection: consumed by FakeSession
         self.fail_next_commits = 0
+        self.fail_next_rollbacks = 0
         self.fail_flush_calls: set[int] = set()  # 1-based flush call numbers
         self.flush_calls = 0
 
@@ -656,6 +660,108 @@ def make_parsed_record(ip: str) -> ParsedLogRecord:
         ),
         raw_line=make_log_line(ip),
     )
+
+
+def _geo_record(ip: str, longitude: float) -> ParsedLogRecord:
+    geo = ParsedGeoData(
+        latitude=51.5,
+        longitude=longitude,
+        geohash=encode(51.5, longitude, precision=5),
+        country_code="GB",
+        country_name="UK",
+        timestamp=datetime.now(timezone.utc),
+        city="London",
+    )
+    return ParsedLogRecord(
+        ip_address=ip,
+        geo_data=geo,
+        access_log=None,
+        raw_line="x",
+    )
+
+
+async def test_commit_failure_counts_lost_records_once_and_success_does_not_increment(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    service, repos, _sessions = make_service([])
+    repos.fail_next_commits = 1
+
+    with caplog.at_level("ERROR"):
+        await service.flush_records([
+            _geo_record(TEST_DB_IPS[0], -0.09),
+            _geo_record(TEST_DB_IPS[1], -0.19),
+        ])
+
+    assert service.failed_batches == 1
+    assert service.failed_records == 2
+    assert any(
+        "ingestion_batch_failed" in record.getMessage()
+        for record in caplog.records
+    )
+
+    await service.flush_records([_geo_record(TEST_DB_IPS[0], -0.29)])
+
+    assert service.failed_batches == 1
+    assert service.failed_records == 2
+
+
+async def test_later_record_failure_counts_earlier_rolled_back_candidates() -> None:
+    service, repos, _sessions = make_service([])
+    repos.fail_flush_calls = {2}
+
+    await service.flush_records([
+        _geo_record(TEST_DB_IPS[0], -0.09),
+        _geo_record(TEST_DB_IPS[1], -0.19),
+        _geo_record(TEST_DB_IPS[0], -0.29),
+    ])
+
+    assert service.failed_batches == 1
+    assert service.failed_records == 2
+    assert len(repos.geo_event.added) == 1
+
+
+async def test_record_and_commit_failures_do_not_double_count_records() -> None:
+    service, repos, _sessions = make_service([])
+    repos.fail_flush_calls = {2}
+    repos.fail_next_commits = 1
+
+    await service.flush_records([
+        _geo_record(TEST_DB_IPS[0], -0.09),
+        _geo_record(TEST_DB_IPS[1], -0.19),
+        _geo_record(TEST_DB_IPS[0], -0.29),
+    ])
+
+    assert service.failed_batches == 1
+    assert service.failed_records == 3
+
+
+async def test_multiple_record_failures_count_each_lost_record_once() -> None:
+    service, repos, _sessions = make_service([])
+    repos.fail_flush_calls = {2, 4}
+
+    await service.flush_records([
+        _geo_record(TEST_DB_IPS[0], -0.09),
+        _geo_record(TEST_DB_IPS[1], -0.19),
+        _geo_record(TEST_DB_IPS[0], -0.29),
+        _geo_record(TEST_DB_IPS[1], -0.39),
+        _geo_record(TEST_DB_IPS[0], -0.49),
+    ])
+
+    assert service.failed_batches == 1
+    assert service.failed_records == 4
+    assert len(repos.geo_event.added) == 1
+
+
+async def test_counters_finalize_when_commit_rollback_raises() -> None:
+    service, repos, _sessions = make_service([])
+    repos.fail_next_commits = 1
+    repos.fail_next_rollbacks = 1
+
+    with pytest.raises(RuntimeError, match="simulated rollback error"):
+        await service.flush_records([_geo_record(TEST_DB_IPS[0], -0.09)])
+
+    assert service.failed_batches == 1
+    assert service.failed_records == 1
 
 
 def test_service_has_no_inprocess_subscriber_api() -> None:

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -248,6 +248,106 @@ async def test_stop_drains_queue_before_exit(tmp_path: Path) -> None:
     assert any(s.commits for s in sessions)  # final flush on stop
 
 
+def _stop_failure_service() -> tuple[LogIngestionService, Any, Any]:
+    from unittest.mock import MagicMock
+
+    service, _repos, _sessions = make_service([])
+    city_reader = MagicMock()
+    asn_reader = MagicMock()
+    service._stop_event = asyncio.Event()
+    service._reader = city_reader
+    service._asn_reader = asn_reader
+    service.is_running = True
+    return service, city_reader, asn_reader
+
+
+async def test_stop_cleans_up_before_propagating_completed_consumer_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    service, city_reader, asn_reader = _stop_failure_service()
+    failure = RuntimeError("consumer failed")
+
+    async def fail() -> None:
+        raise failure
+
+    task = asyncio.create_task(fail(), name="failed-consumer")
+    service._ingestion_task = task
+    await asyncio.sleep(0)
+    assert task.done()
+
+    with pytest.raises(RuntimeError) as caught:
+        await service.stop(timeout=1.0)
+
+    assert caught.value is failure
+    city_reader.close.assert_called_once_with()
+    asn_reader.close.assert_called_once_with()
+    assert service._reader is None
+    assert service._asn_reader is None
+    assert service._ingestion_task is None
+    assert service.is_running is False
+    assert any(
+        "ingestion_consumer_failed_during_stop" in record.getMessage()
+        for record in caplog.records
+    )
+    await service.stop(timeout=1.0)
+
+
+async def test_stop_distinguishes_consumer_timeout_error_from_shutdown_timeout(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    service, city_reader, asn_reader = _stop_failure_service()
+    stop_event = service._stop_event
+    assert stop_event is not None
+    failure = asyncio.TimeoutError("consumer timed out")
+
+    async def fail_when_stopped() -> None:
+        await stop_event.wait()
+        raise failure
+
+    task = asyncio.create_task(fail_when_stopped(), name="timed-out-consumer")
+    service._ingestion_task = task
+
+    with pytest.raises(asyncio.TimeoutError) as caught:
+        await service.stop(timeout=1.0)
+
+    assert caught.value is failure
+    city_reader.close.assert_called_once_with()
+    asn_reader.close.assert_called_once_with()
+    assert service._reader is None
+    assert service._asn_reader is None
+    assert service._ingestion_task is None
+    assert service.is_running is False
+    assert not any(
+        "did not stop gracefully" in record.getMessage()
+        for record in caplog.records
+    )
+    assert any(
+        "ingestion_consumer_failed_during_stop" in record.getMessage()
+        for record in caplog.records
+    )
+    await service.stop(timeout=1.0)
+
+
+async def test_stop_cancels_consumer_after_actual_shutdown_timeout() -> None:
+    service, city_reader, asn_reader = _stop_failure_service()
+
+    async def wait_forever() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(wait_forever(), name="stuck-consumer")
+    service._ingestion_task = task
+
+    await service.stop(timeout=0.01)
+
+    assert task.cancelled()
+    city_reader.close.assert_called_once_with()
+    asn_reader.close.assert_called_once_with()
+    assert service._reader is None
+    assert service._asn_reader is None
+    assert service._ingestion_task is None
+    assert service.is_running is False
+
+
 async def test_missing_file_does_not_block_other_tails(tmp_path: Path) -> None:
     """Waiting for a nonexistent log path does not block another file.
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -249,7 +249,7 @@ async def test_stop_drains_queue_before_exit(tmp_path: Path) -> None:
 
 
 async def test_missing_file_does_not_block_other_tails(tmp_path: Path) -> None:
-    """A nonexistent log path is skipped (with an error log); other files still ingest.
+    """Waiting for a nonexistent log path does not block another file.
 
     DISABLE_WAIT=true (conftest) makes wait_for_path return immediately."""
     good = tmp_path / "good.log"
@@ -294,18 +294,51 @@ async def test_stop_ends_the_wait_for_a_missing_log_file(
     assert all(task.done() and not task.cancelled() for task in service._tail_tasks)
 
 
-async def test_all_tails_dead_stops_service_and_clears_is_running(tmp_path: Path) -> None:
-    """When every tail task exits (all log files missing), the consumer must
-    shut down and is_running must flip to False so /health reports degraded.
+async def test_never_appeared_file_is_reported_missing_and_tailed_once_it_appears(
+    tmp_path: Path,
+) -> None:
+    """A path absent at start stays in the tail loop and begins tailing later.
 
-    DISABLE_WAIT=true (conftest) makes wait_for_path return immediately."""
+    DISABLE_WAIT=true (conftest) makes the grace wait return immediately.
+    """
     missing = tmp_path / "missing.log"
-    service, _repos, _sessions = make_service([make_parser(missing)])
+    parser = make_parser(missing)
+    service, _repos, _sessions = make_service([parser])
+
+    await service.start(skip_validation=True)
+    try:
+        await wait_until(lambda: parser.file_missing)
+        assert service.is_running
+        assert service.missing_files == [str(missing)]
+
+        missing.write_text("", encoding="utf-8")
+        await wait_until(lambda: not parser.file_missing)
+        await asyncio.sleep(0.1)
+        append_line(missing, make_log_line(TEST_DB_IPS[0]))
+        await wait_until(lambda: service.total_processed >= 1)
+    finally:
+        await service.stop(timeout=5.0)
+
+
+async def test_failed_tail_task_stops_service_and_clears_is_running(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The consumer stops when its only tail task fails."""
+    log_file = tmp_path / "a.log"
+    log_file.write_text("", encoding="utf-8")
+    service, _repos, _sessions = make_service([make_parser(log_file)])
+
+    async def fail_tail(*_args: object) -> None:
+        raise RuntimeError("simulated tail failure")
+
+    monkeypatch.setattr(service, "_tail_file", fail_tail)
 
     await service.start(skip_validation=True)
     try:
         await wait_until(lambda: not service.is_running)
         assert not service.is_task_running
+        with pytest.raises(RuntimeError, match="simulated tail failure"):
+            await service._tail_tasks[0]
     finally:
         await service.stop(timeout=5.0)
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -261,6 +261,52 @@ def _stop_failure_service() -> tuple[LogIngestionService, Any, Any]:
     return service, city_reader, asn_reader
 
 
+@pytest.mark.parametrize("failure_type", [OSError, asyncio.CancelledError])
+@pytest.mark.parametrize("shutting_down", [False, True])
+async def test_reload_cleanup_failure_marks_stopped_ingestion_unless_shutting_down(
+    failure_type, shutting_down: bool,
+) -> None:
+    service, city_reader, _ = _stop_failure_service()
+    stop_event = service._stop_event
+    assert stop_event is not None
+    async def consume_until_stopped() -> None:
+        await stop_event.wait()
+
+    service._ingestion_task = asyncio.create_task(consume_until_stopped())
+
+    def fail_close() -> None:
+        if shutting_down:
+            service.disable_reloads()
+        raise failure_type("reader cleanup failed")
+
+    city_reader.close.side_effect = fail_close
+    with pytest.raises(failure_type):
+        await service.reload_readers()
+
+    assert service.is_running is False
+    assert service._ingestion_task is None
+    assert service.unexpected_stop is (not shutting_down)
+
+
+async def test_reload_restart_failure_marks_stopped_ingestion(monkeypatch) -> None:
+    from unittest.mock import AsyncMock
+
+    service, _, _ = _stop_failure_service()
+    stop_event = service._stop_event
+    assert stop_event is not None
+    async def consume_until_stopped() -> None:
+        await stop_event.wait()
+
+    service._ingestion_task = asyncio.create_task(consume_until_stopped())
+    monkeypatch.setattr(service, "start", AsyncMock(side_effect=RuntimeError("restart failed")))
+
+    with pytest.raises(RuntimeError, match="restart failed"):
+        await service.reload_readers()
+
+    assert service.is_running is False
+    assert service.unexpected_stop is True
+
+
 async def test_stop_cleans_up_before_propagating_completed_consumer_error(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -437,10 +437,41 @@ async def test_failed_tail_task_stops_service_and_clears_is_running(
     try:
         await wait_until(lambda: not service.is_running)
         assert not service.is_task_running
+        assert service.unexpected_stop is True
         with pytest.raises(RuntimeError, match="simulated tail failure"):
             await service._tail_tasks[0]
     finally:
         await service.stop(timeout=5.0)
+
+
+async def test_graceful_stop_does_not_mark_ingestion_as_unexpectedly_stopped(
+    tmp_path: Path,
+) -> None:
+    log_file = tmp_path / "a.log"
+    log_file.write_text("", encoding="utf-8")
+    service, _repos, _sessions = make_service([make_parser(log_file)])
+
+    await service.start(skip_validation=True)
+    await service.stop(timeout=5.0)
+
+    assert service.is_running is False
+    assert service.unexpected_stop is False
+    assert service.start_failure is None
+
+
+async def test_missing_city_database_is_recorded_as_start_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import geometrikks.services.ingestion.service as service_module
+
+    monkeypatch.setattr(service_module, "create_reader", lambda *_args, **_kwargs: None)
+    service, _repos, _sessions = make_service([])
+
+    await service.start(skip_validation=True)
+
+    assert service.is_running is False
+    assert service.unexpected_stop is False
+    assert service.start_failure == "geoip"
 
 
 async def test_last_record_at_tracks_ingestion_activity(tmp_path: Path) -> None:

--- a/tests/test_ingestion_advisory.py
+++ b/tests/test_ingestion_advisory.py
@@ -1,0 +1,47 @@
+"""Health advisories for ingestion failures after startup."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from geometrikks.config.settings import Settings
+from geometrikks.domain.system.controllers.health import _collect_advisories
+from geometrikks.server import timescale
+
+
+def _advisories(monkeypatch, *, unexpected_stop: bool):
+    monkeypatch.setattr(timescale, "_hostname_pollution", None)
+    settings = Settings()
+    settings.app.proxy_advisory = False
+    settings.logparser.enabled = True
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            geoip_available=True,
+            asn_available=True,
+            ingestion_service=SimpleNamespace(
+                unexpected_stop=unexpected_stop,
+                failed_batches=0,
+                failed_records=0,
+                is_running=not unexpected_stop,
+            ),
+        )
+    )
+    return _collect_advisories(cast("Any", app), settings)
+
+
+def test_unexpected_ingestion_stop_emits_critical_advisory(monkeypatch):
+    [advisory] = [
+        item for item in _advisories(monkeypatch, unexpected_stop=True)
+        if item.id == "ingestion-stopped"
+    ]
+
+    assert advisory.severity == "critical"
+    assert "new records" in advisory.summary
+    assert "restart" in (advisory.detail or "").lower()
+
+
+def test_running_ingestion_has_no_stopped_advisory(monkeypatch):
+    assert all(
+        item.id != "ingestion-stopped"
+        for item in _advisories(monkeypatch, unexpected_stop=False)
+    )

--- a/tests/test_ingestion_advisory.py
+++ b/tests/test_ingestion_advisory.py
@@ -6,16 +6,18 @@ from typing import Any, cast
 
 from geometrikks.config.settings import Settings
 from geometrikks.domain.system.controllers.health import _collect_advisories
+from geometrikks.lib.advisories import Advisory, AdvisoryRegistry
 from geometrikks.server import timescale
 
 
-def _advisories(monkeypatch, *, unexpected_stop: bool):
+def _advisories(monkeypatch, *, unexpected_stop: bool, registry=None):
     monkeypatch.setattr(timescale, "_hostname_pollution", None)
     settings = Settings()
     settings.app.proxy_advisory = False
     settings.logparser.enabled = True
     app = SimpleNamespace(
         state=SimpleNamespace(
+            advisories=registry,
             geoip_available=True,
             asn_available=True,
             ingestion_service=SimpleNamespace(
@@ -45,3 +47,18 @@ def test_running_ingestion_has_no_stopped_advisory(monkeypatch):
         item.id != "ingestion-stopped"
         for item in _advisories(monkeypatch, unexpected_stop=False)
     )
+
+
+def test_computed_critical_advisory_precedes_registry_warnings(monkeypatch):
+    registry = AdvisoryRegistry()
+    registry.set(Advisory(id="first-warning", severity="warning", summary="First"))
+    registry.set(Advisory(id="second-warning", severity="warning", summary="Second"))
+    registry.set(Advisory(id="registry-critical", severity="critical", summary="Critical"))
+
+    advisories = _advisories(monkeypatch, unexpected_stop=True, registry=registry)
+    relevant = [a.id for a in advisories if a.id in {
+        "first-warning", "second-warning", "registry-critical", "ingestion-stopped",
+    }]
+    assert relevant == [
+        "registry-critical", "ingestion-stopped", "first-warning", "second-warning",
+    ]

--- a/tests/test_lifecycle_geoip.py
+++ b/tests/test_lifecycle_geoip.py
@@ -153,7 +153,7 @@ async def test_no_home_advisory_when_geoip_is_missing(monkeypatch):
         assert "map-home-undetected" not in ids
 
 
-async def test_home_advisory_does_not_promise_a_disabled_scheduler_retry(monkeypatch):
+async def test_home_advisory_qualifies_the_scheduler_retry(monkeypatch):
     from geometrikks.server import lifecycle as lc
     from geometrikks.server import runtime
 
@@ -168,7 +168,11 @@ async def test_home_advisory_does_not_promise_a_disabled_scheduler_retry(monkeyp
         advisories = runtime.get_advisories(cast("Any", app)).snapshot()
         advisory = next(a for a in advisories if a.id == "map-home-undetected")
         assert advisory.detail is not None
-        assert "site-home-refresh" not in advisory.detail
+        assert (
+            "When scheduling and background jobs are active, the site-home refresh "
+            "job retries detection."
+            in advisory.detail
+        )
 
 
 async def test_scheduler_receives_the_app_for_reader_reloads(monkeypatch):
@@ -278,6 +282,21 @@ async def test_scheduler_registers_site_home_refresh_for_a_ui_head(monkeypatch):
     assert job is not None
     assert job.func is refresh_site_home_job
     assert job.args == (session_factory, settings, app)
+
+
+async def test_scheduler_skips_site_home_refresh_for_a_ui_head_without_detection(
+    monkeypatch,
+):
+    from geometrikks.config.settings import MapSettings, Settings
+    from geometrikks.server.scheduler import create_scheduler
+
+    monkeypatch.setenv("LOGPARSER_ENABLED", "false")
+    settings = Settings(map=MapSettings(auto_detect_home=False, _env_file=None))
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    scheduler = await create_scheduler(MagicMock(), settings, app=cast("Any", app))
+
+    assert scheduler.get_job("site-home-refresh") is None
 
 
 async def test_site_home_refresh_uses_its_own_cadence(monkeypatch):

--- a/tests/test_lifecycle_geoip.py
+++ b/tests/test_lifecycle_geoip.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -114,6 +114,63 @@ async def test_asn_failure_does_not_flip_geoip_available(monkeypatch):
     assert app.state.asn_available is False
 
 
+async def test_undetected_home_registers_advisory_when_detection_was_possible(
+    monkeypatch,
+):
+    from geometrikks.server import lifecycle as lc
+    from geometrikks.server import runtime
+
+    monkeypatch.setenv("MAP_AUTO_DETECT_HOME", "true")
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=True, ensure=AsyncMock(return_value=True)
+    )
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    async with enter_lifespan(app):
+        ids = [
+            advisory.id
+            for advisory in runtime.get_advisories(cast("Any", app)).snapshot()
+        ]
+        assert "map-home-undetected" in ids
+
+
+async def test_no_home_advisory_when_geoip_is_missing(monkeypatch):
+    """Geo-degraded mode has its own warning because detection never ran."""
+    from geometrikks.server import lifecycle as lc
+    from geometrikks.server import runtime
+
+    monkeypatch.setenv("MAP_AUTO_DETECT_HOME", "true")
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=True, ensure=AsyncMock(return_value=False)
+    )
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    async with enter_lifespan(app):
+        ids = [
+            advisory.id
+            for advisory in runtime.get_advisories(cast("Any", app)).snapshot()
+        ]
+        assert "map-home-undetected" not in ids
+
+
+async def test_home_advisory_does_not_promise_a_disabled_scheduler_retry(monkeypatch):
+    from geometrikks.server import lifecycle as lc
+    from geometrikks.server import runtime
+
+    monkeypatch.setenv("MAP_AUTO_DETECT_HOME", "true")
+    monkeypatch.setenv("SCHEDULER_ENABLED", "false")
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=True, ensure=AsyncMock(return_value=True)
+    )
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    async with enter_lifespan(app):
+        advisories = runtime.get_advisories(cast("Any", app)).snapshot()
+        advisory = next(a for a in advisories if a.id == "map-home-undetected")
+        assert advisory.detail is not None
+        assert "site-home-refresh" not in advisory.detail
+
+
 async def test_scheduler_receives_the_app_for_reader_reloads(monkeypatch):
     """The geoip-refresh job resolves the ingestion service through the app
     at run time; the lifecycle must hand the app to create_scheduler."""
@@ -194,8 +251,7 @@ async def test_scheduler_registers_site_home_refresh_in_full_mode(monkeypatch):
 
 
 async def test_scheduler_skips_site_home_refresh_when_parser_disabled(monkeypatch):
-    """A UI head never writes site homes; the job must not appear in its
-    (user-visible) scheduler jobs list at all."""
+    """A scheduler without an app cannot refresh app state or site homes."""
     from geometrikks.config.settings import Settings
     from geometrikks.server.scheduler import create_scheduler
 
@@ -203,6 +259,25 @@ async def test_scheduler_skips_site_home_refresh_when_parser_disabled(monkeypatc
     scheduler = await create_scheduler(MagicMock(), Settings())
     job_ids = {job.id for job in scheduler.get_jobs()}
     assert "site-home-refresh" not in job_ids
+
+
+async def test_scheduler_registers_site_home_refresh_for_a_ui_head(monkeypatch):
+    from geometrikks.config.settings import MapSettings, Settings
+    from geometrikks.server.scheduler import create_scheduler, refresh_site_home_job
+
+    monkeypatch.setenv("LOGPARSER_ENABLED", "false")
+    settings = Settings(map=MapSettings(auto_detect_home=True, _env_file=None))
+    app = SimpleNamespace(state=SimpleNamespace())
+    session_factory = MagicMock()
+
+    scheduler = await create_scheduler(
+        session_factory, settings, app=cast("Any", app)
+    )
+    job = scheduler.get_job("site-home-refresh")
+
+    assert job is not None
+    assert job.func is refresh_site_home_job
+    assert job.args == (session_factory, settings, app)
 
 
 async def test_site_home_refresh_uses_its_own_cadence(monkeypatch):

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -143,6 +143,9 @@ async def test_ingestion_start_failure_still_stops_service(monkeypatch):
             pass
 
     ingestion.stop.assert_awaited_once()
+    assert not hasattr(app.state, "ingestion_service")
+    await lc.stop_ingestion(cast("Any", app))
+    ingestion.stop.assert_awaited_once()
 
 
 async def test_db_degraded_mode_skips_scheduler_and_ingestion(monkeypatch):
@@ -161,6 +164,63 @@ async def test_db_degraded_mode_skips_scheduler_and_ingestion(monkeypatch):
 
     cast("AsyncMock", lc.create_scheduler).assert_not_awaited()
     cast("MagicMock", lc.LogIngestionService).assert_not_called()
+
+
+async def test_degraded_start_registers_advisory_and_defers_the_poller(monkeypatch):
+    from geometrikks.server import lifecycle as lc
+    from geometrikks.server import runtime
+
+    _enable_crowdsec(monkeypatch)
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=False, ensure=AsyncMock(return_value=True)
+    )
+    _patch_crowdsec_service(monkeypatch, lc)
+    poller = cast("MagicMock", lc.CrowdSecStreamPoller).return_value
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    async with enter_lifespan(app):
+        assert app.state.db_available is False
+        assert app.state.db_degraded_since is not None
+        assert app.state.crowdsec_stream_poller is None
+        assert app.state.crowdsec_stream_poller_deferred is poller
+        ids = [a.id for a in runtime.get_advisories(cast("Any", app)).snapshot()]
+        # Membership, not equality: geoip_lifespan may register the
+        # map-home advisory too (Task 16).
+        assert "database-unavailable" in ids
+
+
+async def test_stop_functions_are_no_ops_without_state():
+    from geometrikks.server import lifecycle as lc
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    await lc.stop_scheduler(cast("Any", app))
+    await lc.stop_ingestion(cast("Any", app))
+    await lc.stop_scheduler(cast("Any", app))
+    await lc.stop_ingestion(cast("Any", app))
+
+
+async def test_start_scheduler_attaches_state_before_start(monkeypatch):
+    """A start() that raises after activating the scheduler must leave it on
+    state so stop_scheduler can shut it down."""
+    from geometrikks.server import lifecycle as lc
+
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=True, ensure=AsyncMock(return_value=True)
+    )
+    scheduler = cast("AsyncMock", lc.create_scheduler).return_value
+    scheduler.start = MagicMock(side_effect=RuntimeError("job store down"))
+    scheduler.running = True
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    with pytest.raises(RuntimeError, match="job store down"):
+        await lc.start_scheduler(cast("Any", app))
+    assert app.state.scheduler is scheduler
+    await lc.stop_scheduler(cast("Any", app))
+    scheduler.shutdown.assert_called_once_with(wait=True)
+    assert not hasattr(app.state, "scheduler")
+    assert not hasattr(app.state, "scheduler_tracker")
+    await lc.stop_scheduler(cast("Any", app))
+    scheduler.shutdown.assert_called_once_with(wait=True)
 
 
 async def test_agent_mode_waits_for_schema_and_skips_crowdsec(monkeypatch):

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -223,6 +223,74 @@ async def test_start_scheduler_attaches_state_before_start(monkeypatch):
     scheduler.shutdown.assert_called_once_with(wait=True)
 
 
+async def test_stop_scheduler_waits_for_real_shutdown_before_detaching():
+    from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+    from geometrikks.server import lifecycle as lc
+
+    scheduler = AsyncIOScheduler()
+    scheduler.start()
+    app = SimpleNamespace(
+        state=SimpleNamespace(scheduler=scheduler, scheduler_tracker=object())
+    )
+
+    await asyncio.wait_for(lc.stop_scheduler(cast("Any", app)), timeout=2.0)
+
+    assert scheduler.running is False
+    assert not hasattr(app.state, "scheduler")
+    assert not hasattr(app.state, "scheduler_tracker")
+
+
+async def test_cancelled_ingestion_stop_retains_handle_for_later_cleanup(
+    monkeypatch, tmp_path
+):
+    from geometrikks.server import lifecycle as lc
+    from geometrikks.services.ingestion import service as ingestion_module
+    from tests.test_ingestion import make_parser, make_service
+
+    log_path = tmp_path / "stuck.log"
+    log_path.write_text("", encoding="utf-8")
+    parser = make_parser(log_path)
+    tail_started = asyncio.Event()
+    release_tail = asyncio.Event()
+
+    async def stuck_records(*args, **kwargs):
+        tail_started.set()
+        await release_tail.wait()
+        if False:
+            yield None
+
+    monkeypatch.setattr(parser, "iter_parsed_records", stuck_records)
+    service, _repos, _sessions = make_service([parser])
+    await service.start(skip_validation=True)
+    await asyncio.wait_for(tail_started.wait(), timeout=1.0)
+
+    wait_entered = asyncio.Event()
+    real_wait = asyncio.wait
+
+    async def observed_wait(*args, **kwargs):
+        wait_entered.set()
+        return await real_wait(*args, **kwargs)
+
+    monkeypatch.setattr(ingestion_module.asyncio, "wait", observed_wait)
+    app = SimpleNamespace(state=SimpleNamespace(ingestion_service=service))
+    first_stop = asyncio.create_task(lc.stop_ingestion(cast("Any", app)))
+    await asyncio.wait_for(wait_entered.wait(), timeout=1.0)
+    first_stop.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first_stop
+
+    assert app.state.ingestion_service is service
+    assert any(not task.done() for task in service._tail_tasks)
+
+    release_tail.set()
+    await asyncio.wait_for(lc.stop_ingestion(cast("Any", app)), timeout=1.0)
+
+    assert all(task.done() for task in service._tail_tasks)
+    assert not service.is_task_running
+    assert not hasattr(app.state, "ingestion_service")
+
+
 async def test_agent_mode_waits_for_schema_and_skips_crowdsec(monkeypatch):
     """Agent mode never migrates or manages TimescaleDB objects -- it waits
     for the primary instance's schema instead -- and never wires CrowdSec."""

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -626,3 +626,353 @@ async def test_db_availability_accessor_honors_default_and_recorded_state():
     assert is_db_available(cast("Any", app), default=False) is False
     app.state.db_available = False
     assert is_db_available(cast("Any", app)) is False
+
+
+class _RecoveryClock:
+    def __init__(self) -> None:
+        self.entered: asyncio.Queue[float] = asyncio.Queue()
+        self.release = asyncio.Semaphore(0)
+
+    async def sleep(self, seconds: float) -> None:
+        self.entered.put_nowait(seconds)
+        await self.release.acquire()
+
+    async def tick(self, expected: float) -> None:
+        assert await asyncio.wait_for(self.entered.get(), timeout=1.0) == expected
+        self.release.release()
+
+
+def _patch_recovery(monkeypatch, lc, answers: list[bool]) -> _RecoveryClock:
+    clock = _RecoveryClock()
+    monkeypatch.setattr(lc._SYSTEM_CLOCK, "sleep", clock.sleep)
+    monkeypatch.setattr(lc, "_db_available", AsyncMock(side_effect=[False, *answers]))
+    monkeypatch.setattr(lc, "reconcile_override_homes", AsyncMock())
+    monkeypatch.setattr(lc, "upsert_auto_homes", AsyncMock())
+    return clock
+
+
+async def test_recovery_runs_deferred_startup_with_capped_backoff(monkeypatch):
+    from geometrikks.server import lifecycle as lc
+    from geometrikks.server import runtime
+
+    _enable_crowdsec(monkeypatch)
+    ingestion, _ = _patch_startup_collaborators(
+        monkeypatch, lc, db_available=False, ensure=AsyncMock(return_value=True)
+    )
+    _patch_crowdsec_service(monkeypatch, lc)
+    poller = cast("MagicMock", lc.CrowdSecStreamPoller).return_value
+    backend = MagicMock(recover=AsyncMock())
+    clock = _patch_recovery(monkeypatch, lc, [False, False, False, False, True])
+    app = SimpleNamespace(state=SimpleNamespace(channels_backend=backend))
+
+    async with enter_lifespan(app):
+        task = app.state.db_recovery_task
+        assert task.get_name() == "db-recovery"
+        for delay in [10.0, 20.0, 40.0, 60.0, 60.0]:
+            assert app.state.db_available is False
+            await clock.tick(delay)
+        await asyncio.wait_for(task, timeout=1.0)
+
+        cast("AsyncMock", lc.migrate_database).assert_awaited_once()
+        cast("AsyncMock", lc.setup_timescaledb).assert_awaited_once()
+        cast("AsyncMock", lc.reconcile_override_homes).assert_awaited_once()
+        cast("AsyncMock", lc.upsert_auto_homes).assert_awaited_once()
+        backend.recover.assert_awaited_once()
+        assert app.state.crowdsec_stream_poller is poller
+        assert app.state.crowdsec_stream_poller_deferred is None
+        assert app.state.scheduler is cast("AsyncMock", lc.create_scheduler).return_value
+        ingestion.start.assert_awaited_once()
+        assert app.state.db_available is True
+        assert app.state.db_degraded_since is None
+        assert "database-unavailable" not in [
+            a.id for a in runtime.get_advisories(cast("Any", app)).snapshot()
+        ]
+
+    ingestion.stop.assert_awaited_once()
+
+
+@pytest.mark.parametrize("stage", ["migration", "database setup", "scheduler", "ingestion"])
+async def test_recovery_failure_is_terminal_and_unwinds_partial_services(monkeypatch, stage):
+    from geometrikks.lib.advisories import DATABASE_RECOVERY_FAILED
+    from geometrikks.server import lifecycle as lc
+    from geometrikks.server import runtime
+
+    _enable_crowdsec(monkeypatch)
+    ingestion, _ = _patch_startup_collaborators(
+        monkeypatch, lc, db_available=False, ensure=AsyncMock(return_value=True)
+    )
+    _patch_crowdsec_service(monkeypatch, lc)
+    poller = cast("MagicMock", lc.CrowdSecStreamPoller).return_value
+    scheduler = cast("AsyncMock", lc.create_scheduler).return_value
+    scheduler.running = True
+    clock = _patch_recovery(monkeypatch, lc, [True])
+    failure = RuntimeError("recovery failed here")
+    if stage == "migration":
+        cast("AsyncMock", lc.migrate_database).side_effect = failure
+    elif stage == "database setup":
+        cast("AsyncMock", lc.setup_timescaledb).side_effect = failure
+    elif stage == "scheduler":
+        scheduler.start.side_effect = failure
+    else:
+        ingestion.start.side_effect = failure
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    async with enter_lifespan(app):
+        task = app.state.db_recovery_task
+        since = app.state.db_degraded_since
+        await clock.tick(10.0)
+        await asyncio.wait_for(task, timeout=1.0)
+        assert task.done()
+        assert app.state.db_available is False
+        assert app.state.db_degraded_since == since
+        advisories = runtime.get_advisories(cast("Any", app)).snapshot()
+        assert [a.id for a in advisories] == [DATABASE_RECOVERY_FAILED.id]
+        advisory = advisories[0]
+        assert advisory.severity == "critical"
+        if stage == "migration":
+            assert advisory == DATABASE_RECOVERY_FAILED
+        else:
+            assert stage in advisory.summary.lower()
+            assert "migration failed" not in advisory.summary
+            assert advisory.detail is not None and "Restart" in advisory.detail
+        assert not hasattr(app.state, "scheduler")
+        assert not hasattr(app.state, "ingestion_service")
+        assert app.state.crowdsec_stream_poller is None
+        assert app.state.crowdsec_stream_poller_deferred is poller
+        if stage in {"scheduler", "ingestion"}:
+            scheduler.shutdown.assert_called_once_with(wait=True)
+        if stage == "ingestion":
+            ingestion.stop.assert_awaited_once()
+        cast("AsyncMock", lc.migrate_database).assert_awaited_once()
+        assert clock.entered.empty()
+
+
+async def test_recovery_continues_when_channels_backend_recover_fails(monkeypatch):
+    from geometrikks.server import lifecycle as lc
+
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=False, ensure=AsyncMock(return_value=True)
+    )
+    clock = _patch_recovery(monkeypatch, lc, [True])
+    backend = MagicMock(recover=AsyncMock(side_effect=OSError("still refused")))
+    app = SimpleNamespace(state=SimpleNamespace(channels_backend=backend))
+    async with enter_lifespan(app):
+        await clock.tick(10.0)
+        await asyncio.wait_for(app.state.db_recovery_task, timeout=1.0)
+        assert app.state.db_available is True
+        backend.recover.assert_awaited_once()
+        cast("AsyncMock", lc.create_scheduler).assert_awaited_once()
+        backend.on_shutdown.assert_not_called()
+
+
+async def test_shutdown_cancels_a_pending_recovery(monkeypatch):
+    from geometrikks.server import lifecycle as lc
+
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=False, ensure=AsyncMock(return_value=True)
+    )
+    clock = _patch_recovery(monkeypatch, lc, [])
+    app = SimpleNamespace(state=SimpleNamespace())
+    async with enter_lifespan(app):
+        task = app.state.db_recovery_task
+        assert await asyncio.wait_for(clock.entered.get(), timeout=1.0) == 10.0
+        assert not task.done()
+    assert task.cancelled()
+    cast("AsyncMock", lc.migrate_database).assert_not_awaited()
+
+
+@pytest.mark.parametrize("stage", ["migration", "channels", "scheduler", "ingestion"])
+@pytest.mark.parametrize("cancel_before_shutdown", [False, True])
+async def test_shutdown_during_recovery_unwinds_before_client_closes(
+    monkeypatch, stage, cancel_before_shutdown
+):
+    from geometrikks.server import lifecycle as lc
+
+    _enable_crowdsec(monkeypatch)
+    ingestion, _ = _patch_startup_collaborators(
+        monkeypatch, lc, db_available=False, ensure=AsyncMock(return_value=True)
+    )
+    service = _patch_crowdsec_service(monkeypatch, lc)
+    poller = cast("MagicMock", lc.CrowdSecStreamPoller).return_value
+    clock = _patch_recovery(monkeypatch, lc, [True])
+    entered = asyncio.Event()
+    cancelled = asyncio.Event()
+    order: list[str] = []
+
+    async def blocked(*args, **kwargs):
+        entered.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            order.append("cancelled")
+            cancelled.set()
+
+    scheduler = cast("AsyncMock", lc.create_scheduler).return_value
+    scheduler.running = True
+    scheduler.shutdown.side_effect = lambda wait=True: order.append("scheduler")
+    ingestion.stop.side_effect = lambda timeout=None: order.append("ingestion")
+    service.aclose.side_effect = lambda: order.append("client")
+    backend = MagicMock(recover=AsyncMock())
+    if stage == "migration":
+        cast("AsyncMock", lc.migrate_database).side_effect = blocked
+    elif stage == "channels":
+        backend.recover.side_effect = blocked
+    elif stage == "scheduler":
+        original = lc.start_scheduler
+
+        async def start_then_block(app):
+            await original(app)
+            await blocked()
+
+        monkeypatch.setattr(lc, "start_scheduler", start_then_block)
+    else:
+        ingestion.start.side_effect = blocked
+    app = SimpleNamespace(state=SimpleNamespace(channels_backend=backend))
+    async with enter_lifespan(app):
+        task = app.state.db_recovery_task
+        await clock.tick(10.0)
+        await asyncio.wait_for(entered.wait(), timeout=1.0)
+        assert app.state.db_available is False
+        if cancel_before_shutdown:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert not hasattr(app.state, "scheduler")
+            assert not hasattr(app.state, "ingestion_service")
+            assert app.state.crowdsec_stream_poller is None
+            service.aclose.assert_not_awaited()
+    assert task.cancelled()
+    assert cancelled.is_set()
+    assert order == {
+        "migration": ["cancelled", "client"],
+        "channels": ["cancelled", "client"],
+        "scheduler": ["cancelled", "scheduler", "client"],
+        "ingestion": ["cancelled", "ingestion", "scheduler", "client"],
+    }[stage]
+    assert app.state.crowdsec_stream_poller is None
+    assert app.state.crowdsec_stream_poller_deferred is poller
+    assert not hasattr(app.state, "scheduler")
+    assert not hasattr(app.state, "ingestion_service")
+    assert app.state.db_available is False
+
+
+@pytest.mark.parametrize("cleanup_cancelled", [False, True])
+async def test_recovery_cleanup_failure_keeps_handle_and_still_stops_scheduler(
+    monkeypatch, cleanup_cancelled
+):
+    from geometrikks.server import lifecycle as lc
+    from geometrikks.server import runtime
+
+    _enable_crowdsec(monkeypatch)
+    ingestion, _ = _patch_startup_collaborators(
+        monkeypatch, lc, db_available=False, ensure=AsyncMock(return_value=True)
+    )
+    _patch_crowdsec_service(monkeypatch, lc)
+    clock = _patch_recovery(monkeypatch, lc, [True])
+    ingestion.start.side_effect = RuntimeError("tailer exploded")
+    cleanup_error = asyncio.CancelledError() if cleanup_cancelled else RuntimeError("cleanup failed")
+    ingestion.stop.side_effect = [cleanup_error, None]
+    scheduler = cast("AsyncMock", lc.create_scheduler).return_value
+    scheduler.running = True
+    app = SimpleNamespace(state=SimpleNamespace())
+    async with enter_lifespan(app):
+        await clock.tick(10.0)
+        if cleanup_cancelled:
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(app.state.db_recovery_task, timeout=1.0)
+        else:
+            await asyncio.wait_for(app.state.db_recovery_task, timeout=1.0)
+        assert app.state.ingestion_service is ingestion
+        scheduler.shutdown.assert_called_once_with(wait=True)
+        assert not hasattr(app.state, "scheduler")
+        assert app.state.crowdsec_stream_poller is None
+        assert runtime.get_advisories(cast("Any", app)).snapshot()[0].id == "database-recovery-failed"
+    assert ingestion.stop.await_count == 2
+    assert not hasattr(app.state, "ingestion_service")
+
+
+async def test_recovery_lifespan_awaits_already_completed_task(monkeypatch):
+    from geometrikks.server import lifecycle as lc
+
+    monkeypatch.setattr(lc, "_recover_database", AsyncMock(side_effect=RuntimeError("unexpected task error")))
+    app = SimpleNamespace(state=SimpleNamespace(db_available=False))
+    finished = asyncio.Event()
+    with pytest.raises(RuntimeError, match="unexpected task error"):
+        async with lc.db_recovery_lifespan(cast("Any", app)):
+            app.state.db_recovery_task.add_done_callback(lambda task: finished.set())
+            await asyncio.wait_for(finished.wait(), timeout=1.0)
+            assert app.state.db_recovery_task.done()
+
+
+@pytest.mark.parametrize("agent", [False, True])
+async def test_no_recovery_task_for_healthy_startup_or_agent(monkeypatch, agent):
+    from geometrikks.config.settings import Settings
+    from geometrikks.server import lifecycle as lc
+
+    monkeypatch.setenv("APP_MODE", "agent" if agent else "full")
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=True, ensure=AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(lc, "wait_for_schema", AsyncMock(return_value="timeout"))
+    app = SimpleNamespace(state=SimpleNamespace(settings=Settings()))
+    async with enter_lifespan(app):
+        assert not hasattr(app.state, "db_recovery_task")
+
+
+async def test_recovery_respects_disabled_ingestion(monkeypatch):
+    from geometrikks.server import lifecycle as lc
+
+    monkeypatch.setenv("LOGPARSER_ENABLED", "false")
+    ingestion, _ = _patch_startup_collaborators(
+        monkeypatch, lc, db_available=False, ensure=AsyncMock(return_value=True)
+    )
+    clock = _patch_recovery(monkeypatch, lc, [True])
+    app = SimpleNamespace(state=SimpleNamespace())
+    async with enter_lifespan(app):
+        await clock.tick(10.0)
+        await asyncio.wait_for(app.state.db_recovery_task, timeout=1.0)
+        assert app.state.db_available is True
+        cast("AsyncMock", lc.create_scheduler).assert_awaited_once()
+        ingestion.start.assert_not_awaited()
+
+
+async def test_recovery_elapsed_time_includes_bringup_and_service_start(monkeypatch):
+    from datetime import datetime, timedelta, timezone
+
+    from geometrikks.server import lifecycle as lc
+
+    now = datetime(2026, 9, 6, tzinfo=timezone.utc)
+
+    class RecoveryDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return now
+
+    monkeypatch.setattr(lc, "datetime", RecoveryDateTime)
+    log = MagicMock()
+    monkeypatch.setattr(lc, "logger", log)
+    ingestion, _ = _patch_startup_collaborators(
+        monkeypatch, lc, db_available=False, ensure=AsyncMock(return_value=True)
+    )
+    clock = _patch_recovery(monkeypatch, lc, [True])
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    async def migrate(*args):
+        nonlocal now
+        assert app.state.db_available is False
+        now += timedelta(seconds=7)
+
+    async def start(**kwargs):
+        nonlocal now
+        assert app.state.db_available is False
+        now += timedelta(seconds=3)
+
+    cast("AsyncMock", lc.migrate_database).side_effect = migrate
+    ingestion.start.side_effect = start
+    async with enter_lifespan(app):
+        now += timedelta(seconds=10)
+        await clock.tick(10.0)
+        await asyncio.wait_for(app.state.db_recovery_task, timeout=1.0)
+        assert app.state.db_available is True
+        log.info.assert_any_call("db_recovery_started", degraded_seconds=10.0)
+        log.info.assert_any_call("db_recovered", degraded_seconds=20.0)

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -1,6 +1,7 @@
 """Lifespan managers: teardown ordering, partial-failure unwind, degraded mode."""
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -368,3 +369,132 @@ async def test_ingestion_wires_per_file_hostnames(monkeypatch):
     ]
     assert hostnames == ["vps-1", "vps-2"]
     assert cast("MagicMock", lc.LogIngestionService).call_args.kwargs["hostname"] == "vps-1"
+
+
+class _StartupWaitClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    async def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+async def test_wait_for_database_clamps_probe_timeout_to_remaining_budget(monkeypatch):
+    from geometrikks.server import lifecycle as lc
+
+    monkeypatch.setenv("DISABLE_WAIT", "false")
+    clock = _StartupWaitClock()
+    timeouts: list[float] = []
+
+    async def refused(app, timeout: float = 10.0) -> bool:
+        timeouts.append(timeout)
+        clock.now += 7.0
+        return False
+
+    monkeypatch.setattr(lc, "_db_available", refused)
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    assert await lc._wait_for_database(cast("Any", app), 12.0, _clock=clock) is False
+    assert timeouts == [10.0, 3.0]
+    assert clock.sleeps == [2.0]
+
+
+async def test_wait_for_database_does_not_probe_at_deadline(monkeypatch):
+    from geometrikks.server import lifecycle as lc
+
+    monkeypatch.setenv("DISABLE_WAIT", "false")
+    clock = _StartupWaitClock()
+    probes = 0
+
+    async def refused(app, timeout: float = 10.0) -> bool:
+        nonlocal probes
+        probes += 1
+        clock.now += 5.0
+        return False
+
+    monkeypatch.setattr(lc, "_db_available", refused)
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    assert await lc._wait_for_database(cast("Any", app), 5.0, _clock=clock) is False
+    assert probes == 1
+    assert clock.sleeps == []
+
+
+async def test_wait_for_database_returns_on_success(monkeypatch):
+    from geometrikks.server import lifecycle as lc
+
+    monkeypatch.setenv("DISABLE_WAIT", "false")
+    clock = _StartupWaitClock()
+    answers = iter([False, True])
+
+    async def probe(app, timeout: float = 10.0) -> bool:
+        return next(answers)
+
+    monkeypatch.setattr(lc, "_db_available", probe)
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    assert await lc._wait_for_database(cast("Any", app), 30.0, _clock=clock) is True
+    assert clock.sleeps == [lc._PROBE_RETRY_DELAY]
+
+
+@pytest.mark.parametrize("disable_wait", [False, True])
+async def test_wait_for_database_zero_or_disabled_probes_once(
+    monkeypatch, disable_wait: bool
+):
+    from geometrikks.server import lifecycle as lc
+
+    monkeypatch.setenv("DISABLE_WAIT", str(disable_wait).lower())
+    timeouts: list[float] = []
+
+    async def refused(app, timeout: float = 10.0) -> bool:
+        timeouts.append(timeout)
+        return False
+
+    monkeypatch.setattr(lc, "_db_available", refused)
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    wait_seconds = 30.0 if disable_wait else 0.0
+    assert await lc._wait_for_database(cast("Any", app), wait_seconds) is False
+    assert timeouts == [10.0]
+
+
+async def test_wait_for_database_propagates_cancellation(monkeypatch):
+    from geometrikks.server import lifecycle as lc
+
+    monkeypatch.setenv("DISABLE_WAIT", "false")
+
+    async def cancelled(app, timeout: float = 10.0) -> bool:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(lc, "_db_available", cancelled)
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    with pytest.raises(asyncio.CancelledError):
+        await lc._wait_for_database(
+            cast("Any", app), 30.0, _clock=_StartupWaitClock()
+        )
+
+
+async def test_startup_wait_setting_defaults_and_rejects_negative_values():
+    from pydantic import ValidationError
+
+    from geometrikks.config.settings import DatabaseSettings
+
+    assert DatabaseSettings(_env_file=None).startup_wait_seconds == 30
+    with pytest.raises(ValidationError):
+        DatabaseSettings(_env_file=None, startup_wait_seconds=-1)
+
+
+async def test_db_availability_accessor_honors_default_and_recorded_state():
+    from geometrikks.server.runtime import is_db_available
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    assert is_db_available(cast("Any", app)) is True
+    assert is_db_available(cast("Any", app), default=False) is False
+    app.state.db_available = False
+    assert is_db_available(cast("Any", app)) is False

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -781,7 +781,7 @@ async def test_shutdown_cancels_a_pending_recovery(monkeypatch):
     cast("AsyncMock", lc.migrate_database).assert_not_awaited()
 
 
-@pytest.mark.parametrize("stage", ["migration", "channels", "scheduler", "ingestion"])
+@pytest.mark.parametrize("stage", ["channels", "scheduler", "ingestion"])
 @pytest.mark.parametrize("cancel_before_shutdown", [False, True])
 async def test_shutdown_during_recovery_unwinds_before_client_closes(
     monkeypatch, stage, cancel_before_shutdown
@@ -813,9 +813,7 @@ async def test_shutdown_during_recovery_unwinds_before_client_closes(
     ingestion.stop.side_effect = lambda timeout=None: order.append("ingestion")
     service.aclose.side_effect = lambda: order.append("client")
     backend = MagicMock(recover=AsyncMock())
-    if stage == "migration":
-        cast("AsyncMock", lc.migrate_database).side_effect = blocked
-    elif stage == "channels":
+    if stage == "channels":
         backend.recover.side_effect = blocked
     elif stage == "scheduler":
         original = lc.start_scheduler
@@ -844,7 +842,6 @@ async def test_shutdown_during_recovery_unwinds_before_client_closes(
     assert task.cancelled()
     assert cancelled.is_set()
     assert order == {
-        "migration": ["cancelled", "client"],
         "channels": ["cancelled", "client"],
         "scheduler": ["cancelled", "scheduler", "client"],
         "ingestion": ["cancelled", "ingestion", "scheduler", "client"],
@@ -976,3 +973,77 @@ async def test_recovery_elapsed_time_includes_bringup_and_service_start(monkeypa
         assert app.state.db_available is True
         log.info.assert_any_call("db_recovery_started", degraded_seconds=10.0)
         log.info.assert_any_call("db_recovered", degraded_seconds=20.0)
+
+
+@pytest.mark.parametrize("worker_fails", [False, True])
+async def test_recovery_shutdown_waits_for_migration_worker(monkeypatch, worker_fails):
+    import threading
+
+    from geometrikks.server import lifecycle as lc
+    from geometrikks.server import migrations
+
+    _enable_crowdsec(monkeypatch)
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=False, ensure=AsyncMock(return_value=True)
+    )
+    service = _patch_crowdsec_service(monkeypatch, lc)
+    clock = _patch_recovery(monkeypatch, lc, [True])
+    monkeypatch.setattr(lc, "migrate_database", migrations.migrate_database)
+    worker_started = asyncio.Event()
+    waiting_for_worker = asyncio.Event()
+    release_worker = threading.Event()
+    worker_finished = threading.Event()
+    loop = asyncio.get_running_loop()
+
+    def upgrade(database_url):
+        loop.call_soon_threadsafe(worker_started.set)
+        try:
+            release_worker.wait()
+            if worker_fails:
+                raise RuntimeError("worker upgrade failed")
+        finally:
+            worker_finished.set()
+
+    monkeypatch.setattr(migrations, "upgrade_to_head", upgrade)
+    original_info = lc.logger.info
+
+    def info(event, *args, **kwargs):
+        if event == "db_recovery_waiting_for_migration":
+            waiting_for_worker.set()
+        original_info(event, *args, **kwargs)
+
+    monkeypatch.setattr(lc.logger, "info", info)
+    app = SimpleNamespace(state=SimpleNamespace())
+    lifespan = enter_lifespan(app)
+    await lifespan.__aenter__()
+    close_task = None
+    waiting_task = asyncio.create_task(waiting_for_worker.wait())
+    try:
+        await clock.tick(10.0)
+        await asyncio.wait_for(worker_started.wait(), timeout=1.0)
+        close_task = asyncio.create_task(lifespan.__aexit__(None, None, None))
+        done, _ = await asyncio.wait(
+            {close_task, waiting_task}, timeout=1.0, return_when=asyncio.FIRST_COMPLETED
+        )
+        assert waiting_task in done
+        assert not close_task.done()
+        assert not app.state.db_recovery_task.done()
+        assert not worker_finished.is_set()
+        assert app.state.db_available is False
+        service.aclose.assert_not_awaited()
+        cast("AsyncMock", lc.setup_timescaledb).assert_not_awaited()
+        cast("AsyncMock", lc.create_scheduler).assert_not_awaited()
+    finally:
+        release_worker.set()
+        if close_task is None:
+            await lifespan.__aexit__(None, None, None)
+        else:
+            await asyncio.wait_for(close_task, timeout=2.0)
+        waiting_task.cancel()
+        await asyncio.gather(waiting_task, return_exceptions=True)
+
+    assert worker_finished.is_set()
+    assert app.state.db_recovery_task.cancelled()
+    service.aclose.assert_awaited_once()
+    cast("AsyncMock", lc.setup_timescaledb).assert_not_awaited()
+    cast("AsyncMock", lc.create_scheduler).assert_not_awaited()

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -49,6 +49,15 @@ async def test_teardown_runs_in_reverse_startup_order(monkeypatch):
         assert order == []
 
     assert order == ["ingestion", "scheduler", "crowdsec"]
+
+
+async def test_core_state_lifespan_initializes_advisory_registry():
+    from geometrikks.lib.advisories import AdvisoryRegistry
+    from geometrikks.server import lifecycle as lc
+
+    app = SimpleNamespace(state=SimpleNamespace())
+    async with lc.core_state_lifespan(cast("Any", app)):
+        assert isinstance(app.state.advisories, AdvisoryRegistry)
 
 
 async def test_startup_failure_unwinds_started_managers(monkeypatch):

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -691,6 +691,33 @@ async def test_recovery_runs_deferred_startup_with_capped_backoff(monkeypatch):
     ingestion.stop.assert_awaited_once()
 
 
+async def test_scheduler_disabled_recovery_never_activates_crowdsec_poller(monkeypatch):
+    from geometrikks.server import lifecycle as lc
+
+    _enable_crowdsec(monkeypatch)
+    monkeypatch.setenv("SCHEDULER_ENABLED", "false")
+    _patch_startup_collaborators(
+        monkeypatch, lc, db_available=False, ensure=AsyncMock(return_value=True)
+    )
+    _patch_crowdsec_service(monkeypatch, lc)
+    backend = MagicMock(recover=AsyncMock())
+    clock = _patch_recovery(monkeypatch, lc, [True])
+    app = SimpleNamespace(state=SimpleNamespace(channels_backend=backend))
+
+    async with enter_lifespan(app):
+        assert app.state.crowdsec_stream_poller is None
+        assert getattr(app.state, "crowdsec_stream_poller_deferred", None) is None
+        await clock.tick(10.0)
+        await asyncio.wait_for(app.state.db_recovery_task, timeout=1.0)
+        assert app.state.crowdsec_stream_poller is None
+        assert getattr(app.state, "crowdsec_stream_poller_deferred", None) is None
+        create_scheduler_mock = cast("AsyncMock", lc.create_scheduler)
+        assert create_scheduler_mock.await_args is not None
+        assert create_scheduler_mock.await_args.kwargs["crowdsec_poller"] is None
+
+    cast("MagicMock", lc.CrowdSecStreamPoller).assert_not_called()
+
+
 @pytest.mark.parametrize("stage", ["migration", "database setup", "scheduler", "ingestion"])
 async def test_recovery_failure_is_terminal_and_unwinds_partial_services(monkeypatch, stage):
     from geometrikks.lib.advisories import DATABASE_RECOVERY_FAILED

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -696,9 +696,12 @@ async def test_scheduler_disabled_recovery_never_activates_crowdsec_poller(monke
 
     _enable_crowdsec(monkeypatch)
     monkeypatch.setenv("SCHEDULER_ENABLED", "false")
+    real_create_scheduler = lc.create_scheduler
     _patch_startup_collaborators(
         monkeypatch, lc, db_available=False, ensure=AsyncMock(return_value=True)
     )
+    create_scheduler = AsyncMock(wraps=real_create_scheduler)
+    monkeypatch.setattr(lc, "create_scheduler", create_scheduler)
     _patch_crowdsec_service(monkeypatch, lc)
     backend = MagicMock(recover=AsyncMock())
     clock = _patch_recovery(monkeypatch, lc, [True])
@@ -711,11 +714,15 @@ async def test_scheduler_disabled_recovery_never_activates_crowdsec_poller(monke
         await asyncio.wait_for(app.state.db_recovery_task, timeout=1.0)
         assert app.state.crowdsec_stream_poller is None
         assert getattr(app.state, "crowdsec_stream_poller_deferred", None) is None
-        create_scheduler_mock = cast("AsyncMock", lc.create_scheduler)
-        assert create_scheduler_mock.await_args is not None
-        assert create_scheduler_mock.await_args.kwargs["crowdsec_poller"] is None
+        assert create_scheduler.await_args is not None
+        assert create_scheduler.await_args.kwargs["crowdsec_poller"] is None
+        assert app.state.scheduler.running is False
+        assert app.state.scheduler.get_jobs() == []
+        assert not hasattr(app.state, "scheduler_tracker")
 
     cast("MagicMock", lc.CrowdSecStreamPoller).assert_not_called()
+    assert not hasattr(app.state, "scheduler")
+    assert not hasattr(app.state, "scheduler_tracker")
 
 
 @pytest.mark.parametrize("stage", ["migration", "database setup", "scheduler", "ingestion"])

--- a/tests/test_live_ws.py
+++ b/tests/test_live_ws.py
@@ -113,6 +113,24 @@ def test_crowdsec_ws_closes_1013_when_poller_is_deferred():
     assert exc_info.value.detail == "crowdsec stream not running"
 
 
+def test_crowdsec_ws_closes_1013_when_scheduler_disabled(monkeypatch, tmp_path):
+    from geometrikks.domain.realtime.controllers import crowdsec_feed
+    from geometrikks.server import lifecycle
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CROWDSEC_LAPI_URL", "http://crowdsec:8080")
+    monkeypatch.setenv("CROWDSEC_BOUNCER_API_KEY", "key")
+    monkeypatch.setenv("SCHEDULER_ENABLED", "false")
+    app = Litestar(route_handlers=[crowdsec_feed], lifespan=[lifecycle.crowdsec_lifespan])
+    with TestClient(app) as client:
+        assert app.state.crowdsec_service is not None
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with client.websocket_connect("/ws/crowdsec") as ws:
+                ws.receive_json(timeout=2)
+    assert exc_info.value.code == 1013
+    assert exc_info.value.detail == "crowdsec stream not running"
+
+
 def test_ws_counts_dropped_events_beyond_frame_cap():
     """Overflow beyond MAX_EVENTS_PER_FRAME is counted, not silently lost."""
     app, channels = _live_app()

--- a/tests/test_live_ws.py
+++ b/tests/test_live_ws.py
@@ -99,6 +99,20 @@ def test_ws_closes_1013_when_db_unavailable():
     assert exc_info.value.detail == "live feed unavailable (database down)"
 
 
+def test_crowdsec_ws_closes_1013_when_poller_is_deferred():
+    from geometrikks.domain.realtime.controllers import crowdsec_feed
+
+    app = Litestar(route_handlers=[crowdsec_feed])
+    app.state.crowdsec_stream_poller = None
+    app.state.crowdsec_stream_poller_deferred = object()
+    with TestClient(app) as client:
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with client.websocket_connect("/ws/crowdsec") as ws:
+                ws.receive_json(timeout=2)
+    assert exc_info.value.code == 1013
+    assert exc_info.value.detail == "crowdsec stream not running"
+
+
 def test_ws_counts_dropped_events_beyond_frame_cap():
     """Overflow beyond MAX_EVENTS_PER_FRAME is counted, not silently lost."""
     app, channels = _live_app()

--- a/tests/test_live_ws.py
+++ b/tests/test_live_ws.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
+from threading import Event
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 
@@ -277,107 +278,82 @@ class TestLogsFeed:
         from geometrikks.domain.realtime.controllers import logs_feed
         return Litestar(route_handlers=[logs_feed])
 
-    def _receive_data_frame(self, ws, publish, timeout: float = 5.0):
-        """Publish repeatedly until a non-heartbeat frame arrives.
+    def _isolated_broadcaster(self, monkeypatch):
+        from geometrikks.domain.realtime import controllers as live_controller
+        from geometrikks.server.logging import LogBroadcaster
 
-        The handler subscribes shortly AFTER the handshake completes, so a
-        single publish can race the subscribe and be missed; heartbeat frames
-        (empty records, dropped=0) are skipped.
-        """
-        import time
-        deadline = time.time() + timeout
-        while time.time() < deadline:
-            publish()
-            frame = ws.receive_json(timeout=2)
-            if frame["records"]:
-                return frame
-        raise AssertionError("no data frame received")
+        broadcaster = LogBroadcaster()
+        subscribed = Event()
+        subscribe = broadcaster.subscribe
 
-    def test_streams_published_events(self):
-        from geometrikks.server.logging import log_broadcaster
+        def subscribe_and_signal():
+            queue = subscribe()
+            subscribed.set()
+            return queue
+
+        monkeypatch.setattr(broadcaster, "subscribe", subscribe_and_signal)
+        monkeypatch.setattr(live_controller, "log_broadcaster", broadcaster)
+        return broadcaster, subscribed
+
+    def test_streams_published_events(self, monkeypatch):
+        broadcaster, subscribed = self._isolated_broadcaster(monkeypatch)
         with TestClient(app=self._make_app()) as client:
             with client.websocket_connect("/ws/logs") as ws:
-                frame = self._receive_data_frame(
-                    ws,
-                    lambda: log_broadcaster.publish_threadsafe(
-                        {"timestamp": "t", "level": "info", "event": "hello_ws"}
-                    ),
+                assert subscribed.wait(timeout=2)
+                broadcaster.publish_threadsafe(
+                    {"timestamp": "t", "level": "info", "event": "hello_ws"}
                 )
+                frame = ws.receive_json(timeout=2)
                 assert frame["type"] == "log_batch"
                 assert any(r.get("event") == "hello_ws" for r in frame["records"])
 
-    def test_level_filter_drops_lower_levels(self):
-        """log_broadcaster is a process-wide singleton, so under full-suite
-        load unrelated concurrent log records can share frames with this
-        test's own publishes. A single frame's worth of records is not
-        reliable evidence either way (a frame full of other tests' >=warning
-        noise can crowd out our own "boom" record before it's ever seen), so
-        this collects records across frames using unique per-run sentinel
-        event names and keeps going until its own "boom" sentinel is seen
-        rather than trusting whatever showed up in the first frame.
-        """
-        import time
-        import uuid
-
-        from geometrikks.server.logging import log_broadcaster
-
-        marker = uuid.uuid4().hex
-        noise_event = f"noise-{marker}"
-        boom_event = f"boom-{marker}"
+    def test_level_filter_drops_lower_levels(self, monkeypatch):
+        broadcaster, subscribed = self._isolated_broadcaster(monkeypatch)
         with TestClient(app=self._make_app()) as client:
             with client.websocket_connect("/ws/logs?level=warning") as ws:
-                def publish():
-                    log_broadcaster.publish_threadsafe({"level": "debug", "event": noise_event})
-                    log_broadcaster.publish_threadsafe({"level": "error", "event": boom_event})
-
-                seen_events: set[str] = set()
-                deadline = time.time() + 5
-                while time.time() < deadline and boom_event not in seen_events:
-                    publish()
-                    frame = ws.receive_json(timeout=2)
-                    seen_events.update(r.get("event", "") for r in frame["records"])
-                assert boom_event in seen_events
-                assert noise_event not in seen_events
+                assert subscribed.wait(timeout=2)
+                broadcaster.publish_threadsafe({"level": "debug", "event": "noise"})
+                broadcaster.publish_threadsafe({"level": "error", "event": "boom"})
+                frame = ws.receive_json(timeout=2)
+                events = {record.get("event") for record in frame["records"]}
+                assert "boom" in events
+                assert "noise" not in events
 
     def test_sends_empty_log_batch_heartbeat_when_idle(self, monkeypatch):
         from geometrikks.domain.realtime import controllers as live_controller
 
         monkeypatch.setattr(live_controller, "HEARTBEAT_INTERVAL", 0.3, raising=False)
+        _broadcaster, subscribed = self._isolated_broadcaster(monkeypatch)
         with TestClient(app=self._make_app()) as client:
             with client.websocket_connect("/ws/logs") as ws:
+                assert subscribed.wait(timeout=2)
                 frame = ws.receive_json(timeout=5)
         assert frame == {"type": "log_batch", "records": [], "dropped": 0}
 
     def test_counts_dropped_records_beyond_frame_cap(self, monkeypatch):
         from geometrikks.domain.realtime import controllers as live_controller
-        from geometrikks.server.logging import log_broadcaster
 
         monkeypatch.setattr(live_controller, "MAX_RECORDS_PER_FRAME", 3, raising=False)
-        import time
+        broadcaster, subscribed = self._isolated_broadcaster(monkeypatch)
 
         with TestClient(app=self._make_app()) as client:
             with client.websocket_connect("/ws/logs") as ws:
-                deadline = time.time() + 5
-                while time.time() < deadline:
-                    # A burst larger than the frame cap; retried because a
-                    # publish can race the handler's subscribe.
+                assert subscribed.wait(timeout=2)
+
+                def publish_burst() -> None:
                     for i in range(10):
-                        log_broadcaster.publish_threadsafe(
+                        broadcaster.publish_threadsafe(
                             {"level": "info", "event": f"burst{i}"}
                         )
-                    frame = ws.receive_json(timeout=2)
-                    if frame["dropped"]:
-                        break
-                else:
-                    raise AssertionError("no frame with dropped records received")
+
+                client.blocking_portal.call(publish_burst)
+                frame = ws.receive_json(timeout=2)
         assert len(frame["records"]) == 3
         assert frame["dropped"] > 0
 
-    def test_unsubscribes_on_disconnect(self):
-        from geometrikks.server.logging import log_broadcaster
-
-        baseline = len(log_broadcaster._subscribers)
+    def test_unsubscribes_on_disconnect(self, monkeypatch):
+        broadcaster, subscribed = self._isolated_broadcaster(monkeypatch)
         with TestClient(app=self._make_app()) as client:
             with client.websocket_connect("/ws/logs"):
-                pass
-        assert len(log_broadcaster._subscribers) == baseline
+                assert subscribed.wait(timeout=2)
+        assert broadcaster._subscribers == set()

--- a/tests/test_proxy_detection.py
+++ b/tests/test_proxy_detection.py
@@ -114,15 +114,21 @@ def test_collect_advisories_includes_proxy_cards(monkeypatch) -> None:
     from geometrikks.server import runtime, timescale
 
     s = summary(private_share=0.9, private_active=True)
-    service = SimpleNamespace(parsers=[fake_parser(summary=s)])
+    service = SimpleNamespace(
+        parsers=[fake_parser(summary=s)],
+        failed_batches=0,
+        failed_records=0,
+    )
     monkeypatch.setattr(runtime, "get_ingestion_service", lambda app: service)
     monkeypatch.setattr(timescale, "get_hostname_pollution", lambda: None)
+    monkeypatch.setattr(health, "_stale_geoip_advisories", lambda settings: [])
 
     settings = SimpleNamespace(
         app=SimpleNamespace(proxy_advisory=True),
         geoip=SimpleNamespace(asn_enabled=False),
     )
-    cards = health._collect_advisories(app=cast(Any, object()), settings=cast(Any, settings))
+    app = SimpleNamespace(state=SimpleNamespace())
+    cards = health._collect_advisories(app=cast(Any, app), settings=cast(Any, settings))
     assert [c.id for c in cards] == ["proxy-peer-private"]
 
 
@@ -131,16 +137,15 @@ def test_collect_advisories_respects_off_switch(monkeypatch) -> None:
     from geometrikks.domain.system.controllers import health
     from geometrikks.server import runtime, timescale
 
-    monkeypatch.setattr(
-        runtime, "get_ingestion_service",
-        lambda app: (_ for _ in ()).throw(AssertionError("must not be called")),
-    )
+    monkeypatch.setattr(runtime, "get_ingestion_service", lambda app: None)
     monkeypatch.setattr(timescale, "get_hostname_pollution", lambda: None)
+    monkeypatch.setattr(health, "_stale_geoip_advisories", lambda settings: [])
     settings = SimpleNamespace(
         app=SimpleNamespace(proxy_advisory=False),
         geoip=SimpleNamespace(asn_enabled=False),
     )
-    assert health._collect_advisories(app=cast(Any, object()), settings=cast(Any, settings)) == []
+    app = SimpleNamespace(state=SimpleNamespace())
+    assert health._collect_advisories(app=cast(Any, app), settings=cast(Any, settings)) == []
 
 
 def test_collect_advisories_survives_no_ingestion_service(monkeypatch) -> None:
@@ -150,11 +155,13 @@ def test_collect_advisories_survives_no_ingestion_service(monkeypatch) -> None:
 
     monkeypatch.setattr(runtime, "get_ingestion_service", lambda app: None)
     monkeypatch.setattr(timescale, "get_hostname_pollution", lambda: None)
+    monkeypatch.setattr(health, "_stale_geoip_advisories", lambda settings: [])
     settings = SimpleNamespace(
         app=SimpleNamespace(proxy_advisory=True),
         geoip=SimpleNamespace(asn_enabled=False),
     )
-    assert health._collect_advisories(app=cast(Any, object()), settings=cast(Any, settings)) == []
+    app = SimpleNamespace(state=SimpleNamespace())
+    assert health._collect_advisories(app=cast(Any, app), settings=cast(Any, settings)) == []
 
 
 def test_collect_advisories_merges_scan_findings(monkeypatch) -> None:
@@ -167,9 +174,14 @@ def test_collect_advisories_merges_scan_findings(monkeypatch) -> None:
 
     s = summary(cdn_share=0.9, cdn_active=True, top_provider="Fastly")
     local = fake_parser(hostname="web-01", summary=s)
-    service = SimpleNamespace(parsers=[local])
+    service = SimpleNamespace(
+        parsers=[local],
+        failed_batches=0,
+        failed_records=0,
+    )
     monkeypatch.setattr(runtime, "get_ingestion_service", lambda app: service)
     monkeypatch.setattr(timescale, "get_hostname_pollution", lambda: None)
+    monkeypatch.setattr(health, "_stale_geoip_advisories", lambda settings: [])
     scan = [
         ProxyFinding("traefik-01", "", "traefik-json", "cdn", 0.94, 1200, "Cloudflare"),
         ProxyFinding("web-01", "", "nginx", "cdn", 0.8, 999, "Fastly"),  # deduped
@@ -180,7 +192,8 @@ def test_collect_advisories_merges_scan_findings(monkeypatch) -> None:
         app=SimpleNamespace(proxy_advisory=True),
         geoip=SimpleNamespace(asn_enabled=False),
     )
-    [card] = health._collect_advisories(app=cast(Any, object()), settings=cast(Any, settings))
+    app = SimpleNamespace(state=SimpleNamespace())
+    [card] = health._collect_advisories(app=cast(Any, app), settings=cast(Any, settings))
     assert card.id == "proxy-peer-cdn"
     assert "web-01" in card.summary and "traefik-01" in card.summary
     assert card.summary.count("web-01") == 1
@@ -196,6 +209,7 @@ def test_collect_advisories_scan_only_when_no_ingestion_service(monkeypatch) -> 
 
     monkeypatch.setattr(runtime, "get_ingestion_service", lambda app: None)
     monkeypatch.setattr(timescale, "get_hostname_pollution", lambda: None)
+    monkeypatch.setattr(health, "_stale_geoip_advisories", lambda settings: [])
     scan = [ProxyFinding("traefik-01", "", "traefik-json", "cdn", 0.94, 1200, "Cloudflare")]
     monkeypatch.setattr(proxy_scan, "get_scan_findings", lambda: scan)
 
@@ -203,5 +217,6 @@ def test_collect_advisories_scan_only_when_no_ingestion_service(monkeypatch) -> 
         app=SimpleNamespace(proxy_advisory=True),
         geoip=SimpleNamespace(asn_enabled=False),
     )
-    cards = health._collect_advisories(app=cast(Any, object()), settings=cast(Any, settings))
+    app = SimpleNamespace(state=SimpleNamespace())
+    cards = health._collect_advisories(app=cast(Any, app), settings=cast(Any, settings))
     assert [c.id for c in cards] == ["proxy-peer-cdn"]

--- a/tests/test_proxy_scan.py
+++ b/tests/test_proxy_scan.py
@@ -7,8 +7,8 @@ import pytest
 import structlog
 
 from geometrikks.domain.system.proxy_scan import (
-    ScanGroup, ScanProvider, apply_scan_results, get_scan_findings,
-    reset_scan_state, run_proxy_scan,
+    ScanGroup, ScanProvider, apply_scan_results, get_scan_error,
+    get_scan_findings, reset_scan_state, run_proxy_scan,
 )
 
 
@@ -89,7 +89,9 @@ def test_vanished_source_clears() -> None:
 
 
 @pytest.mark.anyio
-async def test_failed_run_clears_cache_and_state() -> None:
+async def test_failed_run_keeps_findings_and_records_the_error() -> None:
+    """A down database must not read as "problem resolved": the last good
+    findings stay and the failure is exposed for /health."""
     apply_scan_results([groups_for("web", 1000, 800)], [ScanProvider("web", 13335, 800)])
     assert len(get_scan_findings()) == 1
 
@@ -98,12 +100,35 @@ async def test_failed_run_clears_cache_and_state() -> None:
 
     with structlog.testing.capture_logs() as logs:
         await run_proxy_scan(broken_factory, set())
-    assert get_scan_findings() == []
+    assert len(get_scan_findings()) == 1
+    assert get_scan_error() == "db down"
     assert any(e["event"] == "proxy_scan_failed" for e in logs)
-    # State is gone too: the next successful run re-detects from scratch.
-    with structlog.testing.capture_logs() as logs:
-        apply_scan_results([groups_for("web", 1000, 800)], [ScanProvider("web", 13335, 800)])
-    assert any(e["event"] == "proxy_peer_detected" for e in logs)
+
+
+@pytest.mark.anyio
+async def test_successful_run_clears_the_error(monkeypatch) -> None:
+    def broken_factory():
+        raise RuntimeError("db down")
+
+    await run_proxy_scan(broken_factory, set())
+    assert get_scan_error() == "db down"
+
+    from geometrikks.domain.system import proxy_scan
+
+    async def fake_query(session, exclude):
+        return [], []
+
+    monkeypatch.setattr(proxy_scan, "_query_scan_rows", fake_query)
+
+    class _Session:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    await run_proxy_scan(cast(Any, lambda: _Session()), set())
+    assert get_scan_error() is None
 
 
 @pytest.mark.anyio

--- a/tests/test_proxy_scan.py
+++ b/tests/test_proxy_scan.py
@@ -127,8 +127,10 @@ async def test_successful_run_clears_the_error(monkeypatch) -> None:
         async def __aexit__(self, *exc):
             return False
 
-    await run_proxy_scan(cast(Any, lambda: _Session()), set())
+    with structlog.testing.capture_logs() as logs:
+        await run_proxy_scan(cast(Any, lambda: _Session()), set())
     assert get_scan_error() is None
+    assert any(e["event"] == "proxy_scan_recovered" for e in logs)
 
 
 @pytest.mark.anyio

--- a/tests/test_proxy_scan.py
+++ b/tests/test_proxy_scan.py
@@ -104,9 +104,21 @@ async def test_failed_run_keeps_findings_and_records_the_error() -> None:
     assert get_scan_error() == "db down"
     assert any(e["event"] == "proxy_scan_failed" for e in logs)
 
+    apply_scan_results(
+        [groups_for("web", 1000, 600)],
+        [ScanProvider("web", 13335, 600)],
+    )
+    assert len(get_scan_findings()) == 1, "failed scan must retain active hysteresis state"
+
 
 @pytest.mark.anyio
 async def test_successful_run_clears_the_error(monkeypatch) -> None:
+    apply_scan_results(
+        [groups_for("old", 1000, 800)],
+        [ScanProvider("old", 13335, 800)],
+    )
+    assert [finding.hostname for finding in get_scan_findings()] == ["old"]
+
     def broken_factory():
         raise RuntimeError("db down")
 
@@ -116,7 +128,10 @@ async def test_successful_run_clears_the_error(monkeypatch) -> None:
     from geometrikks.domain.system import proxy_scan
 
     async def fake_query(session, exclude):
-        return [], []
+        return (
+            [groups_for("new", 1000, 900)],
+            [ScanProvider("new", 13335, 900)],
+        )
 
     monkeypatch.setattr(proxy_scan, "_query_scan_rows", fake_query)
 
@@ -130,6 +145,7 @@ async def test_successful_run_clears_the_error(monkeypatch) -> None:
     with structlog.testing.capture_logs() as logs:
         await run_proxy_scan(cast(Any, lambda: _Session()), set())
     assert get_scan_error() is None
+    assert [finding.hostname for finding in get_scan_findings()] == ["new"]
     assert any(e["event"] == "proxy_scan_recovered" for e in logs)
 
 

--- a/tests/test_scheduler_jobs.py
+++ b/tests/test_scheduler_jobs.py
@@ -79,3 +79,99 @@ async def test_refresh_location_last_hits_reraises_after_logging():
 
     with pytest.raises(RuntimeError, match="deadlock"):
         await AggregationService(session=session).refresh_location_last_hits()
+
+
+async def test_site_home_job_updates_app_state_and_clears_the_advisory(
+    monkeypatch,
+):
+    from types import SimpleNamespace
+
+    from geometrikks.config.settings import MapSettings, Settings
+    from geometrikks.lib.advisories import MAP_HOME_UNDETECTED
+    from geometrikks.server import runtime
+    from geometrikks.services.geoip import home as home_mod
+    from geometrikks.services.geoip import site_homes
+
+    resolved = home_mod.HomeLocation(
+        latitude=59.9, longitude=10.7, source="external_ip"
+    )
+    monkeypatch.setattr(
+        home_mod, "resolve_home_location", AsyncMock(return_value=resolved)
+    )
+    upsert = AsyncMock()
+    monkeypatch.setattr(site_homes, "upsert_auto_homes", upsert)
+
+    settings = Settings(map=MapSettings(auto_detect_home=True, _env_file=None))
+    app = SimpleNamespace(state=SimpleNamespace(map_home_location=None))
+    runtime.get_advisories(cast("Any", app)).set(MAP_HOME_UNDETECTED)
+
+    await sched.refresh_site_home_job(
+        cast("Any", object()), settings, cast("Any", app)
+    )
+
+    assert app.state.map_home_location is resolved
+    assert runtime.get_advisories(cast("Any", app)).snapshot() == []
+    upsert.assert_awaited_once()
+
+
+async def test_site_home_job_updates_a_ui_head_without_writing_the_database(
+    monkeypatch,
+):
+    from types import SimpleNamespace
+
+    from geometrikks.config.settings import LogParserSettings, MapSettings, Settings
+    from geometrikks.lib.advisories import MAP_HOME_UNDETECTED
+    from geometrikks.server import runtime
+    from geometrikks.services.geoip import home as home_mod
+    from geometrikks.services.geoip import site_homes
+
+    resolved = home_mod.HomeLocation(
+        latitude=59.9, longitude=10.7, source="external_ip"
+    )
+    monkeypatch.setattr(
+        home_mod, "resolve_home_location", AsyncMock(return_value=resolved)
+    )
+    upsert = AsyncMock()
+    monkeypatch.setattr(site_homes, "upsert_auto_homes", upsert)
+
+    settings = Settings(
+        logparser=LogParserSettings(enabled=False, _env_file=None),
+        map=MapSettings(auto_detect_home=True, _env_file=None),
+    )
+    app = SimpleNamespace(state=SimpleNamespace(map_home_location=None))
+    runtime.get_advisories(cast("Any", app)).set(MAP_HOME_UNDETECTED)
+
+    await sched.refresh_site_home_job(
+        cast("Any", object()), settings, cast("Any", app)
+    )
+
+    assert app.state.map_home_location is resolved
+    assert runtime.get_advisories(cast("Any", app)).snapshot() == []
+    upsert.assert_not_awaited()
+
+
+async def test_site_home_job_keeps_state_when_detection_fails(monkeypatch):
+    from types import SimpleNamespace
+
+    from geometrikks.config.settings import MapSettings, Settings
+    from geometrikks.services.geoip import home as home_mod
+    from geometrikks.services.geoip import site_homes
+
+    previous = home_mod.HomeLocation(
+        latitude=1.0, longitude=2.0, source="external_ip"
+    )
+    monkeypatch.setattr(
+        home_mod, "resolve_home_location", AsyncMock(return_value=None)
+    )
+    upsert = AsyncMock()
+    monkeypatch.setattr(site_homes, "upsert_auto_homes", upsert)
+
+    settings = Settings(map=MapSettings(auto_detect_home=True, _env_file=None))
+    app = SimpleNamespace(state=SimpleNamespace(map_home_location=previous))
+
+    await sched.refresh_site_home_job(
+        cast("Any", object()), settings, cast("Any", app)
+    )
+
+    assert app.state.map_home_location is previous
+    upsert.assert_awaited_once()

--- a/tests/test_scheduler_jobs.py
+++ b/tests/test_scheduler_jobs.py
@@ -1,0 +1,81 @@
+"""Scheduled job bodies raise on failure so the run tracker records it."""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from geometrikks.server import scheduler as sched
+from geometrikks.server.timescale import ALL_CAGGS
+
+pytestmark = pytest.mark.anyio
+
+
+def _session_factory(session: Any):
+    @asynccontextmanager
+    async def _ctx():
+        yield session
+
+    return lambda: _ctx()
+
+
+async def test_refresh_all_caggs_tries_every_cagg_then_raises(monkeypatch):
+    called: list[str] = []
+
+    async def fake_call(session_factory, sql: str, *args):
+        name = sql.split("'")[1]
+        called.append(name)
+        if name == ALL_CAGGS[1]:
+            raise RuntimeError("lock timeout")
+
+    monkeypatch.setattr(sched, "_execute_call_outside_transaction", fake_call)
+
+    message = (
+        rf"1 of {len(ALL_CAGGS)} aggregates failed to refresh: {ALL_CAGGS[1]}"
+    )
+    with pytest.raises(RuntimeError, match=message):
+        await sched.refresh_all_caggs_job(cast("Any", object()))
+
+    assert called == list(ALL_CAGGS)
+
+
+async def test_refresh_all_caggs_succeeds_quietly(monkeypatch):
+    called: list[str] = []
+
+    async def fake_call(session_factory, sql: str, *args):
+        called.append(sql.split("'")[1])
+
+    monkeypatch.setattr(sched, "_execute_call_outside_transaction", fake_call)
+
+    await sched.refresh_all_caggs_job(cast("Any", object()))
+
+    assert called == list(ALL_CAGGS)
+
+
+async def test_location_refresh_job_propagates_service_failure(monkeypatch):
+    from geometrikks.services.aggregation import service as agg
+
+    session = MagicMock()
+    session.commit = AsyncMock()
+    failing = MagicMock()
+    failing.refresh_location_last_hits = AsyncMock(
+        side_effect=RuntimeError("deadlock")
+    )
+    monkeypatch.setattr(agg, "AggregationService", MagicMock(return_value=failing))
+
+    with pytest.raises(RuntimeError, match="deadlock"):
+        await sched.refresh_location_last_hits_job(_session_factory(session))
+
+    session.commit.assert_not_awaited()
+
+
+async def test_refresh_location_last_hits_reraises_after_logging():
+    from geometrikks.services.aggregation.service import AggregationService
+
+    session = MagicMock()
+    session.execute = AsyncMock(side_effect=RuntimeError("deadlock"))
+
+    with pytest.raises(RuntimeError, match="deadlock"):
+        await AggregationService(session=session).refresh_location_last_hits()

--- a/tests/test_system_controller.py
+++ b/tests/test_system_controller.py
@@ -83,7 +83,9 @@ async def test_lists_jobs_with_run_info():
     assert job["lastStatus"] is None
 
 
-async def test_no_scheduler_reports_disabled():
+async def test_no_scheduler_reports_unavailable():
+    """DB-degraded mode never starts the scheduler; the page must not blame
+    SCHEDULER_ENABLED=false for that."""
     async with AsyncTestClient(app=make_app(with_scheduler=False)) as client:
         resp = await client.get("/api/v1/system/scheduler/jobs")
     assert resp.status_code == 200
@@ -91,7 +93,29 @@ async def test_no_scheduler_reports_disabled():
         "schedulerEnabled": False,
         "schedulerRunning": False,
         "jobs": [],
+        "status": "unavailable",
     }
+
+
+async def test_no_scheduler_reports_unavailable_when_configured_disabled(monkeypatch):
+    monkeypatch.setenv("SCHEDULER_ENABLED", "false")
+    async with AsyncTestClient(app=make_app(with_scheduler=False)) as client:
+        body = (await client.get("/api/v1/system/scheduler/jobs")).json()
+    assert body["status"] == "unavailable"
+
+
+async def test_running_scheduler_reports_status_running():
+    async with AsyncTestClient(app=make_app()) as client:
+        body = (await client.get("/api/v1/system/scheduler/jobs")).json()
+    assert body["status"] == "running"
+
+
+async def test_scheduler_disabled_by_settings_reports_status_disabled(monkeypatch):
+    monkeypatch.setenv("SCHEDULER_ENABLED", "false")
+    async with AsyncTestClient(app=make_app()) as client:
+        body = (await client.get("/api/v1/system/scheduler/jobs")).json()
+    assert body["status"] == "disabled"
+    assert body["schedulerEnabled"] is False
 
 
 async def test_run_now_moves_next_run_time():

--- a/tests/test_system_controller.py
+++ b/tests/test_system_controller.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 import pytest
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -10,6 +11,7 @@ from litestar import Litestar
 from litestar.di import Provide
 from litestar.testing import AsyncTestClient
 
+from geometrikks.config.settings import Settings
 from geometrikks.domain.analytics.asn_classification import hosting_asn_count
 from geometrikks.domain.system import commit
 from geometrikks.domain.system.controllers.system import SystemController
@@ -116,6 +118,50 @@ async def test_scheduler_disabled_by_settings_reports_status_disabled(monkeypatc
         body = (await client.get("/api/v1/system/scheduler/jobs")).json()
     assert body["status"] == "disabled"
     assert body["schedulerEnabled"] is False
+
+
+async def test_disabled_scheduler_stays_unstarted_and_detaches_on_shutdown(monkeypatch):
+    from geometrikks.server import lifecycle as lc
+
+    settings = Settings(scheduler={"enabled": False})
+    monkeypatch.setattr(
+        lc,
+        "get_app_db_config",
+        lambda _app: SimpleNamespace(create_session_maker=lambda: object()),
+    )
+
+    async def startup(app: Litestar) -> None:
+        app.state.settings = settings
+        await lc.start_scheduler(app)
+
+    async def shutdown(app: Litestar) -> None:
+        await lc.stop_scheduler(app)
+
+    app = Litestar(
+        route_handlers=[create_api_v1_router([SystemController])],
+        on_startup=[startup],
+        on_shutdown=[shutdown],
+        dependencies={
+            "settings": Provide(lambda: settings, sync_to_thread=False),
+            "db_engine": Provide(UnreachableEngine, sync_to_thread=False),
+        },
+    )
+
+    async with AsyncTestClient(app=app) as client:
+        scheduler = app.state.scheduler
+        body = (await client.get("/api/v1/system/scheduler/jobs")).json()
+        assert scheduler.running is False
+        assert scheduler.get_jobs() == []
+        assert not hasattr(app.state, "scheduler_tracker")
+        assert body == {
+            "schedulerEnabled": False,
+            "schedulerRunning": False,
+            "jobs": [],
+            "status": "disabled",
+        }
+
+    assert not hasattr(app.state, "scheduler")
+    assert not hasattr(app.state, "scheduler_tracker")
 
 
 async def test_run_now_moves_next_run_time():

--- a/tests/test_timescale_policies.py
+++ b/tests/test_timescale_policies.py
@@ -3,13 +3,18 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from geometrikks.server import timescale
 
 pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture(autouse=True)
+def isolate_policy_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(timescale, "_policy_failures", [], raising=False)
 
 
 @pytest.mark.parametrize("days", [1, 2, 3])
@@ -37,3 +42,148 @@ async def test_setup_refuses_a_bad_retention_before_touching_the_database() -> N
     with pytest.raises(ValueError, match="ANALYTICS_RAW_RETENTION_DAYS"):
         await timescale.setup_timescaledb(engine, cast("Any", analytics))
     engine.begin.assert_not_called()
+
+
+def test_policy_failures_are_recorded_and_reset() -> None:
+    timescale._reset_policy_failures()
+    timescale._record_policy_failure("retention", "geo_events", "permission denied")
+
+    [failure] = timescale.get_policy_failures()
+    assert (failure.policy, failure.target, failure.error) == (
+        "retention",
+        "geo_events",
+        "permission denied",
+    )
+
+    timescale._reset_policy_failures()
+    assert timescale.get_policy_failures() == []
+
+
+async def test_refresh_policy_update_failures_are_recorded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    monkeypatch.setattr(
+        timescale,
+        "_sync_policy_schedule",
+        AsyncMock(side_effect=RuntimeError("refresh update denied")),
+    )
+
+    await timescale._add_refresh_policies(cast("Any", conn), 5)
+
+    failures = timescale.get_policy_failures()
+    assert [(failure.policy, failure.target, failure.error) for failure in failures] == [
+        ("refresh", cagg, "refresh update denied")
+        for cagg, _start_offset, _end_offset in timescale.CAGG_REFRESH_CONFIG
+    ]
+
+
+async def test_retention_policy_update_failures_are_recorded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    monkeypatch.setattr(
+        timescale,
+        "_sync_policy_config",
+        AsyncMock(side_effect=RuntimeError("retention update denied")),
+    )
+
+    await timescale._add_retention_policies(
+        cast("Any", conn),
+        raw_retention_days=180,
+        debug_retention_days=30,
+        hourly_retention_days=60,
+    )
+
+    expected_targets = [
+        "geo_events",
+        "access_logs",
+        "access_log_debug",
+        *timescale.HOURLY_CAGGS,
+    ]
+    failures = timescale.get_policy_failures()
+    assert [(failure.policy, failure.target, failure.error) for failure in failures] == [
+        ("retention", target, "retention update denied") for target in expected_targets
+    ]
+
+
+async def test_compression_policy_update_failures_are_recorded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    monkeypatch.setattr(
+        timescale,
+        "_sync_policy_config",
+        AsyncMock(side_effect=RuntimeError("compression update denied")),
+    )
+
+    await timescale._add_compression_policies(cast("Any", conn), 7)
+
+    failures = timescale.get_policy_failures()
+    assert [(failure.policy, failure.target, failure.error) for failure in failures] == [
+        ("compression", table, "compression update denied")
+        for table in ("geo_events", "access_logs", "access_log_debug")
+    ]
+
+
+async def test_successful_setup_resets_previous_policy_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    timescale._record_policy_failure("retention", "geo_events", "old failure")
+    conn = MagicMock()
+    begin_context = MagicMock()
+    begin_context.__aenter__ = AsyncMock(return_value=conn)
+    begin_context.__aexit__ = AsyncMock(return_value=False)
+    engine = MagicMock()
+    engine.begin.return_value = begin_context
+
+    for name in (
+        "_enable_extensions",
+        "_create_hypertables",
+        "_create_summary_caggs",
+        "_create_geo_summary_caggs",
+        "_create_location_caggs",
+        "_create_ip_location_cagg",
+        "_create_log_ip_caggs",
+        "_create_url_caggs",
+        "_create_user_agent_caggs",
+        "_create_asn_caggs",
+        "_create_host_facet_caggs",
+        "_enable_realtime_aggregation",
+        "_add_refresh_policies",
+        "_add_retention_policies",
+        "_add_compression_policies",
+        "backfill_cagg_gaps",
+    ):
+        monkeypatch.setattr(timescale, name, AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        timescale, "_summary_caggs_need_upgrade", AsyncMock(return_value=False)
+    )
+    monkeypatch.setattr(
+        timescale, "_url_caggs_need_upgrade", AsyncMock(return_value=False)
+    )
+    monkeypatch.setattr(
+        timescale, "_cagg_columns_need_upgrade", AsyncMock(return_value=[])
+    )
+    monkeypatch.setattr(
+        timescale, "_location_caggs_need_upgrade", AsyncMock(return_value=False)
+    )
+    monkeypatch.setattr(
+        timescale,
+        "detect_hostname_pollution",
+        AsyncMock(return_value=timescale.classify_hostnames([])),
+    )
+    analytics = SimpleNamespace(
+        raw_retention_days=180,
+        debug_retention_days=30,
+        hourly_retention_days=60,
+        compression_after_days=7,
+        cagg_refresh_interval_minutes=5,
+    )
+
+    await timescale.setup_timescaledb(engine, cast("Any", analytics))
+
+    assert timescale.get_policy_failures() == []

--- a/tests/test_timescale_policies.py
+++ b/tests/test_timescale_policies.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import structlog
 
 from geometrikks.server import timescale
 
@@ -58,6 +59,30 @@ def test_policy_failures_are_recorded_and_reset() -> None:
 
     timescale._reset_policy_failures()
     assert timescale.get_policy_failures() == []
+
+
+def test_reset_policy_failures_logs_the_cleared_count() -> None:
+    timescale._record_policy_failure("retention", "geo_events", "permission denied")
+    timescale._record_policy_failure("compression", "access_logs", "permission denied")
+
+    with structlog.testing.capture_logs() as logs:
+        timescale._reset_policy_failures()
+
+    assert timescale.get_policy_failures() == []
+    assert [event for event in logs if event["event"] == "policy_failures_cleared"] == [
+        {
+            "count": 2,
+            "event": "policy_failures_cleared",
+            "log_level": "info",
+        }
+    ]
+
+
+def test_reset_policy_failures_does_not_log_when_already_empty() -> None:
+    with structlog.testing.capture_logs() as logs:
+        timescale._reset_policy_failures()
+
+    assert logs == []
 
 
 class _PolicyResult:

--- a/tests/test_timescale_policies.py
+++ b/tests/test_timescale_policies.py
@@ -1,6 +1,7 @@
 """Retention settings must not let a CAGG refresh window reach past raw retention."""
 from __future__ import annotations
 
+import re
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -57,6 +58,155 @@ def test_policy_failures_are_recorded_and_reset() -> None:
 
     timescale._reset_policy_failures()
     assert timescale.get_policy_failures() == []
+
+
+class _PolicyResult:
+    def __init__(self, rows: list[tuple[int, str]] | None = None) -> None:
+        self._rows = rows or []
+
+    def all(self) -> list[tuple[int, str]]:
+        return self._rows
+
+
+class _PolicyTransactionConn:
+    """Model PostgreSQL transaction aborts and savepoint rollback."""
+
+    def __init__(
+        self,
+        targets: list[str],
+        *,
+        missing_targets: set[str] | None = None,
+        fail_add_target: str | None = None,
+        fail_sync_target: str | None = None,
+    ) -> None:
+        self._job_targets = {index: target for index, target in enumerate(targets, start=1)}
+        self._target_jobs = {target: index for index, target in self._job_targets.items()}
+        self._existing = set(targets) - (missing_targets or set())
+        self._fail_add_target = fail_add_target
+        self._fail_sync_target = fail_sync_target
+        self.add_attempts: list[str] = []
+        self.sync_attempts: list[str] = []
+        self._pending_syncs: list[str] = []
+        self.committed_targets: set[str] = set()
+        self.committed_syncs: list[str] = []
+        self.aborted = False
+        self.savepoints = 0
+
+    async def execute(self, statement: Any, params: Any = None) -> _PolicyResult:
+        if self.aborted:
+            raise RuntimeError("current transaction is aborted, commands ignored")
+
+        sql = str(statement)
+        if "add_retention_policy" in sql:
+            match = re.search(r"add_retention_policy\(\s*'([^']+)'", sql)
+            assert match is not None
+            target = match.group(1)
+            self.add_attempts.append(target)
+            if target == self._fail_add_target:
+                self.aborted = True
+                raise RuntimeError("add policy denied")
+            self._existing.add(target)
+            return _PolicyResult()
+
+        if "SELECT j.job_id, j.config->>:key AS current" in sql:
+            target = params["target"]
+            self.sync_attempts.append(target)
+            if target not in self._existing:
+                return _PolicyResult()
+            return _PolicyResult([(self._target_jobs[target], "90 days")])
+
+        if "SELECT alter_job" in sql:
+            target = self._job_targets[params["job_id"]]
+            if target == self._fail_sync_target:
+                self.aborted = True
+                raise RuntimeError("sync update denied")
+            self._pending_syncs.append(target)
+            return _PolicyResult()
+
+        raise AssertionError(f"Unexpected SQL: {sql}")
+
+    def begin_nested(self) -> Any:
+        conn = self
+        existing = set(self._existing)
+        sync_count = len(self._pending_syncs)
+
+        class _Savepoint:
+            async def __aenter__(self) -> None:
+                conn.savepoints += 1
+
+            async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+                if exc_type is not None:
+                    conn._existing = existing
+                    del conn._pending_syncs[sync_count:]
+                    conn.aborted = False
+                return False
+
+        return _Savepoint()
+
+    def commit(self) -> None:
+        if self.aborted:
+            self._existing.clear()
+            self._pending_syncs.clear()
+            return
+        self.committed_targets = set(self._existing)
+        self.committed_syncs = list(self._pending_syncs)
+
+
+async def test_policy_failures_do_not_abort_later_policy_updates() -> None:
+    targets = [
+        "geo_events",
+        "access_logs",
+        "access_log_debug",
+        *timescale.HOURLY_CAGGS,
+    ]
+    conn = _PolicyTransactionConn(targets, fail_sync_target="access_logs")
+
+    await timescale._add_retention_policies(
+        cast("Any", conn),
+        raw_retention_days=180,
+        debug_retention_days=30,
+        hourly_retention_days=60,
+    )
+    conn.commit()
+
+    assert conn.add_attempts == targets
+    assert conn.sync_attempts == targets
+    assert conn.committed_targets == set(targets)
+    assert conn.committed_syncs == [target for target in targets if target != "access_logs"]
+    assert conn.savepoints == len(targets)
+    assert timescale.get_policy_failures() == [
+        timescale.PolicyFailure("retention", "access_logs", "sync update denied")
+    ]
+
+
+async def test_missing_policy_add_failure_is_recorded_and_later_targets_continue() -> None:
+    targets = [
+        "geo_events",
+        "access_logs",
+        "access_log_debug",
+        *timescale.HOURLY_CAGGS,
+    ]
+    conn = _PolicyTransactionConn(
+        targets,
+        missing_targets={"access_logs"},
+        fail_add_target="access_logs",
+    )
+
+    await timescale._add_retention_policies(
+        cast("Any", conn),
+        raw_retention_days=180,
+        debug_retention_days=30,
+        hourly_retention_days=60,
+    )
+    conn.commit()
+
+    assert conn.add_attempts == targets
+    assert conn.sync_attempts == [target for target in targets if target != "access_logs"]
+    assert conn.committed_targets == set(targets) - {"access_logs"}
+    assert conn.committed_syncs == [target for target in targets if target != "access_logs"]
+    assert timescale.get_policy_failures() == [
+        timescale.PolicyFailure("retention", "access_logs", "add policy denied")
+    ]
 
 
 async def test_refresh_policy_update_failures_are_recorded(


### PR DESCRIPTION
A head that restarted while PostgreSQL was down never started its scheduler or live feeds after the database returned. Health still reported healthy because ingestion was disabled on that head.

## What changes

- Wait up to `DB_STARTUP_WAIT_SECONDS` at startup, then serve in degraded mode and keep checking the database in the background. Recovery runs deferred migrations and setup, restores the CrowdSec poller, and starts the scheduler and ingestion.
- Recover the PostgreSQL live-feed listener independently. Shutdown cancels recovery before service teardown and waits for an in-flight migration worker to finish.
- Report paused services through health, the database and CrowdSec cards, the Scheduler page, WebSocket indicators, and the sidebar advisory count.
- Isolate each Timescale policy attempt with a savepoint so a failed update preserves that policy and other successful updates still commit.
- Report policy-update failures, failed proxy scans, missing or stale GeoIP databases, missing map home, listener outages, ingestion write losses, unexpectedly stopped ingestion, and missing log files. A reader reload that leaves ingestion stopped also raises an advisory. Critical advisories appear before warnings. Failed scans retain their previous findings; missing files resume tailing when they appear.
- Let GeoIP, location, and aggregate refresh failures reach the scheduler tracker, and update the process map home after successful detection.

A failed recovery migration stops automatic recovery and leaves a critical advisory. Shutdown waits for a migration already running in its worker thread. If that worker is stuck, shutdown waits too. APScheduler still cancels running jobs without waiting for their asynchronous cleanup. The review reproduced that pre-existing limitation separately.

## Validation

- [GitHub Actions](https://github.com/GilbN/geometrikks/actions/runs/34155025961) at `5424a06`: backend, contracts, and site passed; frontend is still running.
- The full local backend suite passed 1,490 tests before the final review fixes. After those fixes, all 176 affected tests and Python type checking passed. Regression tests cover failed or cancelled reader cleanup, restart failure, normal shutdown exclusions, and critical-first advisory ordering.
- The local frontend suite passed 319 tests, and TypeScript checking passed before the final backend-only fixes.
- The live walkthrough verified startup recovery in the same app process and browser tab, missing-file recovery, dropped ingestion records, listener reconnection, proxy-scan failure and recovery, scheduler errors, and policy-update failure and recovery using disposable services and data.

The walkthrough also identified a remaining visibility gap: generic scheduler failures appear in Scheduler and Recent errors but do not yet create an advisory card. The Status scheduler summary can show the next-run time instead of the failure label.

## How to verify

Use a disposable development stack and a browser profile with Map > Live enabled. The map saves that preference; fresh browser profiles default Live to off.

1. Stop its TimescaleDB container and start the app with `APP_MODE=full`, `LOGPARSER_ENABLED=false`, and `DB_STARTUP_WAIT_SECONDS=5`.
2. Open Settings > Status. Check the critical database advisory, amber sidebar dot with the advisory count, and database card marked "Unreachable". Settings > Scheduler should say "Background jobs not started"; the live-feed indicator should say "Live feed paused". The map can also show its data-loading error while the database is unavailable.
3. Start TimescaleDB while keeping the Map open. Check `db_recovery_started`, `channels_backend_recovered`, and `db_recovered` in the app log. The database advisory should clear, jobs should appear, and the same map tab should reconnect. Recovery time depends on the retry backoff and migrations.
4. Repeat with ingestion enabled. Append valid log lines after recovery and check that new records reach PostgreSQL.
5. Start with the database down once more, then stop the app with Ctrl-C. Check for a clean exit without destroyed-task warnings or unhandled exceptions.

6. On an ingestion-enabled instance, start without a usable City database and check the City advisory. Restore the file and run the GeoIP refresh or restart; the advisory should clear once ingestion loads the reader.
