### PR TITLE
chore: tighten product site copy

### DIFF
--- a/site/src/components/CrowdSec.astro
+++ b/site/src/components/CrowdSec.astro
@@ -17,17 +17,16 @@ import Llama from "../assets/logos/crowdsec.svg";
         widths={[720, 1200, 1912]}
         sizes="(max-width: 900px) 250vw, 1400px"
         format="webp"
-        alt="The IP inspector for a banned address: the ban badge with time left, a still-seen-after-ban warning, request counts, status mix over time and the latest requests"
+        alt="The IP inspector for a banned address, showing when the ban expires, a warning for requests seen after the ban, request counts, response codes over time and recent requests"
         loading="lazy"
       />
     </div>
     <div class="copy">
       <p class="kicker"><Llama width={22} height={22} aria-hidden="true" /> CrowdSec</p>
-      <h2 class="section-title">Bans next to the traffic that earned them.</h2>
+      <h2 class="section-title">Watch hostile traffic fuck around and find out.</h2>
       <p class="sub">
-        Connect the Local API and the Security page joins active decisions with your own logs: the country, city and
-        request count for every banned IP, a Banned badge in the tables, and a map overlay for banned addresses still
-        showing up in the selected range.
+        Connect the Local API to see every CrowdSec ban with its matching requests, country, city and request count.
+        Banned IPs are marked in the tables and on the map.
       </p>
       <dl>
         <div>
@@ -39,10 +38,9 @@ import Llama from "../assets/logos/crowdsec.svg";
           </dd>
         </div>
         <div>
-          <dt>Live within seconds</dt>
+          <dt>Ban changes appear within seconds</dt>
           <dd>
-            The app follows the LAPI decision stream and pushes changes over a WebSocket, so badges react when
-            CrowdSec bans or unbans an IP anywhere, not only from this UI.
+            GeoMetrikks follows CrowdSec's live updates, including bans and unbans made outside GeoMetrikks.
           </dd>
         </div>
         <div>

--- a/site/src/components/Features.astro
+++ b/site/src/components/Features.astro
@@ -1,18 +1,18 @@
 ---
 const cells = [
-  { title: "Live tail", body: "A WebSocket-backed tail on the access-logs page. New rows prepend and pause while you hover.", icon: "M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18zm0 4v5l3 2" },
-  { title: "Access logs", body: "Every request, server-paginated, with free-text search and filters for status, method, IP, host, country and source.", icon: "M4 6h16M4 12h16M4 18h10" },
-  { title: "IP inspector", body: "One panel per address: counts, bytes, hosts and paths hit, other locations it resolved to, and scanner tells like a hosting ASN or a wide path spread.", icon: "M11 4a7 7 0 1 0 0 14 7 7 0 0 0 0-14zm9 16-4-4" },
-  { title: "Geo logs", body: "Traffic grouped by place: which locations send requests, how that changes over time, and which clients keep coming back.", icon: "M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11zm0-8.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5z" },
-  { title: "Batch import", body: "Rotated archives, plain or gzipped, through the same pipeline with one command. Checksum-deduped, so re-running is safe.", icon: "M12 4v10m0 0 4-4m-4 4-4-4M4 17v3h16v-3" },
-  { title: "Debug logs", body: "The raw source lines behind every request, with parse failures called out and linked to their request.", icon: "M8 9l-4 3 4 3m8-6 4 3-4 3m-3-9-2 12" },
+  { title: "Live tail", body: "Watch new requests arrive on the access logs page. The feed pauses while you hover so rows do not move under the cursor.", icon: "M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18zm0 4v5l3 2" },
+  { title: "Access logs", body: "Search every request and filter by status, method, IP, host, country or source. Results are paginated on the server.", icon: "M4 6h16M4 12h16M4 18h10" },
+  { title: "IP inspector", body: "Open an address to see its request count, bandwidth, status codes, user agents, hosts and paths. Check its CrowdSec status or ban it there.", icon: "M11 4a7 7 0 1 0 0 14 7 7 0 0 0 0-14zm9 16-4-4" },
+  { title: "Geo logs", body: "Group traffic by country and city, compare activity over time, and see the top IPs and locations for the selected range.", icon: "M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11zm0-8.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5z" },
+  { title: "Batch import", body: "Import rotated or archived logs, including gzip files, with one command. Checksums prevent the same file from being imported twice.", icon: "M12 4v10m0 0 4-4m-4 4-4-4M4 17v3h16v-3" },
+  { title: "Debug logs", body: "Inspect the raw line for each parsed request. Parse failures appear here too, so you can find log lines GeoMetrikks could not read.", icon: "M8 9l-4 3 4 3m8-6 4 3-4 3m-3-9-2 12" },
 ];
 ---
 
 <section class="features" id="features">
   <div class="wrap">
-    <p class="kicker">And the rest</p>
-    <h2 class="section-title">The map is the front door. The tables are where you find out what happened.</h2>
+    <p class="kicker">Request details</p>
+    <h2 class="section-title">Search, filter and inspect the requests behind the map.</h2>
     <div class="grid">
       {
         cells.map((c) => (

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -19,7 +19,7 @@ import Terminal from "./Terminal.astro";
       </p>
       <div class="cta">
         <a class="btn primary" href="#install">Install with Docker</a>
-        <a class="btn" href="#screens">See the screens</a>
+        <a class="btn" href="#screens">View the map and logs</a>
       </div>
       <ul class="facts">
         <li>MIT</li>

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -5,7 +5,11 @@
 <section class="install" id="install">
   <div class="wrap">
     <p class="kicker">Install</p>
-    <p class="sub">Docker on amd64 or arm64. Two files, one command, and the app is on port 8000.</p>
+    <h2 class="section-title">Run GeoMetrikks with Docker Compose.</h2>
+    <p class="sub">
+      The Compose file starts GeoMetrikks and TimescaleDB on amd64 or arm64. Set the log path and API keys, then open
+      the app on port 8000.
+    </p>
     <div class="cols">
       <pre class="block"><span class="c"># Docker. Images for amd64 and arm64.</span>
 mkdir geometrikks &amp;&amp; cd geometrikks

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -11,7 +11,7 @@ import Wordmark from "./Wordmark.astro";
     </a>
     <ul>
       <li><a href="#sources">Sources</a></li>
-      <li><a href="#screens">Screens</a></li>
+      <li><a href="#screens">Map and logs</a></li>
       <li><a href="#crowdsec">CrowdSec</a></li>
       <li><a href="#agents">Agents</a></li>
       <li><a href="#install">Install</a></li>

--- a/site/src/components/Screens.astro
+++ b/site/src/components/Screens.astro
@@ -13,22 +13,22 @@ const shot = (name: string) => {
 };
 
 const screens = [
-  { id: "map", label: "Map", img: "live.png", video: "/media/map", cap: "Live map. Markers, clusters or a heatmap; flat or globe. Routes fly to your home beacon.", alt: "The live map with markers across Europe, a live request feed and a home beacon in Norway" },
-  { id: "overview", label: "Overview", img: "dashboard.png", cap: "Overview. Requests, visitors, bandwidth and errors for the range, with trends against the previous one.", alt: "Overview dashboard with summary cards and trend charts" },
-  { id: "analytics", label: "Analytics", img: "analytics.png", cap: "Analytics. Volume, status mix, latency percentiles, bytes, top URLs per host, top user agents, top ASNs.", alt: "Analytics page with request, status, bandwidth and latency charts" },
-  { id: "access-logs", label: "Access logs", img: "access-logs.png", cap: "Access logs. Every request, server-paginated, with free-text search and filters for status, method, IP, host, country and source.", alt: "Access logs table with filters and a selected request" },
+  { id: "map", label: "Map", img: "live.png", video: "/media/map", cap: "Live map. Show requests as markers, clusters or a heatmap on a flat map or globe. Live routes end at the server location you configure.", alt: "The live map with markers across Europe, a live request feed and the configured server location in Norway" },
+  { id: "overview", label: "Overview", img: "dashboard.png", cap: "Overview. Requests, visitors, bandwidth and errors for the chosen time period, compared with the previous period.", alt: "Overview dashboard with summary cards and trend charts" },
+  { id: "analytics", label: "Analytics", img: "analytics.png", cap: "Analytics. Request volume, response codes, latency percentiles, bandwidth, top URLs by host, user agents and ASNs.", alt: "Analytics page with request, status, bandwidth and latency charts" },
+  { id: "access-logs", label: "Access logs", img: "access-logs.png", cap: "Access logs. Search every request and filter by status, method, IP, host, country or source.", alt: "Access logs table with filters and a selected request" },
   { id: "geo-logs", label: "Geo logs", img: "geo-logs.png", cap: "Geo logs. Traffic grouped by place: which locations send requests and how that changes over time.", alt: "Geo logs table grouped by country and city" },
-  { id: "ip-inspector", label: "IP inspector", img: "ip-inspector.png", cap: "IP inspector. One panel per address: counts, bytes, status mix over time, hosts and paths hit, user agents, the latest requests, and its CrowdSec status with a ban button.", alt: "IP inspector sheet open over the map for a banned address, with request counts, targets, paths, user agents and latest requests" },
-  { id: "security", label: "Security", img: "crowdsec.png", cap: "Security. Active CrowdSec decisions cross-referenced with your own traffic.", alt: "Security page listing active CrowdSec decisions" },
+  { id: "ip-inspector", label: "IP inspector", img: "ip-inspector.png", cap: "IP inspector. Select an address to see request counts, bandwidth, response codes over time, hosts, paths, user agents, recent requests and CrowdSec status. You can ban it here too.", alt: "IP inspector open over the map for a banned address, with request counts, targets, paths, user agents and recent requests" },
+  { id: "security", label: "Security", img: "crowdsec.png", cap: "Security. CrowdSec bans shown with matching requests from your logs.", alt: "Security page listing active CrowdSec bans" },
   { id: "debug-logs", label: "Debug logs", img: "debug-logs.png", cap: "Debug logs. The raw source lines behind every request, with parse failures called out.", alt: "Debug logs page showing raw log lines and parse failures" },
 ];
 ---
 
 <section class="screens" id="screens">
   <div class="wrap">
-    <p class="kicker">Screens</p>
-    <h2 class="section-title">What it looks like once the log is flowing.</h2>
-    <div class="tabs" role="tablist" aria-label="Screens">
+    <p class="kicker">Inside GeoMetrikks</p>
+    <h2 class="section-title">The logs must flow.</h2>
+    <div class="tabs" role="tablist" aria-label="GeoMetrikks interface">
       {
         screens.map((s, i) => (
           <button

--- a/site/src/components/Terminal.astro
+++ b/site/src/components/Terminal.astro
@@ -148,11 +148,15 @@ const lines: Line[] = [
       transform: none;
     }
   }
-  /* On phones the box grows line by line instead of reserving the full height. */
+  /* Keep the terminal from moving the page as wrapped lines are revealed. */
   @media (max-width: 900px) {
     .body {
+      height: clamp(300px, 55svh, 420px);
       min-height: 0;
       font-size: 12px;
+      overflow-y: auto;
+      overscroll-behavior: contain;
+      scrollbar-width: thin;
     }
     .l:not(.on) {
       display: none;
@@ -175,16 +179,19 @@ const lines: Line[] = [
     lines.forEach((l) => l.classList.add("on"));
   } else {
     const caret = document.createElement("span");
+    const mobile = matchMedia("(max-width: 900px)");
     caret.className = "caret";
     let i = 0;
     const step = () => {
       if (i === lines.length) {
         lines.forEach((l) => l.classList.remove("on"));
+        if (mobile.matches) term.scrollTop = 0;
         i = 0;
       }
       const line = lines[i++];
       line.classList.add("on");
       line.after(caret);
+      if (mobile.matches) term.scrollTop = term.scrollHeight;
       setTimeout(step, "blank" in line.dataset ? 1400 : 650);
     };
     step();


### PR DESCRIPTION
## Summary

- replace vague landing-page copy with concrete feature descriptions
- clarify the CrowdSec and install sections
- keep the animated terminal from changing the page height on mobile

## Testing

- `cd site && bun run check`
- `cd site && bun run build`