### PR TITLE
fix(cli): require ASN backfill table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Geo Logs now records the autonomous system number and organization for every geo event using the GeoLite2 ASN database, including on geo-only installs (`LOGPARSER_SEND_LOGS=false`). Top IPs shows each IP's organization. Top locations has an ASNs tab with hosting classification and exact unique-IP counts. The grouped table adds optional ASN and Organization columns, the detail panel shows the ASN, and ASN include and exclude filters apply to both the table and embedded map. The API adds `GET /api/v1/geo-events/top-asns` and the `asnIn` and `asnNotIn` parameters to the geo-events and geojson endpoints.
-- `litestar backfill-asn` fills missing ASN data in historical geo events and refreshes the per-IP aggregates. On first start, Geometrikks adds the new aggregate columns and refreshes the raw-retention window. This can make startup slow on large installs. Buckets older than raw retention remain without ASN data.
+- `litestar backfill-asn --table geo-events` fills missing ASN data in historical geo events and refreshes the per-IP aggregates without touching Access Logs. The command now requires `--table access-logs`, `--table geo-events`, or `--table all` so it cannot decompress the wrong table by accident. On first start, Geometrikks adds the new aggregate columns and refreshes the raw-retention window. This can make startup slow on large installs. Buckets older than raw retention remain without ASN data.
 
 ## [0.14.3] - 2026-09-07
 

--- a/README.md
+++ b/README.md
@@ -862,20 +862,29 @@ for minutes on a large database.
 
 Rows ingested before the ASN feature (or while the ASN database was
 missing) have no ASN data. `backfill-asn` resolves their IPs against the
-local GeoLite2 ASN database and stamps them retroactively:
+local GeoLite2 ASN database and stamps them retroactively. Choose the table
+explicitly. To backfill Access Logs:
 
 ```bash
-docker compose exec -u geometrikks app litestar backfill-asn
+docker compose exec -u geometrikks app litestar backfill-asn --table access-logs
 ```
+
+Backfill Geo Logs without touching the Access Logs table:
+
+```bash
+docker compose exec -u geometrikks app litestar backfill-asn --table geo-events
+```
+
+Use `--table all` when both tables need a backfill.
 
 It fills **only** rows with no ASN data (idempotent, never overwrites
 stamped values) and asks for confirmation after reporting how many rows and
 distinct IPs are affected (`--yes` skips the prompt). IPs the database
-cannot resolve stay empty. Like `backfill-hostname`, it decompresses
-compressed history chunks first (disk usage grows until the compression
-policy recompresses them) and refreshes the ASN continuous aggregates
-afterwards so the Top ASNs view picks up the history. It may run for
-minutes on a large database.
+cannot resolve stay empty. Like `backfill-hostname`, it decompresses the
+selected table's compressed history first (disk usage grows until the
+compression policy recompresses it) and refreshes the corresponding
+continuous aggregates afterwards. It may run for minutes on a large
+database.
 
 If the aggregate refresh fails, the command exits non-zero and names the
 stale aggregates: the rows are stamped, but the Top ASNs view will not show

--- a/geometrikks/cli.py
+++ b/geometrikks/cli.py
@@ -329,26 +329,38 @@ async def _run_backfill_hostname(name: str, *, consolidate: bool, yes: bool) -> 
         await engine.dispose()
 
 
+ASN_BACKFILL_CHUNK_SIZE = 10_000
+ASN_BACKFILL_TABLES = ("access_logs", "geo_events")
+ASN_BACKFILL_TARGETS = {
+    "access-logs": ("access_logs",),
+    "geo-events": ("geo_events",),
+    "all": ASN_BACKFILL_TABLES,
+}
+
+
 @click.command(name="backfill-asn")
+@click.option(
+    "--table",
+    "target",
+    type=click.Choice(tuple(ASN_BACKFILL_TARGETS)),
+    required=True,
+    help="Table to backfill. Use geo-events for historical Geo Logs.",
+)
 @click.option("--yes", is_flag=True, help="Skip the confirmation prompt.")
-def backfill_asn_command(yes: bool) -> None:
+def backfill_asn_command(target: str, yes: bool) -> None:
     """Stamp ASN data onto historical rows from the current ASN database.
 
-    Fills only access_logs and geo_events rows with NULL
-    autonomous_system_number (idempotent, cannot overwrite stamped values)
-    by resolving each distinct IP through the local GeoLite2-ASN database.
-    IPs the database cannot resolve stay NULL. Refreshes the ASN and per-IP
-    continuous aggregates for the affected ranges when rows changed.
+    Use --table access-logs for Access Logs, --table geo-events for historical
+    Geo Logs, or --table all to process both tables. Only rows with a NULL
+    autonomous_system_number are updated. IPs the database cannot resolve stay
+    NULL. The command refreshes the affected continuous aggregates when rows
+    changed.
     Compressed hypertable chunks are decompressed first (a full-table
     UPDATE would trip the TimescaleDB tuple decompression limit); the
     compression policy recompresses them later. May run for minutes on
     large databases.
     """
-    asyncio.run(_run_backfill_asn(yes=yes))
-
-
-ASN_BACKFILL_CHUNK_SIZE = 10_000
-ASN_BACKFILL_TABLES = ("access_logs", "geo_events")
+    asyncio.run(_run_backfill_asn(yes=yes, tables=ASN_BACKFILL_TARGETS[target]))
 
 
 async def _iter_null_asn_ips(
@@ -427,7 +439,7 @@ async def _apply_asn_mapping(engine, chunks, *, table: str = "access_logs") -> i
         ))).rowcount
 
 
-async def _run_backfill_asn(*, yes: bool) -> None:
+async def _run_backfill_asn(*, yes: bool, tables: tuple[str, ...]) -> None:
     from sqlalchemy import text
 
     from geometrikks.config.settings import get_settings
@@ -435,6 +447,9 @@ async def _run_backfill_asn(*, yes: bool) -> None:
     from geometrikks.server.plugins import get_sqlalchemy_config
     from geometrikks.server.timescale import IP_LOCATION_CAGGS_NAMES, refresh_caggs_range
     from geometrikks.services.ingestion.service import create_reader
+
+    if not tables or any(table not in ASN_BACKFILL_TABLES for table in tables):
+        raise ValueError(f"Unsupported backfill tables: {tables!r}")
 
     logger = get_logger(__name__)
     settings = get_settings()
@@ -457,7 +472,7 @@ async def _run_backfill_asn(*, yes: bool) -> None:
         # nothing left to fill exits before the expensive scans below.
         async with engine.connect() as conn:
             needs_fill = [
-                table for table in ASN_BACKFILL_TABLES
+                table for table in tables
                 if bool((await conn.execute(text(
                     f"SELECT EXISTS (SELECT 1 FROM {table} "  # noqa: S608
                     "WHERE autonomous_system_number IS NULL)"

--- a/resources/components/analytics/traffic-origin-card.tsx
+++ b/resources/components/analytics/traffic-origin-card.tsx
@@ -46,7 +46,8 @@ export function TrafficOriginCard() {
           <p className="text-sm text-muted-foreground">
             None of the {formatNumber(totalRequests)} requests in this range
             have ASN data; requests are enriched from the time the ASN
-            database is first loaded. Run <code className="font-mono">litestar backfill-asn</code>{" "}
+            database is first loaded. Run{" "}
+            <code className="font-mono">litestar backfill-asn --table access-logs</code>{" "}
             to fill in history.
           </p>
         ) : (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -318,7 +318,7 @@ def test_cli_plugin_registers_backfill_asn() -> None:
 
 def _make_asn_engine(
     *, null_rows: int, distinct_ips: list[str], rowcount: int,
-    geo_distinct_ips: list[str] | None = None,
+    geo_distinct_ips: list[str] | None = None, timescale: bool = False,
 ) -> MagicMock:
     """Engine for the backfill-asn flow, dispatching on SQL substrings.
 
@@ -341,11 +341,11 @@ def _make_asn_engine(
         result = MagicMock()
         result.rowcount = rowcount
         if "EXISTS" in sql and "pg_extension" in sql:
-            result.scalar.return_value = False  # no timescale: skip decompress
+            result.scalar.return_value = timescale
         elif "EXISTS" in sql:
             result.scalar.return_value = null_rows > 0
         elif "COUNT(DISTINCT" in sql:
-            result.one.return_value = (null_rows, len(distinct_ips))
+            result.one.return_value = (null_rows, len(pages[_table(sql)][0]))
         elif "MIN(timestamp)" in sql:
             result.one.return_value = (
                 datetime(2026, 1, 1, tzinfo=timezone.utc),
@@ -400,21 +400,66 @@ def _invoke_backfill_asn(
         get_settings.cache_clear()
 
 
-def test_backfill_asn_stamps_and_refreshes(monkeypatch) -> None:
-    """1.128.0.0 resolves via the test db; both tables update and refresh."""
+def test_backfill_asn_access_logs_stamps_and_refreshes(monkeypatch) -> None:
+    """The access-logs target retains the original command's behavior."""
+    engine = _make_asn_engine(null_rows=7, distinct_ips=["1.128.0.0"], rowcount=7)
+    refresh = AsyncMock(return_value=[])
+
+    result = _invoke_backfill_asn(
+        monkeypatch, engine, ["--table", "access-logs", "--yes"], refresh
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "access_logs rows updated: 7" in result.output
+    assert "geo_events" not in result.output
+    refresh.assert_awaited_once()
+    assert refresh.await_args is not None
+    assert refresh.await_args.kwargs["caggs"] == ["asn_hourly_stats", "asn_daily_stats"]
+
+
+def test_backfill_asn_requires_table(monkeypatch) -> None:
     engine = _make_asn_engine(null_rows=7, distinct_ips=["1.128.0.0"], rowcount=7)
     refresh = AsyncMock(return_value=[])
 
     result = _invoke_backfill_asn(monkeypatch, engine, ["--yes"], refresh)
 
+    assert result.exit_code == 2
+    assert "Missing option '--table'" in result.output
+    engine.connect.assert_not_called()
+    refresh.assert_not_awaited()
+
+
+def test_backfill_asn_geo_events_does_not_touch_access_logs(monkeypatch) -> None:
+    """The Geo Logs backfill must not scan, decompress, or update access_logs."""
+    engine = _make_asn_engine(
+        null_rows=7,
+        distinct_ips=["8.8.8.8"],
+        geo_distinct_ips=["1.128.0.0"],
+        rowcount=7,
+        timescale=True,
+    )
+    refresh = AsyncMock(return_value=[])
+
+    result = _invoke_backfill_asn(
+        monkeypatch, engine, ["--table", "geo-events", "--yes"], refresh
+    )
+
     assert result.exit_code == 0, result.output
-    assert "access_logs rows updated: 7" in result.output
     assert "geo_events rows updated: 7" in result.output
-    assert refresh.await_count == 2
-    caggs = [call.kwargs["caggs"] for call in refresh.await_args_list]
-    assert caggs == [
-        ["asn_hourly_stats", "asn_daily_stats"],
-        ["ip_location_hourly_stats", "ip_location_daily_stats"],
+    assert "access_logs" not in result.output
+    sql = [str(call.args[0]) for call in engine.connect.return_value.execute.await_args_list]
+    assert all("access_logs" not in statement for statement in sql)
+    table_params = [
+        call.args[1]["table"]
+        for call in engine.connect.return_value.execute.await_args_list
+        if len(call.args) > 1 and isinstance(call.args[1], dict) and "table" in call.args[1]
+    ]
+    assert table_params == ["geo_events"]
+    refresh.assert_awaited_once()
+    assert refresh.await_args is not None
+    assert refresh.await_args.kwargs["caggs"] == [
+        "ip_location_hourly_stats",
+        "ip_location_daily_stats",
     ]
 
 
@@ -422,7 +467,9 @@ def test_backfill_asn_nothing_to_do(monkeypatch) -> None:
     engine = _make_asn_engine(null_rows=0, distinct_ips=[], rowcount=0)
     refresh = AsyncMock(return_value=[])
 
-    result = _invoke_backfill_asn(monkeypatch, engine, ["--yes"], refresh)
+    result = _invoke_backfill_asn(
+        monkeypatch, engine, ["--table", "access-logs", "--yes"], refresh
+    )
 
     assert result.exit_code == 0, result.output
     assert "Nothing to do" in result.output
@@ -435,7 +482,9 @@ def test_backfill_asn_aborts_without_confirmation(monkeypatch) -> None:
     engine.begin = MagicMock(side_effect=AssertionError("begin() must not run when aborted"))
     refresh = AsyncMock(return_value=[])
 
-    result = _invoke_backfill_asn(monkeypatch, engine, [], refresh, cli_input="n\n")
+    result = _invoke_backfill_asn(
+        monkeypatch, engine, ["--table", "access-logs"], refresh, cli_input="n\n"
+    )
 
     assert result.exit_code == 0, result.output
     assert "Aborted" in result.output
@@ -447,7 +496,7 @@ def test_backfill_asn_fails_without_asn_database(monkeypatch) -> None:
     refresh = AsyncMock(return_value=[])
 
     result = _invoke_backfill_asn(
-        monkeypatch, engine, ["--yes"], refresh,
+        monkeypatch, engine, ["--table", "access-logs", "--yes"], refresh,
         asn_db_path="/nonexistent/GeoLite2-ASN.mmdb",
     )
 
@@ -459,9 +508,11 @@ def test_backfill_asn_exits_nonzero_when_cagg_refresh_fails(monkeypatch) -> None
     """Rows are stamped but the aggregates stayed stale: the run must not
     report success, or long-range analytics silently miss the backfill."""
     engine = _make_asn_engine(null_rows=7, distinct_ips=["1.128.0.0"], rowcount=7)
-    refresh = AsyncMock(side_effect=[[], ["ip_location_daily_stats"]])
+    refresh = AsyncMock(return_value=["ip_location_daily_stats"])
 
-    result = _invoke_backfill_asn(monkeypatch, engine, ["--yes"], refresh)
+    result = _invoke_backfill_asn(
+        monkeypatch, engine, ["--table", "geo-events", "--yes"], refresh
+    )
 
     assert result.exit_code != 0
     assert "rows updated: 7" in result.output


### PR DESCRIPTION
## Summary

- require callers to choose access-logs, geo-events, or all
- keep the Geo Logs backfill from touching access_logs
- update the CLI help, README, dashboard guidance, and changelog
- add a regression test that rejects a missing table and verifies the Geo Logs target never queries access_logs

## Testing

- uv run pytest -q (1527 passed)
- uv run ty check geometrikks/cli.py tests/test_cli.py
- npm run typecheck
- git diff --check