### PR TITLE
Show hostnames in long-range Geo Logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Geo Logs now records the autonomous system number and organization for every geo event using the GeoLite2 ASN database, including on geo-only installs (`LOGPARSER_SEND_LOGS=false`). Top IPs shows each IP's organization. Top locations has an ASNs tab with hosting classification and exact unique-IP counts. The grouped table adds optional ASN and Organization columns, the detail panel shows the ASN, and ASN include and exclude filters apply to both the table and embedded map. The API adds `GET /api/v1/geo-events/top-asns` and the `asnIn` and `asnNotIn` parameters to the geo-events and geojson endpoints.
 - `litestar backfill-asn --table geo-events` fills missing ASN data in historical geo events and refreshes the per-IP aggregates without touching Access Logs. The command now requires `--table access-logs`, `--table geo-events`, or `--table all` so it cannot decompress the wrong table by accident. On first start, Geometrikks adds the new aggregate columns and refreshes the raw-retention window. This can make startup slow on large installs. Buckets older than raw retention remain without ASN data.
 
+### Fixed
+
+- Geo Logs now shows recording hostnames for ranges over 24 hours. Existing installations can fill retained history with `litestar backfill-geo-hostnames`; it refreshes one day at a time and resumes after interruption.
+
 ## [0.14.3] - 2026-09-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -858,6 +858,33 @@ grows until the compression policy recompresses them. It then refreshes the
 affected continuous aggregates so the filter dropdowns update. It may run
 for minutes on a large database.
 
+### backfill-geo-hostnames: fill historical Geo Logs hostnames
+
+Existing installations may show an empty Hostnames column for Geo Logs ranges
+over 24 hours. To fill in the missing hostnames from retained events, run:
+
+```bash
+docker compose exec -u geometrikks app litestar backfill-geo-hostnames
+```
+
+The command prints the pending ranges and asks for confirmation. It refreshes
+one day at a time and resumes with the next unfinished day if you rerun it.
+Use `--yes` to skip confirmation. The app can stay running, but the refresh
+uses database CPU and I/O and may take minutes on a large database.
+
+The aggregate rows record which buckets are complete. If the command stops or
+a batch fails, rerun it to process the remaining buckets. A second simultaneous
+run is rejected. Hourly backfills respect hourly retention, and both views only
+refresh complete buckets within raw retention. Counts remain available while
+hostname history is incomplete. This command cannot recover hostnames after
+their raw events have expired.
+
+The command reads `geo_events` and refreshes the aggregates. It does not rewrite
+source hostnames or explicitly decompress every raw chunk. In-place column
+upgrades require TimescaleDB 2.28 or later. If adding the columns fails, the app
+keeps the existing aggregate and logs `hostname_cagg_columns_unavailable`.
+Fix the database error and restart before running the command.
+
 ### backfill-asn: fill in ASN data for historical rows
 
 Rows ingested before the ASN feature (or while the ASN database was

--- a/geometrikks/cli.py
+++ b/geometrikks/cli.py
@@ -1,4 +1,4 @@
-"""Litestar CLI plugin: `litestar import-logs <paths...>`, `litestar backfill-hostname NAME`, `litestar backfill-asn`, `litestar backfill-timings`.
+"""Litestar CLI commands for log imports and historical data backfills.
 
 Import-time safe: settings, engine, reader are constructed inside the
 command callback, never at module import. The format registry import
@@ -719,11 +719,95 @@ async def _run_backfill_timings(*, hostname: str | None, before: datetime | None
         await engine.dispose()
 
 
+GEO_HOSTNAME_BACKFILL_BATCH_DAYS = 1
+
+
+@click.command(name="backfill-geo-hostnames")
+@click.option("--yes", is_flag=True, help="Skip the confirmation prompt.")
+def backfill_geo_hostnames_command(yes: bool) -> None:
+    """Fill historical hostname sets in the Geo Logs aggregates.
+
+    Run after starting the updated app. Refreshes hourly and daily aggregates
+    from retained geo_events, without rewriting source hostnames. Prints the
+    pending ranges and asks for confirmation. May run for minutes on large
+    databases; the app can stay running. Rerun after interruption to resume
+    unfinished batches. History whose raw events expired cannot be recovered.
+    """
+    asyncio.run(_run_backfill_geo_hostnames(yes=yes))
+
+
+async def _run_backfill_geo_hostnames(*, yes: bool) -> None:
+    from sqlalchemy import text
+
+    from geometrikks.config.settings import get_settings
+    from geometrikks.server.hostname_backfill import hostname_backfill_ranges, pending_hostname_range
+    from geometrikks.server.plugins import get_sqlalchemy_config
+    from geometrikks.server.timescale import refresh_caggs_range
+
+    engine = get_sqlalchemy_config().get_engine()
+    analytics = get_settings().analytics
+    try:
+        # Keep a dedicated session for the advisory lock while refresh CALLs
+        # use their own connections outside transactions.
+        async with engine.connect() as lock_conn:
+            locked = (await lock_conn.execute(text(
+                "SELECT pg_try_advisory_lock(714023, 1)"
+            ))).scalar_one()
+            if not locked:
+                raise click.ClickException("Another Geo Logs hostname backfill is already running.")
+            try:
+                await lock_conn.commit()
+                ranges = await hostname_backfill_ranges(
+                    lock_conn, now=datetime.now(timezone.utc),
+                    raw_retention_days=analytics.raw_retention_days,
+                    hourly_retention_days=analytics.hourly_retention_days,
+                )
+                await lock_conn.commit()
+                if not ranges:
+                    click.echo("Nothing to do: no complete retained hostname buckets need backfilling.")
+                    return
+                for item in ranges:
+                    click.echo(f"{item.view}: {item.start.isoformat()} to {item.end.isoformat()}")
+                click.echo("Only complete retained buckets are refreshed. Expired raw history cannot be recovered.")
+                if not yes and not click.confirm("Backfill these hostname aggregates?"):
+                    click.echo("Aborted.")
+                    return
+                for item in ranges:
+                    start = item.start
+                    while start < item.end:
+                        end = min(
+                            start + timedelta(days=GEO_HOSTNAME_BACKFILL_BATCH_DAYS),
+                            item.end,
+                        )
+                        async with engine.connect() as conn:
+                            pending = await pending_hostname_range(conn, item.view, start, end)
+                        if pending is not None:
+                            click.echo(f"Refreshing {item.view}: {pending.start.isoformat()} to {pending.end.isoformat()} ...")
+                            failed = await refresh_caggs_range(
+                                engine, start=pending.start, end=pending.end, caggs=[item.view], force=True,
+                            )
+                            if failed:
+                                raise click.ClickException(
+                                    f"Refresh failed for {item.view}. Rerun this command to resume."
+                                )
+                        start = end
+                click.echo("Geo Logs hostname backfill complete.")
+            finally:
+                await lock_conn.rollback()
+                await lock_conn.execute(text("SELECT pg_advisory_unlock(714023, 1)"))
+                await lock_conn.commit()
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    finally:
+        await engine.dispose()
+
+
 class ImportLogsCLIPlugin(CLIPlugin):
-    """Registers import-logs, backfill-hostname, backfill-asn and backfill-timings on the litestar CLI group."""
+    """Register log import and backfill commands on the Litestar CLI group."""
 
     def on_cli_init(self, cli: click.Group) -> None:
         cli.add_command(import_logs_command)
         cli.add_command(backfill_hostname_command)
         cli.add_command(backfill_asn_command)
         cli.add_command(backfill_timings_command)
+        cli.add_command(backfill_geo_hostnames_command)

--- a/geometrikks/domain/geo/controllers/events.py
+++ b/geometrikks/domain/geo/controllers/events.py
@@ -143,7 +143,7 @@ class GeoEventController(Controller):
     """Geo-event endpoints: raw event listing and geo-logs page aggregates.
 
     Perf note: only hostname filters force raw geo_events scans for
-    summary/time-series now (no CAGG carries a hostname dimension); those
+    summary/time-series (per-IP CAGGs have no per-hostname counts); those
     queries are bounded by raw_retention_days (default 180d). Country/city/IP
     filters ride the stitched per-IP CAGGs instead.
     """
@@ -209,7 +209,7 @@ class GeoEventController(Controller):
         """One row per (location, IP) pair, sorted by event count by default.
 
         Ranges > 24h are served from the daily per-IP CAGG (day-floored
-        buckets, no hostnames); a hostname filter forces the raw path.
+        buckets, distinct hostnames); a hostname filter forces the raw path.
         """
         from_timestamp = ensure_utc(from_timestamp)
         to_timestamp = ensure_utc(to_timestamp)

--- a/geometrikks/domain/geo/repositories.py
+++ b/geometrikks/domain/geo/repositories.py
@@ -138,7 +138,9 @@ def stitch_params(
     return {"start": start, "end": end, "a_start": a_start, "a_end": a_end}
 
 
-def stitched_ip_location_cte(granularity: StatsGranularity) -> str:
+def stitched_ip_location_cte(
+    granularity: StatsGranularity, *, include_hostnames: bool = False
+) -> str:
     """WITH clause exposing ``combined`` for a per-IP CAGG read.
 
     Reading a CAGG requires whole buckets, so a window that starts mid-bucket
@@ -152,22 +154,26 @@ def stitched_ip_location_cte(granularity: StatsGranularity) -> str:
     keyed by IP on all legs, so ``COUNT(DISTINCT ip_address)`` over it stays
     exact rather than summing per-bucket counts. ``last_seen`` is bucket-granular
     for CAGG rows and exact for the raw edge rows.
+
+    Hostname arrays are optional so count-only readers do not fetch them.
     """
     table, _ = IP_LOCATION_CAGGS[granularity]
     return f"""
         WITH combined AS (
             SELECT s.location_id, s.ip_address, s.event_count, s.bucket AS last_seen,
-                   s.asn, s.as_org
+                   s.asn, s.as_org{", s.hostnames" if include_hostnames else ""}
             FROM {table} s
             WHERE s.bucket >= :a_start AND s.bucket < :a_end
             UNION ALL
             SELECT ge.location_id, ge.ip_address, CAST(1 AS BIGINT), ge.timestamp,
                    ge.autonomous_system_number, ge.autonomous_system_organization
+                   {", ARRAY[ge.hostname] AS hostnames" if include_hostnames else ""}
             FROM geo_events ge
             WHERE ge.timestamp >= :start AND ge.timestamp < :a_start
             UNION ALL
             SELECT ge.location_id, ge.ip_address, CAST(1 AS BIGINT), ge.timestamp,
                    ge.autonomous_system_number, ge.autonomous_system_organization
+                   {", ARRAY[ge.hostname] AS hostnames" if include_hostnames else ""}
             FROM geo_events ge
             WHERE ge.timestamp >= :a_end AND ge.timestamp < :end
         )

--- a/geometrikks/domain/geo/schemas.py
+++ b/geometrikks/domain/geo/schemas.py
@@ -34,8 +34,10 @@ class GeoLogEntry(msgspec.Struct, rename="camel"):
     asn: int | None
     as_organization: str | None
     hostnames: list[str]
-    """Distinct hostnames seen for this group; [] on the CAGG path (the
-    daily CAGG carries no hostname dimension)."""
+    """Distinct recording hostnames seen for this group in the selected range.
+    Pre-upgrade aggregate history is incomplete until the CLI backfill;
+    history beyond raw retention cannot recover its hostname data.
+    """
 
 
 class GeoLogPeriod(msgspec.Struct, rename="camel"):
@@ -165,8 +167,8 @@ class GeoEventFacets(msgspec.Struct, rename="camel"):
 class GeoEventFilters:
     """Optional dimension filters for geo-event aggregate queries.
 
-    Hostname filtering forces the raw geo_events path: no CAGG carries a
-    hostname dimension. Every other filter, ASN included, works on the CAGG
+    Hostname filtering forces the raw geo_events path: per-IP CAGGs store
+    hostname sets, not per-hostname counts. Every other filter, ASN included, works on the CAGG
     paths too (the per-IP CAGGs are keyed by location + IP and carry the
     IP's ASN).
     """

--- a/geometrikks/domain/geo/services.py
+++ b/geometrikks/domain/geo/services.py
@@ -2,7 +2,7 @@
 
 Query routing follows the repository convention:
 - RAW geo_events for ranges ≤ 24h, and whenever a hostname filter is set
-  (no CAGG carries a hostname dimension).
+  (per-IP CAGGs store hostname sets, not per-hostname counts).
 - ip_location_{hourly,daily}_stats for grouped/top-IP queries and for
   country/city/IP-filtered summary/time-series queries on longer ranges
   (keyed by location + IP, so those filters still apply there).
@@ -102,7 +102,9 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
 
         Raw path (≤ 24h or hostname filter): exact counts, last event time and
         distinct hostnames. CAGG path: per-IP CAGG sums stitched with the raw
-        edge buckets — exact counts, bucket-granular last_seen, no hostnames.
+        edge buckets: exact counts and hostnames, bucket-granular last_seen.
+        Pre-upgrade buckets have no hostname history until the CLI backfill;
+        buckets outside raw retention cannot recover it.
 
         NULLs sink on both sort directions, and (location_id, ip_sort) always
         tie-breaks so pagination stays deterministic within equal sort keys.
@@ -152,8 +154,7 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                     CAST(SUM(c.event_count) AS BIGINT) AS event_count,
                     MAX(c.last_seen) AS last_seen,
                     MAX(c.asn) AS asn,
-                    MAX(c.as_org) AS as_organization,
-                    NULL AS hostnames
+                    MAX(c.as_org) AS as_organization
                 FROM combined c
                 JOIN geo_locations gl ON c.location_id = gl.id
                 WHERE TRUE
@@ -176,6 +177,39 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
         count_stmt = text(f"SELECT COUNT(*) FROM ({source}) grouped")
         total = (await self._session.execute(count_stmt, params)).scalar_one()
 
+        hostnames_by_group: dict[tuple[int, str], list[str]] = {
+            (row.location_id, row.ip_address): sorted(row.hostnames) if row.hostnames else []
+            for row in rows
+        } if use_raw else {}
+        from geometrikks.server.timescale import hostname_cagg_available
+
+        if not use_raw and rows and hostname_cagg_available(f"ip_location_{granularity.value}_stats"):
+            # Expand arrays only for the displayed groups, separately from
+            # counts so multiple hostnames cannot multiply event_count.
+            hostname_stmt = text(f"""
+                {stitched_ip_location_cte(granularity, include_hostnames=True)}
+                SELECT c.location_id, host(c.ip_address) AS ip_address,
+                       array_agg(DISTINCT h.hostname ORDER BY h.hostname) AS hostnames
+                FROM combined c
+                JOIN unnest(CAST(:location_ids AS bigint[]), CAST(:ip_addresses AS inet[]))
+                     AS requested(location_id, ip_address)
+                  ON c.location_id = requested.location_id AND c.ip_address = requested.ip_address
+                JOIN geo_locations gl ON c.location_id = gl.id
+                CROSS JOIN LATERAL unnest(c.hostnames) AS h(hostname)
+                WHERE h.hostname IS NOT NULL
+                {filter_sql}
+                GROUP BY c.location_id, c.ip_address
+            """)
+            hostname_rows = await self._session.execute(hostname_stmt, {
+                **params,
+                "location_ids": [row.location_id for row in rows],
+                "ip_addresses": [row.ip_address for row in rows],
+            })
+            hostnames_by_group = {
+                (row.location_id, row.ip_address): list(row.hostnames)
+                for row in hostname_rows
+            }
+
         return [
             GeoLogEntry(
                 location_id=row.location_id,
@@ -192,7 +226,7 @@ class GeoEventService(SQLAlchemyAsyncRepositoryService[GeoEvent]):
                 last_seen=row.last_seen,
                 asn=row.asn,
                 as_organization=row.as_organization,
-                hostnames=sorted(row.hostnames) if row.hostnames else [],
+                hostnames=hostnames_by_group.get((row.location_id, row.ip_address), []),
             )
             for row in rows
         ], total

--- a/geometrikks/server/hostname_backfill.py
+++ b/geometrikks/server/hostname_backfill.py
@@ -1,0 +1,74 @@
+"""Find unfinished hostname aggregates without reading the raw event history."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from geometrikks.server.timescale import IP_LOCATION_CAGGS_NAMES
+
+
+@dataclass(frozen=True)
+class HostnameBackfillRange:
+    view: str
+    start: datetime
+    end: datetime
+
+
+async def pending_hostname_range(
+    conn: AsyncConnection, view: str, start: datetime, end: datetime,
+) -> HostnameBackfillRange | None:
+    if view not in IP_LOCATION_CAGGS_NAMES:
+        raise ValueError(f"Unknown per-IP aggregate: {view}")
+    row = (await conn.execute(text(
+        f"SELECT MIN(bucket), MAX(bucket) FROM {view} "
+        "WHERE hostname_hits IS NULL AND bucket >= :start AND bucket < :end"
+    ), {"start": start, "end": end})).one()
+    if row[0] is None:
+        return None
+    width = timedelta(days=1) if "daily" in view else timedelta(hours=1)
+    return HostnameBackfillRange(view, row[0], row[1] + width)
+
+
+async def hostname_backfill_ranges(
+    conn: AsyncConnection, *, now: datetime, raw_retention_days: int, hourly_retention_days: int,
+) -> list[HostnameBackfillRange]:
+    """Only complete buckets whose raw data and aggregate retention still overlap.
+
+    NULL markers outside that window are permanent historical gaps. Refreshing
+    them after their source rows expired could erase existing counts.
+    """
+    columns = {
+        (r.table_name, r.column_name)
+        for r in await conn.execute(text(
+            "SELECT table_name, column_name FROM information_schema.columns "
+            "WHERE table_schema = 'public' AND table_name = ANY(:views)"
+        ), {"views": IP_LOCATION_CAGGS_NAMES})
+    }
+    for view in IP_LOCATION_CAGGS_NAMES:
+        if not all((view, column) in columns for column in ("hostnames", "hostname_hits")):
+            raise ValueError(
+                f"{view} is missing hostname columns. Start the updated app first. "
+                "If adding the columns failed, check its database setup log; "
+                "in-place column upgrades require TimescaleDB 2.28 or later."
+            )
+    ranges = []
+    for view in IP_LOCATION_CAGGS_NAMES:
+        hourly = "hourly" in view
+        days = min(raw_retention_days, hourly_retention_days) if hourly else raw_retention_days
+        horizon = now - timedelta(days=days)
+        start = horizon.replace(minute=0, second=0, microsecond=0)
+        end = now.replace(minute=0, second=0, microsecond=0)
+        width = timedelta(hours=1)
+        if not hourly:
+            start = start.replace(hour=0)
+            end = end.replace(hour=0)
+            width = timedelta(days=1)
+        if start < horizon:
+            start += width
+        pending = await pending_hostname_range(conn, view, start, end)
+        if pending is not None:
+            ranges.append(pending)
+    return ranges

--- a/geometrikks/server/timescale.py
+++ b/geometrikks/server/timescale.py
@@ -383,7 +383,9 @@ async def _create_ip_location_cagg(conn: "AsyncConnection") -> None:
                 COUNT(*) AS event_count,
                 MAX(autonomous_system_number) AS asn,
                 MAX(autonomous_system_organization) AS as_org,
-                COUNT(autonomous_system_number) AS asn_hits
+                COUNT(autonomous_system_number) AS asn_hits,
+                array_agg(DISTINCT hostname) AS hostnames,
+                COUNT(hostname) AS hostname_hits
             FROM geo_events
             GROUP BY bucket, location_id, ip_address
             WITH NO DATA
@@ -1007,10 +1009,14 @@ class CaggGeneration:
     generation carries its own count so the probe can check each one; a
     refresh interrupted while backfilling an older generation is caught
     even after a newer generation's refresh completed.
+
+    Manual generations add their columns at startup but leave historical
+    refreshes to an operator command.
     """
 
     count: str
     columns: tuple[CaggColumn, ...]
+    manual_backfill: bool = False
 
 
 _SUMMARY_GENERATIONS: tuple[CaggGeneration, ...] = (
@@ -1042,6 +1048,10 @@ _IP_LOCATION_GENERATIONS: tuple[CaggGeneration, ...] = (
         CaggColumn("as_org", "varchar(255)", "MAX(autonomous_system_organization)"),
         CaggColumn("asn_hits", "bigint", "COUNT(autonomous_system_number)"),
     )),
+    CaggGeneration("hostname_hits", (
+        CaggColumn("hostnames", "varchar(255)[]", "array_agg(DISTINCT hostname)"),
+        CaggColumn("hostname_hits", "bigint", "COUNT(hostname)"),
+    ), manual_backfill=True),
 )
 
 IP_LOCATION_CAGGS_NAMES = ["ip_location_hourly_stats", "ip_location_daily_stats"]
@@ -1065,7 +1075,8 @@ CAGG_COLUMNS: dict[str, tuple[CaggColumn, ...]] = {
 
 
 async def _cagg_columns_need_upgrade(
-    conn: "AsyncConnection", *, raw_retention_days: int
+    conn: "AsyncConnection", *, raw_retention_days: int, include_manual: bool = True,
+    columns_only: bool = False,
 ) -> list[str]:
     """Views missing an upgrade column, or not yet backfilled after one.
 
@@ -1084,6 +1095,8 @@ async def _cagg_columns_need_upgrade(
     Args:
         conn: Open connection inside the setup transaction.
         raw_retention_days: Window the forced refresh covers.
+        include_manual: Include generations whose history is filled by a CLI.
+        columns_only: Check schema shape without scanning aggregate history.
     """
     result = await conn.execute(text("""
         SELECT table_name, column_name FROM information_schema.columns
@@ -1093,10 +1106,13 @@ async def _cagg_columns_need_upgrade(
     existing_views = {name for name, _ in columns}
     pending: list[str] = []
     for view, generations in CAGG_GENERATIONS.items():
-        if view not in existing_views:
+        generations = tuple(g for g in generations if include_manual or not g.manual_backfill)
+        if not generations or view not in existing_views:
             continue
-        if any((view, column.name) not in columns for column in CAGG_COLUMNS[view]):
+        if any((view, column.name) not in columns for g in generations for column in g.columns):
             pending.append(view)
+            continue
+        if columns_only:
             continue
         null_counts = " OR ".join(f"{generation.count} IS NULL" for generation in generations)
         has_null = (await conn.execute(
@@ -1111,15 +1127,28 @@ async def _cagg_columns_need_upgrade(
     return pending
 
 
+# A server without in-place ADD COLUMN keeps its old per-IP aggregates.
+# Readers omit hostnames instead of referencing a column that could not be added.
+_hostname_columns_unavailable: set[str] = set()
+
+
+def hostname_cagg_available(view: str) -> bool:
+    return view not in _hostname_columns_unavailable
+
+
 async def _add_cagg_columns(conn: "AsyncConnection", views: list[str]) -> list[str]:
     """Add every missing upgrade column of ``views`` in place.
 
     The in-place ALTER keeps every existing bucket; only the new columns are
-    filled by the forced refresh the caller runs afterwards. TimescaleDB
+    filled by a forced refresh, at startup or through a manual backfill. TimescaleDB
     versions without in-place CAGG columns raise here, and for those the
     old percentile-upgrade route applies: drop the view (setup recreates it
     with the columns) and accept that daily history older than raw retention
     cannot be rebuilt.
+
+    Manual generations preserve the old view if ALTER fails. Their readers
+    omit the unavailable fields and an operator can fix the database version
+    or DDL error before restarting.
 
     Returns:
         Views that were dropped and will be recreated by the CREATE step.
@@ -1134,8 +1163,14 @@ async def _add_cagg_columns(conn: "AsyncConnection", views: list[str]) -> list[s
             """), {"view": view})
         }
         missing = [column for column in CAGG_COLUMNS[view] if column.name not in existing]
+        manual_columns = {
+            column.name for generation in CAGG_GENERATIONS[view] if generation.manual_backfill
+            for column in generation.columns
+        }
+        adding_manual = False
         try:
             for column in missing:
+                adding_manual = column.name in manual_columns
                 # Savepoint: a failed DDL poisons the whole setup transaction, so
                 # without one the fallback DROP below would hit "current
                 # transaction is aborted" and take startup down with it.
@@ -1145,6 +1180,14 @@ async def _add_cagg_columns(conn: "AsyncConnection", views: list[str]) -> list[s
                     ))
                 logger.info("cagg_column_added", view=view, column=column.name)
         except Exception as exc:
+            if adding_manual:
+                _hostname_columns_unavailable.add(view)
+                logger.warning(
+                    "hostname_cagg_columns_unavailable", view=view, error=str(exc),
+                    detail="Existing counts preserved. In-place aggregate columns require "
+                    "TimescaleDB 2.28 or later. Check the database error and restart after fixing it.",
+                )
+                continue
             logger.warning(
                 "In-place column add failed on %s (%s); recreating the view. "
                 "History older than the raw retention window cannot be rebuilt "
@@ -1288,6 +1331,7 @@ async def setup_timescaledb(
     """
     check_refresh_offsets(raw_retention_days=analytics.raw_retention_days)
     _reset_policy_failures()
+    _hostname_columns_unavailable.clear()
 
     async with engine.begin() as conn:
         # Enable extensions
@@ -1314,16 +1358,20 @@ async def setup_timescaledb(
                 "raw retention window cannot be rebuilt and is discarded",
             )
 
-        # Add the upgrade columns (timed-row counts, latency figures) to
-        # pre-existing summary/URL CAGGs. Probed before the CREATE step:
+        # Add upgrade columns before CREATE IF NOT EXISTS. Detect automatic
+        # refreshes separately so hostname history stays a manual backfill.
+        # Probed before the CREATE step:
         # CREATE IF NOT EXISTS never alters an existing view. The forced
         # refresh runs after policies, outside the transaction (CALL cannot
         # run inside one).
         pending_views = await _cagg_columns_need_upgrade(
-            conn, raw_retention_days=analytics.raw_retention_days
+            conn, raw_retention_days=analytics.raw_retention_days, include_manual=False
         )
-        if pending_views:
-            recreated = await _add_cagg_columns(conn, pending_views)
+        column_views = await _cagg_columns_need_upgrade(
+            conn, raw_retention_days=analytics.raw_retention_days, columns_only=True
+        )
+        if column_views:
+            recreated = await _add_cagg_columns(conn, column_views)
             if recreated:
                 logger.info("cagg_views_recreated", views=recreated)
 

--- a/tests/integration/test_geo_logs_hostnames_pg.py
+++ b/tests/integration/test_geo_logs_hostnames_pg.py
@@ -1,0 +1,326 @@
+"""Hostname sets survive CAGG rollups, exact boundaries and column upgrades."""
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import text
+
+from geometrikks.config.settings import get_settings
+from geometrikks.domain.geo.schemas import GeoEventFilters
+from geometrikks.domain.geo.services import GeoEventService
+from geometrikks.server import timescale
+from tests.integration.test_geo_logs_pg import NOW, _insert_events, _seed_locations
+from tests.integration.test_ip_location_asn_columns_pg import _drop_view
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture(autouse=True)
+async def clear_backfill_history(pg_engine, clean_tables):
+    """Startup repair can populate other geo CAGGs while testing an upgrade.
+
+    Remove this module's older buckets too, so later global facet/count tests
+    do not inherit history outside their short refresh windows.
+    """
+    refresh = timescale.refresh_caggs_range
+    yield
+    async with pg_engine.begin() as conn:
+        await conn.execute(text("DELETE FROM geo_events"))
+    assert not await refresh(
+        pg_engine,
+        start=(NOW - timedelta(days=get_settings().analytics.raw_retention_days + 40)).replace(hour=0),
+        end=(NOW + timedelta(days=1)).replace(hour=0),
+        caggs=[view for view, source in timescale.CAGG_SOURCE_TABLES.items() if source == "geo_events"],
+        force=True,
+    )
+
+
+@pytest.mark.parametrize("days", [3, 40])
+async def test_hostname_sets_match_raw_with_partial_buckets(
+    pg_engine, pg_session_maker, clean_tables, days,
+):
+    start = NOW - timedelta(days=days, minutes=25)
+    end = NOW - timedelta(minutes=10)
+    async with pg_session_maker() as session:
+        locs = await _seed_locations(session)
+        # Repeated names, unequal array lengths, raw-only edge names, and
+        # excluded events in the same boundary buckets as included ones.
+        for ts, hostname, n in [
+            (start - timedelta(seconds=1), "outside-start", 7),
+            (start, "head", 2),
+            (start + timedelta(days=1), "web1", 3),
+            (start + timedelta(days=1), "web2", 2),
+            (start + timedelta(days=2), "web1", 1),
+            (end - timedelta(seconds=1), "tail", 1),
+            (end, "outside-end", 8),
+        ]:
+            await _insert_events(session, ts=ts, ip="2001:db8::1", hostname=hostname,
+                                 location_id=locs["no"], n=n)
+        # The same IP in another location, and another IP in the same
+        # location, must not leak names into the requested group.
+        await _insert_events(session, ts=start + timedelta(days=1), ip="2001:db8::1",
+                             hostname="sweden", location_id=locs["se"])
+        await _insert_events(session, ts=start + timedelta(days=1), ip="1.1.1.1",
+                             hostname="other-ip", location_id=locs["no"])
+        await session.commit()
+
+    assert not await timescale.refresh_caggs_range(
+        pg_engine, start=start - timedelta(days=1), end=NOW + timedelta(days=1),
+        caggs=timescale.IP_LOCATION_CAGGS_NAMES,
+    )
+    async with pg_session_maker() as session:
+        service = GeoEventService(session=session)
+        rows, total = await service.get_grouped_logs(start, end, GeoEventFilters(), limit=1, offset=0)
+        assert total == 3
+        assert [(r.location_id, r.ip_address, r.event_count, r.hostnames) for r in rows] == [
+            (locs["no"], "2001:db8::1", 9, ["head", "tail", "web1", "web2"]),
+        ]
+        following, following_total = await service.get_grouped_logs(
+            start, end, GeoEventFilters(), limit=2, offset=1,
+        )
+        assert following_total == total
+        assert [r.hostnames for r in following] == [["other-ip"], ["sweden"]]
+        empty, empty_total = await service.get_grouped_logs(
+            start, end, GeoEventFilters(), limit=2, offset=3,
+        )
+        assert empty == []
+        assert empty_total == total
+        filtered, filtered_total = await service.get_grouped_logs(
+            start, end, GeoEventFilters(hostnames=["web1"]), limit=10, offset=0,
+        )
+        assert filtered_total == 1
+        assert [(r.event_count, r.hostnames) for r in filtered] == [(4, ["web1"])]
+
+
+async def _old_view(conn, view, interval):
+    await _drop_view(conn, view)
+    await conn.execute(text(f"""
+        CREATE MATERIALIZED VIEW {view} WITH (timescaledb.continuous) AS
+        SELECT time_bucket('{interval}', timestamp) AS bucket, location_id, ip_address,
+               COUNT(*) AS event_count, MAX(autonomous_system_number) AS asn,
+               MAX(autonomous_system_organization) AS as_org,
+               COUNT(autonomous_system_number) AS asn_hits
+        FROM geo_events GROUP BY bucket, location_id, ip_address WITH NO DATA
+    """))
+
+
+@pytest.mark.parametrize("suffix, interval", [("hourly", "1 hour"), ("daily", "1 day")])
+async def test_hostname_upgrade_resumes_after_interrupted_refresh(
+    pg_engine, pg_session_maker, clean_tables, suffix, interval, monkeypatch,
+):
+    view = f"ip_location_{suffix}_stats"
+    retention = get_settings().analytics.raw_retention_days
+    async with pg_session_maker() as session:
+        locs = await _seed_locations(session)
+        for name, n in [("web1", 3), ("web2", 2)]:
+            await _insert_events(session, ts=NOW - timedelta(days=8), ip="1.1.1.1",
+                                 hostname=name, location_id=locs["no"], n=n)
+        await session.commit()
+    async with pg_engine.begin() as conn:
+        await _old_view(conn, view, interval)
+    assert not await timescale.refresh_caggs_range(
+        pg_engine, start=NOW - timedelta(days=9), end=NOW, caggs=[view],
+    )
+    async with pg_engine.begin() as conn:
+        # Schema evolution must also work when old materialized chunks
+        # have already been compressed.
+        await conn.execute(text(f"ALTER MATERIALIZED VIEW {view} SET (timescaledb.compress = true)"))
+        await conn.execute(text("""
+            SELECT compress_chunk(c, if_not_compressed => true)
+            FROM timescaledb_information.continuous_aggregates a,
+                 LATERAL show_chunks(format('%I.%I', a.materialization_hypertable_schema,
+                                             a.materialization_hypertable_name)::regclass) c
+            WHERE a.view_name = :view
+        """), {"view": view})
+        before = (await conn.execute(text(f"SELECT '{view}'::regclass::oid"))).scalar_one()
+        assert view in await timescale._cagg_columns_need_upgrade(conn, raw_retention_days=retention)
+        assert await timescale._add_cagg_columns(conn, [view]) == []
+        # Simulate a restart after adding columns but before the refresh.
+        assert view in await timescale._cagg_columns_need_upgrade(conn, raw_retention_days=retention)
+    await timescale.setup_timescaledb(pg_engine, get_settings().analytics)
+    async with pg_engine.connect() as conn:
+        assert view in await timescale._cagg_columns_need_upgrade(conn, raw_retention_days=retention)
+        assert view not in await timescale._cagg_columns_need_upgrade(
+            conn, raw_retention_days=retention, include_manual=False,
+        )
+    await _run_cli(pg_engine, monkeypatch)
+
+    async with pg_engine.connect() as conn:
+        after = (await conn.execute(text(f"SELECT '{view}'::regclass::oid"))).scalar_one()
+        assert after == before, "the aggregate must not be dropped"
+        rows = (await conn.execute(text(
+            f"SELECT event_count, hostnames, hostname_hits FROM {view} WHERE location_id = :loc"
+        ), {"loc": locs["no"]})).all()
+        assert [(r.event_count, sorted(r.hostnames), r.hostname_hits) for r in rows] == [
+            (5, ["web1", "web2"], 5),
+        ]
+        assert view not in await timescale._cagg_columns_need_upgrade(conn, raw_retention_days=retention)
+    async with pg_engine.begin() as conn:
+        await _drop_view(conn, view)
+    await timescale.setup_timescaledb(pg_engine, get_settings().analytics)
+
+
+async def test_hostname_upgrade_preserves_counts_beyond_raw_retention(
+    pg_engine, pg_session_maker, clean_tables, monkeypatch,
+):
+    view = "ip_location_daily_stats"
+    retention = get_settings().analytics.raw_retention_days
+    old = NOW - timedelta(days=retention + 30)
+    async with pg_session_maker() as session:
+        locs = await _seed_locations(session)
+        for ts, name in [(old, "expired"), (NOW - timedelta(days=2), "recent")]:
+            await _insert_events(session, ts=ts, ip="1.1.1.1", hostname=name,
+                                 location_id=locs["no"], n=2)
+        await session.commit()
+    async with pg_engine.begin() as conn:
+        await _old_view(conn, view, "1 day")
+    assert not await timescale.refresh_caggs_range(
+        pg_engine, start=old - timedelta(days=1), end=NOW, caggs=[view],
+    )
+    async with pg_engine.begin() as conn:
+        await conn.execute(text(
+            "SELECT drop_chunks('geo_events', older_than => make_interval(days => :days))"
+        ), {"days": retention + 10})
+    await timescale.setup_timescaledb(pg_engine, get_settings().analytics)
+    await _run_cli(pg_engine, monkeypatch)
+    async with pg_engine.connect() as conn:
+        rows = (await conn.execute(text(
+            f"SELECT event_count, hostnames, hostname_hits FROM {view} "
+            "WHERE location_id = :loc ORDER BY bucket"
+        ), {"loc": locs["no"]})).all()
+        assert [(r.event_count, r.hostnames, r.hostname_hits) for r in rows] == [
+            (2, None, None), (2, ["recent"], 2),
+        ]
+        assert view not in await timescale._cagg_columns_need_upgrade(conn, raw_retention_days=retention)
+    async with pg_session_maker() as session:
+        rows, total = await GeoEventService(session=session).get_grouped_logs(
+            old - timedelta(days=1), NOW, GeoEventFilters(), limit=10, offset=0,
+        )
+        assert total == 1
+        assert [(r.event_count, r.hostnames) for r in rows] == [(4, ["recent"])]
+        old_rows, _ = await GeoEventService(session=session).get_grouped_logs(
+            old - timedelta(days=40), old + timedelta(days=1), GeoEventFilters(), limit=10, offset=0,
+        )
+        assert [(r.event_count, r.hostnames) for r in old_rows] == [(2, [])]
+    async with pg_engine.begin() as conn:
+        await _drop_view(conn, view)
+    await timescale.setup_timescaledb(pg_engine, get_settings().analytics)
+
+
+async def test_hostname_lookup_keeps_asn_filters(pg_engine, pg_session_maker, clean_tables):
+    async with pg_session_maker() as session:
+        locs = await _seed_locations(session)
+        for day, name, asn in [(3, "included", 1221), (2, "excluded", 13335)]:
+            await session.execute(text("""
+                INSERT INTO geo_events (timestamp, ip_address, hostname, location_id,
+                                        autonomous_system_number)
+                VALUES (:ts, '1.1.1.1', :name, :loc, :asn)
+            """), {"ts": NOW - timedelta(days=day), "name": name, "loc": locs["no"], "asn": asn})
+        await session.commit()
+    assert not await timescale.refresh_caggs_range(
+        pg_engine, start=NOW - timedelta(days=4), end=NOW,
+        caggs=timescale.IP_LOCATION_CAGGS_NAMES,
+    )
+    async with pg_session_maker() as session:
+        rows, total = await GeoEventService(session=session).get_grouped_logs(
+            NOW - timedelta(days=4), NOW, GeoEventFilters(asn_include=[1221]), limit=10, offset=0,
+        )
+        assert total == 1
+        assert [(r.event_count, r.hostnames) for r in rows] == [(1, ["included"])]
+
+
+async def _run_cli(engine, monkeypatch):
+    from geometrikks.cli import _run_backfill_geo_hostnames
+    from geometrikks.server import plugins
+
+    monkeypatch.setattr(plugins, "get_sqlalchemy_config", lambda: SimpleNamespace(get_engine=lambda: engine))
+    await _run_backfill_geo_hostnames(yes=True)
+
+
+async def test_cli_failure_resumes_and_completed_run_is_noop(
+    pg_engine, pg_session_maker, clean_tables, monkeypatch,
+):
+    import click
+    from geometrikks.server.hostname_backfill import hostname_backfill_ranges
+
+    view = "ip_location_daily_stats"
+    async with pg_session_maker() as session:
+        locs = await _seed_locations(session)
+        for day in (12, 10, 8):
+            await _insert_events(session, ts=NOW - timedelta(days=day), ip="1.1.1.1",
+                                 hostname=f"web-{day}", location_id=locs["no"])
+        await session.commit()
+    async with pg_engine.begin() as conn:
+        await _old_view(conn, view, "1 day")
+    assert not await timescale.refresh_caggs_range(
+        pg_engine, start=NOW - timedelta(days=14), end=NOW, caggs=[view],
+    )
+    await timescale.setup_timescaledb(pg_engine, get_settings().analytics)
+    real_refresh = timescale.refresh_caggs_range
+    calls = []
+
+    async def fail_second(engine, **kwargs):
+        calls.append(kwargs)
+        if len(calls) == 2:
+            return [view]
+        return await real_refresh(engine, **kwargs)
+
+    monkeypatch.setattr(timescale, "refresh_caggs_range", fail_second)
+    with pytest.raises(click.ClickException, match="Rerun"):
+        await _run_cli(pg_engine, monkeypatch)
+    first_start = calls[0]["start"]
+    assert calls[0]["force"] is True
+    assert calls[0]["end"] - first_start <= timedelta(days=1)
+    await _run_cli(pg_engine, monkeypatch)
+    assert sum(call["start"] == first_start for call in calls) == 1
+    count = len(calls)
+    await _run_cli(pg_engine, monkeypatch)
+    assert len(calls) == count
+    async with pg_engine.connect() as conn:
+        assert await hostname_backfill_ranges(
+            conn, now=NOW, raw_retention_days=180, hourly_retention_days=60,
+        ) == []
+    async with pg_engine.begin() as conn:
+        await _drop_view(conn, view)
+    await timescale.setup_timescaledb(pg_engine, get_settings().analytics)
+
+
+async def test_cli_decline_and_concurrent_run_do_not_refresh(
+    pg_engine, pg_session_maker, clean_tables, monkeypatch,
+):
+    import click
+    from unittest.mock import AsyncMock
+    from geometrikks.cli import _run_backfill_geo_hostnames
+    from geometrikks.server import plugins
+
+    view = "ip_location_daily_stats"
+    async with pg_session_maker() as session:
+        locs = await _seed_locations(session)
+        await _insert_events(session, ts=NOW - timedelta(days=8), ip="1.1.1.1",
+                             hostname="web", location_id=locs["no"])
+        await session.commit()
+    async with pg_engine.begin() as conn:
+        await _old_view(conn, view, "1 day")
+    assert not await timescale.refresh_caggs_range(
+        pg_engine, start=NOW - timedelta(days=10), end=NOW, caggs=[view],
+    )
+    await timescale.setup_timescaledb(pg_engine, get_settings().analytics)
+    monkeypatch.setattr(plugins, "get_sqlalchemy_config", lambda: SimpleNamespace(get_engine=lambda: pg_engine))
+    monkeypatch.setattr(click, "confirm", lambda *args: False)
+    refresh = AsyncMock()
+    with monkeypatch.context() as patch:
+        patch.setattr(timescale, "refresh_caggs_range", refresh)
+        await _run_backfill_geo_hostnames(yes=False)
+        async with pg_engine.connect() as conn:
+            await conn.execute(text("SELECT pg_advisory_lock(714023, 1)"))
+            try:
+                with pytest.raises(click.ClickException, match="already running"):
+                    await _run_backfill_geo_hostnames(yes=True)
+            finally:
+                await conn.execute(text("SELECT pg_advisory_unlock(714023, 1)"))
+        refresh.assert_not_awaited()
+    async with pg_engine.begin() as conn:
+        await _drop_view(conn, view)
+    await timescale.setup_timescaledb(pg_engine, get_settings().analytics)

--- a/tests/integration/test_geo_logs_pg.py
+++ b/tests/integration/test_geo_logs_pg.py
@@ -187,8 +187,7 @@ class TestGroupedLogs:
         assert {r.ip_address for r in by_host} == {"2.2.2.2", "3.3.3.3"}
 
     async def test_cagg_path_parity(self, pg_engine, pg_session_maker, clean_tables):
-        """>24h unfiltered range routes to ip_location_daily_stats: same groups
-        and counts as raw seeding, hostnames unavailable ([])."""
+        """>24h unfiltered range keeps groups, counts and recording hostnames."""
         locs = await seed_multiday(pg_session_maker)
         await refresh_caggs_range(
             pg_engine, start=NOW - timedelta(days=4), end=NOW + timedelta(hours=1)
@@ -203,7 +202,7 @@ class TestGroupedLogs:
             (locs["no"], "1.1.1.1", 6),
             (locs["se"], "2.2.2.2", 3),
         ]
-        assert all(r.hostnames == [] for r in rows)
+        assert [r.hostnames for r in rows] == [["web1"], ["web2"]]
 
     async def test_order_by_city_sinks_nulls_both_directions(self, pg_session_maker, clean_tables):
         locs = await seed_raw(pg_session_maker)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -662,7 +662,7 @@ def test_backfill_timings_logs_audit_before_raising_on_refresh_failure(monkeypat
     assert logger.info.call_args.kwargs["cagg_refresh_failed"] == ["url_daily_stats"]
 
 
-def test_geo_hostname_backfill_cli_registration_and_help():
+def test_geo_hostname_backfill_cli_registration_and_help() -> None:
     import click
     from geometrikks.cli import ImportLogsCLIPlugin
 
@@ -676,7 +676,7 @@ def test_geo_hostname_backfill_cli_registration_and_help():
     assert "--batch-days" not in result.output
 
 
-def test_geo_hostname_backfill_options(monkeypatch):
+def test_geo_hostname_backfill_options(monkeypatch) -> None:
     import geometrikks.cli as module
 
     run = AsyncMock()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -660,3 +660,27 @@ def test_backfill_timings_logs_audit_before_raising_on_refresh_failure(monkeypat
     assert logger.info.call_args.args[0] == "backfill_timings_completed"
     assert logger.info.call_args.kwargs["cleared"] == 7
     assert logger.info.call_args.kwargs["cagg_refresh_failed"] == ["url_daily_stats"]
+
+
+def test_geo_hostname_backfill_cli_registration_and_help():
+    import click
+    from geometrikks.cli import ImportLogsCLIPlugin
+
+    @click.group()
+    def cli(): ...
+
+    ImportLogsCLIPlugin().on_cli_init(cli)
+    result = CliRunner().invoke(cli, ["backfill-geo-hostnames", "--help"])
+    assert result.exit_code == 0
+    assert "--yes" in result.output
+    assert "--batch-days" not in result.output
+
+
+def test_geo_hostname_backfill_options(monkeypatch):
+    import geometrikks.cli as module
+
+    run = AsyncMock()
+    monkeypatch.setattr(module, "_run_backfill_geo_hostnames", run)
+    result = CliRunner().invoke(module.backfill_geo_hostnames_command, ["--yes"])
+    assert result.exit_code == 0, result.output
+    run.assert_awaited_once_with(yes=True)

--- a/tests/test_timescale_cagg_columns.py
+++ b/tests/test_timescale_cagg_columns.py
@@ -72,7 +72,7 @@ def test_column_table_covers_every_upgraded_view() -> None:
 
 def test_ip_location_generation_rolls_the_asn_up_per_ip() -> None:
     names = [c.name for c in timescale.CAGG_COLUMNS["ip_location_hourly_stats"]]
-    assert names == ["asn", "as_org", "asn_hits"]
+    assert names == ["asn", "as_org", "asn_hits", "hostnames", "hostname_hits"]
     by_name = {c.name: c for c in timescale.CAGG_COLUMNS["ip_location_hourly_stats"]}
     assert by_name["asn"].expression == "MAX(autonomous_system_number)"
     assert by_name["as_org"].expression == "MAX(autonomous_system_organization)"
@@ -346,6 +346,7 @@ async def _run_setup(
     dropped: list[str] | None = None,
     url_upgrade: bool = False,
     order: list[str] | None = None,
+    manual_views: list[str] | None = None,
 ) -> tuple[MagicMock, MagicMock]:
     """Run setup_timescaledb with every DDL step stubbed; return (logger, conn).
 
@@ -375,10 +376,12 @@ async def _run_setup(
             order.append("url")
         return url_upgrade
 
-    async def column_probe(_conn: Any, *, raw_retention_days: int) -> list[str]:
+    async def column_probe(
+        _conn: Any, *, raw_retention_days: int, include_manual: bool = True, columns_only: bool = False,
+    ) -> list[str]:
         if order is not None:
             order.append("columns")
-        return pending_views
+        return pending_views + ((manual_views or []) if include_manual else [])
 
     monkeypatch.setattr(timescale, "_url_caggs_need_upgrade", url_probe)
     monkeypatch.setattr(timescale, "_cagg_columns_need_upgrade", AsyncMock(side_effect=column_probe))
@@ -460,7 +463,7 @@ async def test_setup_rebuilds_the_url_views_before_probing_columns(
         monkeypatch, pending_views=[], refresh_failed=[], url_upgrade=True, order=order
     )
 
-    assert order == ["url", "columns"], "the drop must precede the in-place column probe"
+    assert order == ["url", "columns", "columns"], "the drop must precede the in-place column probe"
     drops = [
         str(call.args[0]) for call in conn.execute.call_args_list
         if "DROP MATERIALIZED VIEW" in str(call.args[0])
@@ -497,3 +500,52 @@ async def test_setup_leaves_the_url_views_alone_when_they_carry_host(
     assert "url_caggs_recreated" not in _events(logger.warning)
     refresh = cast("Any", timescale.refresh_caggs_range)
     assert all(c.kwargs.get("caggs") != timescale.URL_CAGGS for c in refresh.await_args_list)
+
+
+async def test_hostname_only_upgrade_does_not_refresh_on_startup(monkeypatch):
+    await _run_setup(
+        monkeypatch, pending_views=[], manual_views=timescale.IP_LOCATION_CAGGS_NAMES,
+        refresh_failed=[],
+    )
+    cast("Any", timescale._add_cagg_columns).assert_awaited_once()
+    assert cast("Any", timescale._add_cagg_columns).await_args.args[1] == timescale.IP_LOCATION_CAGGS_NAMES
+    cast("Any", timescale.refresh_caggs_range).assert_not_awaited()
+
+
+async def test_automatic_probe_ignores_unfilled_hostname_generation():
+    class ProbeConn:
+        async def execute(self, statement, params=None):
+            sql = str(statement)
+            if "information_schema.columns" in sql:
+                return _all_columns()
+            return _Scalar(1 if "hostname_hits IS NULL" in sql else None)
+
+    assert await timescale._cagg_columns_need_upgrade(
+        cast("Any", ProbeConn()), raw_retention_days=180,
+    ) == timescale.IP_LOCATION_CAGGS_NAMES
+    assert await timescale._cagg_columns_need_upgrade(
+        cast("Any", ProbeConn()), raw_retention_days=180, include_manual=False,
+    ) == []
+
+
+async def test_unsupported_hostname_column_preserves_existing_aggregate(monkeypatch):
+    view = "ip_location_daily_stats"
+    monkeypatch.setattr(timescale, "_hostname_columns_unavailable", set())
+    conn = FakeConn(
+        fail_alter_on={view}, existing={view: {"asn", "as_org", "asn_hits"}},
+    )
+    assert await timescale._add_cagg_columns(cast("Any", conn), [view]) == []
+    assert not any("DROP MATERIALIZED VIEW" in sql for sql in conn.statements)
+    assert not timescale.hostname_cagg_available(view)
+    assert not conn.aborted
+
+
+async def test_schema_only_probe_does_not_scan_aggregate_history():
+    class ProbeConn:
+        async def execute(self, statement, params=None):
+            assert "information_schema.columns" in str(statement)
+            return _all_columns()
+
+    assert await timescale._cagg_columns_need_upgrade(
+        cast("Any", ProbeConn()), raw_retention_days=180, columns_only=True,
+    ) == []


### PR DESCRIPTION
Geo Logs now returns recorded hostnames for ranges over 24 hours. Existing installations can backfill retained history with `litestar backfill-geo-hostnames` without delaying startup.