### PR TITLE
Reduce live route updates and add a map FPS counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Optional frame rate counter in the Map tools menu for manual performance testing. It counts map renders without forcing idle maps to repaint.
+
+### Changed
+
+- Live route effects update at most 30 times per second, regardless of display refresh rate, and calculate queued routes only when a packet can start.
+- Map tools contains Go to home location and, on mobile, Fit to data bounds. Mobile filters now appear at the bottom of the drawer.
+
 ## [0.15.0] - 2026-09-09
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.39.0",
+        "mapbox-gl-fps": "1.0.1",
         "maplibre-gl": "^6.6.0",
         "radix-ui": "^1.6.7",
         "react": "^19.2.8",
@@ -1359,6 +1360,8 @@
     "lucide-react": ["lucide-react@1.39.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y8nXoEwvqqIsF927NBWXODa4bfMrcUeEb/9sgpwFqg0gUjgn3j5Hznk+v7STmPgZ2iQ11JKlbQGdFRuTOwvYkA=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, ""],
+
+    "mapbox-gl-fps": ["mapbox-gl-fps@1.0.1", "", {}, "sha512-g/BQaXrBFR++CwwqK6LA9Lqbhyta/9wrZnuzc0jeEIoQDzCAX4YvL3Qj77R1q3xDKmubAlVhu6CCYaqjDov8QA=="],
 
     "maplibre-gl": ["maplibre-gl@6.6.0", "", { "dependencies": { "@mapbox/point-geometry": "^1.1.0", "@mapbox/tiny-sdf": "^2.2.0", "@mapbox/unitbezier": "^1.0.0", "@mapbox/vector-tile": "^3.0.0", "@maplibre/geojson-vt": "^6.1.1", "@maplibre/maplibre-gl-style-spec": "^26.3.0", "@maplibre/mlt": "^1.2.0", "@maplibre/vt-pbf": "^4.3.2", "@types/geojson": "^7946.0.16", "earcut": "^3.2.3", "gl-matrix": "^3.4.4", "kdbush": "^4.1.0", "murmurhash-js": "^1.0.0", "pbf": "^5.1.2", "potpack": "^2.1.0", "quickselect": "^3.0.0", "tinyqueue": "^3.0.0" } }, "sha512-EQql6eZYPhbHvJpqY4AwoiuLkUfXFRBHk67S8mDtzNo1F/jAo7xAxunIzO7gJ1vwTcPMgrK9b64dqKHvnkTlDQ=="],
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.39.0",
+    "mapbox-gl-fps": "1.0.1",
     "maplibre-gl": "^6.6.0",
     "radix-ui": "^1.6.7",
     "react": "^19.2.8",

--- a/resources/components/map/GeoMap.tsx
+++ b/resources/components/map/GeoMap.tsx
@@ -37,6 +37,7 @@ import {
   unclusteredPointLayer,
 } from "./layers"
 import { MapControls } from "./MapControls"
+import { MapFrameRate } from "./MapFrameRate"
 import { LivePulses } from "./LivePulses"
 import { HomeMarker } from "./HomeMarker"
 import { MapPopup, type PopupInfo } from "./MapPopup"
@@ -52,6 +53,8 @@ import { useUrlFilters } from "@/hooks/use-url-filters"
 import { loadLiveOverlays, saveLiveOverlays, type LiveOverlayPreferences } from "@/lib/live-overlays"
 import {
   loadLayerPreference,
+  loadFrameRatePreference,
+  saveFrameRatePreference,
   loadLivePreference,
   saveLayerPreference,
   saveLivePreference,
@@ -174,6 +177,8 @@ function GeoMapInner({
   const [activeLayer, setActiveLayer] = useState<LayerType>(loadLayerPreference)
   const [projection, setProjection] = useState<MapProjection>(loadMapProjectionPreference)
   const [routeEffectsEnabled, setRouteEffectsEnabled] = useState(loadRouteEffectsPreference)
+  const [frameRateEnabled, setFrameRateEnabled] = useState(loadFrameRatePreference)
+  useEffect(() => saveFrameRatePreference(frameRateEnabled), [frameRateEnabled])
   const [homeMarkerEnabled, setHomeMarkerEnabled] = useState(loadHomeMarkerPreference)
   const [liveOverlays, setLiveOverlays] = useState<LiveOverlayPreferences>(loadLiveOverlays)
   const [showBanned, setShowBanned] = useState(false)
@@ -520,6 +525,7 @@ function GeoMapInner({
       >
         {/* Navigation controls */}
         <NavigationControl position="bottom-right" showCompass={true} />
+        {frameRateEnabled && <MapFrameRate />}
         <MapAttribution />
 
         {/* GeoJSON data source */}
@@ -632,6 +638,8 @@ function GeoMapInner({
         liveOverlays={liveOverlays}
         onLiveOverlayChange={changeLiveOverlay}
         routeEffectsEnabled={routeEffectsEnabled}
+        frameRateEnabled={frameRateEnabled}
+        onFrameRateChange={setFrameRateEnabled}
         onRouteEffectsChange={setRouteEffectsEnabled}
         routeHomeAvailable={goHomeDestination !== null}
         homeMarkerEnabled={homeMarkerEnabled}

--- a/resources/components/map/LivePulses.tsx
+++ b/resources/components/map/LivePulses.tsx
@@ -40,6 +40,10 @@ const MAX_VISIBLE_LANES = 8
 const MAX_ACTIVE_TRANSMISSIONS = MAX_VISIBLE_LANES
 const ROUTE_SAMPLES = 48
 const ARRIVAL_LINGER_MS = 900
+// GeoJSON updates rebuild worker-side geometry. Keep this independent of
+// display refresh rate (including 120/144 Hz screens); motion remains timed
+// against the clock rather than the number of animation frames.
+const FRAME_INTERVAL_MS = 1000 / 30
 const EARTH_RADIUS_KM = 6371
 
 function clamp(value: number, min = 0, max = 1): number {
@@ -347,23 +351,20 @@ export function LivePulses({
     const now = performance.now()
     for (const request of requests) {
       const destination = resolveDestination(request.hostname)
-      if (!destination) continue
-      const transmission = createTransmission(
-        request,
-        destination,
-        now,
-        prefersReducedMotion.current,
-      )
-      if (!transmission) continue
+      if (!destination || !request.coordinates) continue
+      const lane = routeLane(request.coordinates)
 
       const laneIsActive = transmissions.current.some(
-        (activeTransmission) => activeTransmission.lane === transmission.lane,
+        (activeTransmission) => activeTransmission.lane === lane,
       )
 
       if (laneIsActive || transmissions.current.length >= MAX_ACTIVE_TRANSMISSIONS) {
-        queuedRequests.current.set(transmission.lane, request)
+        queuedRequests.current.set(lane, request)
       } else {
-        transmissions.current.push(transmission)
+        const transmission = createTransmission(
+          request, destination, now, prefersReducedMotion.current,
+        )
+        if (transmission) transmissions.current.push(transmission)
       }
     }
   }, [resolveDestination])
@@ -387,8 +388,16 @@ export function LivePulses({
       return
     }
     sourceIsEmpty.current = true
-    const tick = () => {
-      const now = performance.now()
+    let lastFrame = -Infinity
+    const tick = (now: number) => {
+      raf.current = requestAnimationFrame(tick)
+      const elapsed = now - lastFrame
+      if (elapsed < FRAME_INTERVAL_MS) return
+      // Preserve the remainder to avoid dropping to 20 Hz when a 60 Hz
+      // frame arrives just before the next 30 Hz deadline.
+      lastFrame = Number.isFinite(lastFrame)
+        ? now - elapsed % FRAME_INTERVAL_MS
+        : now
       transmissions.current = transmissions.current.filter(
         ({ born, duration }) => now - born < duration + ARRIVAL_LINGER_MS,
       )
@@ -422,7 +431,6 @@ export function LivePulses({
         source?.setData(buildFrame(transmissions.current, now))
         sourceIsEmpty.current = idle
       }
-      raf.current = requestAnimationFrame(tick)
     }
     raf.current = requestAnimationFrame(tick)
     return () => cancelAnimationFrame(raf.current)

--- a/resources/components/map/MapControls.tsx
+++ b/resources/components/map/MapControls.tsx
@@ -1,6 +1,7 @@
 /**
  * Map control overlay: one bounded panel with labeled sections, in this
- * order: Visualization, Live (with the rail switch), Filters, Summary, Top IPs.
+ * order on desktop: Visualization, Live, Filters, Summary, Top IPs.
+ * The mobile drawer puts Filters last.
  * Toggles are switch rows rather than buttons so it fits without scrolling.
  * Desktop: a collapsible MapOverlay docked top-right.
  * Mobile: a trigger button portaled into the top header bar (next to the
@@ -12,6 +13,14 @@ import { createPortal } from "react-dom"
 import { MapOverlay } from "./MapOverlay"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import {
   Drawer,
   DrawerContent,
@@ -33,6 +42,7 @@ import {
   Loader2,
   MapPin,
   Maximize2,
+  MoreHorizontal,
   Radio,
   SlidersHorizontal,
   Sparkles,
@@ -58,6 +68,8 @@ interface MapControlsProps {
   liveOverlays: LiveOverlayPreferences
   onLiveOverlayChange: (key: keyof LiveOverlayPreferences, enabled: boolean) => void
   routeEffectsEnabled: boolean
+  frameRateEnabled: boolean
+  onFrameRateChange: (enabled: boolean) => void
   onRouteEffectsChange: (enabled: boolean) => void
   routeHomeAvailable: boolean
   homeMarkerEnabled: boolean
@@ -159,6 +171,8 @@ export function MapControls({
   liveOverlays,
   onLiveOverlayChange,
   routeEffectsEnabled,
+  frameRateEnabled,
+  onFrameRateChange,
   onRouteEffectsChange,
   routeHomeAvailable,
   homeMarkerEnabled,
@@ -200,6 +214,37 @@ export function MapControls({
     setHeaderSlot(document.getElementById("header-actions-slot"))
   }, [])
 
+  const toolsMenu = (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon-sm" title="Map tools" aria-label="Map tools">
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-auto min-w-44">
+        {isMobile && (
+          <DropdownMenuItem onSelect={onFitBounds} disabled={isLoading || events === 0}>
+            <Maximize2 className="h-4 w-4" />
+            Fit to data bounds
+          </DropdownMenuItem>
+        )}
+        {routeHomeAvailable && onGoHome && (
+          <DropdownMenuItem onSelect={onGoHome}>
+            <Home className="h-4 w-4" />
+            Go to home location
+          </DropdownMenuItem>
+        )}
+        {(isMobile || (routeHomeAvailable && onGoHome)) && <DropdownMenuSeparator />}
+        <DropdownMenuCheckboxItem
+          checked={frameRateEnabled}
+          onCheckedChange={onFrameRateChange}
+        >
+          Show frame rate
+        </DropdownMenuCheckboxItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+
   const viewActions = (
     <div className="flex gap-1">
       <Button
@@ -213,19 +258,55 @@ export function MapControls({
         <Maximize2 className="h-4 w-4" />
         <span className="sr-only">Fit to data bounds</span>
       </Button>
-      {routeHomeAvailable && onGoHome && (
+    </div>
+  )
+
+  const filtersSection = (
+    <Section label="Filters">
+      <FilterCombobox
+        label="Country"
+        options={countryOptions}
+        selected={selectedCountries}
+        onChange={onCountriesChange}
+        labelFor={(code) => countryLabels?.[code] ?? code}
+        forceInline={isMobile}
+        className="w-full justify-between"
+      />
+      <FilterCombobox
+        label="City"
+        options={cityOptions}
+        selected={selectedCities}
+        onChange={onCitiesChange}
+        forceInline={isMobile}
+        className="w-full justify-between"
+      />
+      {(sourceOptions.length >= 2 || selectedSources.length > 0) && (
+        <FilterCombobox
+          label="Source"
+          options={sourceOptions}
+          selected={selectedSources}
+          onChange={onSourcesChange}
+          loading={sourcesLoading}
+          emptyText="No sources recorded"
+          forceInline={isMobile}
+          className="w-full justify-between"
+        />
+      )}
+      {activeFilterCount > 0 && (
         <Button
           variant="ghost"
-          size="icon-sm"
-          onClick={onGoHome}
-          title="Go to home location"
-          className="cursor-pointer pointer-coarse:size-10"
+          size="sm"
+          className="h-8 w-full justify-start px-2 pointer-coarse:h-10"
+          onClick={() => {
+            onCountriesChange([])
+            onCitiesChange([])
+            onSourcesChange([])
+          }}
         >
-          <Home className="h-4 w-4" />
-          <span className="sr-only">Go to home location</span>
+          Clear filters
         </Button>
       )}
-    </div>
+    </Section>
   )
 
   // The control sections are shared between the desktop top-right panel and the
@@ -305,54 +386,7 @@ export function MapControls({
         )}
       </Section>
 
-      {/* Country / city / source filters, one per row. */}
-      <Section label="Filters">
-        <FilterCombobox
-          label="Country"
-          options={countryOptions}
-          selected={selectedCountries}
-          onChange={onCountriesChange}
-          labelFor={(code) => countryLabels?.[code] ?? code}
-          forceInline={isMobile}
-          className="w-full justify-between"
-        />
-        <FilterCombobox
-          label="City"
-          options={cityOptions}
-          selected={selectedCities}
-          onChange={onCitiesChange}
-          forceInline={isMobile}
-          className="w-full justify-between"
-        />
-        {(sourceOptions.length >= 2 || selectedSources.length > 0) && (
-          <FilterCombobox
-            label="Source"
-            options={sourceOptions}
-            selected={selectedSources}
-            onChange={onSourcesChange}
-            loading={sourcesLoading}
-            emptyText="No sources recorded"
-            forceInline={isMobile}
-            className="w-full justify-between"
-          />
-        )}
-        {activeFilterCount > 0 && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-8 w-full justify-start px-2 pointer-coarse:h-10"
-            onClick={() => {
-              onCountriesChange([])
-              onCitiesChange([])
-              onSourcesChange([])
-            }}
-          >
-            Clear filters
-          </Button>
-        )}
-      </Section>
-
-      {isMobile && <Section>{viewActions}</Section>}
+      {!isMobile && filtersSection}
 
       <Section>
         <div className="flex flex-col gap-0.5 text-xs text-muted-foreground">
@@ -404,6 +438,7 @@ export function MapControls({
           </div>
         </Section>
       )}
+      {isMobile && filtersSection}
     </>
   )
 
@@ -429,7 +464,10 @@ export function MapControls({
         )}
         <DrawerContent>
           <DrawerHeader>
-            <DrawerTitle>Map controls</DrawerTitle>
+            <div className="flex items-center justify-between gap-2">
+              <DrawerTitle>Map controls</DrawerTitle>
+              {toolsMenu}
+            </div>
             <DrawerDescription className="sr-only">
               Switch map layers, filter by country and city, and view statistics.
             </DrawerDescription>
@@ -482,6 +520,7 @@ export function MapControls({
         <h2 className={FRAME_LABEL}>Map controls</h2>
         <div className="flex items-center gap-0.5">
           {viewActions}
+          {toolsMenu}
           <Button
             size="icon-sm"
             variant="ghost"

--- a/resources/components/map/MapFrameRate.tsx
+++ b/resources/components/map/MapFrameRate.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from "react"
+import { useMap } from "react-map-gl/maplibre"
+
+/** Passive render counter: it must never request a map repaint itself. */
+export function MapFrameRate() {
+  const { current: map } = useMap()
+  const counterRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const instance = map?.getMap()
+    const container = counterRef.current
+    if (!instance || !container) return
+    let disposed = false
+    let remove: (() => void) | undefined
+
+    void import("mapbox-gl-fps/lib/MapboxFPS.js").then(({ FPSMeasurer }) => {
+      if (disposed) return
+      const measurer = new FPSMeasurer()
+      const render = () => measurer.registerRenderFrame()
+      measurer.startMeasuring()
+      instance.on("render", render)
+      // Sample even without renders so an idle map reports zero. Updating this
+      // DOM label does not trigger MapLibre's render loop.
+      const timer = window.setInterval(() => {
+        measurer.updateFPS()
+        // The plugin otherwise retains every sample for the entire session.
+        measurer.measurements.splice(0, Math.max(0, measurer.measurements.length - 120))
+        const label = `${measurer.getLastMeasurement().toFixed(1)} FPS`
+        if (container.textContent !== label) container.textContent = label
+      }, 1000)
+      remove = () => {
+        window.clearInterval(timer)
+        instance.off("render", render)
+        measurer.stopMeasuring()
+      }
+    })
+
+    return () => {
+      disposed = true
+      remove?.()
+    }
+  }, [map])
+
+  return (
+    <div
+      ref={counterRef}
+      data-testid="map-frame-rate"
+      title="Map renders per second. Zero is normal when idle. This counter does not measure CPU usage."
+      className="pointer-events-none absolute bottom-[max(3rem,env(safe-area-inset-bottom))] left-1/2 z-10 min-w-20 -translate-x-1/2 rounded-full border border-border bg-background/90 px-3 py-1 text-center font-mono text-xs tabular-nums text-foreground shadow-sm lg:bottom-[max(1rem,env(safe-area-inset-bottom))]"
+    >
+      0.0 FPS
+    </div>
+  )
+}

--- a/resources/lib/map-preferences.ts
+++ b/resources/lib/map-preferences.ts
@@ -4,6 +4,23 @@
 export const MAP_LAYER_STORAGE_KEY = "geometrikks-map-layer"
 export const MAP_LIVE_STORAGE_KEY = "geometrikks-map-live"
 export const MAP_ATTRIBUTION_STORAGE_KEY = "geometrikks-map-attribution"
+export const MAP_FRAME_RATE_STORAGE_KEY = "geometrikks-map-frame-rate"
+
+export function loadFrameRatePreference(): boolean {
+  try {
+    return localStorage.getItem(MAP_FRAME_RATE_STORAGE_KEY) === "true"
+  } catch {
+    return false
+  }
+}
+
+export function saveFrameRatePreference(enabled: boolean): void {
+  try {
+    localStorage.setItem(MAP_FRAME_RATE_STORAGE_KEY, String(enabled))
+  } catch {
+    // Keep the in-memory preference when storage is unavailable.
+  }
+}
 
 export type MapLayer = "heatmap" | "markers"
 

--- a/resources/types/mapbox-gl-fps.d.ts
+++ b/resources/types/mapbox-gl-fps.d.ts
@@ -1,0 +1,10 @@
+declare module "mapbox-gl-fps/lib/MapboxFPS.js" {
+  export class FPSMeasurer {
+    measurements: number[]
+    startMeasuring(): void
+    stopMeasuring(): void
+    registerRenderFrame(): void
+    updateFPS(): void
+    getLastMeasurement(): number
+  }
+}

--- a/tests/browser/map-frame-rate.pw.ts
+++ b/tests/browser/map-frame-rate.pw.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "@playwright/test"
+
+for (const width of [1280, 390]) {
+  test(`frame rate menu persists and removes its counter at ${width}px`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width, height: 844 })
+    const password =
+      process.env.SMOKE_ADMIN_PASSWORD ?? process.env.APP_ADMIN_PASSWORD
+    if (!password) throw new Error("Administrator credentials are required")
+    const response = await page.request.post("/api/v1/auth/login", {
+      data: {
+        username:
+          process.env.SMOKE_ADMIN_USER ?? process.env.APP_ADMIN_USER ?? "admin",
+        password,
+      },
+    })
+    expect(response.ok()).toBe(true)
+    await page.addInitScript(() =>
+      localStorage.setItem("geometrikks-map-live", "false"),
+    )
+    await page.goto("/map")
+    const monitor = page.getByTestId("map-frame-rate")
+    const toolsMenu = page.getByRole("button", {
+      name: "Map tools",
+      exact: true,
+    })
+    const openMenu = async () => {
+      if (width < 768 && !(await page.locator('[data-slot="drawer-content"]').isVisible())) {
+        await page
+          .getByRole("button", { name: "Map Controls", exact: true })
+          .click()
+      }
+      await toolsMenu.click()
+    }
+    const toggle = page.getByRole("menuitemcheckbox", {
+      name: "Show frame rate",
+      exact: true,
+    })
+    await openMenu()
+    await expect(toggle).toHaveAttribute("aria-checked", "false")
+    await expect(monitor).toHaveCount(0)
+    await toggle.click()
+    if (width < 768) {
+      await page.keyboard.press("Escape")
+      await expect(page.locator('[data-slot="drawer-content"]')).toBeHidden()
+    }
+    await expect(monitor).toHaveCSS("pointer-events", "none")
+    // Let initial tile/style rendering settle before deliberately moving the map.
+    await page.waitForTimeout(2000)
+    await expect(monitor).toHaveText("0.0 FPS", { timeout: 20_000 })
+    const bounds = await monitor.boundingBox()
+    if (!bounds) throw new Error("Frame rate counter is not visible")
+    const x = bounds.x + bounds.width / 2
+    const y = bounds.y + bounds.height / 2
+    // Start on the badge to also exercise dragging through the overlay. Keep
+    // moving across sampling windows so a missing FPS listener cannot pass.
+    await page.mouse.move(x, y)
+    await page.mouse.down()
+    let direction = 1
+    try {
+      await expect
+        .poll(async () => {
+          await page.mouse.move(x + direction * 40, y - 20, { steps: 5 })
+          direction *= -1
+          return Number.parseFloat((await monitor.textContent()) ?? "")
+        }, { intervals: [100], timeout: 10_000 })
+        .toBeGreaterThan(0)
+    } finally {
+      await page.mouse.up()
+    }
+    await expect(monitor).toHaveText("0.0 FPS", { timeout: 20_000 })
+    await page.reload()
+    await openMenu()
+    await expect(toggle).toHaveAttribute("aria-checked", "true")
+    await expect(monitor).toHaveCount(1)
+    await expect(monitor).toHaveText("0.0 FPS", { timeout: 20_000 })
+    await toggle.click()
+    await expect(monitor).toHaveCount(0)
+    await openMenu()
+    await toggle.click()
+    await expect(monitor).toHaveCount(1)
+    await openMenu()
+    await toggle.click()
+    await page.reload()
+    await openMenu()
+    await expect(toggle).toHaveAttribute("aria-checked", "false")
+    await expect(monitor).toHaveCount(0)
+  })
+}


### PR DESCRIPTION
Limit live route updates to 30 Hz and calculate queued routes only when they start. This reduces geometry work; overall CPU savings are not yet confirmed.

Add an optional FPS counter in Map tools. Move Home into the menu, put Fit to bounds there on mobile, and move mobile filters to the bottom of the drawer.

Validated with the production Docker build, 326 unit tests, two desktop/mobile browser tests, and agents-stack checks in both map projections.

Related to #235.
