### PR TITLE
fix(map): fix title on banned map popup

### DIFF
--- a/resources/components/map/BannedMapPopup.tsx
+++ b/resources/components/map/BannedMapPopup.tsx
@@ -174,6 +174,7 @@ export function BannedMapPopup({
   const [selectedIp, setSelectedIp] = useState<string | null>(ips.length === 1 ? ips[0].ip : null)
   const selected = selectedIp === null ? null : ips.find((ip) => ip.ip === selectedIp) ?? null
   const hasIpv6 = ips.some((ip) => ip.ip.includes(":"))
+  const title = selected ? "Banned IP" : `${ips.length.toLocaleString()} banned IP${ips.length === 1 ? "" : "s"}`
 
   return (
     <Popup
@@ -187,6 +188,8 @@ export function BannedMapPopup({
       maxWidth={hasIpv6 ? "380px" : "300px"}
       style={{ background: "transparent" }}
     >
+      {/* The accessible name stays fixed while the visible header changes;
+          tests/browser/banned-map.pw.ts locates this popup by that name. */}
       <div role="dialog" aria-label="Banned IPs">
         <PopupCard
           onClose={onClose}
@@ -194,9 +197,7 @@ export function BannedMapPopup({
           header={
             <>
               <ShieldBan style={{ width: 16, height: 16, color: "var(--destructive)", flexShrink: 0 }} />
-              <span style={{ fontSize: "14px", fontWeight: 600 }}>
-                {ips.length === 1 ? "Banned IP" : `${ips.length.toLocaleString()} banned IPs`}
-              </span>
+              <span style={{ fontSize: "14px", fontWeight: 600 }}>{title}</span>
             </>
           }
         >

--- a/tests/browser/banned-map.pw.ts
+++ b/tests/browser/banned-map.pw.ts
@@ -136,6 +136,20 @@ test("a shrinking location keeps the pager and the selection on the map", async 
   await expect(popup.getByRole("button", { name: /^192\./ })).toHaveCount(19)
 })
 
+test("the popup title follows the list and detail views", async ({ page }) => {
+  const { state, delta } = await setup(page, collection([group("2", 3)]))
+  await openCenterPopup(page)
+  const popup = page.getByRole("dialog", { name: "Banned IPs", exact: true })
+  await expect(popup.getByText("3 banned IPs", { exact: true })).toBeVisible()
+  await popup.getByRole("button", { name: /^192\.0\.2\.3 / }).click()
+  await expect(popup.getByText("Banned IP", { exact: true })).toBeVisible()
+  // The selected IP drops out and the popup returns to the list, where the one
+  // remaining IP still reads as a count.
+  state.data = collection([group("2", 1)])
+  delta()
+  await expect(popup.getByText("1 banned IP", { exact: true })).toBeVisible()
+})
+
 test("errors remain distinct from empty data and retry recovers", async ({ page }) => {
   const { state, delta } = await setup(page)
   state.failed = true


### PR DESCRIPTION
The banned IPs popup header stays fixed at the location's IP count even after drilling into one IP's details.

The header now shows "Banned IP" when a single IP's details are open, and switches back to the count when returning to the list.